### PR TITLE
chore(bench): plot calibration and collect more vm details

### DIFF
--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -22,7 +22,17 @@ secondary: leads scanning health weekly.
   view carries a calibration overlay (`runner.calibrationMs`, higher =
   slower host) so a "regression" that is really a slower runner pool is
   visible as such. This is the dashboard's version of the suite's fail-loud
-  principle.
+  principle. What the score is (a fixed unthrottled CPU workload in the
+  browser) is spelled out once (`CALIBRATION_EXPLAINER`) and reused by every
+  surface that mentions it: chart ⓘ, legend entry, tooltip, run popover.
+- Runs also record **host metadata** (`runner.os/arch/cpus/memGb/nodeVersion`,
+  and from Aug 2026 `cpuModel`, `imageOs`/`imageVersion`, `browserVersion`;
+  `cpuModel` also per-scenario shard). The run popover shows it as a Host
+  section. `cpuModel` is the field that discriminates hosted-runner hardware
+  generations (GitHub rotates CPU models under the same vCPU shape — cpus and
+  memGb stayed identical across the Aug 2026 host-speed step), and
+  `browserVersion` records the measuring instrument, since a Playwright bump
+  moves INP/vitals with no studio change.
 - PR A/B runs are _not_ stored (by design). The dashboard is main-branch
   health; PR verdicts live in PR comments.
 
@@ -35,7 +45,15 @@ secondary: leads scanning health weekly.
    nearest run's document (the run under the crosshair is marked on hover /
    keyboard focus — there are no resting dots, which at 30–90 runs in a small
    multiple were mostly ink).
-   Calibration strip at the top. Time range picker (30/90/all).
+   Time range picker (30/90/all). Every ms-based chart also draws **host
+   calibration as an in-chart context line** (dotted, muted, its own
+   zero-based scale so relative moves compare at the same visual proportion —
+   dots always mean host calibration, dashes always mean a baseline level),
+   using the shard score of the host that measured _that_ scenario — so "did
+   the host spike where the metric spiked?" is answerable without switching
+   tabs. The full unmerged per-shard strip lives in the Calibration tab.
+   Suppressed on non-time metrics (counts/bytes/CLS don't move with a slow
+   host) and when comparing branches.
 2. **Run detail** (P2) — click-through from a dot: the PR-comment tables
    (absolute variant), soak slope chart, flake telemetry, run metadata.
 3. **Drift feed** (P2) — computed client-side, flagging a metric when it
@@ -105,10 +123,10 @@ secondary: leads scanning health weekly.
    slice would make the verdict a function of the range picker.
 
 4. **Layer toggles** — the chart legend doubles as a switchboard: clicking an
-   entry shows/hides that layer (median, p75–p90 band, baseline overlay) across
-   the whole grid, persisted as `?layers=-band` so a stripped-back view is
-   shareable. Global rather than per-card because the grid is 40+ small
-   multiples.
+   entry shows/hides that layer (median, p75–p90 band, host calibration,
+   baseline overlay) across the whole grid, persisted as `?layers=-band` so a
+   stripped-back view is shareable. Global rather than per-card because the
+   grid is 40+ small multiples.
 
 ## Architecture
 

--- a/dev/metrics-studio/schemaTypes/benchRun.ts
+++ b/dev/metrics-studio/schemaTypes/benchRun.ts
@@ -147,6 +147,11 @@ const benchScenario = defineType({
           description: 'Host-speed score (ms for a fixed workload; higher = slower host)',
           type: 'number',
         }),
+        defineField({
+          name: 'cpuModel',
+          description: 'CPU model of the shard machine that ran this scenario',
+          type: 'string',
+        }),
       ],
     }),
     defineField({name: 'kind', type: 'string', options: {list: ['interaction', 'pageload']}}),
@@ -317,6 +322,27 @@ const benchRun = defineType({
         defineField({name: 'cpus', type: 'number'}),
         defineField({name: 'memGb', type: 'number'}),
         defineField({name: 'nodeVersion', type: 'string'}),
+        defineField({
+          name: 'cpuModel',
+          description:
+            'CPU model string — discriminates hosted-runner hardware generations that share the same vCPU count',
+          type: 'string',
+        }),
+        defineField({
+          name: 'imageOs',
+          description: 'GitHub runner image (ImageOS env), e.g. ubuntu24',
+          type: 'string',
+        }),
+        defineField({
+          name: 'imageVersion',
+          description: 'GitHub runner image version (ImageVersion env)',
+          type: 'string',
+        }),
+        defineField({
+          name: 'browserVersion',
+          description: 'Chromium version the sessions ran in — the measuring instrument',
+          type: 'string',
+        }),
         defineField({name: 'ci', type: 'boolean'}),
         defineField({name: 'runId', type: 'string'}),
         defineField({name: 'runAttempt', type: 'number'}),

--- a/dev/metrics-studio/tools/trends/ChartLegend.tsx
+++ b/dev/metrics-studio/tools/trends/ChartLegend.tsx
@@ -1,10 +1,10 @@
 import {Flex, Text} from '@sanity/ui'
 
-import {formatValue, type TrendSeries} from './data'
+import {CALIBRATION_EXPLAINER, formatValue, type TrendSeries} from './data'
 import {baselineDetail, baselineLabel, type DriftResult} from './drift'
 import {ALL_LAYERS_VISIBLE, type Layer, type LayerState} from './layers'
 import {categoricalColor} from './palette'
-import {baselineToDraw, COLOR, seriesHasBand} from './TrendChart'
+import {baselineToDraw, COLOR, seriesHasBand, seriesHasCalibration} from './TrendChart'
 
 function Swatch(props: {children: React.ReactNode; dimmed?: boolean}) {
   return (
@@ -163,7 +163,8 @@ export function ChartLegend(props: {
               y2={5}
               stroke={color}
               strokeWidth={2}
-              strokeDasharray={series.goal === 'context' ? '3 2' : undefined}
+              strokeDasharray={series.goal === 'context' ? '1 3' : undefined}
+              strokeLinecap={series.goal === 'context' ? 'round' : undefined}
             />
           }
         />
@@ -181,6 +182,27 @@ export function ChartLegend(props: {
               <line x1={0} y1={2} x2={16} y2={2} stroke={color} strokeWidth={1} opacity={0.5} />
               <line x1={0} y1={8} x2={16} y2={8} stroke={color} strokeWidth={1} opacity={0.5} />
             </>
+          }
+        />
+      )}
+      {seriesHasCalibration(series) && (
+        <LegendItem
+          layer="calibration"
+          layers={layers}
+          label="host calibration"
+          hint={`${CALIBRATION_EXPLAINER} Drawn on its own zero-based scale — when it moves where the metric moves, suspect the runner, not the studio`}
+          swatch={
+            <line
+              x1={0}
+              y1={5}
+              x2={16}
+              y2={5}
+              stroke={COLOR.context}
+              strokeWidth={1.5}
+              strokeDasharray="1 3"
+              strokeLinecap="round"
+              opacity={0.6}
+            />
           }
         />
       )}

--- a/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
+++ b/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
@@ -16,7 +16,13 @@ import {Popover} from '@sanity/ui/popover'
 import {useEffect, useRef, useState} from 'react'
 import {useIntentLink} from 'sanity/router'
 
-import {formatValue, INP_MIN_INTERACTIONS, type TrendPoint, type TrendSeries} from './data'
+import {
+  CALIBRATION_EXPLAINER,
+  formatValue,
+  INP_MIN_INTERACTIONS,
+  type TrendPoint,
+  type TrendSeries,
+} from './data'
 import {buildInvestigationPrompt} from './investigationPrompt'
 import {backlinksFor, compareUrl, sourceFileUrl} from './links'
 
@@ -39,6 +45,7 @@ export function RunDetailPopover(props: {
   onClose: () => void
 }) {
   const {series, point, previousPoint, referenceElement, onClose} = props
+  const {host} = point
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null)
   // "What landed between this point and the previous one?" — the GitHub
   // compare view answers it directly. Guarded by the full-sha shape so a
@@ -183,6 +190,58 @@ export function RunDetailPopover(props: {
                 </Badge>
               )}
             </Stack>
+
+            {/* The machine that produced this run — the context every absolute
+                number depends on. cpuModel/image/browser exist on documents
+                from Aug 2026 on; older runs show what they recorded. */}
+            {(host || point.calibrationMs !== undefined) && (
+              <Stack gap={2}>
+                <Text size={0} muted weight="medium">
+                  Host
+                </Text>
+                <Stack gap={2}>
+                  {host?.cpuModel && (
+                    <Text size={1} muted>
+                      {host.cpuModel}
+                    </Text>
+                  )}
+                  {host && (host.os || host.cpus !== undefined || host.memGb !== undefined) && (
+                    <Text size={1} muted>
+                      {[
+                        host.os && (host.arch ? `${host.os}/${host.arch}` : host.os),
+                        host.cpus !== undefined ? `${host.cpus} cores` : undefined,
+                        host.memGb !== undefined ? `${host.memGb} GB RAM` : undefined,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </Text>
+                  )}
+                  {(host?.browserVersion || host?.nodeVersion) && (
+                    <Text size={1} muted>
+                      {[
+                        host.browserVersion ? `Chromium ${host.browserVersion}` : undefined,
+                        host.nodeVersion ? `Node ${host.nodeVersion}` : undefined,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </Text>
+                  )}
+                  {(host?.imageOs || host?.imageVersion) && (
+                    <Text size={1} muted>
+                      image {[host.imageOs, host.imageVersion].filter(Boolean).join(' ')}
+                    </Text>
+                  )}
+                  {point.calibrationMs !== undefined && (
+                    <Flex align="center" gap={2} title={CALIBRATION_EXPLAINER}>
+                      <Text size={1} muted>
+                        calibration
+                      </Text>
+                      <Text size={1}>{formatValue(point.calibrationMs, 'ms')}</Text>
+                    </Flex>
+                  )}
+                </Stack>
+              </Stack>
+            )}
 
             {(backlinks.length > 0 || scenarioHref) && (
               <Stack gap={2}>

--- a/dev/metrics-studio/tools/trends/TrendChart.tsx
+++ b/dev/metrics-studio/tools/trends/TrendChart.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {AxisBottom, AxisLeft} from '@visx/axis'
 import {Group} from '@visx/group'
 import {scaleLinear, scaleTime} from '@visx/scale'
@@ -6,6 +6,7 @@ import {Area, LinePath} from '@visx/shape'
 import {useRef, useState} from 'react'
 
 import {
+  CALIBRATION_EXPLAINER,
   formatTick,
   formatValue,
   INP_MIN_INTERACTIONS,
@@ -39,6 +40,38 @@ function previousPointFor(lines: TrendLine[], selected: TrendPoint): TrendPoint 
   return undefined
 }
 
+/**
+ * One-line machine identity for the hover tooltip: CPU model when the run
+ * recorded one (Aug 2026 on), os/arch as the stand-in before that, plus the
+ * always-collected core count and memory. Empty string when the point carries
+ * no host at all, so callers can filter on truthiness.
+ */
+function hostSummary(host: TrendPoint['host']): string {
+  if (!host) return ''
+  return [
+    host.cpuModel ?? (host.os ? (host.arch ? `${host.os}/${host.arch}` : host.os) : undefined),
+    host.cpus !== undefined ? `${host.cpus} cores` : undefined,
+    host.memGb !== undefined ? `${host.memGb} GB` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+}
+
+/**
+ * Toolchain + measuring-instrument line for the hover tooltip (Chromium is
+ * what the sessions actually run in). Empty when the run recorded neither —
+ * documents before Aug 2026 have Node only.
+ */
+function hostVersions(host: TrendPoint['host']): string {
+  if (!host) return ''
+  return [
+    host.browserVersion ? `Chromium ${host.browserVersion}` : undefined,
+    host.nodeVersion ? `Node ${host.nodeVersion}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+}
+
 /** Theme-aware colors via the studio's CSS custom properties. */
 export const COLOR = {
   line: 'var(--card-accent-fg-color, #556bfc)',
@@ -58,7 +91,9 @@ export const COLOR = {
    * must still separate from the axes, which are also muted gray. Use the
    * darker primary foreground so it's a distinct neutral (no hue, so it never
    * collides with a data-series color the way an accent/categorical would);
-   * the dashes keep it reading as reference rather than a measured line.
+   * the dotting keeps it reading as reference rather than a measured line, and
+   * separates it from the baseline overlay's dashed rules — dots always mean
+   * host calibration, dashes always mean a baseline level.
    */
   context: 'var(--card-fg-color, #101112)',
   /**
@@ -104,6 +139,25 @@ export function seriesHasBand(series: TrendSeries): boolean {
     // Relative, so it scales across ms / bytes / CLS without a per-unit table
     return Math.abs(point.p90 - point.p75) > Math.abs(point.value) * 0.02
   })
+}
+
+/**
+ * Whether this chart can draw the host-calibration context line.
+ *
+ * Only where host speed can actually skew the number: time-based (ms) metrics
+ * over run history. Counts, bytes and CLS don't move with a slow host, so a
+ * calibration line there would invite correlations that can't exist. Suppressed
+ * when comparing branches (each branch ran on its own hosts — overlapping
+ * dashed trails are mud, and the Calibration tab already draws them per
+ * branch), on the calibration charts themselves, and on soak minute charts
+ * (calibration is a single per-run score, flat by construction).
+ */
+export function seriesHasCalibration(series: TrendSeries): boolean {
+  if (series.lines.length !== 1) return false
+  if (series.goal === 'context') return false
+  if (series.xKind === 'minute') return false
+  if (series.unit !== 'ms') return false
+  return series.lines[0].points.filter((point) => point.calibrationMs !== undefined).length > 1
 }
 
 /** Per-line color: the studio accent for a lone line, categorical when comparing. */
@@ -372,6 +426,22 @@ export function TrendChart(props: {
   // The band belongs to the line it describes, so it takes that line's color
   const bandColor = lineColorFor(series, 0)
 
+  // Host calibration as an in-chart context line, so "did the host spike where
+  // the metric spiked?" is answerable without switching to the Calibration tab.
+  const calibrationPoints =
+    layers.visible('calibration') && seriesHasCalibration(series)
+      ? lines[0].points.filter((point) => point.calibrationMs !== undefined)
+      : []
+  // Its own scale, but zero-based like the metric's: both lines then show
+  // *relative* movement at the same visual proportion (a 20% slower host dips
+  // as much of its height as a 20% slower metric does), which is exactly the
+  // comparison eyeballing skew needs. A min–max domain would instead stretch
+  // ±2% host jitter to full chart height and manufacture correlations.
+  const calibrationScale = scaleLinear({
+    domain: [0, Math.max(1, ...calibrationPoints.map((point) => point.calibrationMs!)) * 1.1],
+    range: [innerHeight, 0],
+  })
+
   const handleMove = (event: React.PointerEvent<SVGRectElement>) => {
     const rect = event.currentTarget.getBoundingClientRect()
     setHoverMs(xScale.invert(event.clientX - rect.left).getTime())
@@ -508,6 +578,24 @@ export function TrendChart(props: {
               />
             </>
           )}
+          {/* Host calibration context line — under the metric line (it's
+              reference, never the measurement), dotted and muted like the
+              Calibration tab's own charts so it reads as the same thing.
+              Dotted, not dashed: the baseline overlay's "before" rule owns
+              the dash, and two reference marks sharing one pattern in a
+              ~120px small multiple would be indistinguishable. */}
+          {calibrationPoints.length > 1 && (
+            <LinePath<TrendPoint>
+              data={calibrationPoints}
+              x={x}
+              y={(point) => calibrationScale(point.calibrationMs!)}
+              stroke={COLOR.context}
+              strokeWidth={1}
+              strokeDasharray="1 3"
+              strokeLinecap="round"
+              opacity={0.45}
+            />
+          )}
           {lines.map((line, index) => {
             const color = lineColorFor(series, index)
             return (
@@ -519,11 +607,13 @@ export function TrendChart(props: {
                     y={(point) => yScale(point.value)}
                     stroke={color}
                     strokeWidth={1.5}
-                    // Context lines (host calibration) are dashed so they read
-                    // as reference, not as a measured metric line. The darker
+                    // Context lines (host calibration) are dotted so they read
+                    // as reference, not as a measured metric line — the same
+                    // dotting the in-chart calibration overlay uses. The darker
                     // context color separates them from the muted-gray axes;
                     // reduced opacity keeps them recessive despite being darker.
-                    strokeDasharray={series.goal === 'context' ? '4 3' : undefined}
+                    strokeDasharray={series.goal === 'context' ? '1 3' : undefined}
+                    strokeLinecap={series.goal === 'context' ? 'round' : undefined}
                     opacity={series.goal === 'context' ? 0.55 : 1}
                   />
                 )}
@@ -685,48 +775,77 @@ export function TrendChart(props: {
                       : series.xKind === 'minute'
                         ? `minute ${Math.round(entry.point.date.getTime() / 60_000)}`
                         : entry.point.date.toISOString().slice(0, 10)}
-                    {/* Provenance as text — the dot itself is the click target
-                        (opens the run); GitHub backlinks live in the drift feed */}
-                    {series.xKind !== 'minute' &&
-                      (entry.point.prNumber
-                        ? ` · PR #${entry.point.prNumber}`
-                        : entry.point.sha !== 'unknown'
-                          ? ` · ${entry.point.sha.slice(0, 7)}`
-                          : '')}
+                    {/* Provenance as text — PR number only; a truncated sha is
+                        noise at hover speed, and the run popover (click) has
+                        the full commit link */}
+                    {series.xKind !== 'minute' && entry.point.prNumber
+                      ? ` · PR #${entry.point.prNumber}`
+                      : ''}
                   </Text>
                 </Flex>
               ))}
-              {/* What the overlay rules are. Unlabelled in the plot they invite a
-                  fair "that isn't the middle of the data" — a median ignores how
-                  far outliers fall, so it sits with the cluster rather than
-                  between the extremes. Naming the statistic and its window size
-                  makes that readable instead of surprising. */}
-              {overlayBaseline && (
-                <>
-                  <Box
-                    aria-hidden="true"
-                    style={{height: 1, background: 'var(--card-border-color)'}}
-                  />
-                  <Stack gap={1}>
-                    <Flex align="center" gap={2}>
-                      <Text size={0} muted>
-                        baseline (median of {overlayBaseline.baselinePointsMs.length} runs)
+              {/* The hovered run's host-speed score (higher = slower), on its
+                  own labelled line so it never reads as part of the metric
+                  value. Shown whenever the point knows its host — with the
+                  dotted layer hidden, on comparisons, and on charts that don't
+                  qualify for the context line alike. Per branch when
+                  comparing, since each branch ran on its own hosts.
+
+                  Gated on score OR host identity: Calibration-tab points carry
+                  no calibrationMs (their value IS the score — a labelled row
+                  would just repeat it), but their machine identity must still
+                  show on the one chart whose job is host spread. */}
+              {hovered.some(
+                (entry) => entry.point.calibrationMs !== undefined || entry.point.host,
+              ) && (
+                <Stack gap={1}>
+                  {hovered
+                    .filter((entry) => entry.point.calibrationMs !== undefined)
+                    .map((entry) => (
+                      // title spells out what the score is — the tooltip is the
+                      // first place a viewer meets the number, and "calibration
+                      // of what?" is a fair question there
+                      <Flex
+                        key={`calibration-${entry.branch}`}
+                        align="center"
+                        gap={2}
+                        title={CALIBRATION_EXPLAINER}
+                      >
+                        <Text size={0} muted>
+                          host calibration{lines.length > 1 ? ` · ${entry.branch}` : ''}
+                        </Text>
+                        <Text size={0} weight="semibold">
+                          {formatValue(entry.point.calibrationMs!, 'ms')}
+                        </Text>
+                      </Flex>
+                    ))}
+                  {/* Machine identity under the score: the CPU model is what
+                      distinguishes runner hardware generations (os/arch stands
+                      in on documents that predate it), and the versions line
+                      names the toolchain and the measuring instrument — a
+                      Chromium bump moves vitals with no studio change. The
+                      full detail (image version) stays in the run popover. */}
+                  {hovered
+                    .filter((entry) => hostSummary(entry.point.host))
+                    .map((entry) => (
+                      <Text key={`host-${entry.branch}`} size={0} muted>
+                        {lines.length > 1 ? `${entry.branch}: ` : ''}
+                        {hostSummary(entry.point.host)}
                       </Text>
-                      <Text size={0} weight="semibold">
-                        {formatValue(overlayBaseline.baseline, unit)}
+                    ))}
+                  {hovered
+                    .filter((entry) => hostVersions(entry.point.host))
+                    .map((entry) => (
+                      <Text key={`versions-${entry.branch}`} size={0} muted>
+                        {lines.length > 1 ? `${entry.branch}: ` : ''}
+                        {hostVersions(entry.point.host)}
                       </Text>
-                    </Flex>
-                    <Flex align="center" gap={2}>
-                      <Text size={0} muted>
-                        recent (median of {overlayBaseline.recentPointsMs.length} runs)
-                      </Text>
-                      <Text size={0} weight="semibold">
-                        {formatValue(overlayBaseline.recent, unit)}
-                      </Text>
-                    </Flex>
-                  </Stack>
-                </>
+                    ))}
+                </Stack>
               )}
+              {/* No baseline medians here: the legend names the baseline and
+                  its window, the overlay draws the levels, and repeating the
+                  same two labelled rows in every chart's tooltip was noise. */}
             </Stack>
           </Card>
         </div>

--- a/dev/metrics-studio/tools/trends/TrendsTool.tsx
+++ b/dev/metrics-studio/tools/trends/TrendsTool.tsx
@@ -42,6 +42,7 @@ import {ChartLegend} from './ChartLegend'
 import {
   availableBranches,
   buildSeries,
+  CALIBRATION_EXPLAINER,
   latestSoakCharts,
   soakSlopeSeries,
   soakLatestValueSeries,
@@ -61,7 +62,7 @@ import {DriftFeed} from './DriftFeed'
 import {type LayerState, useLayerState} from './layers'
 import {sourceFileUrl, webVitalDocUrl} from './links'
 import {MAX_COMPARE_BRANCHES} from './palette'
-import {TrendChart} from './TrendChart'
+import {seriesHasCalibration, TrendChart} from './TrendChart'
 import {type DriftState, useDriftState} from './useDriftState'
 import {useUrlState} from './useUrlState'
 
@@ -109,7 +110,14 @@ interface LiveState {
   error: string | null
 }
 
-function InfoButton(props: {text: string; label: string; sourceFile?: string; vitalDoc?: string}) {
+function InfoButton(props: {
+  text: string
+  label: string
+  sourceFile?: string
+  vitalDoc?: string
+  /** Shown as a second paragraph on charts that draw the calibration line. */
+  calibrationNote?: string
+}) {
   const [open, setOpen] = useState(false)
   // Popover has no onClickOutside prop (passing it logs an "unknown event
   // handler" error and never closes); useClickOutsideEvent is the @sanity/ui
@@ -131,6 +139,11 @@ function InfoButton(props: {text: string; label: string; sourceFile?: string; vi
             <Text size={1} muted>
               {props.text}
             </Text>
+            {props.calibrationNote && (
+              <Text size={1} muted>
+                {props.calibrationNote}
+              </Text>
+            )}
             {(props.vitalDoc || props.sourceFile) && (
               <Stack gap={2}>
                 {/* Reference doc for the Web Vital itself (web.dev) */}
@@ -355,11 +368,13 @@ function SeriesCard(props: {
       className={focused ? 'chart-focus-pulse' : undefined}
     >
       <Stack gap={3}>
-        {/* Center-aligned: the title + badge co-center with the value/menu/info
-            cluster on the common single-line case, and the title wraps (no
-            ellipsis) within its flex-1 box when it's too long to fit */}
+        {/* Two header rows: the title owns the first (with the menu/info
+            controls right-aligned), and the stat row beneath pairs the drift
+            badge with the latest value — the number sits next to the
+            percentage it contextualizes instead of floating top-right while
+            the badge wraps under a long title. */}
         <Flex align="center" justify="space-between" gap={3}>
-          <Flex align="center" gap={2} flex={1} style={{minWidth: 0, flexWrap: 'wrap'}}>
+          <Box flex={1} style={{minWidth: 0}}>
             {/* Clicking the title deep-links to this chart (shareable focus) */}
             {onFocus ? (
               <Box
@@ -386,27 +401,8 @@ function SeriesCard(props: {
                 {series.title}
               </Text>
             )}
-            {badge && (
-              <Badge tone={badge.tone} fontSize={0} style={{flexShrink: 0}}>
-                {badge.label}
-              </Badge>
-            )}
-            {!badge && silenced && (
-              <Badge tone="default" fontSize={0} style={{flexShrink: 0}}>
-                acknowledged
-              </Badge>
-            )}
-          </Flex>
+          </Box>
           <Flex align="center" gap={2} style={{flexShrink: 0}}>
-            {latest && (
-              <Text
-                size={1}
-                muted
-                aria-label={`Latest run: ${formatValue(latest.value, series.unit)}`}
-              >
-                {formatValue(latest.value, series.unit)}
-              </Text>
-            )}
             {(drift || silenced) && (onAck || onUnack) && (
               <AckMenu
                 seriesKey={(drift ?? silenced)!.seriesKey}
@@ -424,9 +420,37 @@ function SeriesCard(props: {
               label={`About ${series.title}`}
               sourceFile={series.sourceFile}
               vitalDoc={webVitalDocUrl(series.title)}
+              // Explain the dotted context line where the chart is explained —
+              // "calibration of what?" shouldn't require the Calibration tab
+              calibrationNote={seriesHasCalibration(series) ? CALIBRATION_EXPLAINER : undefined}
             />
           </Flex>
         </Flex>
+        {(badge || silenced || latest) && (
+          // Value first, badge after — "64ms ↓ -22%" reads as a statement
+          // qualified by its move, where badge-first read as two stats
+          <Flex align="center" gap={2} style={{flexWrap: 'wrap'}}>
+            {latest && (
+              <Text
+                size={1}
+                muted
+                aria-label={`Latest run: ${formatValue(latest.value, series.unit)}`}
+              >
+                {formatValue(latest.value, series.unit)}
+              </Text>
+            )}
+            {badge && (
+              <Badge tone={badge.tone} fontSize={0} style={{flexShrink: 0}}>
+                {badge.label}
+              </Badge>
+            )}
+            {!badge && silenced && (
+              <Badge tone="default" fontSize={0} style={{flexShrink: 0}}>
+                acknowledged
+              </Badge>
+            )}
+          </Flex>
+        )}
         {/* Explicit height: ParentSize's default height:100% collapses to 0
             inside an auto-height Stack row, and a 0-sized parent means no
             chart gets rendered at all */}

--- a/dev/metrics-studio/tools/trends/data.test.ts
+++ b/dev/metrics-studio/tools/trends/data.test.ts
@@ -3,6 +3,7 @@ import {expect, test} from 'vitest'
 import {
   buildSeries,
   calibrationSeries,
+  soakLatestValueSeries,
   formatTick,
   formatValue,
   type TrendRun,
@@ -22,8 +23,10 @@ function run(options: {
   /** Extra copies of the same metric, as the pageload scenario does for INP. */
   repeats?: number
   calibrationMs?: number
+  /** Per-scenario shard calibration, as mergeShards stamps on multi-shard CI runs. */
+  shardCalibrationMs?: number
 }): TrendRun {
-  const {id, sha, day, value, repeats = 1, calibrationMs = 8} = options
+  const {id, sha, day, value, repeats = 1, calibrationMs = 8, shardCalibrationMs} = options
   return {
     _id: id,
     startedAt: new Date(START + day * DAY).toISOString(),
@@ -35,6 +38,7 @@ function run(options: {
       {
         scenario: 'singleString',
         kind: 'interaction',
+        ...(shardCalibrationMs !== undefined ? {runner: {calibrationMs: shardCalibrationMs}} : {}),
         metrics: Array.from({length: repeats}, () => ({
           label: 'stringField',
           unit: 'ms' as const,
@@ -193,6 +197,61 @@ test('merged INP points keep the median interaction count', () => {
   expect(point.interactions).toBe(55)
 })
 
+// The run popover's Host section reads the machine description off the point;
+// a shard-stamped cpuModel overrides the run-level one, since multi-shard runs
+// land each scenario on its own machine.
+test('points carry the host description, shard cpuModel winning', () => {
+  const base = run({id: 'a', sha: 'sha-1', day: 0, value: 100})
+  const withHost: TrendRun = {
+    ...base,
+    runner: {
+      ...base.runner!,
+      os: 'linux',
+      arch: 'x64',
+      cpus: 8,
+      memGb: 31,
+      nodeVersion: 'v24.19.0',
+      cpuModel: 'AMD EPYC 7763',
+    },
+    scenarios: [{...base.scenarios![0], runner: {calibrationMs: 9, cpuModel: 'Intel Xeon 8370C'}}],
+  }
+  const [point] = pointsOf([withHost])
+  expect(point.host?.os).toBe('linux')
+  expect(point.host?.cpus).toBe(8)
+  expect(point.host?.cpuModel).toBe('Intel Xeon 8370C')
+})
+
+// Old documents recorded nothing beyond run identity — no empty Host section.
+test('points omit host when the run recorded no host details', () => {
+  const [point] = pointsOf([run({id: 'a', sha: 'sha-1', day: 0, value: 100})])
+  expect(point.host).toBeUndefined()
+})
+
+// The in-chart calibration overlay draws the host that measured *this* point:
+// the scenario's own shard score when present (multi-shard CI runs execute each
+// scenario on a separate machine), else the run-level score.
+test('points carry the calibration of the shard that measured them', () => {
+  const points = pointsOf([
+    run({id: 'a', sha: 'sha-1', day: 0, value: 100, calibrationMs: 8, shardCalibrationMs: 11}),
+  ])
+  expect(points[0].calibrationMs).toBe(11)
+})
+
+test('points fall back to the run-level calibration', () => {
+  const points = pointsOf([run({id: 'a', sha: 'sha-1', day: 0, value: 100, calibrationMs: 8})])
+  expect(points[0].calibrationMs).toBe(8)
+})
+
+test('merged points keep the median calibration', () => {
+  const points = pointsOf([
+    run({id: 'a1', sha: 'sha-1', day: 0, value: 100, calibrationMs: 7}),
+    run({id: 'a2', sha: 'sha-1', day: 0, value: 120, calibrationMs: 20}),
+    run({id: 'a3', sha: 'sha-1', day: 0, value: 110, calibrationMs: 9}),
+  ])
+  expect(points).toHaveLength(1)
+  expect(points[0].calibrationMs).toBe(9)
+})
+
 const vitalStub = (title: string) => ({title}) as TrendSeries
 
 // The vitals tab reads by vital ("how is LCP doing, everywhere?"): one section
@@ -263,6 +322,89 @@ test('long durations abbreviate to seconds', () => {
   expect(formatValue(60_000, 'ms')).toBe('60.0s')
   expect(formatValue(33_863, 'ms')).toBe('33.9s')
   expect(formatValue(120_000, 'ms')).toBe('120s')
+})
+
+// A merged point's calibration is a median across machines — attributing it
+// to the last re-run's host would pair a synthetic score with one specific
+// machine. Host survives the merge only when every merged run agrees.
+test('a mixed-host merge drops the host, an agreeing merge keeps it', () => {
+  const withModel = (id: string, cpuModel: string): TrendRun => {
+    const base = run({id, sha: 'sha-1', day: 0, value: 100})
+    return {...base, runner: {...base.runner!, os: 'linux', cpuModel}}
+  }
+  const [mixed] = pointsOf([withModel('a1', 'AMD EPYC 7763'), withModel('a2', 'Intel Xeon 8370C')])
+  expect(mixed.host).toBeUndefined()
+  const [agreeing] = pointsOf([withModel('b1', 'AMD EPYC 7763'), withModel('b2', 'AMD EPYC 7763')])
+  expect(agreeing.host?.cpuModel).toBe('AMD EPYC 7763')
+})
+
+// Each Calibration-tab point names its own shard's machine: the run-level
+// runner block is the first shard's, and multi-shard runs land on different
+// hardware.
+test('calibration points carry their own shard host, not the first shard', () => {
+  const base = run({id: 'a', sha: 'sha-1', day: 0, value: 100})
+  const multiShard: TrendRun = {
+    ...base,
+    runner: {...base.runner!, cpuModel: 'AMD EPYC 7763'},
+    scenarios: [
+      {...base.scenarios![0], runner: {calibrationMs: 6, cpuModel: 'AMD EPYC 7763'}},
+      {
+        ...base.scenarios![0],
+        scenario: 'article',
+        runner: {calibrationMs: 9, cpuModel: 'Intel Xeon 8370C'},
+      },
+    ],
+  }
+  const points = calibrationSeries([multiShard]).lines[0].points
+  expect(points.map((p) => [p.value, p.host?.cpuModel])).toEqual([
+    [6, 'AMD EPYC 7763'],
+    [9, 'Intel Xeon 8370C'],
+  ])
+})
+
+// Soak charts are produced by their own shard too — its calibration enables
+// the in-chart context line, and its cpuModel keeps the popover honest.
+test('soak history points carry the soak shard calibration and host', () => {
+  const soakRun = (id: string, sha: string, day: number, latency: number): TrendRun => ({
+    ...run({id, sha, day, value: 0}),
+    scenarios: [
+      {
+        scenario: 'singleString',
+        kind: 'interaction',
+        runner: {calibrationMs: 9, cpuModel: 'Intel Xeon 8370C'},
+        metrics: [],
+        soak: {
+          minutes: 2,
+          samples: [1, 2].map((minute) => ({
+            minute,
+            heapMb: 100,
+            domNodes: 1000,
+            listeners: 50,
+            latencyP50Ms: latency,
+            cpuTaskMs: 200,
+            connections: 2,
+            requests: 10,
+          })),
+        },
+      },
+    ],
+  })
+  const series = soakLatestValueSeries([soakRun('a', 'sha-1', 0, 40), soakRun('b', 'sha-2', 1, 44)])
+  const latencySeries = series.find((entry) => entry.key === 'soak:latest:latencyP50Ms')
+  const [point] = latencySeries!.lines[0].points
+  expect(point.calibrationMs).toBe(9)
+  expect(point.host?.cpuModel).toBe('Intel Xeon 8370C')
+})
+
+// Host calibration lives at 5–9ms — whole-ms rounding would collapse its whole
+// dynamic range into four buckets. One decimal matches the 0.1ms granularity
+// Chromium's coarsened performance.now() actually measures at; exact integers
+// stay whole so zero ticks don't grow a pointless ".0".
+test('small fractional ms keep one decimal, integers stay whole', () => {
+  expect(formatValue(7.699999999953434, 'ms')).toBe('7.7ms')
+  expect(formatValue(8, 'ms')).toBe('8ms')
+  expect(formatValue(0, 'ms')).toBe('0ms')
+  expect(formatValue(64, 'ms')).toBe('64ms')
 })
 
 // Keystroke latency lives at 30–200ms; "0.09s" would throw away the precision

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -15,14 +15,29 @@ export interface TrendRun {
     prNumber?: number
     mergeBaseSha?: string
   } | null
-  runner: {calibrationMs: number; runId?: string; runAttempt?: number} | null
+  runner: {
+    calibrationMs: number
+    runId?: string
+    runAttempt?: number
+    os?: string
+    arch?: string
+    cpus?: number
+    memGb?: number
+    nodeVersion?: string
+    /** Hardware generation discriminator — collected from Aug 2026 on. */
+    cpuModel?: string
+    imageOs?: string
+    imageVersion?: string
+    /** Chromium the sessions ran in — collected from Aug 2026 on. */
+    browserVersion?: string
+  } | null
   bundle: {experiment: {initialJsBytes: number; totalJsBytes?: number | null} | null} | null
   scenarios:
     | {
         scenario: string
         sourceFile?: string
         /** Per-scenario shard runner calibration (multi-shard CI runs only). */
-        runner?: {calibrationMs: number | null} | null
+        runner?: {calibrationMs: number | null; cpuModel?: string | null} | null
         kind: 'interaction' | 'pageload'
         metrics:
           | {
@@ -58,12 +73,12 @@ export const TREND_QUERY = `*[_type == "benchRun" && mode == "absolute"] | order
   startedAt,
   mode,
   git{sha, branch, committedAt, prNumber, mergeBaseSha},
-  runner{calibrationMs, runId, runAttempt},
+  runner{calibrationMs, runId, runAttempt, os, arch, cpus, memGb, nodeVersion, cpuModel, imageOs, imageVersion, browserVersion},
   bundle{experiment{initialJsBytes, totalJsBytes}},
   scenarios[]{
     scenario,
     sourceFile,
-    runner{calibrationMs},
+    runner{calibrationMs, cpuModel},
     kind,
     metrics[]{label, unit, experiment{summary{median, p75, p90}}},
     soak{minutes, samples[]{minute, heapMb, domNodes, listeners, latencyP50Ms, cpuTaskMs, connections, requests}}
@@ -93,6 +108,32 @@ export interface TrendPoint {
    * percentile rule wants at least INP_MIN_INTERACTIONS.
    */
   interactions?: number
+  /**
+   * Host-speed score of the machine that measured this point (higher = slower
+   * host) — the scenario's own shard calibration on multi-shard CI runs,
+   * falling back to the run-level score. Drawn as a per-chart context line so
+   * a metric spike can be eyeballed against the host that produced it without
+   * leaving the chart (the Calibration tab keeps the full per-shard spread).
+   */
+  calibrationMs?: number
+  /**
+   * The machine that produced this point, for the run popover's Host section.
+   * Run-level metadata, except `cpuModel`, which the scenario's own shard
+   * overrides where stamped (multi-shard runs land on different machines).
+   * Older documents carry only the always-collected fields; cpuModel /
+   * image / browser exist from Aug 2026 on.
+   */
+  host?: {
+    os?: string
+    arch?: string
+    cpus?: number
+    memGb?: number
+    nodeVersion?: string
+    cpuModel?: string
+    imageOs?: string
+    imageVersion?: string
+    browserVersion?: string
+  }
   sha: string
   /** benchRun document id — opens the run in the studio. */
   runId: string
@@ -242,6 +283,21 @@ export const SOAK_METRICS: {
   },
 ]
 
+/**
+ * What the host-calibration score actually is — one string shared by every
+ * surface that mentions it (the Calibration tab, the chart ⓘ, the legend
+ * entry, the tooltip line, the run popover's Host section), so the dashboard
+ * can't describe its own honesty measure in two different ways. Mirrors
+ * calibrateHost in perf/bench/runner/browser.ts. Declared above TREND_GROUPS,
+ * which folds it into the Calibration tab's description.
+ */
+export const CALIBRATION_EXPLAINER =
+  'Host calibration is a fixed CPU workload (an integer-hashing loop, median of 5 runs) executed ' +
+  'unthrottled in the browser on the CI machine before it benchmarks anything. Higher = slower ' +
+  'host. It is an absolute score of its own, with no particular relationship to any metric’s ' +
+  'value — only its movement between runs is meaningful — and it measures CPU speed only, not ' +
+  'memory, disk or network.'
+
 export const TREND_GROUPS: {id: TrendGroup; title: string; description: string}[] = [
   {
     id: 'vitals',
@@ -276,8 +332,7 @@ export const TREND_GROUPS: {id: TrendGroup; title: string; description: string}[
   {
     id: 'environment',
     title: 'Calibration',
-    description:
-      'CI host speed per run. Every number in the other tabs depends on how fast the host was, so check here before trusting a spike.',
+    description: `${CALIBRATION_EXPLAINER} Every number in the other tabs depends on how fast the host was, so check here before trusting a spike.`,
   },
 ]
 
@@ -409,7 +464,13 @@ export function formatValue(value: number, unit: TrendUnit): string {
     // the extra digit is noise and costs width again
     return `${Math.abs(seconds) < 100 ? seconds.toFixed(1) : seconds.toFixed(0)}s`
   }
-  return `${value.toFixed(0)}ms`
+  // Sub-10ms fractional values keep one decimal: host calibration lives at
+  // 5–9ms, where whole-ms rounding collapses its entire dynamic range into
+  // four buckets ("8ms" hiding 7.6→8.4). One decimal matches the 0.1ms
+  // granularity Chromium's coarsened performance.now() actually measures at —
+  // more would be false precision. Exact integers stay whole so axis zero
+  // ticks and round latencies don't grow a pointless ".0".
+  return `${Math.abs(value) < 10 && !Number.isInteger(value) ? value.toFixed(1) : value.toFixed(0)}ms`
 }
 
 /**
@@ -473,16 +534,61 @@ export function filterByRange(runs: TrendRun[], days: number | null): TrendRun[]
  * series holds one line per git branch present in the runs — a single branch
  * renders as one line, several overlay for comparison.
  */
+/** The run-level machine description (see TrendPoint.host), or undefined. */
+function hostOf(run: TrendRun): TrendPoint['host'] {
+  const runner = run.runner
+  if (!runner) return undefined
+  return {
+    os: runner.os,
+    arch: runner.arch,
+    cpus: runner.cpus,
+    memGb: runner.memGb,
+    nodeVersion: runner.nodeVersion,
+    cpuModel: runner.cpuModel,
+    imageOs: runner.imageOs,
+    imageVersion: runner.imageVersion,
+    browserVersion: runner.browserVersion,
+  }
+}
+
+/**
+ * Per-shard attribution for a point produced by one scenario: the shard's own
+ * calibration score (falling back to the run level), and — where mergeShards
+ * stamped one — the shard's CPU model layered over the run-level host, since
+ * multi-shard CI runs land each scenario on a different machine and the
+ * run-level runner block describes only the first shard's. Shared by the
+ * metric, soak and calibration series builders so none of them can
+ * misattribute a shard's host.
+ */
+function shardMeta(
+  run: TrendRun,
+  runner: NonNullable<TrendRun['scenarios']>[number]['runner'],
+): Pick<TrendPoint, 'calibrationMs' | 'host'> {
+  const calibrationMs =
+    typeof runner?.calibrationMs === 'number'
+      ? runner.calibrationMs
+      : (run.runner?.calibrationMs ?? undefined)
+  const shardCpuModel = typeof runner?.cpuModel === 'string' ? runner.cpuModel : undefined
+  return {
+    ...(calibrationMs !== undefined ? {calibrationMs} : {}),
+    ...(shardCpuModel ? {host: {...hostOf(run), cpuModel: shardCpuModel}} : {}),
+  }
+}
+
 /** Backlink + identity fields every TrendPoint carries, derived from a run. */
 function pointMeta(
   run: TrendRun,
-): Pick<TrendPoint, 'sha' | 'runId' | 'prNumber' | 'ciRunId' | 'ciRunAttempt'> {
+): Pick<TrendPoint, 'sha' | 'runId' | 'prNumber' | 'ciRunId' | 'ciRunAttempt' | 'host'> {
+  const host = hostOf(run)
   return {
     sha: run.git?.sha ?? 'unknown',
     runId: run._id,
     prNumber: run.git?.prNumber,
     ciRunId: run.runner?.runId,
     ciRunAttempt: run.runner?.runAttempt,
+    // Only when the run recorded any host detail — an empty Host section
+    // would be noise on documents that predate the metadata
+    ...(host && Object.values(host).some((value) => value != null) ? {host} : {}),
   }
 }
 
@@ -545,12 +651,26 @@ function mergeRunsPerCommit(points: TrendPoint[]): TrendPoint[] {
     const interactionCounts = group
       .map((point) => point.interactions)
       .filter((v): v is number => v !== undefined)
+    const calibrations = group
+      .map((point) => point.calibrationMs)
+      .filter((v): v is number => v !== undefined)
+    // Host identity survives the merge only when every merged run agrees on
+    // it: same-commit re-runs land on different machines exactly when host
+    // context matters, and pairing the median score below with the *last*
+    // re-run's CPU model/browser would attribute a synthetic point to one
+    // specific machine it does not describe.
+    const hostKeys = new Set(group.map((point) => JSON.stringify(point.host ?? null)))
     merged.push({
       ...last,
       value: medianOf(group.map((point) => point.value)),
       p75: p75s.length > 0 ? medianOf(p75s) : undefined,
       p90: p90s.length > 0 ? medianOf(p90s) : undefined,
       interactions: interactionCounts.length > 0 ? medianOf(interactionCounts) : undefined,
+      // Median host speed across the merged runs — consistent with the value
+      // merge, so the context line describes the same synthetic point. The
+      // unmerged per-run spread stays visible in the Calibration tab.
+      calibrationMs: calibrations.length > 0 ? medianOf(calibrations) : undefined,
+      host: hostKeys.size === 1 ? last.host : undefined,
     })
   }
   return merged.sort((a, b) => a.date.getTime() - b.date.getTime())
@@ -567,7 +687,7 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
       'description' | 'goal' | 'group' | 'sourceFile' | 'lineLabel' | 'goodThreshold'
     >,
     run: TrendRun,
-    point: Pick<TrendPoint, 'value' | 'p75' | 'p90' | 'interactions'>,
+    point: Pick<TrendPoint, 'value' | 'p75' | 'p90' | 'interactions' | 'calibrationMs' | 'host'>,
   ) => {
     const existing = series.get(key) ?? {key, title, unit, ...meta, lines: []}
     const branch = run.git?.branch ?? 'unknown'
@@ -590,6 +710,7 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
       const inpInteractions = scenario.metrics?.find(
         (metric) => metric.label === 'INP interactions',
       )?.experiment?.summary?.median
+      const scenarioMeta = shardMeta(run, scenario.runner)
       for (const metric of scenario.metrics ?? []) {
         if (metric.label === 'INP interactions') continue
         // Older documents carry a TTFB metric; skip it. Against the local
@@ -608,6 +729,7 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
             value: summary.median,
             p75: summary.p75,
             p90: summary.p90,
+            ...scenarioMeta,
             ...(metric.label === 'INP' && inpInteractions !== undefined
               ? {interactions: inpInteractions}
               : {}),
@@ -716,26 +838,33 @@ export function calibrationSeries(runs: TrendRun[]): TrendSeries {
     // by mergeShards). Plot each distinct shard calibration as its own point —
     // the vertical spread at one date IS the cross-shard host variance. Older
     // documents (no per-scenario runner) fall back to the run-level score.
-    const shardScores = new Set<number>()
+    // Each point keeps its own shard's identity (via shardMeta): the run-level
+    // runner block is the first shard's, and naming that machine on every
+    // shard's point would misattribute the host in the tooltip and popover.
+    const shards = new Map<string, NonNullable<TrendRun['scenarios']>[number]['runner']>()
     for (const scenario of run.scenarios ?? []) {
       if (typeof scenario.runner?.calibrationMs === 'number') {
-        shardScores.add(scenario.runner.calibrationMs)
+        shards.set(
+          `${scenario.runner.calibrationMs}:${scenario.runner.cpuModel ?? ''}`,
+          scenario.runner,
+        )
       }
     }
-    const values =
-      shardScores.size > 0 ? [...shardScores] : run.runner ? [run.runner.calibrationMs] : []
-    if (values.length === 0) continue
+    const runners = shards.size > 0 ? [...shards.values()] : run.runner ? [null] : []
+    if (runners.length === 0) continue
     const branch = run.git?.branch ?? 'unknown'
     let line = byBranch.get(branch)
     if (!line) {
       line = {branch, points: []}
       byBranch.set(branch, line)
     }
-    for (const value of values) {
+    for (const runner of runners) {
+      const meta = shardMeta(run, runner)
       line.points.push({
         date: runDate(run),
-        value,
+        value: meta.calibrationMs!,
         ...pointMeta(run),
+        ...(meta.host ? {host: meta.host} : {}),
       })
     }
   }
@@ -743,8 +872,7 @@ export function calibrationSeries(runs: TrendRun[]): TrendSeries {
     key: 'runner:calibration',
     title: 'host calibration (higher = slower host)',
     unit: 'ms',
-    description:
-      'A fixed CPU workload run on the CI machine before each benchmark. All numbers above are relative to host speed. When this line spikes where a metric spikes, suspect the runner, not the studio.',
+    description: `${CALIBRATION_EXPLAINER} All numbers in the other tabs are relative to host speed — when this line spikes where a metric spikes, suspect the runner, not the studio.`,
     goal: 'context',
     group: 'environment',
     lines: [...byBranch.values()],
@@ -755,13 +883,19 @@ type SoakScenario = NonNullable<NonNullable<TrendRun['scenarios']>[number]['soak
 type SoakSample = NonNullable<SoakScenario['samples']>[number]
 
 /** Find each run's soak scenario (there's at most one), newest run first. */
-function runsWithSoak(
-  runs: TrendRun[],
-): {run: TrendRun; soak: SoakScenario; sourceFile?: string}[] {
+function runsWithSoak(runs: TrendRun[]): {
+  run: TrendRun
+  soak: SoakScenario
+  sourceFile?: string
+  /** The soak scenario's own shard runner — see shardMeta. */
+  runner: NonNullable<TrendRun['scenarios']>[number]['runner']
+}[] {
   return runs
     .map((run) => {
       const scenario = run.scenarios?.find((s) => s.soak?.samples?.length)
-      return scenario?.soak ? {run, soak: scenario.soak, sourceFile: scenario.sourceFile} : null
+      return scenario?.soak
+        ? {run, soak: scenario.soak, sourceFile: scenario.sourceFile, runner: scenario.runner}
+        : null
     })
     .filter((entry) => entry !== null)
 }
@@ -787,6 +921,7 @@ export function latestSoakCharts(runs: TrendRun[]): {run: TrendRun; charts: Tren
         date: new Date(sample.minute * 60_000),
         value,
         ...pointMeta(latest.run),
+        ...shardMeta(latest.run, latest.runner),
       }))
     return {
       key: `soak:latest:${metric.key}`,
@@ -848,13 +983,13 @@ function soakHistory(
   const byMetric = SOAK_METRICS.map((metric): TrendSeries => {
     const lineByBranch = new Map<string, TrendLine>()
     let sourceFile: string | undefined
-    for (const {run, soak, sourceFile: file} of withSoak) {
+    for (const {run, soak, sourceFile: file, runner} of withSoak) {
       const value = reduce(soak.samples ?? [], metric.key)
       if (value === null) continue
       sourceFile ??= file
       const branch = run.git?.branch ?? 'unknown'
       const line = lineByBranch.get(branch) ?? {branch, points: []}
-      line.points.push({date: runDate(run), value, ...pointMeta(run)})
+      line.points.push({date: runDate(run), value, ...pointMeta(run), ...shardMeta(run, runner)})
       lineByBranch.set(branch, line)
     }
     return {

--- a/dev/metrics-studio/tools/trends/layers.ts
+++ b/dev/metrics-studio/tools/trends/layers.ts
@@ -6,7 +6,7 @@
  */
 import {useCallback, useMemo} from 'react'
 
-export const LAYERS = ['median', 'band', 'baseline'] as const
+export const LAYERS = ['median', 'band', 'calibration', 'baseline'] as const
 export type Layer = (typeof LAYERS)[number]
 
 export interface LayerState {

--- a/perf/bench/cli/commands/runImpl.ts
+++ b/perf/bench/cli/commands/runImpl.ts
@@ -123,7 +123,10 @@ export async function runBench(argv: RunArgs): Promise<void> {
   try {
     const calibration = await calibrateHost(browser)
     console.log(
-      `host calibration: ${calibration.toFixed(0)}ms (fixed workload; higher = slower host), CPU throttle: ${argv.throttle}x` +
+      // One decimal: the score lives at 5–9ms and is measured at 0.1ms
+      // granularity — whole-ms rounding collapses its whole range (see the
+      // dashboard's formatValue, which made the same call)
+      `host calibration: ${calibration.toFixed(1)}ms (fixed workload; higher = slower host), CPU throttle: ${argv.throttle}x` +
         `${reference ? `, mode: A/B (seed ${argv.seed})` : ', mode: absolute'}`,
     )
     const runMetadata = collectRunMetadata({
@@ -132,6 +135,7 @@ export async function runBench(argv: RunArgs): Promise<void> {
       cpuThrottleRate: argv.throttle,
       seed: argv.seed,
       startedAt,
+      browserVersion: browser.version(),
     })
 
     if (argv.mode === 'soak') {

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import os from 'node:os'
 import process from 'node:process'
 
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
@@ -15,6 +16,8 @@ const ENV_KEYS = [
   'BENCH_MERGE_BASE',
   'BENCH_GIT_SHA',
   'BENCH_GIT_COMMITTED_AT',
+  'ImageOS',
+  'ImageVersion',
 ] as const
 let savedEnv: Record<string, string | undefined>
 
@@ -42,6 +45,36 @@ function metadata() {
 }
 
 describe('collectRunMetadata', () => {
+  it('records producer metadata: cpu model, runner image, browser version', () => {
+    process.env.ImageOS = 'ubuntu24'
+    process.env.ImageVersion = '20260810.1.0'
+    const runner = collectRunMetadata({
+      mode: 'ab',
+      calibrationMs: 10,
+      cpuThrottleRate: 4,
+      seed: 1,
+      startedAt: '2026-07-10T05:00:00.000Z',
+      browserVersion: '140.0.7339.16',
+    }).runner
+    expect(runner).toMatchObject({
+      imageOs: 'ubuntu24',
+      imageVersion: '20260810.1.0',
+      browserVersion: '140.0.7339.16',
+    })
+    // Machine-dependent — assert against the same source the code reads so
+    // the test is exact everywhere Node reports a model at all
+    const expectedModel = os.cpus()[0]?.model.trim()
+    if (expectedModel) expect(runner.cpuModel).toBe(expectedModel)
+    else expect(runner.cpuModel).toBeUndefined()
+  })
+
+  it('omits runner image and browser fields when not provided', () => {
+    const runner = metadata().runner
+    expect(runner.imageOs).toBeUndefined()
+    expect(runner.imageVersion).toBeUndefined()
+    expect(runner.browserVersion).toBeUndefined()
+  })
+
   it('extracts the PR number from GITHUB_REF', () => {
     process.env.GITHUB_SHA = 'abc'
     process.env.GITHUB_REF = 'refs/pull/13442/merge'

--- a/perf/bench/report/__tests__/markdown.test.ts
+++ b/perf/bench/report/__tests__/markdown.test.ts
@@ -295,6 +295,23 @@ describe('mergeShards', () => {
     expect(merged.runner).toEqual(RUN.runner)
   })
 
+  it('stamps every scenario with its own shard cpu model', () => {
+    // The CPU model is what stops a scenario being attributed to the first
+    // shard's machine — the calibration assertion above would still pass if
+    // this propagation were dropped.
+    const merged = mergeShards([
+      {...RUN, runner: {...RUN.runner, cpuModel: 'AMD EPYC 7763'}},
+      {...shardTwo, runner: {...shardTwo.runner, cpuModel: 'Intel Xeon 8370C'}},
+    ])
+    for (const scenario of merged.scenarios.slice(0, -1)) {
+      expect(scenario.runner?.cpuModel).toBe('AMD EPYC 7763')
+    }
+    expect(merged.scenarios.at(-1)?.runner).toEqual({
+      calibrationMs: 19,
+      cpuModel: 'Intel Xeon 8370C',
+    })
+  })
+
   it('fails loudly on duplicate scenario reports (they would collide as stored _keys)', () => {
     expect(() => mergeShards([RUN, {...shardTwo, scenarios: [RUN.scenarios[1]]}])).toThrow(
       /duplicate scenario report\(s\): interaction-article/,

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -30,6 +30,8 @@ export function collectRunMetadata(options: {
   cpuThrottleRate: number
   seed: number
   startedAt: string
+  /** Chromium version the sessions run in (`browser.version()`). */
+  browserVersion?: string
 }): Omit<BenchRunDocument, 'scenarios' | 'completedAt' | 'bundle'> {
   const prNumber = Number(
     (process.env.GITHUB_REF ?? '').match(/refs\/pull\/(\d+)\//)?.[1] ?? Number.NaN,
@@ -77,6 +79,17 @@ export function collectRunMetadata(options: {
       cpus: os.cpus().length,
       memGb: Math.round(os.totalmem() / 1024 ** 3),
       nodeVersion: process.version,
+      // The hardware discriminator: GitHub rotates CPU generations under the
+      // same vCPU shape, so cpus/memGb can't explain a host-speed step but
+      // the model string can. Empty on platforms where Node reports none.
+      ...(os.cpus()[0]?.model.trim() ? {cpuModel: os.cpus()[0].model.trim()} : {}),
+      // GitHub runner image identity — pins when the image (toolchain, libs)
+      // rolled, which tends to coincide with host-speed regime changes
+      ...(process.env.ImageOS ? {imageOs: process.env.ImageOS} : {}),
+      ...(process.env.ImageVersion ? {imageVersion: process.env.ImageVersion} : {}),
+      // The measuring instrument: a Playwright bump moves INP/vitals with no
+      // studio change, and this is what makes that visible after the fact
+      ...(options.browserVersion ? {browserVersion: options.browserVersion} : {}),
       ci: process.env.CI === 'true',
       ...(process.env.GITHUB_RUN_ID ? {runId: process.env.GITHUB_RUN_ID} : {}),
       ...(process.env.GITHUB_RUN_ATTEMPT

--- a/perf/bench/report/mergeShards.ts
+++ b/perf/bench/report/mergeShards.ts
@@ -19,7 +19,13 @@ export function mergeShards(shards: BenchRunDocument[]): BenchRunDocument {
   const scenarios = shards.flatMap((shard) =>
     shard.scenarios.map((scenario) => ({
       ...scenario,
-      runner: {calibrationMs: shard.runner.calibrationMs},
+      // The shard's own host speed AND hardware identity — shards can land on
+      // different CPU generations, and the document-level runner (first
+      // shard's) would misattribute both
+      runner: {
+        calibrationMs: shard.runner.calibrationMs,
+        ...(shard.runner.cpuModel ? {cpuModel: shard.runner.cpuModel} : {}),
+      },
     })),
   )
 

--- a/perf/bench/report/types.ts
+++ b/perf/bench/report/types.ts
@@ -32,6 +32,24 @@ export interface BenchRunDocument {
     cpus: number
     memGb: number
     nodeVersion: string
+    /**
+     * CPU model string (`os.cpus()[0].model`) — the field that discriminates
+     * hosted-runner hardware generations: GitHub rotates Xeon/EPYC models
+     * under the same vCPU shape, so cpus/memGb stay identical while the
+     * machine (and every absolute number) changes. Absent where Node reports
+     * no model.
+     */
+    cpuModel?: string
+    /** GitHub runner image (`ImageOS` env), e.g. "ubuntu24" — CI only. */
+    imageOs?: string
+    /** GitHub runner image version (`ImageVersion` env) — pins when the image (toolchain, libs) rolled. */
+    imageVersion?: string
+    /**
+     * Chromium version the sessions ran in (`browser.version()`). The browser
+     * is the measuring instrument — a Playwright bump can move INP/vitals
+     * with no studio change, and this is what makes that visible.
+     */
+    browserVersion?: string
     ci: boolean
     runId?: string
     /** CI run attempt (re-runs increment it) — for the exact Actions URL. */
@@ -68,10 +86,11 @@ export interface ScenarioReport {
    * Host-speed calibration of the runner that produced THIS scenario.
    * CI runs one shard per scenario on separate runners, so the document-level
    * `runner.calibrationMs` (first shard's) doesn't apply to every scenario —
-   * mergeShards stamps each scenario with its own shard's score. Absent on
-   * single-shard/local documents (the document-level value applies).
+   * mergeShards stamps each scenario with its own shard's score (and CPU
+   * model, since shards can land on different hardware generations). Absent
+   * on single-shard/local documents (the document-level value applies).
    */
-  runner?: {calibrationMs: number}
+  runner?: {calibrationMs: number; cpuModel?: string}
   /**
    * How the metrics are rendered/grouped (interaction vs pageload charts).
    * Soak and INP reports reuse these kinds but are distinct measurement modes;


### PR DESCRIPTION
### Description
two smaller tweaks to the bench suite:
- Show host calibration context in trend charts. This plots the host calibration in the trend chart themselves to give an indication of how it may affect the outcome.
- Collect cpu model, runner image and browser version per run so we can easily correlate changes host environment in charts

### What to review
Preview build here: https://studio-metrics-git-metrics-host-calibration-context.sanity.dev/trends

### Testing
Unit tests included

### Notes for release

n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Additive schema and dashboard visualization for bench metadata, not auth or user data. Risk is mainly mis-attributing host vs product regressions if shard merge or overlay scaling is wrong.
> 
> **Overview**
> Makes host-speed skew visible on the same chart as the metric, and records enough runner identity to tell hardware/image/browser changes apart from studio regressions.
> 
> **Collection:** `collectRunMetadata` now stores `cpuModel`, GitHub `ImageOS`/`ImageVersion`, and Chromium `browserVersion`. `mergeShards` stamps each scenario with that shard’s `cpuModel` as well as its calibration score, so multi-shard runs are not attributed to the first machine.
> 
> **Trends:** ms charts draw a dotted, zero-based **host calibration** context line (toggleable via `?layers=`), using the shard that measured that scenario. Tooltips and the run popover show host identity and the shared `CALIBRATION_EXPLAINER`. Same-commit merges keep median calibration and drop host when machines disagree. Sub-10ms values format to one decimal so the 5–9ms calibration range is not rounded away.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957a19c62c90b94108dd120f8e2f6ed5c6c58064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->