### PR TITLE
refactor(sanity): remove obsolete workbench renderer re-export

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.workbench.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.workbench.test-d.ts
@@ -5,7 +5,6 @@
 import type {
   AssetSource,
   AssetSourceComponentProps,
-  renderWorkbench,
   unstable_defineService,
   unstable_defineView,
 } from 'sanity/workbench'
@@ -17,9 +16,6 @@ describe('sanity/workbench', () => {
   })
   test('AssetSourceComponentProps', () => {
     expectTypeOf<AssetSourceComponentProps>().toBeObject()
-  })
-  test('renderWorkbench', () => {
-    expectTypeOf<typeof renderWorkbench>().toBeFunction()
   })
   test('unstable_defineService', () => {
     expectTypeOf<typeof unstable_defineService>().toBeFunction()

--- a/packages/sanity/src/_exports/workbench.ts
+++ b/packages/sanity/src/_exports/workbench.ts
@@ -1,10 +1,4 @@
-/**
- * Note: we are forwarding the workbench render function from the workbench package,
- * to avoid having to install the workbench package as a dependency in the user project.
- */
-
 export {unstable_defineService, unstable_defineView} from '@sanity/cli/runtime'
-export {renderWorkbench} from '@sanity/workbench/_internal'
 // Props an `asset_source` view component receives. Sourced from `@sanity/types`
 // directly (same shape `@sanity/cli/runtime` re-exports) so authors can type an
 // `unstable_defineView('asset_source', …)` component from `sanity/workbench`.

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -1091,7 +1091,6 @@ exports[`exports snapshot 1`] = `
     "useStructureTool": "function",
   },
   "./workbench": {
-    "renderWorkbench": "function",
     "unstable_defineService": "function",
     "unstable_defineView": "function",
   },


### PR DESCRIPTION
## Description

The CLI now inlines the dashboard renderer, so `sanity/workbench` no longer needs to export the obsolete `renderWorkbench` API. The `@sanity/workbench` package is being sunset and everything else in there will the exported from the SDK in the future.

Depends on [sanity-io/cli#1734](https://github.com/sanity-io/cli/pull/1734), to be ✅ merged, ✅ [released](https://github.com/sanity-io/cli/releases#release-@sanity/cli@8.3.0) and ✅ [updated](https://github.com/sanity-io/sanity/pull/14292) in this repo.

## What to review

- `renderWorkbench` is removed from the public workbench export and its export coverage

## Testing

N/A: export fixtures and snapshot updated

## Notes for release

N/A: Internal only


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Drops a public export; any code still importing `renderWorkbench` from `sanity/workbench` will break at compile time until it uses the CLI-owned renderer path.
> 
> **Overview**
> Removes **`renderWorkbench`** from the public **`sanity/workbench`** entry point now that the CLI owns dashboard rendering, so the package no longer re-exports it from `@sanity/workbench/_internal`.
> 
> **`unstable_defineService`**, **`unstable_defineView`**, and the **`AssetSource`** / **`AssetSourceComponentProps`** types stay exported. Export coverage is updated via the DTS fixture and the **`exports.test.ts`** snapshot so **`renderWorkbench`** is no longer part of the documented public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf3bb77fbe6fe1a40355b6a0e24fb034c0fd9fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->