### PR TITLE
test(form): cover url skip required two-arg validation

### DIFF
--- a/dev/test-studio/schema/debug/twoArgValidationRepro.ts
+++ b/dev/test-studio/schema/debug/twoArgValidationRepro.ts
@@ -2,22 +2,20 @@
  * Reproduction schema for https://linear.app/sanity/issue/SAPP-4084
  * and the customer report in https://linear.app/sanity/issue/SAPP-3960
  *
- * Issue: `url`, `number`, and `array` fields crash at render when their
- * `validation` is a two-argument function `(rule, context) => ...`:
+ * Used to crash: `url`, `number`, and `array` fields threw at render when
+ * `validation` was a two-argument function `(rule, context) => ...`:
  *
  *   Schema type "url"'s `validation` was not run though `inferFromSchema`
  *
- * The single-argument form `(rule) => ...` works. The docs recommend the
- * two-argument form for conditionally hidden fields, but only `string` (and
- * other inputs that never call `getValidationRule`) survive it today.
+ * Fixed in #13878 (sanity@6.9.1). Keep this type to manually confirm
+ * two-arg validation still renders, and that skip/required + hidden on url
+ * matches string (SAPP-3960).
  *
- * Manual repro:
- * 1. Structure → Inputs → Debug → Two-arg validation repro (SAPP-4084).
- * 2. Create a new document.
- * 3. `url`, `number`, and `array` fields should render (they used to show a
- *    red "An error occurred" box). The `string` control field is the baseline.
- * 4. Toggle "Hide fields" to confirm skip/required two-arg validation on url
- *    still hides and skips the same way as string (SAPP-3960).
+ * Manual check:
+ * 1. Structure → Inputs → Debug → Two-arg validation repro.
+ * 2. Create a new document — url/number/array should render as inputs.
+ * 3. Toggle "Hide fields" — the skip/required url and string fields hide
+ *    and should not fail required validation.
  */
 import {defineArrayMember, defineField, defineType} from 'sanity'
 

--- a/dev/test-studio/schema/debug/twoArgValidationRepro.ts
+++ b/dev/test-studio/schema/debug/twoArgValidationRepro.ts
@@ -1,5 +1,6 @@
 /**
  * Reproduction schema for https://linear.app/sanity/issue/SAPP-4084
+ * and the customer report in https://linear.app/sanity/issue/SAPP-3960
  *
  * Issue: `url`, `number`, and `array` fields crash at render when their
  * `validation` is a two-argument function `(rule, context) => ...`:
@@ -13,16 +14,18 @@
  * Manual repro:
  * 1. Structure → Inputs → Debug → Two-arg validation repro (SAPP-4084).
  * 2. Create a new document.
- * 3. `url`, `number`, and `array` fields show a red "An error occurred" box.
- * 4. `string` control field renders normally.
+ * 3. `url`, `number`, and `array` fields should render (they used to show a
+ *    red "An error occurred" box). The `string` control field is the baseline.
+ * 4. Toggle "Hide fields" to confirm skip/required two-arg validation on url
+ *    still hides and skips the same way as string (SAPP-3960).
  */
 import {defineArrayMember, defineField, defineType} from 'sanity'
 
 export const twoArgValidationRepro = defineType({
   name: 'twoArgValidationRepro',
   type: 'document',
-  title: 'Two-arg validation repro (SAPP-4084)',
-  description: 'url/number/array fields crash when validation uses (rule, context) => ...',
+  title: 'Two-arg validation repro (SAPP-4084 / SAPP-3960)',
+  description: 'url/number/array fields used to crash when validation uses (rule, context) => ...',
   fields: [
     defineField({
       name: 'title',
@@ -37,23 +40,42 @@ export const twoArgValidationRepro = defineType({
       title: 'How to reproduce',
       readOnly: true,
       initialValue:
-        'The url, number, and array fields below use two-argument validation and crash at render. The string control field uses the same pattern but works.',
+        'The url, number, and array fields below use two-argument validation and used to crash at render. Toggle Hide fields to exercise skip/required on url vs string (SAPP-3960).',
+    }),
+
+    defineField({
+      name: 'hideFields',
+      type: 'boolean',
+      title: 'Hide fields',
+      description:
+        'When true, the skip/required url and string fields below should hide and skip validation (SAPP-3960).',
+      initialValue: false,
     }),
 
     defineField({
       name: 'link',
       type: 'url',
-      title: 'URL (two-arg validation — crashes)',
+      title: 'URL (two-arg validation)',
       description:
-        'Two-argument validation on url fields triggers getValidationRule during render.',
+        'Two-argument validation on url fields used to crash getValidationRule during render.',
       validation: (rule, context) =>
         context?.hidden ? rule.skip() : rule.required().uri({scheme: ['https']}),
     }),
 
     defineField({
+      name: 'conditionalUrl',
+      type: 'url',
+      title: 'URL skip/required (SAPP-3960)',
+      description:
+        'Exact customer pattern: two-arg skip/required plus hidden. Used to throw inferFromSchema.',
+      hidden: ({parent}) => parent?.hideFields === true,
+      validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required()),
+    }),
+
+    defineField({
       name: 'amount',
       type: 'number',
-      title: 'Number (two-arg validation — crashes)',
+      title: 'Number (two-arg validation)',
       description:
         'Two-argument validation on number fields triggers getValidationRule during render.',
       validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required().min(1)),
@@ -62,7 +84,7 @@ export const twoArgValidationRepro = defineType({
     defineField({
       name: 'tags',
       type: 'array',
-      title: 'Array (two-arg validation — crashes)',
+      title: 'Array (two-arg validation)',
       description:
         'Two-argument validation on array fields triggers getValidationRule during render.',
       of: [defineArrayMember({type: 'string'})],
@@ -72,9 +94,9 @@ export const twoArgValidationRepro = defineType({
     defineField({
       name: 'label',
       type: 'string',
-      title: 'String control (two-arg validation — works)',
-      description:
-        'Same two-argument pattern on string; StringInput never reads validation rules at render.',
+      title: 'String skip/required (SAPP-3960 control)',
+      description: 'Same skip/required + hidden pattern on string, which never crashed at render.',
+      hidden: ({parent}) => parent?.hideFields === true,
       validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required().min(1)),
     }),
   ],
@@ -83,7 +105,7 @@ export const twoArgValidationRepro = defineType({
     prepare({title}) {
       return {
         title: title || 'Two-arg validation repro',
-        subtitle: 'SAPP-4084',
+        subtitle: 'SAPP-4084 / SAPP-3960',
       }
     },
   },

--- a/packages/sanity/src/core/form/inputs/UrlInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/UrlInput.test.tsx
@@ -45,4 +45,19 @@ describe('url-input', () => {
 
     expect(result.container.querySelector('input')).toHaveAttribute('type', 'text')
   })
+
+  it('renders when two-arg validation only calls skip or required (SAPP-3960)', async () => {
+    const {result} = await renderStringInput({
+      fieldDefinition: {
+        name: 'url',
+        title: 'Url',
+        type: 'url',
+        hidden: ({parent}) => parent?.hideFields === true,
+        validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required()),
+      },
+      render: (inputProps) => <UrlInput {...inputProps} />,
+    })
+
+    expect(result.container.querySelector('input')).toHaveAttribute('type', 'url')
+  })
 })

--- a/packages/sanity/src/core/form/utils/getValidationRule.test.ts
+++ b/packages/sanity/src/core/form/utils/getValidationRule.test.ts
@@ -66,6 +66,12 @@ const schema = createSchema({
           // validating a document
           validation: (rule, context) => rule.uri({scheme: [context!.document!._type]}),
         }),
+        defineField({
+          name: 'urlSkipRequired',
+          type: 'url',
+          hidden: ({parent}) => parent?.hideFields === true,
+          validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required()),
+        }),
       ],
     }),
     arrayValidationDoc,
@@ -114,5 +120,11 @@ describe('getValidationRule', () => {
     expect(
       getValidationRule(getFieldType('validationArity', 'urlUnsafeContextAccess'), 'uri'),
     ).toBeNull()
+  })
+
+  test('keeps default url uri and required hints for skip/required two-arg validation (SAPP-3960)', () => {
+    const type = getFieldType('validationArity', 'urlSkipRequired')
+    expect(getValidationRule(type, 'uri')).not.toBeNull()
+    expect(getValidationRule(type, 'presence')?.constraint).toBe('required')
   })
 })

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -356,6 +356,74 @@ describe('validateItem', () => {
       },
     ])
   })
+
+  it('skips required url validation when the field is hidden (SAPP-3960)', async () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        {
+          name: 'validationRepro',
+          type: 'document',
+          fields: [
+            {name: 'hideFields', type: 'boolean'},
+            {
+              name: 'url',
+              type: 'url',
+              hidden: ({parent}: {parent?: {hideFields?: boolean}}) => parent?.hideFields === true,
+              validation: (rule: RuleWithSkip, context?: ValidationContext) =>
+                context?.hidden ? rule.skip() : rule.required(),
+            },
+            {
+              name: 'string',
+              type: 'string',
+              hidden: ({parent}: {parent?: {hideFields?: boolean}}) => parent?.hideFields === true,
+              validation: (rule: RuleWithSkip, context?: ValidationContext) =>
+                context?.hidden ? rule.skip() : rule.required(),
+            },
+          ],
+        },
+      ],
+    })
+
+    const baseDocument: SanityDocument = {
+      _id: 'validation-repro-id',
+      _type: 'validationRepro',
+      _createdAt: '2024-01-01T00:00:00.000Z',
+      _updatedAt: '2024-01-01T00:00:00.000Z',
+      _rev: 'validation-repro-rev',
+    }
+
+    const validate = (document: SanityDocument) =>
+      validateItem({
+        getClient,
+        schema,
+        value: document,
+        document,
+        parent: undefined,
+        path: [],
+        type: schema.get('validationRepro'),
+        i18n: getFallbackLocaleSource(),
+        environment: 'studio',
+        getDocumentExists: undefined,
+      })
+
+    await expect(validate({...baseDocument, hideFields: true})).resolves.toEqual([])
+
+    await expect(validate({...baseDocument, hideFields: false})).resolves.toMatchObject([
+      {path: ['url'], level: 'error', item: {message: 'Required'}},
+      {path: ['string'], level: 'error', item: {message: 'Required'}},
+    ])
+
+    await expect(
+      validate({
+        ...baseDocument,
+        hideFields: false,
+        url: 'https://example.com',
+        string: 'ok',
+      }),
+    ).resolves.toEqual([])
+  })
+
   it("runs nested validation on an undefined value for object types if it's required", async () => {
     const validation = (rule: Rule) => [
       rule.required().error('This is required!'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

SAPP-3960 is the customer-facing report of the same crash already fixed in SAPP-4084 / #13878 (shipped in 6.9.1): `UrlInput` threw `Schema type "url"'s validation was not run though inferFromSchema` when `validation` used the documented two-argument form.

That PR covered the render crash. The original Polaris schema was specifically skip/required (`(R, ctx) => ctx?.hidden ? R.skip() : R.required()`), which was not locked at the `validateItem` layer — url types also inject a default `.uri()` rule that `skip()` must clear.

No production code change: the runtime path already does the right thing. Alternatives considered:

- Re-open a form-layer fix — the throw is gone; `getValidationRule` already lazy-normalizes two-arg functions.
- Close SAPP-3960 as a duplicate with no extra tests — would leave the exact customer schema unasserted.

### What to review

- `packages/sanity/test/validation/validateDocument.test.ts`: visible empty url/string are required; hidden skips both.
- `UrlInput` / `getValidationRule` tests for the skip/required url field (still reads the default `uri` hint, still renders `type="url"`).
- `dev/test-studio` debug schema: Hide fields toggle matching the customer repro.

### Testing

- New unit tests for `validateItem`, `UrlInput`, and `getValidationRule` using the SAPP-3960 schema.
- Existing two-arg crash coverage in #13878 is unchanged.

### Notes for release

N/A – already shipped in 6.9.1 (`fix(form): resolve context-aware validation rules in inputs`). This PR only adds regression tests for the original customer schema.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b58616-0c9a-4356-999f-5b4489125953?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b58616-0c9a-4356-999f-5b4489125953&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

