### PR TITLE
fix(form): remove compiler-blocking react hooks suppressions

### DIFF
--- a/dev/test-studio/components/documentViews/VariantVersionsView.tsx
+++ b/dev/test-studio/components/documentViews/VariantVersionsView.tsx
@@ -334,10 +334,8 @@ function VersionSlotCard({label, contextTitle, snapshot, status}: VersionSlot) {
       await client.delete(documentId)
     } catch (deleteErr: unknown) {
       setDeleteError(deleteErr instanceof Error ? deleteErr.message : 'Failed to delete document')
-      // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
-    } finally {
-      setDeleting(false)
     }
+    setDeleting(false)
   }, [client, documentId])
 
   return (

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -129,6 +129,9 @@ function CommandListComponent({
   wrapAround = true,
   ...paddingProps
 }: CommandListProps & RefAttributes<CommandListHandle>) {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const isMountedRef = useRef(false)
   const [commandListId] = useState(useId())
   const activeIndexRef = useRef(initialIndex ?? 0)
@@ -157,7 +160,7 @@ function CommandListComponent({
   )
 
   // This will trigger a re-render whenever its internal state changes
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     count: items.length,
     getItemKey,

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
@@ -47,6 +47,9 @@ interface VirtualizedArrayListProps<Item extends ObjectItem> {
 export function VirtualizedArrayList<Item extends ObjectItem>(
   props: VirtualizedArrayListProps<Item>,
 ) {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const {
     members,
     memberKeys,
@@ -192,7 +195,7 @@ export function VirtualizedArrayList<Item extends ObjectItem>(
   // custom components can have different dimensions and the library recalculate the size of the element
   const estimateSize = useCallback(() => 53, [])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     count: members.length,
     estimateSize,

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
@@ -62,23 +62,15 @@ function ImageInputAssetComponent(props: {
     [onSelectFile],
   )
 
-  const handleFileTargetFocus = useCallback(
-    (event: FocusEvent) => {
-      // We want to handle focus when the file target element *itself* receives
-      // focus, not when an interactive child element receives focus. Since React has decided
-      // to let focus bubble, so this workaround is needed
-      // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
-      if (
-        event.currentTarget === event.target &&
-        event.currentTarget === elementProps.ref?.current
-      ) {
-        inputProps.elementProps.onFocus(event)
-      }
-    },
-    // oxlint-disable-next-line react/rule-suppression -- pre-existing violation, to be fixed in a follow-up
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [inputProps, elementProps.ref?.current],
-  )
+  function handleFileTargetFocus(event: FocusEvent) {
+    // We want to handle focus when the file target element *itself* receives
+    // focus, not when an interactive child element receives focus. Since React has decided
+    // to let focus bubble, so this workaround is needed
+    // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
+    if (event.currentTarget === event.target && event.currentTarget === elementProps.ref?.current) {
+      inputProps.elementProps.onFocus(event)
+    }
+  }
 
   return (
     <div style={customProperties}>

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -10,7 +10,6 @@ import * as PathUtils from '@sanity/util/paths'
 import {type ComponentProps, useCallback, useMemo, type RefAttributes} from 'react'
 import {combineLatest, from, of, throwError} from 'rxjs'
 import {catchError, map, mergeMap, switchMap} from 'rxjs/operators'
-import {useEffectEvent} from 'use-effect-event'
 
 import {useSchema} from '../../../../hooks/useSchema'
 import {usePerspective} from '../../../../perspective/usePerspective'
@@ -93,8 +92,8 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   const disableNew = inheritedOptions.disableNew ?? schemaType.options?.disableNew === true
   const getClient = source.getClient
 
-  const handleSearch = useEffectEvent((searchString: string) =>
-    from(
+  function handleSearch(searchString: string) {
+    return from(
       resolveUserDefinedFilter({
         options: schemaType.options,
         document: documentValue,
@@ -174,8 +173,8 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
         }
         return throwError(() => err)
       }),
-    ),
-  )
+    )
+  }
 
   const template = props.value?._strengthenOnPublish?.template
   const EditReferenceLink = useMemo(
@@ -267,12 +266,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   return (
     <ReferenceInput
       {...props}
-      onSearch={
-        // TODO(oxlint): remove this suppression in a follow-up once useEffectEvent support is fixed
-        // oxlint-disable-next-line react/rule-suppression -- pre-existing violation, to be fixed in a follow-up
-        // oxlint-disable-next-line react-hooks/rules-of-hooks
-        handleSearch
-      }
+      onSearch={handleSearch}
       liveEdit={isDocumentLiveEdit}
       getReferenceInfo={getReferenceInfo}
       selectedState={selectedState}

--- a/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
@@ -57,11 +57,9 @@ export function EditReleaseDialog({
         status: 'error',
         title: t('release.toast.edit-release-error.title'),
       })
-      // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
-    } finally {
-      isSavingRef.current = false
-      setIsSaving(false)
     }
+    isSavingRef.current = false
+    setIsSaving(false)
   }, [description, onClose, release, t, title, toast, updateRelease])
 
   // Ignore click-outside / Escape / close while a save is in flight: dismissing mid-mutation would

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -60,6 +60,9 @@ const TableInner = <TableData, AdditionalRowTableData>({
   scrollContainerRef,
   hideTableInlinePadding = false,
 }: TableProps<TableData, AdditionalRowTableData>) => {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const {searchTerm, sort} = useTableContext()
 
   const filteredData = useMemo(() => {
@@ -101,7 +104,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
     })
   }, [columnDefs, data, searchFilter, searchTerm, sort])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const rowVirtualizer = useVirtualizer({
     count: filteredData.length,
     getScrollElement: () => scrollContainerRef,

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
@@ -44,6 +44,9 @@ export const ReleaseActivityList = ({
   loadMore,
   isLoading,
 }: ReleaseActivityListProps) => {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const virtualizerContainerRef = useRef<HTMLDivElement | null>(null)
 
   const listEvents: ReleaseEvent[] = useMemo(() => {
@@ -77,7 +80,7 @@ export const ReleaseActivityList = ({
     })
   }, [events, hasMore, isLoading])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     // If we have more events, or the events are loading, we add a loader row at the end
     count: hasMore || isLoading ? listEvents.length + 1 : listEvents.length,

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
@@ -50,8 +50,6 @@ const ToolPreview = (props: Props) => {
         />
       )
     }
-    // oxlint-disable-next-line react/immutability -- displayName assignment on render-local component
-    Component.displayName = 'LinkComponent'
     return Component
   }, [schemaType, visibleDocument])
 

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
@@ -68,6 +68,9 @@ const VirtualList = () => {
 export default VirtualList
 
 function useVirtualizedSchedules(activeSchedules: Schedule[], sortBy?: ScheduleSort) {
+  // TanStack Virtual returns functions that cannot be memoized safely.
+  'use no memo'
+
   const containerRef = useRef<HTMLDivElement>(null)
 
   const listSourceItems = useMemo(() => {
@@ -94,7 +97,7 @@ function useVirtualizedSchedules(activeSchedules: Schedule[], sortBy?: ScheduleS
     return items
   }, [activeSchedules, sortBy])
 
-  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
+  // oxlint-disable-next-line react/incompatible-library -- TanStack Virtual; function is opted out with 'use no memo'
   const virtualizer = useVirtualizer({
     count: listSourceItems.length,
     getScrollElement: () => containerRef.current,

--- a/packages/sanity/src/structure/components/IntentButton.tsx
+++ b/packages/sanity/src/structure/components/IntentButton.tsx
@@ -28,8 +28,6 @@ export function IntentButton(
         />
       )
     }
-    // oxlint-disable-next-line react/immutability -- displayName assignment on render-local component
-    LinkComponent.displayName = 'Link'
     return LinkComponent
   }, [intent])
 

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -169,15 +169,14 @@ function IncomingReferencesTypeList({
             description: 'The document you are trying to link cannot be linked to',
             status: 'error',
           })
-          return
+        } else {
+          // if the document is published and the schema is not live edit, we want to update the draft id, not the published id
+          // If it's a version, we can update the version document.
+          if (isPublishedId(documentId) && !liveEdit) {
+            linkedDocument._id = getDraftId(documentId)
+          }
+          await client.createOrReplace(linkedDocument)
         }
-
-        // if the document is published and the schema is not live edit, we want to update the draft id, not the published id
-        // If it's a version, we can update the version document.
-        if (isPublishedId(documentId) && !liveEdit) {
-          linkedDocument._id = getDraftId(documentId)
-        }
-        await client.createOrReplace(linkedDocument)
       } catch (err) {
         // The fetch or write failed (e.g. insufficient permissions) —
         // tell the user.
@@ -187,14 +186,12 @@ function IncomingReferencesTypeList({
           description: err instanceof Error ? err.message : undefined,
           status: 'error',
         })
-        // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
-      } finally {
-        // Always clear the optimistic placeholder. The effect below also clears
-        // it once the linked document shows up in `documents`, but that never
-        // happens if the references stream has degraded to an empty list (e.g.
-        // after a load error), so don't rely on it alone.
-        setNewReferenceId(null)
       }
+      // Always clear the optimistic placeholder. The effect below also clears
+      // it once the linked document shows up in `documents`, but that never
+      // happens if the references stream has degraded to an empty list (e.g.
+      // after a load error), so don't rely on it alone.
+      setNewReferenceId(null)
     },
     [client, onLinkDocument, referenced, publishedExists, toast, schemaType],
   )

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -155,7 +155,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
             if (!template || !intent) return null
 
             const resolvedIntent = intent
-            const Link = (linkProps: {children?: ReactNode; ref?: Ref<HTMLElement>}) => {
+            function Link(linkProps: {children?: ReactNode; ref?: Ref<HTMLElement>}) {
               const {ref: linkRef, ...rest} = linkProps
               return disabled ? (
                 <button type="button" disabled {...rest} ref={linkRef as Ref<HTMLButtonElement>} />
@@ -169,9 +169,6 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
                 />
               )
             }
-
-            // oxlint-disable-next-line react/immutability -- displayName assignment on render-local component
-            Link.displayName = 'Link'
 
             const {title} = getI18nText({
               ...item,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Any `oxlint-disable` of `react-hooks/rules-of-hooks` or `exhaustive-deps` makes React Compiler skip the entire component (`Suppression`). Those disables were covering two real issues.

Image asset focus listed `elementProps.ref?.current` as a `useCallback` dep (render-time ref read). The handler already reads `.current` at event time, so it does not need memo wrapping.

Reference search used `useEffectEvent` and passed the result as `onSearch`. React forbids passing Effect Events as props, which is why `rules-of-hooks` was disabled. A plain function in the component is what the compiler is meant to memoize.

Stacked on #14227 (2/5).

### What to review

- `StudioReferenceInput` search still closes over the latest filter/client/perspective values
- Image file-target focus still ignores bubbled child focus

### Testing

Oxlint on the two files is clean without suppressions. End-to-end check is `pnpm dev` on the stack tip with no `Suppression` diagnostics.

### Notes for release

N/A – Internal only.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81cf7506-fcf0-4364-bf43-eb49d8b6a442?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81cf7506-fcf0-4364-bf43-eb49d8b6a442&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

