### PR TITLE
fix(core): hide default variant label when variants are disabled

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -42,10 +42,11 @@ export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: stri
   const {data: releases} = useActiveReleases()
   const {byId: variantsById} = useAllVariants()
   const {loading, versions} = useDocumentVersions({documentId: documentGroupId})
+  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
 
   const versionGroups = useMemo(
-    () => groupDocumentVersionsForStatus(versions, releases ?? [], variantsById),
-    [releases, variantsById, versions],
+    () => groupDocumentVersionsForStatus(versions, releases ?? [], variantsById, variantsEnabled),
+    [releases, variantsById, variantsEnabled, versions],
   )
 
   if (loading) {
@@ -67,7 +68,7 @@ export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: stri
           paddingBottom={groupIndex < allGroups.length - 1 ? 1 : 0}
         >
           {group.items.map((item) => (
-            <VersionStatus key={item.version._id} {...item} />
+            <VersionStatus key={item.version._id} variantsEnabled={variantsEnabled} {...item} />
           ))}
         </Card>
       ))}
@@ -75,11 +76,15 @@ export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: stri
   )
 }
 
-function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
+function VersionStatus({
+  release,
+  version,
+  variant,
+  variantsEnabled,
+}: DocumentVersionStatusItem & {variantsEnabled: boolean}) {
   const {t} = useTranslation()
   const schema = useSchema()
   const {bundles} = useAgentBundles()
-  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
   const liveEdit = Boolean(version._type && schema.get(version._type)?.liveEdit)
 
   const variantTitle = variant ? getVariantTitle(variant) : t('document-group.base-variant')

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -13,6 +13,7 @@ import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {useAgentBundles} from '../../store/agent/useAgentBundles'
+import {useWorkspace} from '../../studio/workspace'
 import {readVersionType} from '../../util/versionsUtils'
 import {getVersionFilterLabel} from '../../variants/plugin/components/getVersionFilterLabel'
 import {useAllVariants} from '../../variants/store/useAllVariants'
@@ -24,6 +25,7 @@ import {
   versionStatusItem,
 } from './DocumentVersionsStatus.css'
 import {getDocumentVersionStatusTimestampKey} from './getDocumentVersionStatusTimestampKey'
+import {getDocumentVersionStatusTitle} from './getDocumentVersionStatusTitle'
 import {
   type DocumentVersionStatusItem,
   groupDocumentVersionsForStatus,
@@ -77,6 +79,7 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
   const {t} = useTranslation()
   const schema = useSchema()
   const {bundles} = useAgentBundles()
+  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
   const liveEdit = Boolean(version._type && schema.get(version._type)?.liveEdit)
 
   const variantTitle = variant ? getVariantTitle(variant) : t('document-group.base-variant')
@@ -87,6 +90,11 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
     fullTitle,
     isTruncated,
   } = getVersionFilterLabel(releasePerspective, t, bundles)
+  const title = getDocumentVersionStatusTitle({
+    variantsEnabled,
+    variantTitle,
+    releaseTitle,
+  })
 
   const updatedAt = useRelativeTime(version._updatedAt, {
     minimal: true,
@@ -101,14 +109,14 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
       <Flex gap={2} justify="space-between" paddingY={2}>
         <Stack className={titleStack} gap={2}>
           <Text size={1} title={isTruncated ? fullTitle : undefined} weight="medium">
-            {variantTitle} · {releaseTitle}
+            {title}
           </Text>
           <Text className={updatedAtText} muted size={1}>
             {timestampLabel}
           </Text>
         </Stack>
         <Flex align="center" flex="none" gap={1} paddingRight={2}>
-          {variant ? (
+          {variantsEnabled && variant ? (
             <Card className={variantIconCard} tone="suggest">
               <Text size={2}>
                 <RhombusIcon />

--- a/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
@@ -181,4 +181,17 @@ describe('DocumentVersionsStatus', () => {
     expect(screen.queryByText(/All users/)).not.toBeInTheDocument()
     expect(document.querySelector('[data-sanity-icon="rhombus"]')).toBeInTheDocument()
   })
+
+  it('does not render variant documents when variants are disabled', async () => {
+    await renderStatus({
+      versions: [publishedDefault, draftDefault, publishedVariant, draftVariant],
+      variantsById: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+    })
+
+    expect(screen.getByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+    expect(screen.queryByText(/Alpha audience/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/All users/)).not.toBeInTheDocument()
+    expect(document.querySelector('[data-sanity-icon="rhombus"]')).not.toBeInTheDocument()
+  })
 })

--- a/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
@@ -1,0 +1,184 @@
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {useRelativeTime} from '../../../hooks/useRelativeTime'
+import {useDocumentVersions} from '../../../releases/hooks/useDocumentVersions'
+import {type VersionInfoDocumentStub} from '../../../releases/store/types'
+import {useActiveReleases} from '../../../releases/store/useActiveReleases'
+import {useAgentBundles} from '../../../store/agent/useAgentBundles'
+import {variantAlphaAudience} from '../../../variants/__fixtures__/variants.fixture'
+import {useAllVariants} from '../../../variants/store/useAllVariants'
+import {DocumentVersionsStatus} from '../DocumentVersionsStatus'
+
+vi.mock('../../../releases/hooks/useDocumentVersions', () => ({
+  useDocumentVersions: vi.fn(() => ({
+    data: [],
+    versions: [],
+    error: null,
+    loading: false,
+  })),
+}))
+
+vi.mock('../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [],
+    error: undefined,
+    loading: false,
+    dispatch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../../variants/store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => ({
+    data: [],
+    byId: new Map(),
+    loading: false,
+    error: undefined,
+  })),
+}))
+
+vi.mock('../../../hooks/useRelativeTime', () => ({
+  useRelativeTime: vi.fn(() => '2d ago'),
+}))
+
+vi.mock('../../../store/agent/useAgentBundles', () => ({
+  useAgentBundles: vi.fn(() => ({bundles: [], loading: false})),
+}))
+
+const mockUseDocumentVersions = useDocumentVersions as Mock<typeof useDocumentVersions>
+const mockUseActiveReleases = useActiveReleases as Mock<typeof useActiveReleases>
+const mockUseAllVariants = useAllVariants as Mock<typeof useAllVariants>
+const mockUseRelativeTime = useRelativeTime as Mock<typeof useRelativeTime>
+const mockUseAgentBundles = useAgentBundles as Mock<typeof useAgentBundles>
+
+const GROUP_ID = 'article-1'
+
+function createVersion({
+  id,
+  bundleId,
+  variantRef,
+}: {
+  id: string
+  bundleId?: string
+  variantRef?: string
+}): VersionInfoDocumentStub {
+  return {
+    _id: id,
+    _type: 'article',
+    _rev: `${id}-rev`,
+    _createdAt: '2026-01-01T00:00:00.000Z',
+    _updatedAt: '2026-01-02T00:00:00.000Z',
+    _system: {
+      bundleId,
+      group: {_ref: GROUP_ID, _weak: true},
+      variant: variantRef ? {_ref: variantRef, _weak: true} : undefined,
+    },
+  }
+}
+
+const publishedDefault = createVersion({id: GROUP_ID})
+const draftDefault = createVersion({id: `drafts.${GROUP_ID}`, bundleId: 'drafts'})
+const publishedVariant = createVersion({
+  id: `published.alpha.${GROUP_ID}`,
+  variantRef: variantAlphaAudience._id,
+})
+const draftVariant = createVersion({
+  id: `drafts.alpha.${GROUP_ID}`,
+  bundleId: 'drafts',
+  variantRef: variantAlphaAudience._id,
+})
+
+async function renderStatus({
+  versions,
+  variantsEnabled = false,
+  variantsById = new Map(),
+}: {
+  versions: VersionInfoDocumentStub[]
+  variantsEnabled?: boolean
+  variantsById?: Map<string, typeof variantAlphaAudience>
+}) {
+  mockUseDocumentVersions.mockReturnValue({
+    data: versions.map((version) => version._id),
+    versions,
+    error: null,
+    loading: false,
+  })
+  mockUseAllVariants.mockReturnValue({
+    data: Array.from(variantsById.values()),
+    byId: variantsById,
+    loading: false,
+    error: undefined,
+  })
+
+  const wrapper = await createTestProvider({
+    ...(variantsEnabled ? {config: {beta: {variants: {enabled: true}}}} : undefined),
+  })
+
+  return render(<DocumentVersionsStatus documentGroupId={GROUP_ID} />, {wrapper})
+}
+
+describe('DocumentVersionsStatus', () => {
+  beforeEach(() => {
+    mockUseDocumentVersions.mockReset()
+    mockUseActiveReleases.mockReset()
+    mockUseAllVariants.mockReset()
+    mockUseRelativeTime.mockReset()
+    mockUseAgentBundles.mockReset()
+
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [],
+      error: null,
+      loading: false,
+    })
+    mockUseActiveReleases.mockReturnValue({
+      data: [],
+      error: undefined,
+      loading: false,
+      dispatch: vi.fn(),
+    })
+    mockUseAllVariants.mockReturnValue({
+      data: [],
+      byId: new Map(),
+      loading: false,
+      error: undefined,
+    })
+    mockUseRelativeTime.mockReturnValue('2d ago')
+    mockUseAgentBundles.mockReturnValue({bundles: [], loading: false})
+  })
+
+  it('shows only perspective titles when variants are disabled', async () => {
+    await renderStatus({versions: [publishedDefault, draftDefault]})
+
+    expect(screen.getByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+    expect(screen.queryByText(/All users/)).not.toBeInTheDocument()
+    expect(document.querySelector('[data-sanity-icon="rhombus"]')).not.toBeInTheDocument()
+  })
+
+  it('prefixes the default variant title when variants are enabled', async () => {
+    await renderStatus({
+      versions: [publishedDefault, draftDefault],
+      variantsEnabled: true,
+    })
+
+    expect(screen.getByText('All users (Default) · Published')).toBeInTheDocument()
+    expect(screen.getByText('All users (Default) · Draft')).toBeInTheDocument()
+    expect(screen.queryByText('Published', {exact: true})).not.toBeInTheDocument()
+    expect(document.querySelector('[data-sanity-icon="rhombus"]')).not.toBeInTheDocument()
+  })
+
+  it('shows the named variant title and rhombus when variants are enabled', async () => {
+    await renderStatus({
+      versions: [publishedVariant, draftVariant],
+      variantsEnabled: true,
+      variantsById: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+    })
+
+    expect(screen.getByText('Alpha audience · Published')).toBeInTheDocument()
+    expect(screen.getByText('Alpha audience · Draft')).toBeInTheDocument()
+    expect(screen.queryByText(/All users/)).not.toBeInTheDocument()
+    expect(document.querySelector('[data-sanity-icon="rhombus"]')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/components/documentStatus/__tests__/getDocumentVersionStatusTitle.test.ts
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/getDocumentVersionStatusTitle.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from 'vitest'
+
+import {getDocumentVersionStatusTitle} from '../getDocumentVersionStatusTitle'
+
+describe('getDocumentVersionStatusTitle', () => {
+  it('prefixes the default variant title when variants are enabled', () => {
+    expect(
+      getDocumentVersionStatusTitle({
+        variantsEnabled: true,
+        variantTitle: 'All users (Default)',
+        releaseTitle: 'Published',
+      }),
+    ).toBe('All users (Default) · Published')
+  })
+
+  it('prefixes a named variant title when variants are enabled', () => {
+    expect(
+      getDocumentVersionStatusTitle({
+        variantsEnabled: true,
+        variantTitle: 'Returning visitors',
+        releaseTitle: 'Draft',
+      }),
+    ).toBe('Returning visitors · Draft')
+  })
+
+  it('returns only the perspective when variants are disabled', () => {
+    expect(
+      getDocumentVersionStatusTitle({
+        variantsEnabled: false,
+        variantTitle: 'All users (Default)',
+        releaseTitle: 'Published',
+      }),
+    ).toBe('Published')
+  })
+
+  it('ignores a named variant title when variants are disabled', () => {
+    expect(
+      getDocumentVersionStatusTitle({
+        variantsEnabled: false,
+        variantTitle: 'Returning visitors',
+        releaseTitle: 'Draft',
+      }),
+    ).toBe('Draft')
+  })
+})

--- a/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
@@ -235,4 +235,47 @@ describe('groupDocumentVersionsForStatus', () => {
       'versions.agent-abc.article-1',
     ])
   })
+
+  it('omits variant documents when variants are disabled', () => {
+    const groups = groupDocumentVersionsForStatus(
+      [
+        createVersion({
+          id: 'drafts.returning.article-1',
+          bundleId: 'drafts',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+          variantRef: variantReturning._id,
+        }),
+        createVersion({
+          id: 'article-1',
+          createdAt: '2025-06-02T00:00:00Z',
+          updatedAt: '2025-06-02T00:00:00Z',
+        }),
+        createVersion({
+          id: 'drafts.article-1',
+          bundleId: 'drafts',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+        }),
+        createVersion({
+          id: 'versions.rSummer.returning.article-1',
+          bundleId: 'rSummer',
+          createdAt: '2025-06-02T00:00:00Z',
+          updatedAt: '2025-06-02T00:00:00Z',
+          releaseRef: releaseSummer._id,
+          variantRef: variantReturning._id,
+        }),
+      ],
+      [releaseSummer],
+      new Map([[variantReturning._id, variantReturning]]),
+      false,
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.variantId).toBeUndefined()
+    expect(groups[0]?.items.map((item) => item.version._id)).toEqual([
+      'article-1',
+      'drafts.article-1',
+    ])
+  })
 })

--- a/packages/sanity/src/core/components/documentStatus/getDocumentVersionStatusTitle.ts
+++ b/packages/sanity/src/core/components/documentStatus/getDocumentVersionStatusTitle.ts
@@ -1,0 +1,24 @@
+/**
+ * Title line in the document versions status tooltip.
+ *
+ * When variants are enabled, the default lane is a real variant, so unvarianted versions are
+ * labeled "All users (Default) · Published". Without variants, only the perspective
+ * (Published / Draft / release) is shown.
+ *
+ * @internal
+ */
+export function getDocumentVersionStatusTitle({
+  variantsEnabled,
+  variantTitle,
+  releaseTitle,
+}: {
+  variantsEnabled: boolean
+  variantTitle: string
+  releaseTitle: string
+}): string {
+  if (!variantsEnabled) {
+    return releaseTitle
+  }
+
+  return `${variantTitle} · ${releaseTitle}`
+}

--- a/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
+++ b/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
@@ -112,17 +112,24 @@ function compareDocumentVersionsForStatus(
  * published → drafts → releases → agent bundles. Releases follow `sortReleases()`: undecided, then
  * scheduled, then ASAP (each by date descending). Releases missing from that list fall back to title.
  *
+ * When `variantsEnabled` is false, versions that belong to a variant are omitted so the tooltip
+ * only lists default-lane perspectives.
+ *
  * @internal
  */
 export function groupDocumentVersionsForStatus(
   versions: VersionInfoDocumentStub[],
   releases: ReleaseDocument[],
   variantsById: Map<string, SystemVariant>,
+  variantsEnabled = true,
 ): DocumentVersionStatusGroup[] {
   const sortedReleases = sortReleases(releases)
   const releasesById = new Map(sortedReleases.map((release) => [release._id, release]))
+  const visibleVersions = variantsEnabled
+    ? versions
+    : versions.filter((version) => !version._system.variant?._ref)
 
-  const sortedVersions = versions.toSorted((left, right) =>
+  const sortedVersions = visibleVersions.toSorted((left, right) =>
     compareDocumentVersionsForStatus(left, right, releasesById, sortedReleases),
   )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The versions tooltip from #14167 always prefixes **All users (Default)** when a document has no variant, and lists every version including variant documents. That is the right label and inventory when `beta.variants.enabled` is on — the default lane is a real variant. For everyone else it is noise: they only need default-lane perspectives (Published, Draft, or the release), not variant copies.

Gating the title, rhombus, and listed versions on the variants flag keeps the tooltip useful in both modes. Stacking this on #14167 rather than landing it there keeps the original review focused on the new tooltip.

### What to review

- Title composition in `getDocumentVersionStatusTitle` and how `DocumentVersionsStatus` reads `useWorkspace().beta?.variants?.enabled`
- That `groupDocumentVersionsForStatus` drops versions with a variant ref when the flag is off
- That named variants still render `Variant · Perspective` plus the rhombus when the flag is on
- `packages/sanity` only

### Testing

- Unit tests for `getDocumentVersionStatusTitle` (flag on/off, default vs named variant)
- Unit tests for `groupDocumentVersionsForStatus` omitting variant documents when the flag is off
- Component tests for `DocumentVersionsStatus` covering variants off (perspective only, no variant documents), variants on (default prefix), and a named variant with the rhombus

### Notes for release

N/A – Part of content variants; tooltip copy and listed versions only change for studios without `beta.variants.enabled`

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17cbe3e8-2ebe-461c-89a5-7fcd07929f5e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17cbe3e8-2ebe-461c-89a5-7fcd07929f5e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

