### PR TITLE
fix(core): apply the selected style to every block in the selection, not only the focus block

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Styles.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Styles.browser.test.tsx
@@ -1,6 +1,7 @@
+import {type SanityDocument} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
 import {render} from 'vitest-browser-react'
-import {page} from 'vitest/browser'
+import {page, userEvent} from 'vitest/browser'
 
 import {testHelpers} from '../../../../../../test/browser/testHelpers'
 import {StylesStory} from './StylesStory'
@@ -43,6 +44,146 @@ describe('Portable Text Input', () => {
           .element()
           .querySelector('button#block-style-select')
         expect(styleSelectButton).toBeNull()
+      })
+
+      it('Applies the chosen style to every block in the selection, not just the focus block', async () => {
+        const documentValue: SanityDocument = {
+          _id: '123',
+          _type: 'test',
+          _createdAt: new Date().toISOString(),
+          _updatedAt: new Date().toISOString(),
+          _rev: '123',
+          defaultStyles: [
+            {
+              _type: 'block',
+              _key: 'b0',
+              style: 'h2',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's0', text: 'Heading text', marks: []}],
+            },
+            {
+              _type: 'block',
+              _key: 'b1',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's1', text: 'Normal text', marks: []}],
+            },
+          ],
+        }
+
+        const {getFocusedPortableTextInput, waitForFocusedNodeText, waitForDocumentState} =
+          testHelpers()
+        void render(<StylesStory document={documentValue} />)
+        const $portableTextInput = await getFocusedPortableTextInput('field-defaultStyles')
+
+        const $headingText = [...$portableTextInput.element().querySelectorAll('*')].find(
+          (node) => node.childElementCount === 0 && node.textContent === 'Heading text',
+        )
+        await userEvent.click($headingText as HTMLElement)
+        // Place the selection anchor at the end of the `h2` block, then extend
+        // the focus down into the `normal` block below it, so the selection
+        // spans both blocks with its focus outside the `h2` block.
+        await userEvent.keyboard('{End}')
+        await userEvent.keyboard('{Shift>}{ArrowDown}{/Shift}')
+        await waitForFocusedNodeText('Normal text')
+
+        const $styleSelectButton = $portableTextInput.getByTestId('block-style-select')
+        await $styleSelectButton.click()
+        const $menu = page.getByRole('menu')
+        await $menu.getByText('Normal', {exact: true}).click()
+
+        const documentState = await waitForDocumentState(
+          (state) => state?.defaultStyles?.[0]?.style === 'normal',
+        )
+        expect(documentState.defaultStyles).toEqual([
+          {
+            _type: 'block',
+            _key: 'b0',
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', _key: 's0', text: 'Heading text', marks: []}],
+          },
+          {
+            _type: 'block',
+            _key: 'b1',
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', _key: 's1', text: 'Normal text', marks: []}],
+          },
+        ])
+      })
+
+      it('Leaves a style-less block alone when it already resolves to the chosen style', async () => {
+        const documentValue: SanityDocument = {
+          _id: '123',
+          _type: 'test',
+          _createdAt: new Date().toISOString(),
+          _updatedAt: new Date().toISOString(),
+          _rev: '123',
+          defaultStyles: [
+            {
+              _type: 'block',
+              _key: 'b0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's0', text: 'Explicit normal text', marks: []}],
+            },
+            {
+              _type: 'block',
+              _key: 'b1',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's1', text: 'Unstyled text', marks: []}],
+            },
+          ],
+        }
+
+        const {getFocusedPortableTextInput, waitForFocusedNodeText, waitForDocumentState} =
+          testHelpers()
+        void render(<StylesStory document={documentValue} />)
+        const $portableTextInput = await getFocusedPortableTextInput('field-defaultStyles')
+        const $firstText = [...$portableTextInput.element().querySelectorAll('*')].find(
+          (node) => node.childElementCount === 0 && node.textContent === 'Explicit normal text',
+        )
+        await userEvent.click($firstText as HTMLElement)
+        await userEvent.keyboard('{End}')
+        await userEvent.keyboard('{Shift>}{ArrowDown}{/Shift}')
+        await waitForFocusedNodeText('Unstyled text')
+
+        const $styleSelectButton = $portableTextInput.getByTestId('block-style-select')
+        await $styleSelectButton.click()
+        const $menu = page.getByRole('menu')
+        await $menu.getByText('Normal', {exact: true}).click()
+        await expect.element($menu).not.toBeInTheDocument()
+
+        // A no-op leaves no `onChange` to `waitFor`, so anchor on a keystroke
+        // instead. Typed into block A, not B: typing normalizes the edited
+        // block's own style, which would mask whether the no-op touched block
+        // B's absent one.
+        await userEvent.click($firstText as HTMLElement)
+        await userEvent.keyboard('X')
+
+        const documentState = await waitForDocumentState(
+          (state) =>
+            state?.defaultStyles?.[0]?.children?.[0]?.text?.length ===
+            'Explicit normal text'.length + 1,
+        )
+        const typedText: string = documentState.defaultStyles[0].children[0].text
+        expect(typedText.replace('X', '')).toBe('Explicit normal text')
+        expect(documentState.defaultStyles).toEqual([
+          {
+            _type: 'block',
+            _key: 'b0',
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', _key: 's0', text: typedText, marks: []}],
+          },
+          {
+            _type: 'block',
+            _key: 'b1',
+            markDefs: [],
+            children: [{_type: 'span', _key: 's1', text: 'Unstyled text', marks: []}],
+          },
+        ])
       })
     })
   })

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/StylesStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/StylesStory.tsx
@@ -1,4 +1,4 @@
-import {defineArrayMember, defineField, defineType} from '@sanity/types'
+import {defineArrayMember, defineField, defineType, type SanityDocument} from '@sanity/types'
 
 import {TestForm} from '../../../../../../test/browser/TestForm'
 import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
@@ -31,10 +31,10 @@ const SCHEMA_TYPES = [
     ],
   }),
 ]
-export function StylesStory() {
+export function StylesStory(props: {document?: SanityDocument}) {
   return (
     <TestWrapper schemaTypes={SCHEMA_TYPES}>
-      <TestForm />
+      <TestForm document={props.document} />
     </TestWrapper>
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
@@ -1,4 +1,5 @@
-import {PortableTextEditor, usePortableTextEditor} from '@portabletext/editor'
+import {useEditor} from '@portabletext/editor'
+import {isActiveStyle} from '@portabletext/editor/selectors'
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {Text} from '@sanity/ui'
 import {
@@ -76,8 +77,7 @@ export const BlockStyleSelect = memo(function BlockStyleSelect(
 ): React.JSX.Element {
   const {disabled, items: itemsProp, boundaryElement} = props
   const applicable = useApplicableSchema()
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const editor = usePortableTextEditor()
+  const editor = useEditor()
   const schemaTypes = usePortableTextMemberSchemaTypes()
   const focusBlock = useFocusBlock()
   const {t} = useTranslation()
@@ -121,12 +121,18 @@ export const BlockStyleSelect = memo(function BlockStyleSelect(
 
   const handleChange = useCallback(
     (item: BlockStyleItem): void => {
-      if (focusBlock && item.style !== focusBlock.style) {
-        // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        PortableTextEditor.toggleBlockStyle(editor, item.style)
-        // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        PortableTextEditor.focus(editor)
+      if (!focusBlock) return
+
+      editor.send({type: 'focus'})
+
+      if (isActiveStyle(item.style)(editor.getSnapshot())) {
+        // Without this no-op, `style.add` writes the default style onto
+        // blocks that carry none: a patch with no visible change.
+        return
       }
+
+      // `style.add`, never `style.toggle`: a select must not unset.
+      editor.send({type: 'style.add', style: item.style})
     },
     [editor, focusBlock],
   )


### PR DESCRIPTION
### Description

Applying a style to a multi-block selection in the Portable Text Input was a noop if the focus block (the block where the caret in the cross-selection ended) already had the selected style. 

For example, if the selection starts in an `h1` and ends in a `normal` block and `normal` is selected in the style selector, nothing would happen

<img width="223" height="229" alt="Screenshot 2026-08-21 at 09 01 47" src="https://github.com/user-attachments/assets/92b694fe-805c-4ee4-a4bd-ec40e4640495" />

This has been fixed by no longer checking the focus block `style`, but instead use the `isActiveStyle` selector which checks the entire selection. The `style.add` is used to apply the selected style since a `style.toggle` would flip styles in a mixed-style selection.

### What to review

The change is one handler in `BlockStyleSelect.tsx`. To see the bug on `main`, write two blocks, a Normal and a Heading 2, select from the heading into the normal text, and pick Normal in the style selector: nothing happens. With the fix, the heading becomes normal. Worth a quick manual check that single-block style switching still behaves as before.

### Testing

Added two browser tests. The first reproduces the bug and fails on `main`. The second checks that picking a style the selection already has leaves the document untouched.

### Notes for release

Fixes a bug where applying a text style to a selection spanning multiple blocks in the Portable Text editor could silently do nothing when one of the selected blocks already had the chosen style.

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Editor toolbar behavior only; no auth, data, or API changes. Risk is limited to style application edge cases in Portable Text.
> 
> **Overview**
> Fixes a Portable Text toolbar bug where picking a block style did nothing if the **focus** block already had that style, even when other selected blocks did not.
> 
> `BlockStyleSelect` now uses `isActiveStyle` on the full selection and sends `style.add` instead of toggling, so mixed selections (e.g. heading into normal, then pick Normal) update every selected block. If the style is already active, it no-ops so unstyled blocks that already resolve to the default are not patched.
> 
> Browser tests cover the multi-block apply path and the no-op for style-less blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2379c23cfa0818b22b2a31cb24b1f881ef567454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->