### PR TITLE
chore(core): expose type on useDocumentVersions stubs

### DIFF
--- a/packages/sanity/src/core/components/documentStatusIndicator/__tests__/DocumentVersionsStatusIndicator.test.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/__tests__/DocumentVersionsStatusIndicator.test.tsx
@@ -32,6 +32,7 @@ function versionStub(id: string, system: Omit<DocumentSystem, 'group'>): Version
     _rev: '',
     _createdAt: '',
     _updatedAt: '',
+    _type: 'article',
     _system: {group: groupRef, ...system},
   }
 }

--- a/packages/sanity/src/core/components/documentStatusIndicator/__tests__/resolveDocumentVersionsStatusIcons.test.ts
+++ b/packages/sanity/src/core/components/documentStatusIndicator/__tests__/resolveDocumentVersionsStatusIcons.test.ts
@@ -21,6 +21,7 @@ function versionStub(
     _rev: '',
     _createdAt: '',
     _updatedAt: '',
+    _type: 'article',
     _system: {group: groupRef, ...system},
   }
 }

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -100,6 +100,7 @@ function versionStub(id: string): VersionInfoDocumentStub {
     _rev: 'rev',
     _createdAt: '2024-01-01T00:00:00.000Z',
     _updatedAt: '2024-01-01T00:00:00.000Z',
+    _type: 'article',
     _system: isDraftId(id)
       ? {bundleId: 'drafts', group}
       : isVersionId(id) && typeof bundleId === 'string'

--- a/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.test.ts
@@ -18,6 +18,7 @@ function variant(id: string, name: string): Variant {
       _rev: 'rev',
       _createdAt: '2026-01-01T00:00:00.000Z',
       _updatedAt: '2026-01-01T00:00:00.000Z',
+      _type: 'article',
       _system: isDraftId(id) ? {bundleId: 'drafts', group} : {group},
     },
   }

--- a/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
@@ -29,6 +29,7 @@ function stub(id: string, system: Partial<DocumentSystem> = {}): VersionInfoDocu
     _rev: 'rev',
     _createdAt: '2026-01-01T00:00:00.000Z',
     _updatedAt: '2026-01-01T00:00:00.000Z',
+    _type: 'article',
     _system: {
       group: {_ref: PUBLISHED_ID, _weak: true},
       ...system,

--- a/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
+++ b/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
@@ -21,6 +21,7 @@ const versionStub = (
   _rev: '',
   _createdAt: '',
   _updatedAt: '',
+  _type: 'article',
   ...stub,
 })
 

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -23,6 +23,7 @@ describe('getOrCreateDocumentVersionsObservable', () => {
         of({
           _id: 'drafts.article-1',
           _rev: 'rev-1',
+          _type: 'article',
           _createdAt: '2024-01-01T00:00:00.000Z',
           _updatedAt: '2024-01-02T00:00:00.000Z',
           _system: {
@@ -64,6 +65,7 @@ describe('getOrCreateDocumentVersionsObservable', () => {
           {
             _id: 'drafts.article-1',
             _rev: 'rev-1',
+            _type: 'article',
             _createdAt: '2024-01-01T00:00:00.000Z',
             _updatedAt: '2024-01-02T00:00:00.000Z',
             _system: {
@@ -91,6 +93,7 @@ function createSystemlessPreviewStore(versionIds: string[]) {
       of({
         _id: '_id' in value ? value._id : '',
         _rev: '',
+        _type: 'article',
         _createdAt: '',
         _updatedAt: '',
       }),

--- a/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
@@ -32,6 +32,7 @@ const publishedVersion: VersionInfoDocumentStub = {
   _rev: 'published-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-02T00:00:00Z',
+  _type: 'article',
   _system: {
     group: {_ref: publishedId, _weak: true},
   },
@@ -42,6 +43,7 @@ const draftVersion: VersionInfoDocumentStub = {
   _rev: 'draft-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-03T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'drafts',
     group: {_ref: publishedId, _weak: true},
@@ -53,6 +55,7 @@ const releaseVersion: VersionInfoDocumentStub = {
   _rev: 'release-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-04T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'release1',
     release: {_ref: '_.releases.release1', _weak: true},
@@ -66,6 +69,7 @@ const opaqueAgentVersion: VersionInfoDocumentStub = {
   _rev: 'agent-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-05T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'agent.user-123',
     group: {_ref: publishedId, _weak: true},
@@ -78,6 +82,7 @@ const variantVersion: VersionInfoDocumentStub = {
   _rev: 'variant-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-06T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'release1',
     release: {_ref: '_.releases.release1', _weak: true},
@@ -92,6 +97,7 @@ const variantDraftVersion: VersionInfoDocumentStub = {
   _rev: 'variant-draft-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-07T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'drafts',
     variant: {_ref: '_.variants.test', _weak: true},

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -70,6 +70,7 @@ async function setupMocks({
             ? {
                 _id: id,
                 _rev: '',
+                _type: 'article',
                 _createdAt: '',
                 _updatedAt: '',
                 _system: {
@@ -81,6 +82,7 @@ async function setupMocks({
             : {
                 _id: id,
                 _rev: '',
+                _type: 'article',
                 _createdAt: '',
                 _updatedAt: '',
               },
@@ -136,6 +138,7 @@ describe('useDocumentVersions', () => {
       {
         _id: 'versions.rASAP.document-1',
         _rev: '',
+        _type: 'article',
         _createdAt: '',
         _updatedAt: '',
         _system: {
@@ -161,6 +164,7 @@ describe('useDocumentVersions', () => {
       {
         _id: 'versions.rASAP.document-1',
         _rev: '',
+        _type: 'article',
         _createdAt: '',
         _updatedAt: '',
         _system: {
@@ -188,6 +192,7 @@ describe('useDocumentVersions', () => {
       {
         _id: 'drafts.document-1',
         _rev: '',
+        _type: 'article',
         _createdAt: '',
         _updatedAt: '',
         _system: {
@@ -231,6 +236,7 @@ describe('getOrCreateDocumentVersionsObservable — subscriber churn', () => {
         of({
           _id: (value as {_id: string})._id,
           _rev: '',
+          _type: 'article',
           _createdAt: '',
           _updatedAt: '',
         }),
@@ -305,6 +311,7 @@ describe('getOrCreateDocumentVersionsObservable — subscriber churn', () => {
         of({
           _id: (value as {_id: string})._id,
           _rev: '',
+          _type: 'article',
           _createdAt: '',
           _updatedAt: '',
         }),

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -261,6 +261,7 @@ export function getOrCreateDocumentVersionsObservable(options: {
                   ({
                     _id: id,
                     _rev: versionInfo?._rev ?? '',
+                    _type: versionInfo?._type ?? '',
                     _createdAt: versionInfo?._createdAt ?? '',
                     _updatedAt: versionInfo?._updatedAt ?? '',
                     [DOCUMENT_SYSTEM_FIELD]: versionInfo?.[DOCUMENT_SYSTEM_FIELD] as DocumentSystem,

--- a/packages/sanity/src/core/releases/store/__tests__/useDocumentVersionInfo.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/useDocumentVersionInfo.test.ts
@@ -17,6 +17,7 @@ const publishedVersion: VersionInfoDocumentStub = {
   _rev: 'published-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-02T00:00:00Z',
+  _type: 'article',
   _system: {
     group: {_ref: publishedId, _weak: true},
   },
@@ -27,6 +28,7 @@ const draftVersion: VersionInfoDocumentStub = {
   _rev: 'draft-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-03T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'drafts',
     group: {_ref: publishedId, _weak: true},
@@ -38,6 +40,7 @@ const releaseVersion: VersionInfoDocumentStub = {
   _rev: 'release-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-04T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'release1',
     release: {_ref: '_.releases.release1', _weak: true},
@@ -51,6 +54,7 @@ const variantVersion: VersionInfoDocumentStub = {
   _rev: 'variant-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-05T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'drafts',
     variant: {_ref: '_.variants.test', _weak: true},

--- a/packages/sanity/src/core/releases/store/types.ts
+++ b/packages/sanity/src/core/releases/store/types.ts
@@ -52,5 +52,6 @@ export interface VersionInfoDocumentStub {
   _rev: string
   _createdAt: string
   _updatedAt: string
+  _type: string
   _system: DocumentSystem
 }

--- a/packages/sanity/src/core/releases/util/__tests__/getDocumentVersionInfoFromVersions.test.ts
+++ b/packages/sanity/src/core/releases/util/__tests__/getDocumentVersionInfoFromVersions.test.ts
@@ -10,6 +10,7 @@ const publishedVersion: VersionInfoDocumentStub = {
   _rev: 'published-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-02T00:00:00Z',
+  _type: 'article',
   _system: {
     group: {_ref: publishedId, _weak: true},
   },
@@ -20,6 +21,7 @@ const draftVersion: VersionInfoDocumentStub = {
   _rev: 'draft-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-03T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'drafts',
     group: {_ref: publishedId, _weak: true},
@@ -31,6 +33,7 @@ const releaseVersion: VersionInfoDocumentStub = {
   _rev: 'release-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-04T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'release1',
     release: {_ref: '_.releases.release1', _weak: true},
@@ -44,6 +47,7 @@ const variantVersion: VersionInfoDocumentStub = {
   _rev: 'variant-rev',
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-05T00:00:00Z',
+  _type: 'article',
   _system: {
     bundleId: 'drafts',
     variant: {_ref: '_.variants.test', _weak: true},

--- a/packages/sanity/src/core/util/__tests__/getTargetDocument.test.ts
+++ b/packages/sanity/src/core/util/__tests__/getTargetDocument.test.ts
@@ -20,6 +20,7 @@ const versionStub = (
   _rev: '',
   _createdAt: '',
   _updatedAt: '',
+  _type: 'article',
   ...stub,
 })
 

--- a/packages/sanity/src/core/util/versionsUtils.test.ts
+++ b/packages/sanity/src/core/util/versionsUtils.test.ts
@@ -12,6 +12,7 @@ function createVersion(
     _rev: 'rev',
     _createdAt: '2026-01-01T00:00:00.000Z',
     _updatedAt: '2026-01-01T00:00:00.000Z',
+    _type: 'article',
     _system: {
       group: {
         _ref: 'doc1',

--- a/packages/sanity/src/core/variants/documents/__tests__/isDocumentInSelectedVariant.test.ts
+++ b/packages/sanity/src/core/variants/documents/__tests__/isDocumentInSelectedVariant.test.ts
@@ -15,6 +15,7 @@ const versionStub = (
   _rev: '',
   _createdAt: '',
   _updatedAt: '',
+  _type: 'article',
   ...stub,
 })
 

--- a/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
@@ -32,6 +32,7 @@ const siblingStub: VersionInfoDocumentStub = {
   _rev: 'rev-pub',
   _createdAt: '2026-01-01T00:00:00Z',
   _updatedAt: '2026-01-02T00:00:00Z',
+  _type: 'article',
   _system: {
     group: {_ref: PUBLISHED_ID, _weak: true},
     variant: {_ref: variantAlphaAudience._id, _weak: true},

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DocumentNotInVariantBanner.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DocumentNotInVariantBanner.test.tsx
@@ -108,6 +108,7 @@ const versionStub = (
 ): VersionInfoDocumentStub => ({
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-01T00:00:00Z',
+  _type: 'article',
   ...stub,
 })
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/findVariantCreateBaseDocument.test.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/findVariantCreateBaseDocument.test.ts
@@ -16,6 +16,7 @@ const versionStub = (
 ): VersionInfoDocumentStub => ({
   _createdAt: '',
   _updatedAt: '',
+  _type: 'article',
   ...stub,
 })
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/DocumentTargetBadges.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/DocumentTargetBadges.test.tsx
@@ -32,6 +32,7 @@ const versionStub = (
   _rev: '',
   _createdAt: '',
   _updatedAt: '',
+  _type: 'article',
   ...stub,
 })
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
@@ -21,6 +21,7 @@ const versionStub = (
   _rev: '',
   _createdAt: '',
   _updatedAt: '',
+  _type: 'article',
   ...stub,
 })
 


### PR DESCRIPTION
### Description

`useDocumentVersions` already requested `_type` from the preview store, but the stub mapper dropped it, so callers had the ids and system metadata without the schema type. This wires `_type` through as a required field on `VersionInfoDocumentStub`, using the same empty-string fallback as `_rev`, `_createdAt`, and `_updatedAt`.

Making it optional would keep the data half-present and force every consumer to re-check; the field is always on the document, so it is required.

### What to review

- Stub mapping in `packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx`
- Required `_type` on `VersionInfoDocumentStub` (`packages/sanity/src/core/releases/store/types.ts`) — `@internal` but exported, so this is a type-level addition for anyone constructing stubs

### Testing

- Hook tests now include `_type` on `observePaths` mocks and assert it on `versions`
- Existing `VersionInfoDocumentStub` fixtures updated so typecheck passes

### Notes for release

`useDocumentVersions().versions` now includes a required `_type` (the document schema type) on each version stub.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4022281c3fd9e5c773c3e37b8a5ad1f1b8af2e20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->