### PR TITLE
fix: key useDocumentValues memo on path contents to prevent render loops

### DIFF
--- a/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
+++ b/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
@@ -170,11 +170,12 @@ export function RenderLoopRepro() {
               useDocumentValues render loop → stalled document open
             </Text>
             <Text size={1} muted>
-              The preview rows pass an inline paths array to useDocumentValues and re-render in a
-              tight loop. The simulated document open below starts mounting immediately, but every
-              loop iteration restarts it — it stays stuck at "mounting…" until the rows remove
-              themselves after {LOOP_DURATION_MS / 1000} seconds, then lands instantly. The stall
-              lasts exactly as long as the loop.
+              The preview rows pass an inline paths array to useDocumentValues. On studio versions
+              where the hook memoizes on the array reference, the rows re-render in a tight loop and
+              the simulated document open below stays stuck at "mounting…" until the rows remove
+              themselves after {LOOP_DURATION_MS / 1000} seconds — the stall lasts exactly as long
+              as the loop. With the hardened hook (memo keyed on path contents) the rows settle
+              immediately and the mount lands right away.
             </Text>
           </Stack>
         </Card>

--- a/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
+++ b/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
@@ -1,0 +1,192 @@
+import {Badge, Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {startTransition, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {useObservable} from 'react-rx'
+import {combineLatest} from 'rxjs'
+import {useDocumentPreviewStore, useDocumentValues} from 'sanity'
+
+/**
+ * Reproduces a customer-reported stall: document panes that never finish
+ * opening while list previews are on screen.
+ *
+ * The preview rows below call `useDocumentValues(id, ['title'])` with an
+ * inline paths array — the natural call shape. The hook memoizes its
+ * observable on the array REFERENCE, so every render builds a new observable;
+ * react-rx v5 treats each one as a brand-new store whose warm-up replays the
+ * cached value synchronously, and the fresh snapshot forces another render —
+ * a self-sustaining loop.
+ *
+ * The pane simulates opening a document at the same time: a heavy subtree
+ * mounts in a transition the moment the pane opens. Every loop iteration is
+ * an urgent update that restarts the in-flight mount, so the status line
+ * stays stuck at "mounting…" for as long as the loop runs. After 15 seconds
+ * the loop rows remove themselves — and the mount lands immediately. That is
+ * the customer's timeline: the stall lasts exactly as long as the pressure.
+ *
+ * Once useDocumentValues keys its memo on path CONTENTS instead of the array
+ * reference, the rows settle after a couple of renders and the mount
+ * completes right away.
+ *
+ * The cache warmer keeps a stable subscription to the same documents so the
+ * preview store replays synchronously on every resubscribe — without it the
+ * loop ticks at refetch cadence instead of render speed and looks harmless
+ * (in real studios the actual document list plays this role).
+ *
+ * Unit-level twin:
+ * packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
+ */
+
+const DOC_IDS = ['render-loop-1', 'render-loop-2', 'render-loop-3', 'render-loop-4']
+const PREVIEW_PATHS = ['title']
+const LOOP_DURATION_MS = 15_000
+
+const renderCounts = {rows: 0}
+
+function CacheWarmer() {
+  const previewStore = useDocumentPreviewStore()
+  const warm$ = useMemo(
+    () =>
+      combineLatest(
+        DOC_IDS.map((id) =>
+          previewStore.observePaths({_ref: id, _type: 'reference'}, PREVIEW_PATHS),
+        ),
+      ),
+    [previewStore],
+  )
+  useObservable(warm$)
+  return null
+}
+
+function PreviewRow({id}: {id: string}) {
+  // oxlint-disable-next-line react/immutability -- deliberate render counter: this repro exists to make the loop measurable
+  renderCounts.rows++
+  // The footgun: a fresh array literal on every render
+  const {value, isLoading} = useDocumentValues<{title?: string}>(id, ['title'])
+  return (
+    <Card border padding={3} radius={2}>
+      <Stack gap={2}>
+        <Text size={1} weight="medium">
+          {isLoading ? 'Loading…' : value?.title || '(untitled)'}
+        </Text>
+        <Text size={0} muted>
+          {id}
+        </Text>
+      </Stack>
+    </Card>
+  )
+}
+
+/**
+ * Renders/second meter. Stops updating when `running` flips false so its own
+ * interval doesn't keep interrupting the transition mount after the loop ends.
+ */
+function RateBadge({running}: {running: boolean}) {
+  const [rate, setRate] = useState(0)
+  const [total, setTotal] = useState(0)
+  useEffect(() => {
+    if (!running) return undefined
+    let last = renderCounts.rows
+    const interval = setInterval(() => {
+      const now = renderCounts.rows
+      setRate((now - last) * 2)
+      setTotal(now)
+      last = now
+    }, 500)
+    return () => clearInterval(interval)
+  }, [running])
+  return (
+    <Flex gap={2} align="center">
+      <Badge tone={rate > 50 ? 'critical' : 'positive'}>{rate} renders/s</Badge>
+      <Text size={0} muted>
+        {total} total
+      </Text>
+    </Flex>
+  )
+}
+
+/* oxlint-disable react/purity -- deliberately impure render: simulates one expensive component of a mounting document pane */
+function BusySlice() {
+  const end = performance.now() + 1
+  while (performance.now() < end) {
+    // burn main-thread time
+  }
+  return <span hidden />
+}
+/* oxlint-enable react/purity */
+
+const SLICES = Array.from({length: 100}, (_, index) => index)
+
+function HeavySubtree({onMounted}: {onMounted: () => void}) {
+  useEffect(() => onMounted(), [onMounted])
+  return (
+    <>
+      {SLICES.map((slice) => (
+        <BusySlice key={slice} />
+      ))}
+    </>
+  )
+}
+
+/**
+ * Simulates opening a document: transition-mounts a ~100ms subtree as soon as
+ * the pane opens and reports how long the mount took. While the loop runs,
+ * every iteration restarts this mount — the status stays at "mounting…".
+ */
+function DocumentOpenSimulation() {
+  const [show, setShow] = useState(false)
+  const [mountedAfterMs, setMountedAfterMs] = useState<number | null>(null)
+  const startedAtRef = useRef(0)
+  useEffect(() => {
+    startedAtRef.current = performance.now()
+    startTransition(() => setShow(true))
+  }, [])
+  const handleMounted = useCallback(() => {
+    setMountedAfterMs(performance.now() - startedAtRef.current)
+  }, [])
+  return (
+    <Card border padding={3} radius={2} tone={mountedAfterMs === null ? 'critical' : 'positive'}>
+      <Text size={1} weight="medium">
+        {mountedAfterMs === null
+          ? 'Document open simulation: mounting… (stalled by the loop)'
+          : `Document open simulation: mounted after ${(mountedAfterMs / 1000).toFixed(1)}s`}
+      </Text>
+      {show && <HeavySubtree onMounted={handleMounted} />}
+    </Card>
+  )
+}
+
+export function RenderLoopRepro() {
+  const [loopRunning, setLoopRunning] = useState(true)
+  useEffect(() => {
+    const timeout = setTimeout(() => setLoopRunning(false), LOOP_DURATION_MS)
+    return () => clearTimeout(timeout)
+  }, [])
+  return (
+    <Box padding={4}>
+      <CacheWarmer />
+      <Stack gap={4}>
+        <Card padding={3} radius={2} tone="caution">
+          <Stack gap={3}>
+            <Text size={1} weight="medium">
+              useDocumentValues render loop → stalled document open
+            </Text>
+            <Text size={1} muted>
+              The preview rows pass an inline paths array to useDocumentValues and re-render in a
+              tight loop. The simulated document open below starts mounting immediately, but every
+              loop iteration restarts it — it stays stuck at "mounting…" until the rows remove
+              themselves after {LOOP_DURATION_MS / 1000} seconds, then lands instantly. The stall
+              lasts exactly as long as the loop.
+            </Text>
+          </Stack>
+        </Card>
+        <DocumentOpenSimulation />
+        <Flex align="center" justify="space-between">
+          <Text size={1} weight="medium">
+            {loopRunning ? 'Preview rows (looping)' : 'Preview rows removed — loop over'}
+          </Text>
+          <RateBadge running={loopRunning} />
+        </Flex>
+        {loopRunning && DOC_IDS.map((id) => <PreviewRow key={id} id={id} />)}
+      </Stack>
+    </Box>
+  )
+}

--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -25,6 +25,7 @@ import {
 } from 'sanity/structure'
 
 import {DebugPane} from '../components/panes/debug/DebugPane'
+import {RenderLoopRepro} from '../components/panes/debug/RenderLoopRepro'
 import {JsonDocumentDump} from '../components/panes/JsonDocumentDump'
 import {PerspectiveExample} from '../components/PerspectiveExample'
 import {TranslateExample} from '../components/TranslateExample'
@@ -154,6 +155,14 @@ export const structure: StructureResolver = (
             .id('custom')
             .title('Custom panes')
             .items([
+              S.listItem()
+                .id('render-loop-repro')
+                .title('useDocumentValues render loop (repro)')
+                .child(
+                  S.component(RenderLoopRepro)
+                    .id('render-loop-repro')
+                    .title('useDocumentValues render loop'),
+                ),
               S.listItem()
                 .id('component1')
                 .title('Component pane (1)')

--- a/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
+++ b/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
@@ -15,6 +15,12 @@
  * The control (module-constant paths array) renders a handful of times and
  * settles.
  *
+ * Version-linked: under react-rx v4 (studio < 6.9.0) the same inline-literal
+ * case renders exactly twice and settles — the footgun was latent. Under v5
+ * (adopted in 6.9.0 via #13799 + #13814) each new identity schedules a
+ * deferred second pass that recreates the identity, closing the loop
+ * (verified by swapping the react-rx resolution to 4.2.5 and re-running).
+ *
  * Mounted via a raw createRoot with IS_REACT_ACT_ENVIRONMENT disabled: act
  * would flush and mask the loop's scheduling.
  */

--- a/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
+++ b/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Reproduces the render loop behind a customer-reported studio-wide slowdown
+ * (traced from a Firefox profile: ~60 update passes/second, sustained).
+ *
+ * `useDocumentValues(documentId, paths)` memoizes its observable on the
+ * `paths` ARRAY REFERENCE. A caller passing an inline literal — the natural
+ * call shape, e.g. `useDocumentValues(id, ['title'])` — busts the memo every
+ * render: each render builds a new observable (the preview store's
+ * observePaths returns a fresh pipeline per call), react-rx treats it as a
+ * brand-new external store whose warm-up replays the cached value
+ * synchronously, the snapshot is a fresh object (asLoadable maps per
+ * emission), useSyncExternalStore sees "changed" and re-renders — around
+ * again forever. One looping preview component per visible list item.
+ *
+ * The control (module-constant paths array) renders a handful of times and
+ * settles.
+ *
+ * Mounted via a raw createRoot with IS_REACT_ACT_ENVIRONMENT disabled: act
+ * would flush and mask the loop's scheduling.
+ */
+import {createRoot, type Root} from 'react-dom/client'
+import {BehaviorSubject} from 'rxjs'
+import {map} from 'rxjs/operators'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useDocumentValues} from '../useDocumentValues'
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined
+}
+
+// Mirrors the real preview store's shape: the underlying value is cached and
+// replays synchronously to new subscribers, but every observePaths() call
+// returns a NEW observable identity (createPathObserver builds a fresh
+// pipeline per call)
+const cachedValue$ = new BehaviorSubject<Record<string, unknown>>({title: 'hello'})
+// The store instance itself is stable (as the real one is) — only the
+// observable returned per observePaths() call has a fresh identity
+const mockPreviewStore = {
+  observePaths: () => cachedValue$.pipe(map((value) => value)),
+}
+vi.mock('../../../datastores', () => ({
+  useDocumentPreviewStore: () => mockPreviewStore,
+}))
+
+const counters = {inline: 0, stable: 0}
+
+function InlineProbe() {
+  // oxlint-disable-next-line react/immutability -- deliberate render counter: this repro exists to make the loop measurable
+  counters.inline++
+  // The footgun: fresh array literal every render
+  useDocumentValues('doc-inline', ['title'])
+  return null
+}
+
+const STABLE_PATHS = ['title']
+
+function StableProbe() {
+  // oxlint-disable-next-line react/immutability -- deliberate render counter: this repro exists to make the loop measurable
+  counters.stable++
+  useDocumentValues('doc-stable', STABLE_PATHS)
+  return null
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe('useDocumentValues render loop (repro)', () => {
+  let container: HTMLElement
+  let root: Root
+  let previousActEnvironment: boolean | undefined
+
+  beforeEach(() => {
+    counters.inline = 0
+    counters.stable = 0
+    previousActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT
+    globalThis.IS_REACT_ACT_ENVIRONMENT = false
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    root.unmount()
+    container.remove()
+    globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
+  })
+
+  it('a stable paths array settles after a handful of renders', async () => {
+    root.render(<StableProbe />)
+    await sleep(500)
+    expect(counters.stable).toBeLessThan(10)
+  })
+
+  it('an inline paths array re-renders unboundedly', async () => {
+    root.render(<InlineProbe />)
+    await sleep(500)
+    // The loop: hundreds of renders in half a second with no external input
+    expect(counters.inline).toBeGreaterThan(50)
+  })
+})

--- a/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
+++ b/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
@@ -1,25 +1,22 @@
 /**
- * Reproduces the render loop behind a customer-reported studio-wide slowdown
- * (traced from a Firefox profile: ~60 update passes/second, sustained).
+ * Regression guard for a render loop reported from the field (customer
+ * profile showed ~60 update passes/second, sustained, studio-wide slowdown).
  *
- * `useDocumentValues(documentId, paths)` memoizes its observable on the
- * `paths` ARRAY REFERENCE. A caller passing an inline literal — the natural
- * call shape, e.g. `useDocumentValues(id, ['title'])` — busts the memo every
- * render: each render builds a new observable (the preview store's
- * observePaths returns a fresh pipeline per call), react-rx treats it as a
+ * `useDocumentValues(documentId, paths)` used to memoize its observable on
+ * the `paths` ARRAY REFERENCE. A caller passing an inline literal — the
+ * natural call shape, e.g. `useDocumentValues(id, ['title'])` — busted the
+ * memo every render: each render built a new observable (the preview store's
+ * observePaths returns a fresh pipeline per call), react-rx treated it as a
  * brand-new external store whose warm-up replays the cached value
- * synchronously, the snapshot is a fresh object (asLoadable maps per
- * emission), useSyncExternalStore sees "changed" and re-renders — around
- * again forever. One looping preview component per visible list item.
+ * synchronously, and the fresh snapshot forced another render — around again
+ * forever (~22k renders in 500ms before the fix; the hook now keys the memo
+ * on path CONTENTS via useShallowUnique).
  *
- * The control (module-constant paths array) renders a handful of times and
- * settles.
- *
- * Version-linked: under react-rx v4 (studio < 6.9.0) the same inline-literal
- * case renders exactly twice and settles — the footgun was latent. Under v5
- * (adopted in 6.9.0 via #13799 + #13814) each new identity schedules a
- * deferred second pass that recreates the identity, closing the loop
- * (verified by swapping the react-rx resolution to 4.2.5 and re-running).
+ * Version-linked: under react-rx v4 (studio before 6.9.0) the unfixed inline case
+ * rendered exactly twice and settled — the footgun was latent. Under v5
+ * (adopted in 6.9.0 via #13799 + #13814) each new identity's deferred pass
+ * re-rendered and minted another identity, closing the loop (verified by
+ * swapping the react-rx resolution to 4.2.5 and re-running).
  *
  * Mounted via a raw createRoot with IS_REACT_ACT_ENVIRONMENT disabled: act
  * would flush and mask the loop's scheduling.
@@ -40,11 +37,8 @@ declare global {
 // returns a NEW observable identity (createPathObserver builds a fresh
 // pipeline per call)
 const cachedValue$ = new BehaviorSubject<Record<string, unknown>>({title: 'hello'})
-// The store instance itself is stable (as the real one is) — only the
-// observable returned per observePaths() call has a fresh identity
-const mockPreviewStore = {
-  observePaths: () => cachedValue$.pipe(map((value) => value)),
-}
+const observePaths = vi.fn(() => cachedValue$.pipe(map((value) => value)))
+const mockPreviewStore = {observePaths}
 vi.mock('../../../datastores', () => ({
   useDocumentPreviewStore: () => mockPreviewStore,
 }))
@@ -52,19 +46,24 @@ vi.mock('../../../datastores', () => ({
 const counters = {inline: 0, stable: 0}
 
 function InlineProbe() {
-  // oxlint-disable-next-line react/immutability -- deliberate render counter: this repro exists to make the loop measurable
+  // oxlint-disable-next-line react/immutability -- deliberate render counter: this guard exists to make a loop measurable
   counters.inline++
-  // The footgun: fresh array literal every render
-  useDocumentValues('doc-inline', ['title'])
-  return null
+  // The footgun call shape: fresh array literal every render
+  const {value} = useDocumentValues<{title?: string}>('doc-inline', ['title'])
+  return <div data-testid="inline">{value?.title}</div>
 }
 
 const STABLE_PATHS = ['title']
 
 function StableProbe() {
-  // oxlint-disable-next-line react/immutability -- deliberate render counter: this repro exists to make the loop measurable
+  // oxlint-disable-next-line react/immutability -- deliberate render counter: this guard exists to make a loop measurable
   counters.stable++
   useDocumentValues('doc-stable', STABLE_PATHS)
+  return null
+}
+
+function PathsProbe(props: {paths: string[]}) {
+  useDocumentValues('doc-paths', props.paths)
   return null
 }
 
@@ -74,7 +73,7 @@ function sleep(ms: number) {
   })
 }
 
-describe('useDocumentValues render loop (repro)', () => {
+describe('useDocumentValues render stability', () => {
   let container: HTMLElement
   let root: Root
   let previousActEnvironment: boolean | undefined
@@ -82,6 +81,8 @@ describe('useDocumentValues render loop (repro)', () => {
   beforeEach(() => {
     counters.inline = 0
     counters.stable = 0
+    observePaths.mockClear()
+    cachedValue$.next({title: 'hello'})
     previousActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT
     globalThis.IS_REACT_ACT_ENVIRONMENT = false
     container = document.createElement('div')
@@ -95,16 +96,41 @@ describe('useDocumentValues render loop (repro)', () => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
   })
 
-  it('a stable paths array settles after a handful of renders', async () => {
+  it('settles despite an inline paths array (regression: render loop)', async () => {
+    root.render(<InlineProbe />)
+    await sleep(500)
+    expect(counters.inline).toBeLessThan(10)
+    // One observable for the one logical (id, paths) pair — not one per render
+    expect(observePaths).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles with a stable paths array', async () => {
     root.render(<StableProbe />)
     await sleep(500)
     expect(counters.stable).toBeLessThan(10)
   })
 
-  it('an inline paths array re-renders unboundedly', async () => {
+  it('still propagates value updates from the store', async () => {
     root.render(<InlineProbe />)
-    await sleep(500)
-    // The loop: hundreds of renders in half a second with no external input
-    expect(counters.inline).toBeGreaterThan(50)
+    await sleep(100)
+    expect(container.textContent).toBe('hello')
+    cachedValue$.next({title: 'updated'})
+    await sleep(100)
+    expect(container.textContent).toBe('updated')
+  })
+
+  it('rebuilds the observable when the path contents actually change', async () => {
+    root.render(<PathsProbe paths={['title']} />)
+    await sleep(100)
+    expect(observePaths).toHaveBeenCalledTimes(1)
+    // Same contents, new array identity: no rebuild
+    root.render(<PathsProbe paths={['title']} />)
+    await sleep(100)
+    expect(observePaths).toHaveBeenCalledTimes(1)
+    // Different contents: rebuild
+    root.render(<PathsProbe paths={['name']} />)
+    await sleep(100)
+    expect(observePaths).toHaveBeenCalledTimes(2)
+    expect(observePaths).toHaveBeenLastCalledWith({_type: 'reference', _ref: 'doc-paths'}, ['name'])
   })
 })

--- a/packages/sanity/src/core/store/document/hooks/useDocumentValues.ts
+++ b/packages/sanity/src/core/store/document/hooks/useDocumentValues.ts
@@ -2,6 +2,7 @@ import {useMemo} from 'react'
 import {type Observable, of} from 'rxjs'
 
 import {type LoadableState, useLoadable} from '../../../util/useLoadable'
+import {useShallowUnique} from '../../../util/useShallowUnique'
 import {useDocumentPreviewStore} from '../../datastores'
 
 /** @internal */
@@ -11,15 +12,22 @@ export function useDocumentValues<T = Record<string, unknown>>(
 ): LoadableState<T | undefined> {
   const documentPreviewStore = useDocumentPreviewStore()
 
+  // Consumers routinely pass `paths` as an inline literal. Keying the memo on
+  // the array reference would rebuild the observable on every render, which
+  // react-rx v5 turns into a self-sustaining render loop (each new identity's
+  // deferred pass re-renders, minting another identity — see
+  // __tests__/useDocumentValuesRenderLoop.repro.test.tsx). Key on contents.
+  const stablePaths = useShallowUnique(paths)
+
   const documentValues$ = useMemo(
     () =>
       documentId
         ? (documentPreviewStore.observePaths(
             {_type: 'reference', _ref: documentId},
-            paths,
+            stablePaths,
           ) as Observable<T>)
         : of(undefined),
-    [documentId, documentPreviewStore, paths],
+    [documentId, documentPreviewStore, stablePaths],
   )
 
   return useLoadable(documentValues$)

--- a/packages/sanity/src/core/util/useShallowUnique.ts
+++ b/packages/sanity/src/core/util/useShallowUnique.ts
@@ -1,0 +1,19 @@
+import {useState} from 'react'
+import shallowEquals from 'shallow-equals'
+
+/**
+ * Returns the previous value whenever the next one is shallow-equal to it, so
+ * derived values (e.g. freshly built arrays with unchanged contents) keep a
+ * stable identity across renders and don't cascade into memo invalidation or
+ * subscription teardown downstream.
+ *
+ * @internal
+ */
+export function useShallowUnique<ValueType>(value: ValueType): ValueType {
+  const [previous, setPrevious] = useState<ValueType>(value)
+  if (!shallowEquals(previous, value)) {
+    setPrevious(value)
+    return value
+  }
+  return previous
+}


### PR DESCRIPTION
### Description

> Written by an AI agent on behalf of @bjoerge, who has reviewed it.

`useDocumentValues` memoized its observable on the `paths` array reference, so a caller passing an inline literal — `useDocumentValues(id, ['title'])`, the natural call shape, rebuilt the observable on every render. Since react-rx v5 (studio 6.9.0) that sustains an infinite render loop (~22k renders per 500ms per component, react-rx v4 settled after two renders). Reported by a customer as studio-wide sluggishness and document panes that never finish opening. The memo now keys on path contents.

Also adds a self-running repro pane to the test-studio (Debug -> Custom panes): looping preview rows stall a simulated document open for as long as they run; with the fix the same pane settles immediately.

Possible follow-ups, not in this PR:
- the same hardening for `createHookFromObservableFactory`
- react-rx-side settling plus a dev warning for per-render observable identity churn.

### What to review

- Before: https://test-studio-gx5owfom2.sanity.dev/test/structure/custom;render-loop-repro
- After: https://test-studio-git-render-loop-repro.sanity.dev/test/structure/custom;render-loop-repro

Note that the problem is less pronounced in production builds, and impact gets more visible when enabling CPU slowdown in browser devtools

The hook change and the regression test thresholds. `core/util/useShallowUnique` knowingly duplicates the structure package's copy as core can't import from structure; deduping is a follow-up.

### Testing

New regression suite: the inline-literal call shape settles under 10 renders and builds one observable per logical (id, paths) pair; value updates still propagate; genuine path changes still rebuild the observable.

### Notes for release

Fixes a render loop that could make the studio sluggish (and document panes slow to open) when a custom preview component or plugin calls `useDocumentValues` with an inline `paths` array.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches a widely used document preview hook and subscription identity, so a memo-key mistake could miss updates or still loop. The change is small and covered by a dedicated regression test.
> 
> **Overview**
> Stops a customer-reported infinite render loop in `useDocumentValues` when callers pass an inline `paths` array (e.g. `['title']`). The hook previously memoized on array identity; with react-rx v5 that rebuilt the observable every render and never settled, stalling document pane opens.
> 
> The memo now keys on path **contents** via a new core `useShallowUnique` helper. A regression test asserts the inline call shape settles, still rebuilds when paths actually change, and still receives store updates. Test studio also gets a debug pane that reproduces the stall vs. the fixed behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afe2c88d84c41aba2d745b5b55e89005dd80ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->