### PR TITLE
perf(compiler): opt out tanstack virtualizer from react compiler

### DIFF
--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -129,6 +129,9 @@ function CommandListComponent({
   wrapAround = true,
   ...paddingProps
 }: CommandListProps & RefAttributes<CommandListHandle>) {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const isMountedRef = useRef(false)
   const [commandListId] = useState(useId())
   const activeIndexRef = useRef(initialIndex ?? 0)
@@ -157,7 +160,7 @@ function CommandListComponent({
   )
 
   // This will trigger a re-render whenever its internal state changes
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     count: items.length,
     getItemKey,

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -129,9 +129,6 @@ function CommandListComponent({
   wrapAround = true,
   ...paddingProps
 }: CommandListProps & RefAttributes<CommandListHandle>) {
-  // TanStack Virtual returns functions that cannot be memoized safely.
-  'use no memo'
-
   const isMountedRef = useRef(false)
   const [commandListId] = useState(useId())
   const activeIndexRef = useRef(initialIndex ?? 0)

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
@@ -47,6 +47,9 @@ interface VirtualizedArrayListProps<Item extends ObjectItem> {
 export function VirtualizedArrayList<Item extends ObjectItem>(
   props: VirtualizedArrayListProps<Item>,
 ) {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const {
     members,
     memberKeys,
@@ -192,7 +195,7 @@ export function VirtualizedArrayList<Item extends ObjectItem>(
   // custom components can have different dimensions and the library recalculate the size of the element
   const estimateSize = useCallback(() => 53, [])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     count: members.length,
     estimateSize,

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
@@ -47,9 +47,6 @@ interface VirtualizedArrayListProps<Item extends ObjectItem> {
 export function VirtualizedArrayList<Item extends ObjectItem>(
   props: VirtualizedArrayListProps<Item>,
 ) {
-  // TanStack Virtual returns functions that cannot be memoized safely.
-  'use no memo'
-
   const {
     members,
     memberKeys,

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -60,6 +60,9 @@ const TableInner = <TableData, AdditionalRowTableData>({
   scrollContainerRef,
   hideTableInlinePadding = false,
 }: TableProps<TableData, AdditionalRowTableData>) => {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const {searchTerm, sort} = useTableContext()
 
   const filteredData = useMemo(() => {
@@ -101,7 +104,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
     })
   }, [columnDefs, data, searchFilter, searchTerm, sort])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const rowVirtualizer = useVirtualizer({
     count: filteredData.length,
     getScrollElement: () => scrollContainerRef,

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -60,9 +60,6 @@ const TableInner = <TableData, AdditionalRowTableData>({
   scrollContainerRef,
   hideTableInlinePadding = false,
 }: TableProps<TableData, AdditionalRowTableData>) => {
-  // TanStack Virtual returns functions that cannot be memoized safely.
-  'use no memo'
-
   const {searchTerm, sort} = useTableContext()
 
   const filteredData = useMemo(() => {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
@@ -44,9 +44,6 @@ export const ReleaseActivityList = ({
   loadMore,
   isLoading,
 }: ReleaseActivityListProps) => {
-  // TanStack Virtual returns functions that cannot be memoized safely.
-  'use no memo'
-
   const virtualizerContainerRef = useRef<HTMLDivElement | null>(null)
 
   const listEvents: ReleaseEvent[] = useMemo(() => {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
@@ -44,6 +44,9 @@ export const ReleaseActivityList = ({
   loadMore,
   isLoading,
 }: ReleaseActivityListProps) => {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const virtualizerContainerRef = useRef<HTMLDivElement | null>(null)
 
   const listEvents: ReleaseEvent[] = useMemo(() => {
@@ -77,7 +80,7 @@ export const ReleaseActivityList = ({
     })
   }, [events, hasMore, isLoading])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     // If we have more events, or the events are loading, we add a loader row at the end
     count: hasMore || isLoading ? listEvents.length + 1 : listEvents.length,

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
@@ -68,6 +68,9 @@ const VirtualList = () => {
 export default VirtualList
 
 function useVirtualizedSchedules(activeSchedules: Schedule[], sortBy?: ScheduleSort) {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const containerRef = useRef<HTMLDivElement>(null)
 
   const listSourceItems = useMemo(() => {
@@ -94,7 +97,7 @@ function useVirtualizedSchedules(activeSchedules: Schedule[], sortBy?: ScheduleS
     return items
   }, [activeSchedules, sortBy])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     count: listSourceItems.length,
     getScrollElement: () => containerRef.current,

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
@@ -68,9 +68,6 @@ const VirtualList = () => {
 export default VirtualList
 
 function useVirtualizedSchedules(activeSchedules: Schedule[], sortBy?: ScheduleSort) {
-  // TanStack Virtual returns functions that cannot be memoized safely.
-  'use no memo'
-
   const containerRef = useRef<HTMLDivElement>(null)
 
   const listSourceItems = useMemo(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

React Compiler cannot memoize TanStack Virtual's `useVirtualizer()` (it returns functions that go stale if compiled). That skip is correct, but oxc now prints it on every `pnpm dev`.

`'use no memo'` on the five callers makes the skip explicit and silent. Wrapping `useVirtualizer` in a tiny hook so the parent still compiles was rejected: compiling those parents is what the diagnostic is warning against.

Stacked on #14226 (1/5). Oxlint still flags `react/incompatible-library` even inside `'use no memo'` functions, so those disables stay.

### What to review

- Directive is on the function that *calls* `useVirtualizer` (`CommandListComponent`, `VirtualizedArrayList`, `TableInner`, `ReleaseActivityList`, `useVirtualizedSchedules`), not a wrapper
- Virtualized lists still scroll/measure as before (no behavior change)

### Testing

No new tests. Confirmed on the stack tip that `pnpm dev` no longer prints `IncompatibleLibrary` for these files.

### Notes for release

N/A – Internal only. These list components were already skipped by the compiler; this only silences the warning.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81cf7506-fcf0-4364-bf43-eb49d8b6a442?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81cf7506-fcf0-4364-bf43-eb49d8b6a442&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

