### PR TITLE
fix(search): exclude agent versions from raw perspective results

### DIFF
--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  EXCLUDE_AGENT_VERSIONS_GROQ,
+  getExcludeAgentVersionsFilter,
+} from './excludeAgentVersionsFilter'
+
+describe('getExcludeAgentVersionsFilter', () => {
+  it('returns the agent-version exclusion when perspective is raw', () => {
+    expect(getExcludeAgentVersionsFilter('raw')).toBe(EXCLUDE_AGENT_VERSIONS_GROQ)
+  })
+
+  it('returns the agent-version exclusion when raw is in a perspective stack', () => {
+    expect(getExcludeAgentVersionsFilter(['raw'])).toBe(EXCLUDE_AGENT_VERSIONS_GROQ)
+  })
+
+  it('does not exclude agent versions for published, drafts, or release perspectives', () => {
+    expect(getExcludeAgentVersionsFilter(undefined)).toBeUndefined()
+    expect(getExcludeAgentVersionsFilter('published')).toBeUndefined()
+    expect(getExcludeAgentVersionsFilter('drafts')).toBeUndefined()
+    expect(getExcludeAgentVersionsFilter(['rSummer', 'drafts'])).toBeUndefined()
+  })
+
+  it('matches path-based and opaque agent version ids', () => {
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('versions.agent-')
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('_system.bundleId')
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('agent-')
+  })
+})

--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
@@ -28,6 +28,8 @@ describe('getExcludeAgentVersionsFilter', () => {
   })
 
   it('guards the bundleId check so missing _system does not null the filter', () => {
-    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('defined(_system.bundleId)')
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain(
+      '(defined(_system.bundleId) && string::startsWith(_system.bundleId, "agent-"))',
+    )
   })
 })

--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
@@ -1,3 +1,4 @@
+import {evaluate, parse} from 'groq-js'
 import {describe, expect, it} from 'vitest'
 
 import {
@@ -11,7 +12,9 @@ describe('getExcludeAgentVersionsFilter', () => {
   })
 
   it('returns the agent-version exclusion when raw is in a perspective stack', () => {
-    expect(getExcludeAgentVersionsFilter(['raw'])).toBe(EXCLUDE_AGENT_VERSIONS_GROQ)
+    expect(getExcludeAgentVersionsFilter(['rSummer', 'raw', 'drafts'])).toBe(
+      EXCLUDE_AGENT_VERSIONS_GROQ,
+    )
   })
 
   it('does not exclude agent versions for published, drafts, or release perspectives', () => {
@@ -21,15 +24,22 @@ describe('getExcludeAgentVersionsFilter', () => {
     expect(getExcludeAgentVersionsFilter(['rSummer', 'drafts'])).toBeUndefined()
   })
 
-  it('matches path-based and opaque agent version ids', () => {
-    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('versions.agent-')
-    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('_system.bundleId')
-    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('agent-')
-  })
+  it('excludes agent versions without dropping other raw documents', async () => {
+    const dataset = [
+      {_id: 'article'},
+      {_id: 'drafts.article'},
+      {_id: 'versions.release.article', _system: {bundleId: 'release'}},
+      {_id: 'versions.agent-run.article', _system: {bundleId: 'agent-run'}},
+      {_id: 'opaque-agent-version', _system: {bundleId: 'agent-run'}},
+      {_id: 'near-miss', _system: {bundleId: 'not-agent-run'}},
+    ]
+    const value = await evaluate(parse(`*[${EXCLUDE_AGENT_VERSIONS_GROQ}]._id`), {dataset})
 
-  it('guards the bundleId check so missing _system does not null the filter', () => {
-    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain(
-      '(defined(_system.bundleId) && string::startsWith(_system.bundleId, "agent-"))',
-    )
+    expect(await value.get()).toEqual([
+      'article',
+      'drafts.article',
+      'versions.release.article',
+      'near-miss',
+    ])
   })
 })

--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
@@ -26,4 +26,8 @@ describe('getExcludeAgentVersionsFilter', () => {
     expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('_system.bundleId')
     expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('agent-')
   })
+
+  it('guards the bundleId check so missing _system does not null the filter', () => {
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('defined(_system.bundleId)')
+  })
 })

--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
@@ -1,6 +1,6 @@
 import {type ClientPerspective} from '@sanity/client'
 
-import {AGENT_BUNDLE_PREFIX} from '../../store/agent/createAgentBundlesStore'
+import {AGENT_BUNDLE_PREFIX} from '../../store/agent/constants'
 import {VERSION_FOLDER} from '../../util/draftUtils'
 
 const AGENT_VERSION_ID_PREFIX = `${VERSION_FOLDER}.${AGENT_BUNDLE_PREFIX}`
@@ -14,7 +14,7 @@ const AGENT_VERSION_ID_PREFIX = `${VERSION_FOLDER}.${AGENT_BUNDLE_PREFIX}`
  * `null`, and `false || null` stays `null`. GROQ filters only keep `true`,
  * so a bare `startsWith` on that field would drop those documents from search.
  */
-const IS_AGENT_VERSION_GROQ = `(string::startsWith(_id, "${AGENT_VERSION_ID_PREFIX}") || defined(_system.bundleId) && string::startsWith(_system.bundleId, "${AGENT_BUNDLE_PREFIX}"))`
+const IS_AGENT_VERSION_GROQ = `(string::startsWith(_id, "${AGENT_VERSION_ID_PREFIX}") || (defined(_system.bundleId) && string::startsWith(_system.bundleId, "${AGENT_BUNDLE_PREFIX}")))`
 
 /**
  * Filter used when searching with `perspective: 'raw'` so agent versions do not

--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
@@ -8,8 +8,13 @@ const AGENT_VERSION_ID_PREFIX = `${VERSION_FOLDER}.${AGENT_BUNDLE_PREFIX}`
 /**
  * GROQ clause that matches Content Agent version documents: path-based ids
  * (`versions.agent-*.<id>`) and opaque ids that carry an agent `_system.bundleId`.
+ *
+ * `defined()` is required before reading `_system.bundleId`: published and
+ * classic draft documents leave it unset, `string::startsWith(null, …)` is
+ * `null`, and `false || null` stays `null`. GROQ filters only keep `true`,
+ * so a bare `startsWith` on that field would drop those documents from search.
  */
-const IS_AGENT_VERSION_GROQ = `(string::startsWith(_id, "${AGENT_VERSION_ID_PREFIX}") || string::startsWith(_system.bundleId, "${AGENT_BUNDLE_PREFIX}"))`
+const IS_AGENT_VERSION_GROQ = `(string::startsWith(_id, "${AGENT_VERSION_ID_PREFIX}") || defined(_system.bundleId) && string::startsWith(_system.bundleId, "${AGENT_BUNDLE_PREFIX}"))`
 
 /**
  * Filter used when searching with `perspective: 'raw'` so agent versions do not

--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
@@ -1,0 +1,43 @@
+import {type ClientPerspective} from '@sanity/client'
+
+import {AGENT_BUNDLE_PREFIX} from '../../store/agent/createAgentBundlesStore'
+import {VERSION_FOLDER} from '../../util/draftUtils'
+
+const AGENT_VERSION_ID_PREFIX = `${VERSION_FOLDER}.${AGENT_BUNDLE_PREFIX}`
+
+/**
+ * GROQ clause that matches Content Agent version documents: path-based ids
+ * (`versions.agent-*.<id>`) and opaque ids that carry an agent `_system.bundleId`.
+ */
+const IS_AGENT_VERSION_GROQ = `(string::startsWith(_id, "${AGENT_VERSION_ID_PREFIX}") || string::startsWith(_system.bundleId, "${AGENT_BUNDLE_PREFIX}"))`
+
+/**
+ * Filter used when searching with `perspective: 'raw'` so agent versions do not
+ * appear as duplicate, often inaccessible hits.
+ *
+ * @internal
+ */
+export const EXCLUDE_AGENT_VERSIONS_GROQ = `!${IS_AGENT_VERSION_GROQ}`
+
+/**
+ * Agent versions are only readable by their author. `perspective: 'raw'` still
+ * returns them as distinct hits, which show up as duplicate empty documents for
+ * everyone else. Searching while an agent bundle is selected is unaffected:
+ * that perspective rewrites `_id` to the published id, so this filter does not
+ * apply.
+ *
+ * Own agent versions are also excluded. They still duplicate the published or
+ * draft article in global search, and authors can open proposed changes from
+ * the document itself.
+ *
+ * @internal
+ */
+export function getExcludeAgentVersionsFilter(
+  perspective: ClientPerspective | undefined,
+): string | undefined {
+  if (perspective === 'raw') return EXCLUDE_AGENT_VERSIONS_GROQ
+  if (Array.isArray(perspective) && perspective.includes('raw')) {
+    return EXCLUDE_AGENT_VERSIONS_GROQ
+  }
+  return undefined
+}

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -2,6 +2,7 @@ import {Schema} from '@sanity/schema'
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
 
+import {EXCLUDE_AGENT_VERSIONS_GROQ} from '../common/excludeAgentVersionsFilter'
 import {DEFAULT_LIMIT} from '../weighted/createSearchQuery'
 import {createSearchQuery} from './createSearchQuery'
 
@@ -181,6 +182,59 @@ describe('createSearchQuery', () => {
 
       expect(query).toContain('*[_type in $__types && (randomCondition == $customParam)]')
       expect(params.customParam).toEqual('custom')
+    })
+
+    it('should exclude agent versions when perspective is raw', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        '',
+        {perspective: 'raw'},
+      )
+
+      expect(query).toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should not exclude agent versions when perspective is not raw', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        '',
+        {perspective: ['rSummer', 'drafts']},
+      )
+
+      expect(query).not.toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should AND agent-version exclusion with an existing filter when perspective is raw', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        '',
+        {filter: 'randomCondition == $customParam', perspective: 'raw'},
+      )
+
+      expect(query).toContain(
+        `*[_type in $__types && ${EXCLUDE_AGENT_VERSIONS_GROQ} && (randomCondition == $customParam)]`,
+      )
     })
 
     it('should use configured tag', () => {

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -8,6 +8,7 @@ import groupBy from 'lodash-es/groupBy.js'
 
 import {compileSortExpression, type CompiledSortEntry} from '../common/compileSortExpression'
 import {deriveSearchWeightsFromType2024} from '../common/deriveSearchWeightsFromType2024'
+import {getExcludeAgentVersionsFilter} from '../common/excludeAgentVersionsFilter'
 import {prefixLast} from '../common/token'
 import {toOrderClause} from '../common/toOrderClause'
 import {
@@ -135,11 +136,13 @@ export function createSearchQuery(
   // Unscored has no `[_score > 0]` gate, so the reference match must live in the
   // filter for documents found only through a referenced leaf to surface.
   const unscoredMatch = hasReferenceIds ? `(${baseMatch} || references($__refIds))` : baseMatch
+  const excludeAgentVersions = getExcludeAgentVersionsFilter(perspective)
 
   const filters: string[] = [
     '_type in $__types',
     // If the search request doesn't use scoring, directly filter documents.
     isScored ? [] : unscoredMatch,
+    excludeAgentVersions ?? [],
     filter ? `(${filter})` : [],
     searchTerms.filter ? `(${searchTerms.filter})` : [],
     cursor ?? [],

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
@@ -2,6 +2,7 @@ import {Schema} from '@sanity/schema'
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import {describe, expect, it, test} from 'vitest'
 
+import {EXCLUDE_AGENT_VERSIONS_GROQ} from '../common/excludeAgentVersionsFilter'
 import {FINDABILITY_MVI} from '../constants'
 import {
   createSearchQuery,
@@ -325,6 +326,44 @@ describe('createSearchQuery', () => {
         '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && (randomCondition == $customParam)]',
       )
       expect(params.customParam).toEqual('custom')
+    })
+
+    it('should exclude agent versions when perspective is raw', () => {
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        {perspective: 'raw'},
+      )
+
+      expect(query).toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should not exclude agent versions when perspective is not raw', () => {
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        {perspective: ['rSummer', 'drafts']},
+      )
+
+      expect(query).not.toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should AND agent-version exclusion with an existing filter when perspective is raw', () => {
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        {filter: 'randomCondition == $customParam', perspective: 'raw'},
+      )
+
+      expect(query).toContain(
+        `*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && ${EXCLUDE_AGENT_VERSIONS_GROQ} && (randomCondition == $customParam)]`,
+      )
     })
 
     it('should add configured common limit', () => {

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -11,6 +11,7 @@ import words from 'lodash-es/words.js'
 
 import {compileSortExpression} from '../common/compileSortExpression'
 import {deriveSearchWeightsFromType} from '../common/deriveSearchWeightsFromType'
+import {getExcludeAgentVersionsFilter} from '../common/excludeAgentVersionsFilter'
 import {toOrderClause} from '../common/toOrderClause'
 import {
   ORDERINGS_PROJECTION_KEY,
@@ -133,11 +134,13 @@ export function createSearchQuery(
 
   // Extract search terms from string query, factoring in phrases wrapped in quotes
   const terms = extractTermsFromQuery(searchTerms.query)
+  const excludeAgentVersions = getExcludeAgentVersionsFilter(perspective)
 
   // Construct search filters used in this GROQ query
   const filters = [
     '_type in $__types',
     ...createConstraints(terms, specs),
+    excludeAgentVersions ?? '',
     filter ? `(${filter})` : '',
     searchTerms.filter ? `(${searchTerms.filter})` : '',
   ].filter(Boolean)

--- a/packages/sanity/src/core/store/agent/constants.ts
+++ b/packages/sanity/src/core/store/agent/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Prefix for Content Agent bundle ids (`agent-<id>`) and version document ids
+ * (`versions.agent-<id>.<publishedId>`).
+ *
+ * Kept in this leaf module so search can reuse it without importing the
+ * agent-bundles store (rxjs + EventSource listener).
+ *
+ * @internal
+ */
+export const AGENT_BUNDLE_PREFIX = 'agent-'

--- a/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
+++ b/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
@@ -13,7 +13,8 @@ import {
   switchMap,
 } from 'rxjs'
 
-const AGENT_BUNDLE_PREFIX = 'agent-'
+/** @internal */
+export const AGENT_BUNDLE_PREFIX = 'agent-'
 
 /**
  * A single active agent bundle as reported by the SSE endpoint.

--- a/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
+++ b/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
@@ -13,8 +13,7 @@ import {
   switchMap,
 } from 'rxjs'
 
-/** @internal */
-export const AGENT_BUNDLE_PREFIX = 'agent-'
+import {AGENT_BUNDLE_PREFIX} from './constants'
 
 /**
  * A single active agent bundle as reported by the SSE endpoint.

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -233,6 +233,9 @@ export function SearchProvider({
           skipSortByScore: ordering.ignoreScore,
           ...(ordering.sort ? {sort: [ordering.sort]} : {}),
           cursor: cursor || undefined,
+          // Raw so drafts, published, and release versions are all findable.
+          // Agent versions are dropped in the search GROQ — they are only
+          // readable by their author and otherwise appear as empty duplicates.
           perspective: 'raw',
         },
         terms: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Global search uses `perspective=raw` so drafts, published docs, and release versions are all findable. That also returns Content Agent versions (`versions.agent-*` and opaque ids with an agent `_system.bundleId`). Those versions are only readable by their author, so everyone else gets duplicate hits that open an empty document.

This filters agent versions out of both groq2024 and weighted search whenever the perspective is `raw`. Searching while an agent bundle is selected is unchanged: that perspective rewrites `_id` to the published id, so the filter does not apply.

Keeping the current user's own agent versions was considered and rejected: they still duplicate the published/draft article in global search, and wiring ownership through the agent-bundles SSE would re-run search as bundles load. Authors can still open proposed changes from the document itself.

Fixes [SAPP-3895](https://linear.app/sanity/issue/SAPP-3895/search-shows-duplicate-inaccessible-agent-documents)

### What to review

- `getExcludeAgentVersionsFilter` and that it only applies for `perspective: 'raw'`
- Both search strategies (`groq2024` and weighted) AND the filter with existing constraints
- Whether excluding *all* agent versions from raw search is the right call vs keeping the author's

Affected package: `sanity`.

### Testing

Unit tests cover the filter helper and both `createSearchQuery` builders: raw perspective excludes agent versions, other perspectives do not, and an existing `filter` is still AND-ed. The helper test executes the generated GROQ against representative published, draft, release, path-based agent, opaque agent, and near-miss documents so GROQ null/three-valued-logic regressions fail directly.

### Notes for release

Studio search no longer lists Content Agent document versions when querying across all versions. Those versions were often duplicates of the real article and opened as empty documents for anyone who was not the author.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75dd764b-b817-49b1-8fe5-4adf2f190fe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75dd764b-b817-49b1-8fe5-4adf2f190fe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

