### PR TITLE
perf(form): reconcile previous values without refs during render

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -43,7 +43,7 @@ import {useDocumentDivergences} from '../../contexts/DivergencesProvider'
 import {SANITY_PATCH_TYPE} from '../../patch/patch'
 import {type ArrayOfObjectsItemMember} from '../../store/types/members'
 import {type ObjectFormNode} from '../../store/types/nodes'
-import {immutableReconcile} from '../../store/utils/immutableReconcile'
+import {useImmutableReconcile} from '../../store/utils/useImmutableReconcile'
 import {type EditorChange, type PortableTextInputProps} from '../../types/inputProps'
 import {Compositor} from './Compositor'
 import {useFullscreenPTE} from './contexts/fullscreen'
@@ -306,55 +306,40 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   )
 
   // Handle editor changes
-  const handleEditorChange = useCallback(
-    (change: EditorChange): void => {
-      switch (change.type) {
-        case 'mutation':
-          onChange(toFormPatches(change.patches))
-          break
-        case 'selection':
-          setFocusPathFromEditorSelection(
-            change.selection,
-            editorRef.current?.getSnapshot() ?? null,
-          )
-          break
-        case 'focus':
-          setIsActive(true)
-          setHasFocusWithin(true)
-          break
-        case 'blur':
-          onBlur(change.event)
-          setHasFocusWithin(false)
-          break
-        case 'invalidValue':
-          setInvalidValue(change)
-          break
-        case 'error':
-          toast.push({
-            status: change.level,
-            description: change.description,
-          })
-          break
-        case 'ready':
-          setReady(true)
-          break
-        default:
-      }
-      if (legacyEditorRef.current && onEditorChange) {
-        onEditorChange(change, legacyEditorRef.current)
-      }
-    },
-    // oxlint-disable-next-line react/preserve-manual-memoization -- pre-existing violation, to be fixed in a follow-up
-    [
-      legacyEditorRef,
-      editorRef,
-      onEditorChange,
-      onChange,
-      setFocusPathFromEditorSelection,
-      onBlur,
-      toast,
-    ],
-  )
+  function handleEditorChange(change: EditorChange): void {
+    switch (change.type) {
+      case 'mutation':
+        onChange(toFormPatches(change.patches))
+        break
+      case 'selection':
+        setFocusPathFromEditorSelection(change.selection, editorRef.current?.getSnapshot() ?? null)
+        break
+      case 'focus':
+        setIsActive(true)
+        setHasFocusWithin(true)
+        break
+      case 'blur':
+        onBlur(change.event)
+        setHasFocusWithin(false)
+        break
+      case 'invalidValue':
+        setInvalidValue(change)
+        break
+      case 'error':
+        toast.push({
+          status: change.level,
+          description: change.description,
+        })
+        break
+      case 'ready':
+        setReady(true)
+        break
+      default:
+    }
+    if (legacyEditorRef.current && onEditorChange) {
+      onEditorChange(change, legacyEditorRef.current)
+    }
+  }
 
   useEffect(() => {
     // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
@@ -366,23 +351,19 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     setIgnoreValidationError(true)
   }, [])
 
-  const respondToInvalidContent = useMemo(() => {
-    if (invalidValue && invalidValue.resolution) {
-      return (
-        <Box marginBottom={2}>
-          <RespondToInvalidContent
-            onChange={handleEditorChange}
-            onIgnore={handleIgnoreInvalidValue}
-            resolution={invalidValue.resolution}
-            readOnly={readOnly}
-          />
-        </Box>
-      )
-    }
-    return null
-  }, [handleEditorChange, handleIgnoreInvalidValue, invalidValue, readOnly])
+  const respondToInvalidContent =
+    invalidValue && invalidValue.resolution ? (
+      <Box marginBottom={2}>
+        <RespondToInvalidContent
+          onChange={handleEditorChange}
+          onIgnore={handleIgnoreInvalidValue}
+          resolution={invalidValue.resolution}
+          readOnly={readOnly}
+        />
+      </Box>
+    ) : null
 
-  const handleActivate = useCallback((): void => {
+  function handleActivate(): void {
     if (!isActive) {
       setIsActive(true)
       if (legacyEditorRef.current) {
@@ -390,10 +371,9 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         PortableTextEditor.focus(legacyEditorRef.current)
       }
     }
-    // oxlint-disable-next-line react/preserve-manual-memoization -- pre-existing violation, to be fixed in a follow-up
-  }, [legacyEditorRef, isActive])
+  }
 
-  const previousRangeDecorations = useRef<RangeDecoration[]>([])
+  const reconcileRangeDecorations = useImmutableReconcile<RangeDecoration[]>()
 
   const rangeDecorations = useMemo((): RangeDecoration[] => {
     // Portable Text Editor cannot reliably handle overlapping range decorations. In the worst case,
@@ -410,12 +390,14 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
       ? diffRangeDecorations
       : [...(rangeDecorationsProp || []), ...presenceCursorDecorations]
 
-    // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
-    const reconciled = immutableReconcile(previousRangeDecorations.current, result)
-    // oxlint-disable-next-line react/refs -- see above
-    previousRangeDecorations.current = reconciled
-    return reconciled
-  }, [diffRangeDecorations, displayInlineChanges, presenceCursorDecorations, rangeDecorationsProp])
+    return reconcileRangeDecorations(result)
+  }, [
+    diffRangeDecorations,
+    displayInlineChanges,
+    presenceCursorDecorations,
+    rangeDecorationsProp,
+    reconcileRangeDecorations,
+  ])
 
   return (
     <Box>

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -43,7 +43,7 @@ import {useDocumentDivergences} from '../../contexts/DivergencesProvider'
 import {SANITY_PATCH_TYPE} from '../../patch/patch'
 import {type ArrayOfObjectsItemMember} from '../../store/types/members'
 import {type ObjectFormNode} from '../../store/types/nodes'
-import {immutableReconcile} from '../../store/utils/immutableReconcile'
+import {useImmutableReconcile} from '../../store/utils/useImmutableReconcile'
 import {type EditorChange, type PortableTextInputProps} from '../../types/inputProps'
 import {Compositor} from './Compositor'
 import {useFullscreenPTE} from './contexts/fullscreen'
@@ -304,55 +304,40 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   )
 
   // Handle editor changes
-  const handleEditorChange = useCallback(
-    (change: EditorChange): void => {
-      switch (change.type) {
-        case 'mutation':
-          onChange(toFormPatches(change.patches))
-          break
-        case 'selection':
-          setFocusPathFromEditorSelection(
-            change.selection,
-            editorRef.current?.getSnapshot() ?? null,
-          )
-          break
-        case 'focus':
-          setIsActive(true)
-          setHasFocusWithin(true)
-          break
-        case 'blur':
-          onBlur(change.event)
-          setHasFocusWithin(false)
-          break
-        case 'invalidValue':
-          setInvalidValue(change)
-          break
-        case 'error':
-          toast.push({
-            status: change.level,
-            description: change.description,
-          })
-          break
-        case 'ready':
-          setReady(true)
-          break
-        default:
-      }
-      if (legacyEditorRef.current && onEditorChange) {
-        onEditorChange(change, legacyEditorRef.current)
-      }
-    },
-    // oxlint-disable-next-line react/preserve-manual-memoization -- pre-existing violation, to be fixed in a follow-up
-    [
-      legacyEditorRef,
-      editorRef,
-      onEditorChange,
-      onChange,
-      setFocusPathFromEditorSelection,
-      onBlur,
-      toast,
-    ],
-  )
+  function handleEditorChange(change: EditorChange): void {
+    switch (change.type) {
+      case 'mutation':
+        onChange(toFormPatches(change.patches))
+        break
+      case 'selection':
+        setFocusPathFromEditorSelection(change.selection, editorRef.current?.getSnapshot() ?? null)
+        break
+      case 'focus':
+        setIsActive(true)
+        setHasFocusWithin(true)
+        break
+      case 'blur':
+        onBlur(change.event)
+        setHasFocusWithin(false)
+        break
+      case 'invalidValue':
+        setInvalidValue(change)
+        break
+      case 'error':
+        toast.push({
+          status: change.level,
+          description: change.description,
+        })
+        break
+      case 'ready':
+        setReady(true)
+        break
+      default:
+    }
+    if (legacyEditorRef.current && onEditorChange) {
+      onEditorChange(change, legacyEditorRef.current)
+    }
+  }
 
   useEffect(() => {
     // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
@@ -364,23 +349,19 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     setIgnoreValidationError(true)
   }, [])
 
-  const respondToInvalidContent = useMemo(() => {
-    if (invalidValue && invalidValue.resolution) {
-      return (
-        <Box marginBottom={2}>
-          <RespondToInvalidContent
-            onChange={handleEditorChange}
-            onIgnore={handleIgnoreInvalidValue}
-            resolution={invalidValue.resolution}
-            readOnly={readOnly}
-          />
-        </Box>
-      )
-    }
-    return null
-  }, [handleEditorChange, handleIgnoreInvalidValue, invalidValue, readOnly])
+  const respondToInvalidContent =
+    invalidValue && invalidValue.resolution ? (
+      <Box marginBottom={2}>
+        <RespondToInvalidContent
+          onChange={handleEditorChange}
+          onIgnore={handleIgnoreInvalidValue}
+          resolution={invalidValue.resolution}
+          readOnly={readOnly}
+        />
+      </Box>
+    ) : null
 
-  const handleActivate = useCallback((): void => {
+  function handleActivate(): void {
     if (!isActive) {
       setIsActive(true)
       if (legacyEditorRef.current) {
@@ -388,10 +369,9 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         PortableTextEditor.focus(legacyEditorRef.current)
       }
     }
-    // oxlint-disable-next-line react/preserve-manual-memoization -- pre-existing violation, to be fixed in a follow-up
-  }, [legacyEditorRef, isActive])
+  }
 
-  const previousRangeDecorations = useRef<RangeDecoration[]>([])
+  const reconcileRangeDecorations = useImmutableReconcile<RangeDecoration[]>()
 
   const rangeDecorations = useMemo((): RangeDecoration[] => {
     // Portable Text Editor cannot reliably handle overlapping range decorations. In the worst case,
@@ -408,12 +388,14 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
       ? diffRangeDecorations
       : [...(rangeDecorationsProp || []), ...presenceCursorDecorations]
 
-    // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
-    const reconciled = immutableReconcile(previousRangeDecorations.current, result)
-    // oxlint-disable-next-line react/refs -- see above
-    previousRangeDecorations.current = reconciled
-    return reconciled
-  }, [diffRangeDecorations, displayInlineChanges, presenceCursorDecorations, rangeDecorationsProp])
+    return reconcileRangeDecorations(result)
+  }, [
+    diffRangeDecorations,
+    displayInlineChanges,
+    presenceCursorDecorations,
+    rangeDecorationsProp,
+    reconcileRangeDecorations,
+  ])
 
   return (
     <Box>

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useMemberValidation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useMemberValidation.tsx
@@ -1,9 +1,9 @@
 import {type FormNodeValidation} from '@sanity/types'
-import {useMemo, useRef} from 'react'
+import {useMemo} from 'react'
 
 import {EMPTY_ARRAY} from '../../../../util/empty'
 import {type BaseFormNode} from '../../../store/types/nodes'
-import {immutableReconcile} from '../../../store/utils/immutableReconcile'
+import {useImmutableReconcile} from '../../../store/utils/useImmutableReconcile'
 import {useChildValidation} from '../../../studio/contexts/Validation'
 import {isBlockType} from '../_helpers'
 
@@ -11,7 +11,6 @@ const NONEXISTENT_PATH = ['@@_NONEXISTENT_PATH_@@']
 
 /** @internal */
 export function useMemberValidation(member: BaseFormNode | undefined) {
-  const prev = useRef<FormNodeValidation[] | null>(null)
   const memberValidation =
     member?.validation && member.validation.length > 0 ? member.validation : EMPTY_ARRAY
   const childValidation = useChildValidation(member?.path || NONEXISTENT_PATH)
@@ -33,10 +32,8 @@ export function useMemberValidation(member: BaseFormNode | undefined) {
     [validation],
   )
 
-  // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
-  const reconciled = immutableReconcile(prev.current, validation)
-  // oxlint-disable-next-line react/refs -- see above
-  prev.current = reconciled
+  const reconcile = useImmutableReconcile<FormNodeValidation[]>()
+  const reconciled = reconcile(validation)
 
   return useMemo(() => {
     return {

--- a/packages/sanity/src/core/form/store/utils/__tests__/useImmutableReconcile.test.ts
+++ b/packages/sanity/src/core/form/store/utils/__tests__/useImmutableReconcile.test.ts
@@ -1,0 +1,50 @@
+import {renderHook} from '@testing-library/react'
+import {StrictMode} from 'react'
+import {describe, expect, it} from 'vitest'
+
+import {useImmutableReconcile} from '../useImmutableReconcile'
+
+describe('useImmutableReconcile', () => {
+  it('returns the previous identity when the next value is deeply equal', () => {
+    const {result, rerender} = renderHook(
+      ({value}: {value: {arr: {foo: string}[]}}) => {
+        const reconcile = useImmutableReconcile<typeof value>()
+        return reconcile(value)
+      },
+      {initialProps: {value: {arr: [{foo: 'bar'}]}}},
+    )
+
+    const first = result.current
+    rerender({value: {arr: [{foo: 'bar'}]}})
+    expect(result.current).toBe(first)
+  })
+
+  it('returns a new identity when the next value differs', () => {
+    const {result, rerender} = renderHook(
+      ({value}: {value: {foo: string}}) => {
+        const reconcile = useImmutableReconcile<typeof value>()
+        return reconcile(value)
+      },
+      {initialProps: {value: {foo: 'bar'}}},
+    )
+
+    const first = result.current
+    rerender({value: {foo: 'baz'}})
+    expect(result.current).not.toBe(first)
+    expect(result.current).toEqual({foo: 'baz'})
+  })
+
+  it('keeps previous identity under StrictMode when values are equal', () => {
+    const {result, rerender} = renderHook(
+      ({value}: {value: {foo: string}}) => {
+        const reconcile = useImmutableReconcile<typeof value>()
+        return reconcile(value)
+      },
+      {initialProps: {value: {foo: 'bar'}}, wrapper: StrictMode},
+    )
+
+    const first = result.current
+    rerender({value: {foo: 'bar'}})
+    expect(result.current).toBe(first)
+  })
+})

--- a/packages/sanity/src/core/form/store/utils/useImmutableReconcile.ts
+++ b/packages/sanity/src/core/form/store/utils/useImmutableReconcile.ts
@@ -1,0 +1,22 @@
+import {useState} from 'react'
+
+import {immutableReconcile} from './immutableReconcile'
+
+/**
+ * Returns a stable function that structurally shares the previous value when the
+ * next value is deeply equal. Keeps previous identity in a closure instead of a
+ * ref so React Compiler can compile the calling component.
+ *
+ * @internal
+ */
+export function useImmutableReconcile<T>(): (value: T) => T {
+  const [reconcile] = useState(() => {
+    let last: T | null = null
+    return (value: T) => {
+      const next = immutableReconcile(last, value)
+      last = next
+      return next
+    }
+  })
+  return reconcile
+}

--- a/packages/sanity/src/core/form/studio/contexts/Presence.tsx
+++ b/packages/sanity/src/core/form/studio/contexts/Presence.tsx
@@ -1,10 +1,10 @@
 import {type Path} from '@sanity/types'
 import {isEqual, startsWith} from '@sanity/util/paths'
-import {type ReactNode, useContext, useRef} from 'react'
+import {type ReactNode, useContext} from 'react'
 import {PresenceContext} from 'sanity/_singletons'
 
 import {type FormNodePresence} from '../../../presence/types'
-import {immutableReconcile} from '../../store/utils/immutableReconcile'
+import {useImmutableReconcile} from '../../store/utils/useImmutableReconcile'
 
 export function PresenceProvider(props: {presence: FormNodePresence[]; children: ReactNode}) {
   return (
@@ -27,15 +27,10 @@ export function useFormFieldPresence(): FormNodePresence[] {
  */
 export function useChildPresence(path: Path, inclusive?: boolean): FormNodePresence[] {
   const presence = useFormFieldPresence()
-  const prev = useRef(presence)
-  const next = immutableReconcile(
-    // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
-    prev.current,
+  const reconcile = useImmutableReconcile<FormNodePresence[]>()
+  return reconcile(
     presence.filter(
       (item) => startsWith(path, item.path) && (inclusive || !isEqual(path, item.path)),
     ),
   )
-  // oxlint-disable-next-line react/refs -- see above
-  prev.current = next
-  return next
 }

--- a/packages/sanity/src/core/form/studio/contexts/Presence.tsx
+++ b/packages/sanity/src/core/form/studio/contexts/Presence.tsx
@@ -1,10 +1,10 @@
 import {type Path} from '@sanity/types'
 import {isEqual, startsWith} from '@sanity/util/paths'
-import {type ReactNode, useContext, useRef} from 'react'
+import {type ReactNode, useContext} from 'react'
 import {PresenceContext} from 'sanity/_singletons'
 
 import {type FormNodePresence} from '../../../presence/types'
-import {immutableReconcile} from '../../store/utils/immutableReconcile'
+import {useImmutableReconcile} from '../../store/utils/useImmutableReconcile'
 
 export function PresenceProvider(props: {presence: FormNodePresence[]; children: ReactNode}) {
   return (
@@ -28,15 +28,10 @@ export function useFormFieldPresence(): FormNodePresence[] {
  */
 export function useChildPresence(path: Path, inclusive?: boolean): FormNodePresence[] {
   const presence = useFormFieldPresence()
-  const prev = useRef(presence)
-  const next = immutableReconcile(
-    // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
-    prev.current,
+  const reconcile = useImmutableReconcile<FormNodePresence[]>()
+  return reconcile(
     presence.filter(
       (item) => startsWith(path, item.path) && (inclusive || !isEqual(path, item.path)),
     ),
   )
-  // oxlint-disable-next-line react/refs -- see above
-  prev.current = next
-  return next
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

React Compiler skips a component that reads or writes `ref.current` during render (`Refs`), and it also skips when a `useCallback` dep list names a ref object while the body reads `ref.current` (`PreserveManualMemo`).

Presence, PTE member validation, and PTE range decorations only used those refs to structurally share the previous `immutableReconcile` result. `useFormState` already does this with a `useState` closure. That pattern is now `useImmutableReconcile`.

PTE `handleEditorChange` / `handleActivate` dropped their `useCallback` wrappers for the same reason: the compiler infers `legacyEditorRef.current`, which cannot appear in a dep array without a render-time ref read.

**Still needed after the `oxc-transform-react` 0.148 bump:** that version stopped logging recoverable bail-outs, so `sanity dev` is quiet now, but the compiler still skips `useChildPresence`, `useMemberValidation`, and `PortableTextInput` on `main`. This branch flips all three to compiled (verified by transforming the files and checking for the `_c()` cache) and removes six grandfathered `react/refs` / `react/preserve-manual-memoization` suppressions.

Rebased onto `main`: #14226 merged, #14227 was closed (compiler auto-opts-out `useVirtualizer`), #14228 landed via #13970. Only this PR's own commit remains. The stack still lists the closed #14228 as this PR's base, so the "Files changed" tab is wrong until that entry is removed from the stack; the real diff is `git diff main...cursor/compiler-reconcile-a442` (5 files).

### What to review

- `useImmutableReconcile`: closure via `useState`, same semantics as the old ref-based reconcile
- `Presence.tsx`, `useMemberValidation.tsx`, `PortableTextInput.tsx` call sites (`packages/sanity`)
- PTE `handleEditorChange` / `handleActivate` as plain functions; `respondToInvalidContent` no longer memoized (its `useMemo` deps could not be satisfied)

### Testing

- New `useImmutableReconcile.test.ts` (identity preserved when deeply equal, including StrictMode)
- `pnpm vitest run --project=sanity` on `useImmutableReconcile` + `immutableReconcile`: pass
- `oxc-transform-react` 0.148 per-function check on this branch: `useChildPresence`, `useMemberValidation`, `PortableTextInput` compiled (all skipped on `main`)

### Notes for release

N/A – Internal only. Lets more form components compile under React Compiler; no user-facing API change.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81cf7506-fcf0-4364-bf43-eb49d8b6a442?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81cf7506-fcf0-4364-bf43-eb49d8b6a442&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

