### PR TITLE
chore: migrate box in remaining src files

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -1,6 +1,7 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
+import {Box} from 'ui5'
 
 import {RhombusIcon} from '../../components/temporary-icons/Rhombus'
 import {useRelativeTime} from '../../hooks/useRelativeTime'

--- a/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsDialog.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsDialog.tsx
@@ -177,7 +177,7 @@ export function StudioAnnouncementsDialog({
       onClose={onClose}
       onClickOutside={onClose}
       width={1}
-      bodyHeight="fill"
+      bodyHeight="100%"
       padding={false}
       __unstable_hideCloseButton
       __unstable_autoFocus={false}

--- a/packages/sanity/src/core/studio/upsell/UpsellDialog.tsx
+++ b/packages/sanity/src/core/studio/upsell/UpsellDialog.tsx
@@ -64,7 +64,7 @@ export function UpsellDialog(props: UpsellDialogProps) {
       onClose={onClose}
       onClickOutside={onClose}
       __unstable_hideCloseButton
-      bodyHeight="fill"
+      bodyHeight="100%"
       padding={false}
       zOffset={800}
       footer={{

--- a/packages/sanity/src/core/variants/plugin/components/PerspectiveFilter.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/PerspectiveFilter.tsx
@@ -1,6 +1,7 @@
 import {RemoveIcon} from '@sanity/icons/Remove'
-import {Box, Card, Flex, Text, type CardTone} from '@sanity/ui'
+import {Card, Flex, Text, type CardTone} from '@sanity/ui'
 import {type ReactNode} from 'react'
+import {Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {AnimatedTextWidth} from '../../../perspective/navbar/AnimatedTextWidth'

--- a/packages/sanity/src/insert-menu/InsertMenu.tsx
+++ b/packages/sanity/src/insert-menu/InsertMenu.tsx
@@ -3,12 +3,13 @@ import {SearchIcon} from '@sanity/icons/Search'
 import {ThLargeIcon} from '@sanity/icons/ThLarge'
 import {UlistIcon} from '@sanity/icons/Ulist'
 import {type InsertMenuOptions, type SchemaType} from '@sanity/types'
-import {Box, Button, Flex, Grid, Stack, Tab, TabList, Text, TextInput} from '@sanity/ui'
+import {Button, Flex, Grid, Stack, Tab, TabList, Text, TextInput} from '@sanity/ui'
 import {Menu, MenuItem, type MenuItemProps} from '@sanity/ui/menu'
 import {Tooltip} from '@sanity/ui/tooltip'
 import startCase from 'lodash-es/startCase.js'
 import {useReducer, useState, type ChangeEvent, type CSSProperties} from 'react'
 import {isValidElementType} from 'react-is'
+import {Box} from 'ui5'
 
 import {getSchemaTypeIcon} from './getSchemaTypeIcon'
 
@@ -106,7 +107,7 @@ export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
           {showingFilterOrViews ? (
             <Flex flex="none" align="center" paddingTop={1} paddingX={1} gap={1}>
               {showFilter ? (
-                <Box flex={1}>
+                <Box flexBasis="0%" flexGrow={1}>
                   <TextInput
                     autoFocus
                     border={false}
@@ -121,7 +122,7 @@ export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
                 </Box>
               ) : null}
               {state.views.length > 1 ? (
-                <Box flex="none">
+                <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
                   <ViewToggle
                     views={state.views}
                     onToggle={(name) => {
@@ -257,7 +258,9 @@ function GridMenuItem(props: GridMenuItemProps) {
     <MenuItem padding={0} radius={2} onClick={props.onClick} style={{overflow: 'hidden'}}>
       <Flex direction="column" gap={1} padding={1}>
         <Box
-          flex="none"
+          flexBasis="auto"
+          flexGrow={0}
+          flexShrink={0}
           style={{
             backgroundColor: 'var(--card-muted-bg-color)',
             paddingBottom: '66.6%',
@@ -309,7 +312,7 @@ function GridMenuItem(props: GridMenuItemProps) {
             }}
           />
         </Box>
-        <Box flex="none" paddingX={2} paddingY={1}>
+        <Box flexBasis="auto" flexGrow={0} flexShrink={0} paddingX={2} paddingY={1}>
           <Text size={1} weight="medium">
             {props.schemaType.title ?? props.schemaType.name}
           </Text>

--- a/packages/sanity/src/media-library/plugin/VideoInput/InvalidVideoWarning.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/InvalidVideoWarning.tsx
@@ -1,6 +1,7 @@
 import {ResetIcon} from '@sanity/icons/Reset'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Box} from 'ui5'
 
 import {useTranslation} from '../../../core/i18n/hooks/useTranslation'
 import {Button} from '../../../ui-components/button/Button'

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoActionsMenu.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoActionsMenu.tsx
@@ -1,5 +1,6 @@
-import {Box, Card} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {lazy, type ReactNode, type RefObject, Suspense} from 'react'
+import {Box} from 'ui5'
 
 import {MenuActionsWrapper} from '../../../core/form/inputs/files/common/MenuActionsWrapper.styled'
 import {OptionsMenuPopover} from '../../../core/form/inputs/files/common/OptionsMenuPopover'

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoAsset.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoAsset.tsx
@@ -1,6 +1,7 @@
 import {type AssetSource} from '@sanity/types'
-import {Box, Card} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
+import {Box} from 'ui5'
 
 import {ChangeIndicator} from '../../../core/changeIndicators/ChangeIndicator'
 import {AssetSourceBrowser} from '../../../core/form/inputs/files/common/AssetSourceBrowser'

--- a/packages/sanity/src/presentation/components/ErrorCard.tsx
+++ b/packages/sanity/src/presentation/components/ErrorCard.tsx
@@ -1,6 +1,7 @@
-import {Box, Card, type CardProps, Container, Flex, Inline, Stack, Text} from '@sanity/ui'
+import {Card, type CardProps, Container, Flex, Inline, Stack, Text} from '@sanity/ui'
 import {type ReactNode} from 'react'
 import {useTranslation} from 'sanity'
+import {Box} from 'ui5'
 
 import {Button} from '../../ui-components/button/Button'
 import {presentationLocaleNamespace} from '../i18n'

--- a/packages/sanity/src/presentation/document/LocationsBanner.tsx
+++ b/packages/sanity/src/presentation/document/LocationsBanner.tsx
@@ -3,12 +3,13 @@ import {DesktopIcon} from '@sanity/icons/Desktop'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Box, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import {type ComponentType, type ReactNode, useCallback, useContext, useState} from 'react'
 import {type ObjectSchemaType, useTranslation} from 'sanity'
 import {PresentationContext} from 'sanity/_singletons'
 import {useIntentLink} from 'sanity/router'
 import {usePaneRouter} from 'sanity/structure'
+import {Box} from 'ui5'
 
 import {DEFAULT_TOOL_NAME, DEFAULT_TOOL_TITLE} from '../constants'
 import {presentationLocaleNamespace} from '../i18n'
@@ -71,13 +72,13 @@ export function LocationsBanner(props: {
         {!locations && (
           <Flex align="flex-start" gap={3} padding={3}>
             {tone && ToneIcon && (
-              <Box flex="none">
+              <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
                 <Text size={1}>
                   <ToneIcon />
                 </Text>
               </Box>
             )}
-            <Box flex={1}>
+            <Box flexBasis="0%" flexGrow={1}>
               <Text size={1} weight="medium">
                 {showPresentationTitle && <>{options.title || DEFAULT_TOOL_TITLE} &middot; </>}
                 {title}
@@ -95,7 +96,7 @@ export function LocationsBanner(props: {
               tone="inherit"
             >
               <Flex gap={3}>
-                <Box flex="none">
+                <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
                   {isResolving ? (
                     <Spinner size={1} />
                   ) : (
@@ -113,7 +114,7 @@ export function LocationsBanner(props: {
                     </Text>
                   )}
                 </Box>
-                <Box flex={1}>
+                <Box flexBasis="0%" flexGrow={1}>
                   <Text size={1} weight="medium">
                     {showPresentationTitle && <>{options.title || DEFAULT_TOOL_TITLE} &middot; </>}
                     {title}
@@ -195,7 +196,7 @@ function LocationItem(props: {
       tone="inherit"
     >
       <Flex gap={3}>
-        <Box flex="none">
+        <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
           <Text size={1}>
             <Icon />
           </Text>

--- a/packages/sanity/src/presentation/editor/ContentEditor.tsx
+++ b/packages/sanity/src/presentation/editor/ContentEditor.tsx
@@ -1,5 +1,5 @@
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Card, Flex, Text} from '@sanity/ui'
 import {type HTMLProps, useCallback, useMemo} from 'react'
 import {
   getPreviewValueWithFallback,
@@ -10,6 +10,7 @@ import {
   useTranslation,
 } from 'sanity'
 import {StateLink} from 'sanity/router'
+import {Box} from 'ui5'
 
 import {presentationLocaleNamespace} from '../i18n'
 import {
@@ -127,12 +128,12 @@ export function ContentEditor(props: {
           ) : (
             <Card padding={2} radius={2} tone="inherit">
               <Flex gap={3}>
-                <Box flex="none">
+                <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
                   <Text size={1}>
                     <WarningOutlineIcon />
                   </Text>
                 </Box>
-                <Box flex={1}>
+                <Box flexBasis="0%" flexGrow={1}>
                   <Text size={1}>
                     <Translate
                       t={t}

--- a/packages/sanity/src/presentation/preview/IFrame.tsx
+++ b/packages/sanity/src/presentation/preview/IFrame.tsx
@@ -1,4 +1,3 @@
-import {Box} from '@sanity/ui'
 import {motion, type VariantLabels, type Variants} from 'motion/react'
 import {
   type ReactEventHandler,
@@ -8,6 +7,7 @@ import {
   type RefAttributes,
 } from 'react'
 import {createGlobalStyle, styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {useId} from '../useId'
 

--- a/packages/sanity/src/presentation/preview/PreviewHeader.tsx
+++ b/packages/sanity/src/presentation/preview/PreviewHeader.tsx
@@ -3,10 +3,11 @@ import {MobileDeviceIcon} from '@sanity/icons/MobileDevice'
 import {PanelLeftIcon} from '@sanity/icons/PanelLeft'
 import {RefreshIcon} from '@sanity/icons/Refresh'
 import {withoutSecretSearchParams} from '@sanity/preview-url-secret/without-secret-search-params'
-import {Box, Card, Flex, Hotkeys, Switch, Text} from '@sanity/ui'
+import {Card, Flex, Hotkeys, Switch, Text} from '@sanity/ui'
 import {useSelector} from '@xstate/react'
 import {type RefObject, useCallback, useMemo} from 'react'
 import {useTranslation} from 'sanity'
+import {Box} from 'ui5'
 
 import {Button} from '../../ui-components/button/Button'
 import {Tooltip} from '../../ui-components/tooltip/Tooltip'
@@ -164,7 +165,7 @@ const PreviewHeaderDefault = (props: Omit<PreviewHeaderProps, 'renderDefault'>) 
         </Card>
       </Tooltip>
 
-      <Box flex={1}>
+      <Box flexBasis="0%" flexGrow={1}>
         <PreviewLocationInput
           previewUrlRef={previewUrlRef}
           prefix={

--- a/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
+++ b/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
@@ -8,13 +8,14 @@ import {
   enablePreviewAccessSharing,
 } from '@sanity/preview-url-secret/toggle-preview-access-sharing'
 import {setSecretSearchParams} from '@sanity/preview-url-secret/without-secret-search-params'
-import {Box, Card, Grid, Spinner, Stack, Switch, Text} from '@sanity/ui'
+import {Card, Grid, Spinner, Stack, Switch, Text} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
 import {useToast} from '@sanity/ui/toast'
 import {AnimatePresence, motion} from 'motion/react'
 import {lazy, Suspense, useCallback, useEffect, useMemo, useState} from 'react'
 import {useClient, useCurrentUser, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {Button} from '../../ui-components/button/Button'
 import {MenuButton} from '../../ui-components/menuButton/MenuButton'

--- a/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectDialog/InspectDialog.tsx
@@ -51,7 +51,7 @@ export function InspectDialog(props: InspectDialogProps) {
 
   return (
     <Dialog
-      bodyHeight="fill"
+      bodyHeight="100%"
       id={`${dialogIdPrefix}dialog`}
       header={
         isDocumentLike(value) ? (

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
@@ -16,7 +16,7 @@ import {
 } from 'sanity'
 import {DocumentChangeContext} from 'sanity/_singletons'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Box, Grid} from 'ui5'
 
 import {structureLocaleNamespace} from '../../../../i18n'
 import {TimelineError} from '../../timeline/TimelineError'
@@ -28,15 +28,6 @@ const Scroller = styled(ScrollContainer)`
   overflow: auto;
   position: relative;
   scroll-behavior: smooth;
-`
-
-const Grid = styled(Box)`
-  &:not([hidden]) {
-    display: grid;
-  }
-  grid-template-columns: 48px 1fr;
-  align-items: center;
-  gap: 0.25em;
 `
 
 export function ChangesInspector({showChanges}: {showChanges: boolean}): React.JSX.Element {
@@ -83,7 +74,12 @@ export function ChangesInspector({showChanges}: {showChanges: boolean}): React.J
   return (
     <Flex data-testid="review-changes-pane" direction="column" height="fill" overflow="hidden">
       <Box padding={3}>
-        <Grid paddingX={2} paddingBottom={2}>
+        <Grid
+          paddingX={2}
+          paddingBottom={2}
+          gridTemplateColumns="48px 1fr"
+          style={{alignItems: 'center', gap: '0.25em'}}
+        >
           <Text size={1} muted>
             {structureT('changes.from.label')}
           </Text>

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sanity'
 import {DocumentChangeContext} from 'sanity/_singletons'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Box, Grid} from 'ui5'
 
 import {structureLocaleNamespace} from '../../../../i18n'
 import {EventsTimelineMenu} from '../../timeline/events/EventsTimelineMenu'
@@ -34,15 +34,6 @@ const Scroller = styled(ScrollContainer)`
   overflow: auto;
   position: relative;
   scroll-behavior: smooth;
-`
-
-const Grid = styled(Box)`
-  &:not([hidden]) {
-    display: grid;
-  }
-  grid-template-columns: 48px 1fr;
-  align-items: center;
-  gap: 0.25em;
 `
 
 const SpinnerContainer = styled(Flex)`
@@ -208,7 +199,12 @@ export function EventsInspector({showChanges}: {showChanges: boolean}): ReactEle
   return (
     <Flex data-testid="review-changes-pane" direction="column" height="fill" overflow="hidden">
       <Box padding={3} style={{position: 'relative'}}>
-        <Grid paddingX={2} paddingBottom={2}>
+        <Grid
+          paddingX={2}
+          paddingBottom={2}
+          gridTemplateColumns="48px 1fr"
+          style={{alignItems: 'center', gap: '0.25em'}}
+        >
           <Text size={1} muted>
             {t('changes.inspector.from-label')}
           </Text>

--- a/packages/sanity/src/ui-components/confirmPopover/ConfirmPopover.tsx
+++ b/packages/sanity/src/ui-components/confirmPopover/ConfirmPopover.tsx
@@ -1,6 +1,5 @@
 /* oxlint-disable no-restricted-imports, @sanity/i18n/no-i18next-import */
 import {
-  Box,
   Button as UIButton,
   Flex,
   Grid,
@@ -12,6 +11,7 @@ import {
 import {Popover as UIPopover, type PopoverProps as UIPopoverProps} from '@sanity/ui/popover'
 import {type ComponentType, type ReactNode, useCallback, useRef} from 'react'
 import {useTranslation} from 'react-i18next'
+import {Box} from 'ui5'
 
 export interface ConfirmPopoverProps {
   cancelButtonIcon?: ReactNode | ComponentType
@@ -101,7 +101,7 @@ function ConfirmPopoverContent({
 
   return (
     <Flex direction="column" ref={ref} style={{minWidth: 280, maxWidth: 350}}>
-      <Box flex={1} overflow="auto" padding={4}>
+      <Box flexBasis="0%" flexGrow={1} overflow="auto" padding={4}>
         <Text size={1}>{message}</Text>
       </Box>
       <Box paddingX={4} paddingY={3} style={{borderTop: '1px solid var(--card-border-color)'}}>

--- a/packages/sanity/src/ui-components/dialog/Dialog.tsx
+++ b/packages/sanity/src/ui-components/dialog/Dialog.tsx
@@ -1,7 +1,5 @@
 /* oxlint-disable no-restricted-imports */
 import {
-  Box,
-  type BoxHeight,
   Button as UIButton,
   Dialog as UIDialog,
   type DialogProps as UIDialogProps,
@@ -16,6 +14,7 @@ import {
   type RefAttributes,
 } from 'react'
 import {useTranslation} from 'react-i18next'
+import {Box} from 'ui5'
 
 /** @internal */
 export type DialogProps = Pick<
@@ -36,10 +35,10 @@ export type DialogProps = Pick<
 > & {
   /**
    * Dialog body height.
-   * Set this to 'fill' (i.e. 100%) if you want overflow body content to be contained
+   * Set this to '100%' if you want overflow body content to be contained
    * and not trigger dynamic border visibility.
    */
-  bodyHeight?: BoxHeight
+  bodyHeight?: string
   children?: ReactNode
   zOffset?: number
   footer?: {
@@ -85,7 +84,7 @@ export function Dialog({
         (footer?.confirmButton || footer?.cancelButton) && (
           <Flex gap={3} justify="flex-end" padding={3} align="center">
             {footer?.description && (
-              <Box flex={1} paddingLeft={1}>
+              <Box flexBasis="0%" flexGrow={1} paddingLeft={1}>
                 <Text size={1} muted>
                   {footer.description}
                 </Text>

--- a/packages/sanity/src/ui-components/dialog/Dialog.tsx
+++ b/packages/sanity/src/ui-components/dialog/Dialog.tsx
@@ -14,7 +14,7 @@ import {
   type RefAttributes,
 } from 'react'
 import {useTranslation} from 'react-i18next'
-import {Box} from 'ui5'
+import {Box, type BoxProps} from 'ui5'
 
 /** @internal */
 export type DialogProps = Pick<
@@ -38,7 +38,7 @@ export type DialogProps = Pick<
    * Set this to '100%' if you want overflow body content to be contained
    * and not trigger dynamic border visibility.
    */
-  bodyHeight?: string
+  bodyHeight?: BoxProps['height']
   children?: ReactNode
   zOffset?: number
   footer?: {

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable no-restricted-imports */
-import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
+import {Badge, Flex, Stack, Text} from '@sanity/ui'
 import {MenuItem as UIMenuItem, type MenuItemProps as UIMenuItemProps} from '@sanity/ui/menu'
 import {
   type ElementType,
@@ -12,6 +12,7 @@ import {
 } from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {Hotkeys} from '../../core/components/Hotkeys'
 import {Tooltip, type TooltipProps} from '../tooltip/Tooltip'

--- a/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
+++ b/packages/sanity/src/ui-components/tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import {Box, Flex, type HotkeysProps, Text} from '@sanity/ui'
+import {Flex, type HotkeysProps, Text} from '@sanity/ui'
 import {
   // oxlint-disable-next-line no-restricted-imports
   Tooltip as UITooltip,
@@ -6,6 +6,7 @@ import {
   type TooltipProps as UITooltipProps,
 } from '@sanity/ui/tooltip'
 import {type RefAttributes} from 'react'
+import {Box} from 'ui5'
 
 import {Hotkeys} from '../../core/components/Hotkeys'
 import {TOOLTIP_DELAY_PROPS} from './constants'
@@ -46,12 +47,12 @@ export function Tooltip(props: TooltipProps & RefAttributes<HTMLDivElement>) {
         content={
           <Flex align="center">
             {content && (
-              <Box flex={1} padding={1}>
+              <Box flexBasis="0%" flexGrow={1} padding={1}>
                 <Text size={1}>{content}</Text>
               </Box>
             )}
             {hotkeys && (
-              <Box flex="none">
+              <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
                 <Hotkeys keys={hotkeys} />
               </Box>
             )}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR migrates the Box component from `@sanity/ui` v4 to v5 in all the remaining directories in  `packages/sanity/src`. It updates Box across 26 files containing 40 JSX or styled-component instances.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop updates look correct.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I manually tested:

- Compare Versions popup
- Reverting a change in History/Review Changes
- Studio announcement
- Nested array in the Debug Inputs and Videos in Standard Inputs

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Layout-only UI primitive swap with no auth, data, or business-logic changes. Residual risk is visual/layout regressions where flex or dialog height mapping is wrong.
> 
> **Overview**
> Migrates remaining `Box` usage in `packages/sanity/src` from `@sanity/ui` to `ui5`.
> 
> Shorthand flex props are rewritten for the v5 API (`flex={1}` → `flexBasis="0%" flexGrow={1}`, `flex="none"` → `flexBasis="auto" flexGrow={0} flexShrink={0}`). Dialog `bodyHeight` changes from `'fill'` to `'100%'` (including the `Dialog` wrapper type). Review-changes inspectors drop styled `Grid` wrappers and use `ui5` `Grid` with `gridTemplateColumns` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a37939765aa322c1a6333a76b8be782ef7824e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->