### PR TITLE
fix(structure): keep templateId when serializing initial value template items

### DIFF
--- a/packages/sanity/src/structure/structureBuilder/InitialValueTemplateItem.ts
+++ b/packages/sanity/src/structure/structureBuilder/InitialValueTemplateItem.ts
@@ -147,7 +147,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
 
     return {
       id: this.spec.id,
-      templateId: this.spec.id,
+      templateId: this.spec.templateId,
       schemaType: template.schemaType,
       type: 'initialValueTemplateItem',
       // oxlint-disable-next-line no-deprecated -- will fix in follow up PR

--- a/packages/sanity/src/structure/structureBuilder/__tests__/InitialValueTemplateItem.test.ts
+++ b/packages/sanity/src/structure/structureBuilder/__tests__/InitialValueTemplateItem.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from 'vitest'
+
+import {InitialValueTemplateItemBuilder} from '../InitialValueTemplateItem'
+import {type StructureContext} from '../types'
+
+// Minimal mock of StructureContext for testing
+const mockContext = {
+  templates: [{id: 'my-template', title: 'My template', schemaType: 'myType'}],
+} as unknown as StructureContext
+
+describe('InitialValueTemplateItemBuilder', () => {
+  describe('templateId()', () => {
+    it('should serialize the template id when it matches the item id', () => {
+      const serialized = new InitialValueTemplateItemBuilder(mockContext)
+        .templateId('my-template')
+        .serialize()
+
+      expect(serialized.id).toBe('my-template')
+      expect(serialized.templateId).toBe('my-template')
+    })
+
+    it('should keep the template id when the item has its own id', () => {
+      const serialized = new InitialValueTemplateItemBuilder(mockContext)
+        .id('my-template-variant-a')
+        .templateId('my-template')
+        .serialize()
+
+      expect(serialized.id).toBe('my-template-variant-a')
+      expect(serialized.templateId).toBe('my-template')
+    })
+
+    it('should let several items share one template while keeping distinct ids', () => {
+      const items = ['a', 'b', 'c'].map((variant) =>
+        new InitialValueTemplateItemBuilder(mockContext)
+          .id(`my-template-${variant}`)
+          .templateId('my-template')
+          .parameters({variant})
+          .serialize(),
+      )
+
+      expect(new Set(items.map((item) => item.id)).size).toBe(3)
+      expect(new Set(items.map((item) => item.templateId))).toEqual(new Set(['my-template']))
+      expect(items.map((item) => item.parameters)).toEqual([
+        {variant: 'a'},
+        {variant: 'b'},
+        {variant: 'c'},
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## Description

`InitialValueTemplateItemBuilder.serialize()` validates `spec.templateId` and uses it to resolve the template — then writes the item's **`id`** into the returned `templateId`:

```ts
return {
  id: this.spec.id,
  templateId: this.spec.id,   // ← discards the validated spec.templateId
```

So a serialized item's `id` can never differ from its template id, and the public `.templateId()` setter has no effect on the output.

This makes it impossible to offer several create entries backed by one parametrised template — a documented use case, since templates accept `parameters`. It shows up two ways:

- **Duplicate React keys.** Every entry serializes with the same `id`/`templateId`, so `PaneHeaderCreateButton` renders them under one key ("Encountered two children with the same key…"). In a pane whose entries change at runtime this can reconcile to the wrong label.
- **`.id()` breaks resolution.** Giving each entry its own id — the obvious remedy — fails with `Error: template not found: "<item-id>"`, because `getTemplatePermissions()` looks the template up by `serializedItem.templateId`.

This is a long-standing regression, not a recent change: `serialize()` returned the correct `templateId` up to `10682a446` (2021-12-18) and has returned `spec.id` since `971edb64b` (2022-06-09, the `@sanity/base` → `sanity` move). `91b483d8b` later rewrote it to `this.spec.id` without changing behaviour.

It stayed unnoticed because `id === templateId` holds for the common `S.initialValueTemplateItem('my-template')` call, and `.templateId()` back-fills the id (`paneId = this.spec.id || templateId`) — the two only diverge when set deliberately.

## What changed

One line: return the validated `this.spec.templateId`. It narrows to `string` through the existing guard, so no cast is needed.

Added `__tests__/InitialValueTemplateItem.test.ts` covering the unchanged case, an item with its own id, and several items sharing one template.

## Backwards compatibility

Wherever `id` and `templateId` are already the same string — all usage that works today — the serialized output is byte-identical. Only the previously broken case changes.

## Testing

Verified by executing the builder against the `v6.10.1` tag (`bd5182d`) and against `main`:

- before the change, the two new assertions fail (`got "my-template-variant-a", expected "my-template"`, and 3 distinct `templateId`s instead of 1)
- after the change, all pass, including the pre-existing single-entry behaviour

Note for reviewers: I exercised the builder in isolation rather than through the repo's own vitest run, so please let CI confirm the new test file under the standard harness.

Fixes #14200

---

Authored with an AI agent (see the `Co-Authored-By` trailer on the commit). Per `AGENTS.md` this PR
should carry the `🤖 bot` label — I can't apply labels as an outside contributor, so could a
maintainer add it? Opened as a draft per the same guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 61be7412b98ac6bf46315205b4030adf4d3f56a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->