### PR TITLE
fix(core): shim the deprecated markdown-config callback args in the PTE input

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -1,7 +1,10 @@
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {BehaviorPlugin} from '@portabletext/editor/plugins'
 import {htmlToPortableText} from '@portabletext/html'
-import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
+import {
+  MarkdownShortcutsPlugin,
+  type MarkdownShortcutsPluginProps,
+} from '@portabletext/plugin-markdown-shortcuts'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {PasteLinkPlugin} from '@portabletext/plugin-paste-link'
 import {createDecoratorGuard, TypographyPlugin} from '@portabletext/plugin-typography'
@@ -12,6 +15,7 @@ import {useMiddlewareComponents} from '../../../../config/components/useMiddlewa
 import {pickPortableTextEditorPluginsComponent} from '../../../form-components-hooks/picks'
 import {type MarkdownConfig, type PortableTextPluginsProps} from '../../../types/blockProps'
 import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
+import {_withLegacyMarkdownArgs} from './helpers'
 import {PortableTextTablePlugin} from './TablePlugin'
 
 const markdownConfig: MarkdownConfig = {
@@ -161,7 +165,11 @@ function DefaultMarkdownShortcutsPlugin(
   if (!props.config) {
     const {enabled: _enabled, config: _config, ...markdownShortcutsPluginProps} = props
 
-    return <MarkdownShortcutsPlugin {...markdownShortcutsPluginProps} />
+    return (
+      <MarkdownShortcutsPlugin
+        {..._withLegacyMarkdownArgs<MarkdownShortcutsPluginProps>(markdownShortcutsPluginProps)}
+      />
+    )
   }
 
   // oxlint-disable-next-line no-deprecated -- backwards-compat bridge for plugin authors still using the old field names
@@ -171,9 +179,11 @@ function DefaultMarkdownShortcutsPlugin(
 
   return (
     <MarkdownShortcutsPlugin
-      orderedList={orderedList ?? orderedListStyle}
-      unorderedList={unorderedList ?? unorderedListStyle}
-      {...restMarkdownConfig}
+      {..._withLegacyMarkdownArgs<MarkdownShortcutsPluginProps>({
+        orderedList: orderedList ?? orderedListStyle,
+        unorderedList: unorderedList ?? unorderedListStyle,
+        ...restMarkdownConfig,
+      })}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
@@ -1,7 +1,7 @@
 import {type ObjectSchemaType} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
 
-import {_getModalOption} from './helpers'
+import {_getModalOption, _withLegacyMarkdownArgs} from './helpers'
 
 const withModal = (modal: unknown): ObjectSchemaType =>
   ({options: {modal}}) as unknown as ObjectSchemaType
@@ -41,5 +41,66 @@ describe('_getModalOption', () => {
 
   it('ignores an invalid modal type', () => {
     expect(_getModalOption(withModal({type: 'sidebar'}))?.type).toBeUndefined()
+  })
+})
+
+describe('_withLegacyMarkdownArgs', () => {
+  const schema = {decorators: [{name: 'strong'}]}
+
+  type BoldDecoratorField = {
+    boldDecorator: (arg: {context: {schema: typeof schema}}) => unknown
+  }
+  type HeadingStyleField = {
+    headingStyle: (arg: {context: {schema: typeof schema}; props: {level: number}}) => unknown
+  }
+
+  it('feeds an old-shape callback a `schema` merged in from `context.schema`', () => {
+    const oldShape = ({schema: s}: {schema: unknown}) => s
+    const wrapped = _withLegacyMarkdownArgs<BoldDecoratorField>({boldDecorator: oldShape})
+
+    // Simulates the plugin calling the callback with only `context`, as it does
+    // once the deprecated top-level `schema` param is removed.
+    expect(wrapped.boldDecorator({context: {schema}})).toBe(schema)
+  })
+
+  it('an old-shape callback called directly (unwrapped) gets `undefined` for `schema`', () => {
+    const oldShape = ({schema: s}: {context?: unknown; schema?: unknown}) => s
+
+    // Same call shape as above, but skipping `_withLegacyMarkdownArgs`: this is
+    // what breaks once the plugin stops passing the deprecated top-level `schema`.
+    expect(oldShape({context: {schema}})).toBeUndefined()
+  })
+
+  it('feeds an old-shape `headingStyle` callback a `level` merged in from `props.level`', () => {
+    const oldShape = ({level}: {level: number}) => level
+    const wrapped = _withLegacyMarkdownArgs<HeadingStyleField>({headingStyle: oldShape})
+
+    expect(wrapped.headingStyle({context: {schema}, props: {level: 2}})).toBe(2)
+  })
+
+  it('passes a new-shape callback through unharmed', () => {
+    const newShape = ({context}: {context: {schema: typeof schema}}) => context.schema
+    const wrapped = _withLegacyMarkdownArgs<BoldDecoratorField>({boldDecorator: newShape})
+
+    expect(wrapped.boldDecorator({context: {schema}})).toBe(schema)
+  })
+
+  it('passes a non-function field through untouched', () => {
+    const wrapped = _withLegacyMarkdownArgs<{enabled: boolean}>({enabled: false})
+
+    expect(wrapped.enabled).toBe(false)
+  })
+
+  it('wraps the same callback reference to the same wrapped function across separate calls', () => {
+    // The plugin keys its behaviors on callback identity, so a config rebuilt from
+    // scratch on every render (the documented spread-and-override pattern) must still
+    // produce the same wrapped function for the same underlying callback, or every
+    // render re-registers the plugin's behaviors.
+    const boldDecorator = ({context}: {context: {schema: typeof schema}}) => context.schema
+
+    const first = _withLegacyMarkdownArgs<BoldDecoratorField>({boldDecorator})
+    const second = _withLegacyMarkdownArgs<BoldDecoratorField>({boldDecorator})
+
+    expect(second.boldDecorator).toBe(first.boldDecorator)
   })
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
@@ -1,5 +1,12 @@
 import {type ObjectSchemaType} from '@sanity/types'
 
+import {type _WithLegacyMarkdownArgs} from '../../../types/blockProps'
+
+type LegacyMarkdownCallbackArg = {
+  context: {schema: unknown}
+  props?: {level?: number}
+}
+
 const parseResponsiveWidth = (value: unknown): (number | 'auto')[] => {
   if (Array.isArray(value)) {
     return value.flatMap(parseResponsiveWidth)
@@ -11,6 +18,47 @@ const parseResponsiveWidth = (value: unknown): (number | 'auto')[] => {
 }
 const parseModalType = (value: unknown): 'popover' | 'dialog' | undefined => {
   return value === 'dialog' || value === 'popover' ? value : undefined
+}
+
+// Keyed on the caller's own callback so a config rebuilt from scratch on every
+// render (the documented spread-and-override pattern) still yields the same
+// wrapped function reference, and the plugin's identity-keyed behaviors don't
+// re-register every render.
+const wrappedMarkdownCallbacks = new WeakMap<object, (arg: LegacyMarkdownCallbackArg) => unknown>()
+
+/**
+ * The markdown shortcuts plugin already calls every callback except
+ * `horizontalRuleObject` and `linkObject` with a top-level `schema` (and
+ * `headingStyle` additionally with a top-level `level`), so merging those
+ * legacy fields back into the argument here is a no-op today for the
+ * callbacks that get them, and harmlessly adds a `schema` key the plugin
+ * never passed for `horizontalRuleObject`/`linkObject`. It becomes the
+ * compat layer once the plugin drops the deprecated top-level
+ * `schema`/`level` params, keeping `boldDecorator: ({schema}) => ...`-style
+ * studio configs working. Do not remove this as unused indirection before
+ * that plugin bump lands.
+ */
+export function _withLegacyMarkdownArgs<T extends Record<string, unknown>>(
+  config: _WithLegacyMarkdownArgs<T>,
+): T {
+  const wrapped: Record<string, unknown> = {...config}
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value !== 'function') {
+      continue
+    }
+    let wrappedFn = wrappedMarkdownCallbacks.get(value)
+    if (!wrappedFn) {
+      wrappedFn = (arg: LegacyMarkdownCallbackArg) =>
+        value({
+          ...arg,
+          schema: arg.context.schema,
+          ...(arg.props?.level !== undefined && {level: arg.props.level}),
+        })
+      wrappedMarkdownCallbacks.set(value, wrappedFn)
+    }
+    wrapped[key] = wrappedFn
+  }
+  return wrapped as T
 }
 
 export function _getModalOption(

--- a/packages/sanity/src/core/form/types/blockProps.test-d.ts
+++ b/packages/sanity/src/core/form/types/blockProps.test-d.ts
@@ -1,6 +1,61 @@
 import {expectTypeOf, test} from 'vitest'
 
-import {type PortableTextPluginsProps} from './blockProps'
+import {
+  type MarkdownConfig,
+  type PortableTextPluginsProps,
+  type _WithLegacyMarkdownArgs,
+} from './blockProps'
+
+test('old-shape callbacks destructuring the deprecated top-level `schema`/`level` are assignable to `MarkdownConfig`', () => {
+  const config: MarkdownConfig = {
+    // oxlint-disable-next-line no-deprecated -- pins that the deprecated top-level `schema` still typechecks
+    boldDecorator: ({schema}) =>
+      schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
+    // oxlint-disable-next-line no-deprecated -- pins that the deprecated top-level `schema`/`level` still typecheck
+    headingStyle: ({schema, level}) =>
+      schema.styles.find((style) => style.name === `h${level}`)?.name,
+  }
+  expectTypeOf(config).toExtend<MarkdownConfig>()
+})
+
+test('new-shape callbacks reading `context` are assignable to `MarkdownConfig`', () => {
+  const config: MarkdownConfig = {
+    boldDecorator: ({context}) =>
+      context.schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
+  }
+  expectTypeOf(config).toExtend<MarkdownConfig>()
+})
+
+test('`_WithLegacyMarkdownArgs` keeps accepting old-shape callbacks even once the plugin drops the deprecated params from its own types', () => {
+  // Mimics `@portabletext/plugin-markdown-shortcuts` after it removes the deprecated
+  // top-level `schema`/`level` fields: the callback args below carry only `context`
+  // (and `props.level` for `headingStyle`). If the old-shape callbacks below still
+  // typecheck against `_WithLegacyMarkdownArgs<PostRemovalMarkdownShortcutsPluginProps>`,
+  // the deprecated fields are coming from Studio's own mapped type, not from whatever
+  // the installed plugin version happens to still declare.
+  type PostRemovalMarkdownShortcutsPluginProps = {
+    boldDecorator?: (arg: {context: {schema: {decorators: {name: string}[]}}}) => string | undefined
+    headingStyle?: (arg: {
+      context: {schema: {styles: {name: string}[]}}
+      props: {level: number}
+    }) => string | undefined
+    horizontalRuleObject?: (arg: {context: {schema: unknown}}) => {_type: string} | undefined
+    linkObject?: (arg: {
+      context: {schema: unknown}
+      props: {href: string}
+    }) => {_type: string} | undefined
+  }
+
+  const config: _WithLegacyMarkdownArgs<PostRemovalMarkdownShortcutsPluginProps> = {
+    // oxlint-disable-next-line no-deprecated -- pins that the deprecated top-level `schema` still typechecks
+    boldDecorator: ({schema}) =>
+      schema.decorators.find((decorator) => decorator.name === 'strong')?.name,
+    // oxlint-disable-next-line no-deprecated -- pins that the deprecated top-level `schema`/`level` still typecheck
+    headingStyle: ({schema, level}) =>
+      schema.styles.find((style) => style.name === `h${level}`)?.name,
+  }
+  expectTypeOf(config).toExtend<_WithLegacyMarkdownArgs<PostRemovalMarkdownShortcutsPluginProps>>()
+})
 
 test('plugins.markdown accepts spreading the incoming value and overriding `enabled`', () => {
   // A structural assertion misses this: the excess-property error only fires on

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -465,7 +465,7 @@ export interface PortableTextPluginsProps {
            */
           enabled?: boolean
         }
-      | (MarkdownShortcutsPluginProps & {
+      | (_WithLegacyMarkdownArgs<MarkdownShortcutsPluginProps> & {
           config?: undefined
           /**
            * @defaultValue true
@@ -516,20 +516,81 @@ export interface PortableTextPluginsProps {
   }
 }
 
+type MarkdownCallbackArg<TField> =
+  NonNullable<TField> extends (arg: infer TArg) => unknown ? TArg : never
+
+/**
+ * The markdown shortcuts plugin's own `context.schema` type, read off one of
+ * its callback fields rather than imported from `@portabletext/editor`
+ * directly, so this stays in sync with whichever plugin version is
+ * installed without reaching into editor internals.
+ */
+type MarkdownCallbackSchema =
+  MarkdownCallbackArg<MarkdownShortcutsPluginProps['boldDecorator']> extends {
+    context: {schema: infer TSchema}
+  }
+    ? TSchema
+    : never
+
+/**
+ * The markdown shortcuts plugin passes a deprecated top-level `schema` to
+ * every callback except `horizontalRuleObject` and `linkObject` (which never
+ * had one), and additionally passes a deprecated top-level `level` to
+ * `headingStyle` only. Adding these fields here, rather than relying on the
+ * plugin's own (possibly future) types to still declare them, keeps
+ * `boldDecorator: ({schema}) => ...`-style configs typechecking even after
+ * the plugin drops the deprecated params.
+ */
+type LegacyMarkdownSchemaArg = {
+  /**
+   * @deprecated Use `context.schema` instead
+   */
+  schema: MarkdownCallbackSchema
+}
+
+type LegacyMarkdownHeadingArgs = LegacyMarkdownSchemaArg & {
+  /**
+   * @deprecated Use `props.level` instead
+   */
+  level: number
+}
+
+type WithLegacyMarkdownArg<TField, TLegacy = LegacyMarkdownSchemaArg> = TField extends (
+  arg: infer TArg,
+) => infer TResult
+  ? (arg: TArg & TLegacy) => TResult
+  : TField
+
+/**
+ * Rewrites each markdown shortcuts callback field so its argument also
+ * accepts the deprecated top-level fields the plugin used to pass:
+ * `schema` on every callback except `horizontalRuleObject` and `linkObject`,
+ * plus `level` on `headingStyle`.
+ */
+export type _WithLegacyMarkdownArgs<T> = {
+  [K in keyof T]: K extends 'headingStyle'
+    ? WithLegacyMarkdownArg<T[K], LegacyMarkdownHeadingArgs>
+    : K extends 'horizontalRuleObject' | 'linkObject'
+      ? T[K]
+      : WithLegacyMarkdownArg<T[K]>
+}
+
 /**
  * @beta
  */
-export type MarkdownConfig = Omit<MarkdownShortcutsPluginProps, 'unorderedList' | 'orderedList'> &
+export type MarkdownConfig = _WithLegacyMarkdownArgs<
+  Omit<MarkdownShortcutsPluginProps, 'unorderedList' | 'orderedList'>
+> &
   (
     | {
         orderedList?: undefined
         /**
          * @deprecated - use `orderedList` instead
          */
-        orderedListStyle?: MarkdownShortcutsPluginProps['orderedList']
+        orderedListStyle?: WithLegacyMarkdownArg<MarkdownShortcutsPluginProps['orderedList']>
       }
     | {
-        orderedList?: MarkdownShortcutsPluginProps['orderedList']
+        orderedList?: WithLegacyMarkdownArg<MarkdownShortcutsPluginProps['orderedList']>
         /**
          * @deprecated - use `orderedList` instead
          */
@@ -542,10 +603,10 @@ export type MarkdownConfig = Omit<MarkdownShortcutsPluginProps, 'unorderedList' 
         /**
          * @deprecated - use `unorderedList` instead
          */
-        unorderedListStyle?: MarkdownShortcutsPluginProps['unorderedList']
+        unorderedListStyle?: WithLegacyMarkdownArg<MarkdownShortcutsPluginProps['unorderedList']>
       }
     | {
-        unorderedList?: MarkdownShortcutsPluginProps['unorderedList']
+        unorderedList?: WithLegacyMarkdownArg<MarkdownShortcutsPluginProps['unorderedList']>
         /**
          * @deprecated - use `unorderedList` instead
          */


### PR DESCRIPTION
`components.portableText.plugins` types its markdown config off the plugin's own `MarkdownShortcutsPluginProps`, so studio configs written against the deprecated top-level `schema`/`level` callback params (`boldDecorator: ({schema}) => ...`) would break, at compile time and at runtime, the moment Studio bumps to a plugin version that removes them, and Studio ships plugin bumps in minors. This PR moves that compat into the PTE input, where the semver promise lives.

Two halves. At the mount site, a wrapper merges the legacy fields back into every callback argument from `context`/`props`; with the current plugin this is a no-op, since it still passes them itself. In `MarkdownConfig`, the legacy fields come from Studio's own intersection instead of the plugin's types, `schema` on every callback that historically had it and a required `level` on `headingStyle` (`horizontalRuleObject` and `linkObject` never carried them and stay untouched). A type test simulates the post-removal plugin shape and pins that old-shape callbacks stay assignable through Studio's layer alone.

Wrapped callbacks are cached by the original function's identity: the plugin registers editor behaviors keyed on callback identity, and a config rebuilt per render (the documented spread-and-override pattern) must not re-register them on every keystroke.
