### PR TITLE
fix(core): hide agent versions from the document versions tooltip

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -30,6 +30,7 @@ import {getDocumentVersionStatusTitle} from './getDocumentVersionStatusTitle'
 import {
   type DocumentVersionStatusItem,
   groupDocumentVersionsForStatus,
+  SHOW_AGENT_VERSIONS_IN_STATUS,
 } from './sortDocumentVersionsForStatus'
 
 /**
@@ -46,7 +47,11 @@ export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: stri
   const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
 
   const versionGroups = useMemo(
-    () => groupDocumentVersionsForStatus(versions, releases ?? [], variantsById, variantsEnabled),
+    () =>
+      groupDocumentVersionsForStatus(versions, releases ?? [], variantsById, {
+        variantsEnabled,
+        showAgentVersions: SHOW_AGENT_VERSIONS_IN_STATUS,
+      }),
     [releases, variantsById, variantsEnabled, versions],
   )
 

--- a/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
@@ -196,12 +196,25 @@ describe('DocumentVersionsStatus', () => {
   })
 
   it('does not show agent versions in the tooltip', async () => {
-    const agentVersion = createVersion({
-      id: `versions.agent-abc.${GROUP_ID}`,
-      bundleId: 'agent-abc',
+    const ownAgentBundle = 'agent-mine'
+    const otherAgentBundle = 'agent-other'
+    const ownAgentVersion = createVersion({
+      id: `versions.${ownAgentBundle}.${GROUP_ID}`,
+      bundleId: ownAgentBundle,
+    })
+    const otherAgentVersion = createVersion({
+      id: `versions.${otherAgentBundle}.${GROUP_ID}`,
+      bundleId: otherAgentBundle,
     })
 
-    await renderStatus({versions: [publishedDefault, draftDefault, agentVersion]})
+    mockUseAgentBundles.mockReturnValue({
+      bundles: [{id: ownAgentBundle, applicationKey: 'app'}],
+      loading: false,
+    })
+
+    await renderStatus({
+      versions: [publishedDefault, draftDefault, ownAgentVersion, otherAgentVersion],
+    })
 
     expect(screen.getByText('Published')).toBeInTheDocument()
     expect(screen.getByText('Draft')).toBeInTheDocument()

--- a/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
@@ -194,4 +194,18 @@ describe('DocumentVersionsStatus', () => {
     expect(screen.queryByText(/All users/)).not.toBeInTheDocument()
     expect(document.querySelector('[data-sanity-icon="rhombus"]')).not.toBeInTheDocument()
   })
+
+  it('does not show agent versions in the tooltip', async () => {
+    const agentVersion = createVersion({
+      id: `versions.agent-abc.${GROUP_ID}`,
+      bundleId: 'agent-abc',
+    })
+
+    await renderStatus({versions: [publishedDefault, draftDefault, agentVersion]})
+
+    expect(screen.getByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+    expect(screen.queryByText('Proposed changes')).not.toBeInTheDocument()
+    expect(screen.queryByText('Agent changes')).not.toBeInTheDocument()
+  })
 })

--- a/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
@@ -196,7 +196,29 @@ describe('groupDocumentVersionsForStatus', () => {
     ])
   })
 
-  it('sorts agent versions after published, drafts, and releases', () => {
+  it('omits agent versions by default', () => {
+    const groups = groupDocumentVersionsForStatus(
+      [
+        createVersion({
+          id: 'versions.agent-abc.article-1',
+          bundleId: 'agent-abc',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+        }),
+        createVersion({
+          id: 'article-1',
+          createdAt: '2025-06-02T00:00:00Z',
+          updatedAt: '2025-06-02T00:00:00Z',
+        }),
+      ],
+      [],
+      new Map(),
+    )
+
+    expect(groups[0]?.items.map((item) => item.version._id)).toEqual(['article-1'])
+  })
+
+  it('sorts agent versions after published, drafts, and releases when shown', () => {
     const groups = groupDocumentVersionsForStatus(
       [
         createVersion({
@@ -226,6 +248,7 @@ describe('groupDocumentVersionsForStatus', () => {
       ],
       [releaseSummer],
       new Map(),
+      {showAgentVersions: true},
     )
 
     expect(groups[0]?.items.map((item) => item.version._id)).toEqual([
@@ -268,7 +291,7 @@ describe('groupDocumentVersionsForStatus', () => {
       ],
       [releaseSummer],
       new Map([[variantReturning._id, variantReturning]]),
-      false,
+      {variantsEnabled: false},
     )
 
     expect(groups).toHaveLength(1)

--- a/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
+++ b/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
@@ -7,6 +7,19 @@ import {type SystemVariant} from '../../variants/types'
 
 type ReleaseLaneKind = 'published' | 'drafts' | 'release' | 'agent'
 
+/**
+ * Temporary switch for whether agent bundle versions (Proposed changes / Agent changes) appear in
+ * the document versions tooltip. Flip to `true` to show them again.
+ *
+ * @internal
+ */
+export const SHOW_AGENT_VERSIONS_IN_STATUS = false
+
+interface GroupDocumentVersionsForStatusOptions {
+  variantsEnabled?: boolean
+  showAgentVersions?: boolean
+}
+
 const KIND_ORDER: Record<ReleaseLaneKind, number> = {
   published: 0,
   drafts: 1,
@@ -113,7 +126,8 @@ function compareDocumentVersionsForStatus(
  * scheduled, then ASAP (each by date descending). Releases missing from that list fall back to title.
  *
  * When `variantsEnabled` is false, versions that belong to a variant are omitted so the tooltip
- * only lists default-lane perspectives.
+ * only lists default-lane perspectives. Agent bundle versions are omitted unless
+ * `showAgentVersions` is true (see `SHOW_AGENT_VERSIONS_IN_STATUS`).
  *
  * @internal
  */
@@ -121,13 +135,22 @@ export function groupDocumentVersionsForStatus(
   versions: VersionInfoDocumentStub[],
   releases: ReleaseDocument[],
   variantsById: Map<string, SystemVariant>,
-  variantsEnabled = true,
+  {
+    variantsEnabled = true,
+    showAgentVersions = SHOW_AGENT_VERSIONS_IN_STATUS,
+  }: GroupDocumentVersionsForStatusOptions = {},
 ): DocumentVersionStatusGroup[] {
   const sortedReleases = sortReleases(releases)
   const releasesById = new Map(sortedReleases.map((release) => [release._id, release]))
-  const visibleVersions = variantsEnabled
-    ? versions
-    : versions.filter((version) => !version._system.variant?._ref)
+  const visibleVersions = versions.filter((version) => {
+    if (!variantsEnabled && version._system.variant?._ref) {
+      return false
+    }
+    if (!showAgentVersions && readVersionType(version) === 'agent') {
+      return false
+    }
+    return true
+  })
 
   const sortedVersions = visibleVersions.toSorted((left, right) =>
     compareDocumentVersionsForStatus(left, right, releasesById, sortedReleases),


### PR DESCRIPTION
### Description

The new document versions tooltip currently lists agent bundles (Proposed changes / Agent changes) alongside published, draft, and release versions. We want those hidden for now without ripping the sorting/display path out.

A studio config flag was rejected because this is a short-lived toggle; `SHOW_AGENT_VERSIONS_IN_STATUS` in `sortDocumentVersionsForStatus.ts` can be flipped to `true` when we are ready to show them again.

Fixes [SAPP-4331](https://linear.app/sanity/issue/SAPP-4331/hide-agent-changes-from-the-new-documentversionsstatus-tooltip).

### What to review

`packages/sanity` — `groupDocumentVersionsForStatus` now filters agent versions unless the flag is on. Confirm the flag default stays `false` and that passing `{showAgentVersions: true}` still sorts agents last.

### Testing

- Grouping omits agent versions by default and still sorts them last when shown
- Tooltip UI test asserts Proposed changes / Agent changes are not rendered

### Notes for release

The document status tooltip no longer lists agent bundle versions (Proposed changes / Agent changes). Published, draft, and release versions are unchanged.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only filtering of tooltip items; no auth, data, or persistence changes. The grouping API is internal and callers were updated.
> 
> **Overview**
> Hides agent bundle versions (Proposed changes / Agent changes) from the document versions tooltip by default, without removing the grouping/sort path.
> 
> `groupDocumentVersionsForStatus` now takes an options object (`variantsEnabled`, `showAgentVersions`) instead of a boolean. Agent versions are filtered unless `showAgentVersions` is true. A temporary `SHOW_AGENT_VERSIONS_IN_STATUS` flag (currently `false`) can be flipped to restore them. Tests cover omit-by-default and last-in-sort when shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ed1a43bd483d73cad2d5672332aeb7e1015ac2a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->