### PR TITLE
fix(core): only deprecate useClient when called without options

### DIFF
--- a/packages/sanity/src/core/hooks/useClient.ts
+++ b/packages/sanity/src/core/hooks/useClient.ts
@@ -48,7 +48,7 @@ export function useClient(clientOptions?: SourceClientOptions): SanityClient {
   const source = useSource()
   if (!clientOptions) {
     console.warn(
-      'Calling `useClient()` without specifying an API version is deprecated and will stop working in the next major version - please specify a date, e.g. `useClient({apiVersion: "2025-02-10"})`.',
+      'Calling `useClient()` without specifying an API version is deprecated and will stop working in the next major version - please specify a date, e.g. `useClient({apiVersion: "2025-02-07"})`.',
     )
     return source.getClient({apiVersion: 'v2025-02-07'})
   }

--- a/packages/sanity/src/core/hooks/useClient.ts
+++ b/packages/sanity/src/core/hooks/useClient.ts
@@ -4,27 +4,6 @@ import {type SourceClientOptions} from '../config/types'
 import {useSource} from '../studio/source'
 
 /**
- *
- * @deprecated Calling `useClient()` without specifying an API version is deprecated - specify a date to prevent breaking changes, e.g. `useClient({apiVersion: "2025-02-07"})`.
- *
- * React hook that returns a configured Sanity client instance based on the given configuration.
- * Automatically uses the correct project and dataset based on the current active workspace.
- *
- * @public
- * @returns A configured Sanity client instance
- * @remarks The client instance is automatically memoized based on API version
- * @remarks The client will fallback to `v2025-02-07` of the API
- * @example Instantiating a client
- * ```ts
- * function MyComponent() {
- *   const client = useClient({apiVersion: '2021-06-07'})
- *   // ... do something with client instance ...
- * }
- * ```
- */
-export function useClient(): SanityClient
-
-/**
  * React hook that returns a configured Sanity client instance based on the given configuration.
  * Automatically uses the correct project and dataset based on the current active workspace.
  *
@@ -44,6 +23,26 @@ export function useClient(): SanityClient
  * ```
  */
 export function useClient(clientOptions: SourceClientOptions): SanityClient
+/**
+ *
+ * @deprecated Calling `useClient()` without specifying an API version is deprecated - specify a date to prevent breaking changes, e.g. `useClient({apiVersion: "2025-02-07"})`.
+ *
+ * React hook that returns a configured Sanity client instance based on the given configuration.
+ * Automatically uses the correct project and dataset based on the current active workspace.
+ *
+ * @public
+ * @returns A configured Sanity client instance
+ * @remarks The client instance is automatically memoized based on API version
+ * @remarks The client will fallback to `v2025-02-07` of the API
+ * @example Instantiating a client
+ * ```ts
+ * function MyComponent() {
+ *   const client = useClient({apiVersion: '2021-06-07'})
+ *   // ... do something with client instance ...
+ * }
+ * ```
+ */
+export function useClient(): SanityClient
 export function useClient(clientOptions?: SourceClientOptions): SanityClient {
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const source = useSource()

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
@@ -36,7 +36,6 @@ describe('useDocumentRevertStates', () => {
     }
   }
 
-  // @ts-expect-error -- pre-existing, fix later
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const mockUseClient = useClient as Mock<typeof useClient>
   const mockGetTransactionsLogs = getTransactionsLogs as Mock<typeof getTransactionsLogs>


### PR DESCRIPTION
### Description

Fix by [Chris Nolan](https://github.com/ChrisNolan): TypeScript treats a function as deprecated if its **first** overload is tagged `@deprecated`. The no-arg `useClient()` signature was listed first, so IDEs strikethrough `import {useClient} from 'sanity'` even when the only call sites pass `{apiVersion}`.

Putting the required-options overload first keeps the import and `useClient({apiVersion})` non-deprecated. `useClient()` with no arguments still resolves to the second overload and stays deprecated.

### What to review

`packages/sanity/src/core/hooks/useClient.ts` — overload order and JSDoc placement. Confirm hover/import deprecation in an IDE after a types rebuild.

### Testing

No runtime change. Verified by inspecting the generated `.d.ts` overloads: the non-deprecated signature is first, the `@deprecated` no-arg signature is second. Runtime deprecation still warns only when called without options.

Also dropped an unused `@ts-expect-error` in `useDocumentRevertStates.test.ts` that existed only because the symbol itself used to be deprecated.

### Notes for release

Fix by [Chris Nolan](https://github.com/ChrisNolan): `useClient` is no longer shown as deprecated on import. Only calling `useClient()` without `{apiVersion}` is deprecated; pass an API version, e.g. `useClient({apiVersion: '2025-02-07'})`.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> TypeScript overload and JSDoc ordering only; no runtime or API behavior change beyond IDE/type-checker deprecation display.
> 
> **Overview**
> **Fixes incorrect deprecation on `useClient` imports and typed call sites.** TypeScript applies `@deprecated` from the **first** overload, so when the no-arg `useClient()` signature was listed first, IDEs strikethrough `import {useClient}` and `useClient({apiVersion})` even though only the zero-argument call is meant to be deprecated.
> 
> The overload order in `useClient.ts` is swapped: **`useClient(clientOptions: SourceClientOptions)`** is first (with full param JSDoc, no deprecation), and **`useClient()`** is second (carrying `@deprecated` and the fallback API version remark). The implementation is unchanged—runtime still warns and falls back to `v2025-02-07` only when called with no options.
> 
> A follow-up test cleanup removes an obsolete `@ts-expect-error` on the `useClient` mock in `useDocumentRevertStates.test.ts` that existed only while the hook symbol itself appeared deprecated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c54911102846ab3f454aa90175554bae87d49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->