### PR TITLE
fix(releases): honour document action filters in version and release menus

### DIFF
--- a/dev/test-studio/documentActions/index.ts
+++ b/dev/test-studio/documentActions/index.ts
@@ -39,6 +39,14 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaTyp
   if (schemaType === 'removeRestoreActionTest') {
     return prev.filter(({action}) => action !== 'restore')
   }
+
+  // Mirrors customer configs that strip discard/delete-schedule from the document
+  // action menu (SAPP-4330). The version chip / inventory context menu must honour
+  // the same filter — keep only publish so discardVersion and schedule are absent.
+  if (schemaType === 'restrictedVersionActionsTest') {
+    return prev.filter(({action}) => action === 'publish')
+  }
+
   if (schemaType === 'book') {
     return prev.concat(useCreateAnonymousVersion)
   }

--- a/dev/test-studio/documentActions/index.ts
+++ b/dev/test-studio/documentActions/index.ts
@@ -39,14 +39,6 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaTyp
   if (schemaType === 'removeRestoreActionTest') {
     return prev.filter(({action}) => action !== 'restore')
   }
-
-  // Mirrors customer configs that strip discard/delete-schedule from the document
-  // action menu (SAPP-4330). The version chip / inventory context menu must honour
-  // the same filter — keep only publish so discardVersion and schedule are absent.
-  if (schemaType === 'restrictedVersionActionsTest') {
-    return prev.filter(({action}) => action === 'publish')
-  }
-
   if (schemaType === 'book') {
     return prev.concat(useCreateAnonymousVersion)
   }

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -315,6 +315,11 @@ const defaultWorkspace = defineConfig({
   },
   document: {
     actions: (prev, ctx) => {
+      // SAPP-4330: workspace-level filter (runs after release/scheduled-draft plugins)
+      // so version chip + inventory menus can mirror footer action visibility.
+      if (ctx.schemaType === 'restrictedVersionActionsTest') {
+        return prev.filter(({action}) => action === 'publish')
+      }
       if (ctx.schemaType === 'book' && ctx.releaseId) {
         return [useTestVersionAction, ...prev]
       }

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -315,8 +315,6 @@ const defaultWorkspace = defineConfig({
   },
   document: {
     actions: (prev, ctx) => {
-      // SAPP-4330: workspace-level filter (runs after release/scheduled-draft plugins)
-      // so version chip + inventory menus can mirror footer action visibility.
       if (ctx.schemaType === 'restrictedVersionActionsTest') {
         return prev.filter(({action}) => action === 'publish')
       }

--- a/dev/test-studio/schema/debug/restrictedVersionActions.ts
+++ b/dev/test-studio/schema/debug/restrictedVersionActions.ts
@@ -1,0 +1,12 @@
+export default {
+  type: 'document',
+  name: 'restrictedVersionActionsTest',
+  title: 'Restricted version actions',
+  fields: [
+    {
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+    },
+  ],
+}

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -100,6 +100,7 @@ import recursivePopover from './debug/recursivePopover'
 import {pageDocRepro, sectionDocRepro} from './debug/referenceCreateButtonRepro'
 import removeRestoreAction from './debug/removeRestoreAction'
 import reservedFieldNames from './debug/reservedFieldNames'
+import restrictedVersionActions from './debug/restrictedVersionActions'
 import review from './debug/review'
 import * as scrollBugTypes from './debug/scrollBug'
 import select from './debug/select'
@@ -262,6 +263,7 @@ export function createSchemaTypes(projectId: string) {
     ...hiddenFieldValidationTypes,
     fieldsets,
     removeRestoreAction,
+    restrictedVersionActions,
 
     fieldValidationInferReproSharedObject,
     fieldValidationInferReproDoc,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -91,6 +91,7 @@ export const DEBUG_INPUT_TYPES = [
   'recursiveObjectTest',
   'recursivePopoverTest',
   'removeRestoreActionTest',
+  'restrictedVersionActionsTest',
   'reservedKeywordsTest',
   'scrollBug',
   'select',

--- a/packages/sanity/src/core/config/document/__tests__/useConfiguredDocumentActionIds.test.ts
+++ b/packages/sanity/src/core/config/document/__tests__/useConfiguredDocumentActionIds.test.ts
@@ -1,0 +1,81 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  getDiscardDocumentActionId,
+  getVersionContextMenuActionsContext,
+} from '../useConfiguredDocumentActionIds'
+
+describe('getVersionContextMenuActionsContext', () => {
+  it('resolves scheduled-draft context from a cardinality-one release chip', () => {
+    expect(
+      getVersionContextMenuActionsContext({
+        schemaType: 'article',
+        documentGroupId: 'doc-1',
+        fromRelease: 'r1',
+        isScheduledDraft: true,
+      }),
+    ).toEqual({
+      schemaType: 'article',
+      documentId: 'doc-1',
+      versionType: 'scheduled-draft',
+      releaseId: 'r1',
+    })
+  })
+
+  it('resolves version context for a regular release chip', () => {
+    expect(
+      getVersionContextMenuActionsContext({
+        schemaType: 'article',
+        documentGroupId: 'doc-1',
+        fromRelease: 'r1',
+      }),
+    ).toEqual({
+      schemaType: 'article',
+      documentId: 'doc-1',
+      versionType: 'version',
+      releaseId: 'r1',
+    })
+  })
+
+  it('resolves draft and published system perspectives without a releaseId', () => {
+    expect(
+      getVersionContextMenuActionsContext({
+        schemaType: 'article',
+        documentGroupId: 'doc-1',
+        fromRelease: 'draft',
+      }),
+    ).toEqual({
+      schemaType: 'article',
+      documentId: 'doc-1',
+      versionType: 'draft',
+      releaseId: undefined,
+    })
+
+    expect(
+      getVersionContextMenuActionsContext({
+        schemaType: 'article',
+        documentGroupId: 'doc-1',
+        fromRelease: 'published',
+      }),
+    ).toEqual({
+      schemaType: 'article',
+      documentId: 'doc-1',
+      versionType: 'published',
+      releaseId: undefined,
+    })
+  })
+})
+
+describe('getDiscardDocumentActionId', () => {
+  it('maps draft chips to discardChanges and release chips to discardVersion', () => {
+    expect(getDiscardDocumentActionId({fromRelease: 'draft'})).toBe('discardChanges')
+    expect(getDiscardDocumentActionId({fromRelease: 'r1'})).toBe('discardVersion')
+    expect(getDiscardDocumentActionId({fromRelease: 'r1', isScheduledDraft: true})).toBe(
+      'discardVersion',
+    )
+  })
+
+  it('returns null for published chips', () => {
+    expect(getDiscardDocumentActionId({fromRelease: 'published'})).toBeNull()
+  })
+})

--- a/packages/sanity/src/core/config/document/useConfiguredDocumentActionIds.ts
+++ b/packages/sanity/src/core/config/document/useConfiguredDocumentActionIds.ts
@@ -19,7 +19,7 @@ import {type DocumentActionKeys} from './actions'
 export function useConfiguredDocumentActionIds(
   context: PartialContext<DocumentActionsContext>,
 ): ReadonlySet<keyof DocumentActionKeys> {
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
+  // oxlint-disable-next-line no-deprecated -- deprecated for external consumers; the document pane resolves document.actions from this same source instance
   const source = useSource()
   const resolveDocumentActions = source.document.actions
 
@@ -32,15 +32,7 @@ export function useConfiguredDocumentActionIds(
       versionType,
       releaseId,
     })
-    const ids = new Set<keyof DocumentActionKeys>()
-
-    for (const action of configured) {
-      if (action.action) {
-        ids.add(action.action)
-      }
-    }
-
-    return ids
+    return new Set(configured.flatMap(({action}) => (action ? [action] : [])))
   }, [schemaType, documentId, versionType, releaseId, resolveDocumentActions])
 }
 
@@ -95,8 +87,8 @@ export function getDiscardDocumentActionId(options: {
     return null
   }
 
-  if (fromRelease === 'draft' && !isScheduledDraft) {
-    return 'discardChanges'
+  if (fromRelease === 'draft') {
+    return isScheduledDraft ? 'discardVersion' : 'discardChanges'
   }
 
   return 'discardVersion'

--- a/packages/sanity/src/core/config/document/useConfiguredDocumentActionIds.ts
+++ b/packages/sanity/src/core/config/document/useConfiguredDocumentActionIds.ts
@@ -1,0 +1,103 @@
+import {useMemo} from 'react'
+
+import {useSource} from '../../studio/source'
+import {
+  type DocumentActionsContext,
+  type DocumentActionsVersionType,
+  type PartialContext,
+} from '../types'
+import {type DocumentActionKeys} from './actions'
+
+/**
+ * Resolves the set of configured document action identifiers for a given
+ * document context. Reflects `document.actions` filtering from the studio
+ * config (and plugins), so callers can hide surfaces that mirror those
+ * actions — for example the version chip / document group inventory context menu.
+ *
+ * @internal
+ */
+export function useConfiguredDocumentActionIds(
+  context: PartialContext<DocumentActionsContext>,
+): ReadonlySet<keyof DocumentActionKeys> {
+  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
+  const source = useSource()
+  const resolveDocumentActions = source.document.actions
+
+  const {schemaType, documentId, versionType, releaseId} = context
+
+  return useMemo(() => {
+    const configured = resolveDocumentActions({
+      schemaType,
+      documentId,
+      versionType,
+      releaseId,
+    })
+    const ids = new Set<keyof DocumentActionKeys>()
+
+    for (const action of configured) {
+      if (action.action) {
+        ids.add(action.action)
+      }
+    }
+
+    return ids
+  }, [schemaType, documentId, versionType, releaseId, resolveDocumentActions])
+}
+
+/**
+ * Derives the document-actions context for a version chip / inventory row
+ * context menu from the chip's release identity.
+ *
+ * @internal
+ */
+export function getVersionContextMenuActionsContext(options: {
+  schemaType: string
+  documentGroupId: string
+  fromRelease: string
+  isScheduledDraft?: boolean
+}): PartialContext<DocumentActionsContext> {
+  const {schemaType, documentGroupId, fromRelease, isScheduledDraft = false} = options
+
+  let versionType: DocumentActionsVersionType
+  if (isScheduledDraft) {
+    versionType = 'scheduled-draft'
+  } else if (fromRelease === 'published') {
+    versionType = 'published'
+  } else if (fromRelease === 'draft') {
+    versionType = 'draft'
+  } else {
+    versionType = 'version'
+  }
+
+  const releaseId = fromRelease === 'published' || fromRelease === 'draft' ? undefined : fromRelease
+
+  return {
+    schemaType,
+    documentId: documentGroupId,
+    versionType,
+    releaseId,
+  }
+}
+
+/**
+ * The document action identifier that corresponds to discarding the version
+ * represented by a context menu (draft discard vs version discard).
+ *
+ * @internal
+ */
+export function getDiscardDocumentActionId(options: {
+  fromRelease: string
+  isScheduledDraft?: boolean
+}): keyof DocumentActionKeys | null {
+  const {fromRelease, isScheduledDraft = false} = options
+
+  if (fromRelease === 'published') {
+    return null
+  }
+
+  if (fromRelease === 'draft' && !isScheduledDraft) {
+    return 'discardChanges'
+  }
+
+  return 'discardVersion'
+}

--- a/packages/sanity/src/core/config/document/useConfiguredDocumentActionIds.ts
+++ b/packages/sanity/src/core/config/document/useConfiguredDocumentActionIds.ts
@@ -8,6 +8,8 @@ import {
 } from '../types'
 import {type DocumentActionKeys} from './actions'
 
+const NO_ACTION_IDS: ReadonlySet<keyof DocumentActionKeys> = new Set()
+
 /**
  * Resolves the set of configured document action identifiers for a given
  * document context. Reflects `document.actions` filtering from the studio
@@ -17,15 +19,21 @@ import {type DocumentActionKeys} from './actions'
  * @internal
  */
 export function useConfiguredDocumentActionIds(
-  context: PartialContext<DocumentActionsContext>,
+  context: PartialContext<DocumentActionsContext> | null,
 ): ReadonlySet<keyof DocumentActionKeys> {
   // oxlint-disable-next-line no-deprecated -- deprecated for external consumers; the document pane resolves document.actions from this same source instance
   const source = useSource()
   const resolveDocumentActions = source.document.actions
 
-  const {schemaType, documentId, versionType, releaseId} = context
+  const schemaType = context?.schemaType
+  const documentId = context?.documentId
+  const versionType = context?.versionType
+  const releaseId = context?.releaseId
 
   return useMemo(() => {
+    // Resolving without an identity would hand a `ctx.schemaType` predicate an undefined value.
+    if (schemaType === undefined || versionType === undefined) return NO_ACTION_IDS
+
     const configured = resolveDocumentActions({
       schemaType,
       documentId,

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
@@ -29,7 +29,8 @@ interface CanonicalReleaseContextMenuProps {
   hasDiscardPermission: boolean
   isPublished: boolean
   /**
-   * Whether the UI permits discarding versions.
+   * Whether the UI permits discarding versions, which includes whether the
+   * discard action is still configured in `document.actions`.
    * Defaults to `true`.
    */
   isDiscardable?: boolean

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
@@ -27,6 +27,21 @@ interface ScheduledDraftContextMenuProps {
   scheduledDraftMenuActions: UseScheduledDraftMenuActionsReturn
   documentType: string
   release?: ReleaseDocument
+  /**
+   * Whether the Publish now action is configured in `document.actions`.
+   * Defaults to `true`.
+   */
+  showPublishNow?: boolean
+  /**
+   * Whether the Edit schedule action is configured in `document.actions`.
+   * Defaults to `true`.
+   */
+  showEditSchedule?: boolean
+  /**
+   * Whether the Delete schedule action is configured in `document.actions`.
+   * Defaults to `true`.
+   */
+  showDeleteSchedule?: boolean
 }
 
 export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu(
@@ -44,6 +59,9 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
     scheduledDraftMenuActions,
     documentType,
     release,
+    showPublishNow = true,
+    showEditSchedule = true,
+    showDeleteSchedule = true,
   } = props
   const {t} = useTranslation()
   const hasCopyToDraftOption = useHasCopyToDraftOption(documentType, bundleId)
@@ -52,13 +70,15 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
   const copyToReleaseOptions = releases.filter((r) => !isReleaseScheduledOrScheduling(r))
   const isReleasesEnabled = !!useWorkspace().releases?.enabled
   const showCopyToReleaseMenuItem = isReleasesEnabled && copyToReleaseOptions.length > 0
+  const showCopySection = showCopyToReleaseMenuItem || hasCopyToDraftOption
+  const showEditScheduleItem = showEditSchedule && !isPausedCardinalityOneRelease(release)
 
   const {actions} = scheduledDraftMenuActions
 
   return (
     <Menu>
-      <MenuItem {...actions.publishNow} />
-      {!isPausedCardinalityOneRelease(release) && <MenuItem {...actions.editSchedule} />}
+      {showPublishNow && <MenuItem {...actions.publishNow} />}
+      {showEditScheduleItem && <MenuItem {...actions.editSchedule} />}
       <IntentLink
         intent={RELEASES_SCHEDULED_DRAFTS_INTENT}
         params={{view: 'drafts'}}
@@ -67,8 +87,8 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
       >
         <MenuItem icon={CalendarIcon} text={t('release.action.view-scheduled-drafts')} />
       </IntentLink>
-      <MenuDivider />
-      {(showCopyToReleaseMenuItem || hasCopyToDraftOption) && (
+      {(showCopySection || showDeleteSchedule) && <MenuDivider />}
+      {showCopySection && (
         <>
           <CopyToReleaseMenuGroup
             releases={copyToReleaseOptions}
@@ -82,10 +102,10 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
             hasCreatePermission={hasCreatePermission}
             documentType={documentType}
           />
-          <MenuDivider />
+          {showDeleteSchedule && <MenuDivider />}
         </>
       )}
-      <MenuItem {...actions.deleteSchedule} />
+      {showDeleteSchedule && <MenuItem {...actions.deleteSchedule} />}
     </Menu>
   )
 })

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
@@ -27,21 +27,10 @@ interface ScheduledDraftContextMenuProps {
   scheduledDraftMenuActions: UseScheduledDraftMenuActionsReturn
   documentType: string
   release?: ReleaseDocument
-  /**
-   * Whether the Publish now action is configured in `document.actions`.
-   * Defaults to `true`.
-   */
-  showPublishNow?: boolean
-  /**
-   * Whether the Edit schedule action is configured in `document.actions`.
-   * Defaults to `true`.
-   */
-  showEditSchedule?: boolean
-  /**
-   * Whether the Delete schedule action is configured in `document.actions`.
-   * Defaults to `true`.
-   */
-  showDeleteSchedule?: boolean
+  /** Each gated on the matching `document.actions` id still being configured. */
+  showPublishNow: boolean
+  showEditSchedule: boolean
+  showDeleteSchedule: boolean
 }
 
 export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu(
@@ -59,9 +48,9 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
     scheduledDraftMenuActions,
     documentType,
     release,
-    showPublishNow = true,
-    showEditSchedule = true,
-    showDeleteSchedule = true,
+    showPublishNow,
+    showEditSchedule,
+    showDeleteSchedule,
   } = props
   const {t} = useTranslation()
   const hasCopyToDraftOption = useHasCopyToDraftOption(documentType, bundleId)
@@ -72,6 +61,7 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
   const showCopyToReleaseMenuItem = isReleasesEnabled && copyToReleaseOptions.length > 0
   const showCopySection = showCopyToReleaseMenuItem || hasCopyToDraftOption
   const showEditScheduleItem = showEditSchedule && !isPausedCardinalityOneRelease(release)
+  const showCopyToDeleteDivider = showCopySection && showDeleteSchedule
 
   const {actions} = scheduledDraftMenuActions
 
@@ -102,7 +92,7 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
             hasCreatePermission={hasCreatePermission}
             documentType={documentType}
           />
-          {showDeleteSchedule && <MenuDivider />}
+          {showCopyToDeleteDivider && <MenuDivider />}
         </>
       )}
       {showDeleteSchedule && <MenuItem {...actions.deleteSchedule} />}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -1,6 +1,11 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {memo, useEffect, useRef, useState} from 'react'
+import {memo, useEffect, useMemo, useRef, useState} from 'react'
 
+import {
+  getDiscardDocumentActionId,
+  getVersionContextMenuActionsContext,
+  useConfiguredDocumentActionIds,
+} from '../../../../config/document/useConfiguredDocumentActionIds'
 import {type UseScheduledDraftMenuActionsReturn} from '../../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
 import {useDocumentPairPermissions} from '../../../../store/grants/documentPairPermissions'
 import {getVersionFromId, isPublishedId} from '../../../../util/draftUtils'
@@ -58,6 +63,24 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
   const isPublished = isPublishedId(versionId)
   const versionName = getVersionFromId(versionId)
 
+  const documentActionsContext = useMemo(
+    () =>
+      getVersionContextMenuActionsContext({
+        schemaType: type,
+        documentGroupId,
+        fromRelease,
+        isScheduledDraft,
+      }),
+    [type, documentGroupId, fromRelease, isScheduledDraft],
+  )
+  const configuredActionIds = useConfiguredDocumentActionIds(documentActionsContext)
+
+  const discardActionId = getDiscardDocumentActionId({fromRelease, isScheduledDraft})
+  const isDiscardActionConfigured = discardActionId
+    ? configuredActionIds.has(discardActionId)
+    : false
+  const canDiscardVersion = isDiscardable && isDiscardActionConfigured
+
   const {checkWithPermissionGuard} = useReleasePermissions()
   const {createRelease} = useReleaseOperations()
   const [hasCreatePermission, setHasCreatePermission] = useState<boolean | null>(null)
@@ -103,6 +126,9 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
         hasCreatePermission={hasCreatePermission}
         scheduledDraftMenuActions={scheduledDraftMenuActions}
         documentType={type}
+        showPublishNow={configuredActionIds.has('publish')}
+        showEditSchedule={configuredActionIds.has('schedule')}
+        showDeleteSchedule={configuredActionIds.has('discardVersion')}
       />
     )
   }
@@ -123,7 +149,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
       hasCreatePermission={hasCreatePermission}
       hasDiscardPermission={hasDiscardPermission || false}
       isPublished={isPublished}
-      isDiscardable={isDiscardable}
+      isDiscardable={canDiscardVersion}
       documentType={type}
     />
   )

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {memo, useEffect, useMemo, useRef, useState} from 'react'
+import {memo, useEffect, useRef, useState} from 'react'
 
 import {
   getDiscardDocumentActionId,
@@ -63,23 +63,20 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
   const isPublished = isPublishedId(versionId)
   const versionName = getVersionFromId(versionId)
 
-  const documentActionsContext = useMemo(
-    () =>
-      getVersionContextMenuActionsContext({
-        schemaType: type,
-        documentGroupId,
-        fromRelease,
-        isScheduledDraft,
-      }),
-    [type, documentGroupId, fromRelease, isScheduledDraft],
+  const configuredActionIds = useConfiguredDocumentActionIds(
+    getVersionContextMenuActionsContext({
+      schemaType: type,
+      documentGroupId,
+      fromRelease,
+      isScheduledDraft,
+    }),
   )
-  const configuredActionIds = useConfiguredDocumentActionIds(documentActionsContext)
 
   const discardActionId = getDiscardDocumentActionId({fromRelease, isScheduledDraft})
   const isDiscardActionConfigured = discardActionId
     ? configuredActionIds.has(discardActionId)
     : false
-  const canDiscardVersion = isDiscardable && isDiscardActionConfigured
+  const isDiscardVersionAvailable = isDiscardable && isDiscardActionConfigured
 
   const {checkWithPermissionGuard} = useReleasePermissions()
   const {createRelease} = useReleaseOperations()
@@ -149,7 +146,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
       hasCreatePermission={hasCreatePermission}
       hasDiscardPermission={hasDiscardPermission || false}
       isPublished={isPublished}
-      isDiscardable={canDiscardVersion}
+      isDiscardable={isDiscardVersionAvailable}
       documentType={type}
     />
   )

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -157,7 +157,6 @@ describe('VersionContextMenu', () => {
     const wrapper = await createTestProvider({
       config: {
         document: {
-          // Axios-style filter: keep only publish so discardVersion is gone by omission
           actions: (prev) => prev.filter((action) => action.action === 'publish'),
         },
       },

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -151,6 +151,100 @@ describe('VersionContextMenu', () => {
     expect(defaultProps.onDiscard).toHaveBeenCalled()
   })
 
+  it('hides discard version when discardVersion is filtered from document.actions', async () => {
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
+    const wrapper = await createTestProvider({
+      config: {
+        document: {
+          actions: (prev) => prev.filter((action) => action.action !== 'discardVersion'),
+        },
+      },
+    })
+
+    render(<VersionContextMenu {...defaultProps} />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
+  })
+
+  it('hides delete schedule when discardVersion is filtered from document.actions', async () => {
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
+    const scheduledRelease: ReleaseDocument = {
+      ...mockReleases[0],
+      metadata: {
+        ...mockReleases[0].metadata,
+        cardinality: 'one',
+      },
+    }
+
+    const scheduledDraftMenuActions = {
+      actions: {
+        publishNow: {
+          'icon': undefined,
+          'text': 'Publish now',
+          'tone': 'default' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'publish-now-menu-item',
+        },
+        editSchedule: {
+          'icon': undefined,
+          'text': 'Edit schedule',
+          'tone': 'default' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'edit-schedule-menu-item',
+        },
+        schedulePublish: {
+          'icon': undefined,
+          'text': 'Schedule',
+          'tone': 'default' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'schedule-publish-menu-item',
+        },
+        deleteSchedule: {
+          'icon': undefined,
+          'text': 'Delete schedule',
+          'tone': 'critical' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'delete-schedule-menu-item',
+        },
+      },
+      dialogs: null,
+      isPerformingOperation: false,
+      selectedAction: null,
+      handleDialogClose: vi.fn(),
+    }
+
+    const wrapper = await createTestProvider({
+      config: {
+        document: {
+          // Axios-style filter: keep only publish so delete schedule (discardVersion) is gone
+          actions: (prev) => prev.filter((action) => action.action === 'publish'),
+        },
+      },
+    })
+
+    render(
+      <VersionContextMenu
+        {...defaultProps}
+        release={scheduledRelease}
+        isScheduledDraft
+        scheduledDraftMenuActions={scheduledDraftMenuActions}
+      />,
+      {wrapper},
+    )
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.getByTestId('publish-now-menu-item')).toBeInTheDocument()
+    expect(screen.queryByTestId('edit-schedule-menu-item')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('delete-schedule-menu-item')).not.toBeInTheDocument()
+  })
+
   it('calls onCreateRelease when a "new release" is clicked', async () => {
     mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -1,7 +1,7 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {useDocumentPairPermissionsMockReturn} from '../../../../../../../test/mocks/useDocumentPairPermissions.mock'
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../../test/testUtils/flushMicrotasks'
@@ -36,6 +36,12 @@ const discardChangesAction: DocumentActionComponent = Object.assign(() => null, 
 })
 
 describe('VersionContextMenu', () => {
+  // `defaultProps` holds shared `vi.fn()`s, so without this a test asserting on one of them can
+  // pass on a call an earlier test made.
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   const mockReleases: ReleaseDocument[] = [
     {
       _id: '_.releases.release1',
@@ -355,7 +361,7 @@ describe('VersionContextMenu', () => {
     expect(defaultProps.onCreateRelease).toHaveBeenCalled()
   })
 
-  it('calls onCreateVersion when a release is clicked and sets the perspective to the release', async () => {
+  it('calls onCreateVersion with the target release when a release is clicked', async () => {
     mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider()
@@ -372,7 +378,7 @@ describe('VersionContextMenu', () => {
     await userEvent.click(screen.getByTestId('copy-version-to-release-button-group'))
 
     await userEvent.click(screen.getByText('Release 2'))
-    expect(defaultProps.onCreateRelease).toHaveBeenCalled()
+    expect(defaultProps.onCreateVersion).toHaveBeenCalledWith('_.releases.release2')
   })
 
   it('disables the copy version to option if the document is going to be unpublished', async () => {

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -299,7 +299,6 @@ describe('VersionContextMenu', () => {
     const wrapper = await createTestProvider({
       config: {
         document: {
-          // Axios-style filter: keep only publish so delete schedule (discardVersion) is gone
           actions: (prev) => prev.filter((action) => action.action === 'publish'),
         },
       },

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -223,7 +223,6 @@ describe('VersionContextMenu', () => {
     const wrapper = await createTestProvider({
       config: {
         document: {
-          // Axios-style filter: keep only duplicate so publish is gone by omission
           actions: (prev) => prev.filter((action) => action.action === 'duplicate'),
         },
       },

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -35,6 +35,47 @@ const discardChangesAction: DocumentActionComponent = Object.assign(() => null, 
   action: 'discardChanges' as const,
 })
 
+const createScheduledDraftMenuActions = () => ({
+  actions: {
+    publishNow: {
+      'icon': undefined,
+      'text': 'Publish now',
+      'tone': 'default' as const,
+      'onClick': vi.fn(),
+      'disabled': false,
+      'data-testid': 'publish-now-menu-item',
+    },
+    editSchedule: {
+      'icon': undefined,
+      'text': 'Edit schedule',
+      'tone': 'default' as const,
+      'onClick': vi.fn(),
+      'disabled': false,
+      'data-testid': 'edit-schedule-menu-item',
+    },
+    schedulePublish: {
+      'icon': undefined,
+      'text': 'Schedule',
+      'tone': 'default' as const,
+      'onClick': vi.fn(),
+      'disabled': false,
+      'data-testid': 'schedule-publish-menu-item',
+    },
+    deleteSchedule: {
+      'icon': undefined,
+      'text': 'Delete schedule',
+      'tone': 'critical' as const,
+      'onClick': vi.fn(),
+      'disabled': false,
+      'data-testid': 'delete-schedule-menu-item',
+    },
+  },
+  dialogs: null,
+  isPerformingOperation: false,
+  selectedAction: null,
+  handleDialogClose: vi.fn(),
+})
+
 describe('VersionContextMenu', () => {
   // `defaultProps` holds shared `vi.fn()`s, so without this a test asserting on one of them can
   // pass on a call an earlier test made.
@@ -92,47 +133,6 @@ describe('VersionContextMenu', () => {
   const createScheduledDraftRelease = (): ReleaseDocument => ({
     ...mockReleases[0],
     metadata: {...mockReleases[0].metadata, cardinality: 'one'},
-  })
-
-  const createScheduledDraftMenuActions = () => ({
-    actions: {
-      publishNow: {
-        'icon': undefined,
-        'text': 'Publish now',
-        'tone': 'default' as const,
-        'onClick': vi.fn(),
-        'disabled': false,
-        'data-testid': 'publish-now-menu-item',
-      },
-      editSchedule: {
-        'icon': undefined,
-        'text': 'Edit schedule',
-        'tone': 'default' as const,
-        'onClick': vi.fn(),
-        'disabled': false,
-        'data-testid': 'edit-schedule-menu-item',
-      },
-      schedulePublish: {
-        'icon': undefined,
-        'text': 'Schedule',
-        'tone': 'default' as const,
-        'onClick': vi.fn(),
-        'disabled': false,
-        'data-testid': 'schedule-publish-menu-item',
-      },
-      deleteSchedule: {
-        'icon': undefined,
-        'text': 'Delete schedule',
-        'tone': 'critical' as const,
-        'onClick': vi.fn(),
-        'disabled': false,
-        'data-testid': 'delete-schedule-menu-item',
-      },
-    },
-    dialogs: null,
-    isPerformingOperation: false,
-    selectedAction: null,
-    handleDialogClose: vi.fn(),
   })
 
   it('renders the menu items correctly', async () => {

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -151,13 +151,14 @@ describe('VersionContextMenu', () => {
     expect(defaultProps.onDiscard).toHaveBeenCalled()
   })
 
-  it('hides discard version when discardVersion is filtered from document.actions', async () => {
+  it('hides discard version when discardVersion is omitted from document.actions', async () => {
     mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const wrapper = await createTestProvider({
       config: {
         document: {
-          actions: (prev) => prev.filter((action) => action.action !== 'discardVersion'),
+          // Axios-style filter: keep only publish so discardVersion is gone by omission
+          actions: (prev) => prev.filter((action) => action.action === 'publish'),
         },
       },
     })
@@ -168,7 +169,84 @@ describe('VersionContextMenu', () => {
     expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
   })
 
-  it('hides delete schedule when discardVersion is filtered from document.actions', async () => {
+  it('hides publish now when publish is omitted from document.actions', async () => {
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
+    const scheduledRelease: ReleaseDocument = {
+      ...mockReleases[0],
+      metadata: {
+        ...mockReleases[0].metadata,
+        cardinality: 'one',
+      },
+    }
+
+    const scheduledDraftMenuActions = {
+      actions: {
+        publishNow: {
+          'icon': undefined,
+          'text': 'Publish now',
+          'tone': 'default' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'publish-now-menu-item',
+        },
+        editSchedule: {
+          'icon': undefined,
+          'text': 'Edit schedule',
+          'tone': 'default' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'edit-schedule-menu-item',
+        },
+        schedulePublish: {
+          'icon': undefined,
+          'text': 'Schedule',
+          'tone': 'default' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'schedule-publish-menu-item',
+        },
+        deleteSchedule: {
+          'icon': undefined,
+          'text': 'Delete schedule',
+          'tone': 'critical' as const,
+          'onClick': vi.fn(),
+          'disabled': false,
+          'data-testid': 'delete-schedule-menu-item',
+        },
+      },
+      dialogs: null,
+      isPerformingOperation: false,
+      selectedAction: null,
+      handleDialogClose: vi.fn(),
+    }
+
+    const wrapper = await createTestProvider({
+      config: {
+        document: {
+          // Axios-style filter: keep only duplicate so publish is gone by omission
+          actions: (prev) => prev.filter((action) => action.action === 'duplicate'),
+        },
+      },
+    })
+
+    render(
+      <VersionContextMenu
+        {...defaultProps}
+        release={scheduledRelease}
+        isScheduledDraft
+        scheduledDraftMenuActions={scheduledDraftMenuActions}
+      />,
+      {wrapper},
+    )
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.queryByTestId('publish-now-menu-item')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('edit-schedule-menu-item')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('delete-schedule-menu-item')).not.toBeInTheDocument()
+  })
+
+  it('hides delete schedule when discardVersion is omitted from document.actions', async () => {
     mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
     const scheduledRelease: ReleaseDocument = {

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -6,6 +6,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {useDocumentPairPermissionsMockReturn} from '../../../../../../../test/mocks/useDocumentPairPermissions.mock'
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {type DocumentActionComponent} from '../../../../../config/document/actions'
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
@@ -28,6 +29,11 @@ vi.mock('../../../../store/useReleasePermissions', () => ({
 vi.mock('../../../../../store/grants/documentPairPermissions', () => ({
   useDocumentPairPermissions: vi.fn(() => useDocumentPairPermissionsMockReturn),
 }))
+
+// `discardChanges` is contributed by the structure tool, which the core test harness does not load.
+const discardChangesAction: DocumentActionComponent = Object.assign(() => null, {
+  action: 'discardChanges' as const,
+})
 
 describe('VersionContextMenu', () => {
   const mockReleases: ReleaseDocument[] = [
@@ -74,6 +80,54 @@ describe('VersionContextMenu', () => {
     disabled: false,
     type: 'document',
   }
+
+  const draftChipProps = {...defaultProps, fromRelease: 'draft', versionId: 'drafts.doc1'}
+
+  const createScheduledDraftRelease = (): ReleaseDocument => ({
+    ...mockReleases[0],
+    metadata: {...mockReleases[0].metadata, cardinality: 'one'},
+  })
+
+  const createScheduledDraftMenuActions = () => ({
+    actions: {
+      publishNow: {
+        'icon': undefined,
+        'text': 'Publish now',
+        'tone': 'default' as const,
+        'onClick': vi.fn(),
+        'disabled': false,
+        'data-testid': 'publish-now-menu-item',
+      },
+      editSchedule: {
+        'icon': undefined,
+        'text': 'Edit schedule',
+        'tone': 'default' as const,
+        'onClick': vi.fn(),
+        'disabled': false,
+        'data-testid': 'edit-schedule-menu-item',
+      },
+      schedulePublish: {
+        'icon': undefined,
+        'text': 'Schedule',
+        'tone': 'default' as const,
+        'onClick': vi.fn(),
+        'disabled': false,
+        'data-testid': 'schedule-publish-menu-item',
+      },
+      deleteSchedule: {
+        'icon': undefined,
+        'text': 'Delete schedule',
+        'tone': 'critical' as const,
+        'onClick': vi.fn(),
+        'disabled': false,
+        'data-testid': 'delete-schedule-menu-item',
+      },
+    },
+    dialogs: null,
+    isPerformingOperation: false,
+    selectedAction: null,
+    handleDialogClose: vi.fn(),
+  })
 
   it('renders the menu items correctly', async () => {
     mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
@@ -168,57 +222,64 @@ describe('VersionContextMenu', () => {
     expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
   })
 
+  it('shows discard version on a draft chip while discardChanges is configured', async () => {
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
+    const wrapper = await createTestProvider({
+      config: {document: {actions: (prev) => [...prev, discardChangesAction]}},
+    })
+
+    render(<VersionContextMenu {...draftChipProps} />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.getByText('Discard version')).toBeInTheDocument()
+  })
+
+  it('hides discard version on a draft chip when discardChanges is omitted', async () => {
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
+    const wrapper = await createTestProvider({
+      config: {
+        document: {
+          actions: (prev) =>
+            [...prev, discardChangesAction].filter((action) => action.action !== 'discardChanges'),
+        },
+      },
+    })
+
+    render(<VersionContextMenu {...draftChipProps} />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.getByTestId('copy-version-to-release-button-group')).toBeInTheDocument()
+    expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
+  })
+
+  it('shows every scheduled draft action when document.actions is unfiltered', async () => {
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+
+    const wrapper = await createTestProvider()
+
+    render(
+      <VersionContextMenu
+        {...defaultProps}
+        release={createScheduledDraftRelease()}
+        isScheduledDraft
+        scheduledDraftMenuActions={createScheduledDraftMenuActions()}
+      />,
+      {wrapper},
+    )
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.getByTestId('publish-now-menu-item')).toBeInTheDocument()
+    expect(screen.getByTestId('edit-schedule-menu-item')).toBeInTheDocument()
+    expect(screen.getByTestId('delete-schedule-menu-item')).toBeInTheDocument()
+  })
+
   it('hides publish now when publish is omitted from document.actions', async () => {
     mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
-    const scheduledRelease: ReleaseDocument = {
-      ...mockReleases[0],
-      metadata: {
-        ...mockReleases[0].metadata,
-        cardinality: 'one',
-      },
-    }
-
-    const scheduledDraftMenuActions = {
-      actions: {
-        publishNow: {
-          'icon': undefined,
-          'text': 'Publish now',
-          'tone': 'default' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'publish-now-menu-item',
-        },
-        editSchedule: {
-          'icon': undefined,
-          'text': 'Edit schedule',
-          'tone': 'default' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'edit-schedule-menu-item',
-        },
-        schedulePublish: {
-          'icon': undefined,
-          'text': 'Schedule',
-          'tone': 'default' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'schedule-publish-menu-item',
-        },
-        deleteSchedule: {
-          'icon': undefined,
-          'text': 'Delete schedule',
-          'tone': 'critical' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'delete-schedule-menu-item',
-        },
-      },
-      dialogs: null,
-      isPerformingOperation: false,
-      selectedAction: null,
-      handleDialogClose: vi.fn(),
-    }
+    const scheduledRelease = createScheduledDraftRelease()
+    const scheduledDraftMenuActions = createScheduledDraftMenuActions()
 
     const wrapper = await createTestProvider({
       config: {
@@ -247,54 +308,8 @@ describe('VersionContextMenu', () => {
   it('hides delete schedule when discardVersion is omitted from document.actions', async () => {
     mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
 
-    const scheduledRelease: ReleaseDocument = {
-      ...mockReleases[0],
-      metadata: {
-        ...mockReleases[0].metadata,
-        cardinality: 'one',
-      },
-    }
-
-    const scheduledDraftMenuActions = {
-      actions: {
-        publishNow: {
-          'icon': undefined,
-          'text': 'Publish now',
-          'tone': 'default' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'publish-now-menu-item',
-        },
-        editSchedule: {
-          'icon': undefined,
-          'text': 'Edit schedule',
-          'tone': 'default' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'edit-schedule-menu-item',
-        },
-        schedulePublish: {
-          'icon': undefined,
-          'text': 'Schedule',
-          'tone': 'default' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'schedule-publish-menu-item',
-        },
-        deleteSchedule: {
-          'icon': undefined,
-          'text': 'Delete schedule',
-          'tone': 'critical' as const,
-          'onClick': vi.fn(),
-          'disabled': false,
-          'data-testid': 'delete-schedule-menu-item',
-        },
-      },
-      dialogs: null,
-      isPerformingOperation: false,
-      selectedAction: null,
-      handleDialogClose: vi.fn(),
-    }
+    const scheduledRelease = createScheduledDraftRelease()
+    const scheduledDraftMenuActions = createScheduledDraftMenuActions()
 
     const wrapper = await createTestProvider({
       config: {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -99,12 +99,13 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       return (
         <DocumentActions
           document={rowProps.datum}
+          releaseId={releaseId}
           releaseTitle={release.metadata.title}
           versionType={rowVersionType}
         />
       )
     },
-    [release.metadata.title, release.state, rowVersionType],
+    [release.metadata.title, release.state, releaseId, rowVersionType],
   )
 
   const documentTableColumnDefs = useMemo(

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -6,6 +6,7 @@ import {useToast} from '@sanity/ui/toast'
 import {type CSSProperties, useCallback, useEffect, useMemo, useState} from 'react'
 
 import {Button} from '../../../../ui-components/button/Button'
+import {type DocumentActionsVersionType} from '../../../config/types'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useWorkspace} from '../../../studio/workspace'
 import {getVersionId} from '../../../util/draftUtils'
@@ -81,15 +82,29 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
 
   const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
 
+  const isCardinalityOne = isCardinalityOneRelease(release)
+
+  // Rows of a cardinality-one release are scheduled drafts, and that plugin resolves a different
+  // action list, so the row menu has to ask about the same version type the footer does.
+  const rowVersionType: DocumentActionsVersionType = isCardinalityOne
+    ? 'scheduled-draft'
+    : 'version'
+
   const renderRowActions = useCallback(
     (rowProps: {datum: BundleDocumentRow | unknown}) => {
       if (release.state !== 'active') return null
       if (!isBundleDocumentRow(rowProps.datum)) return null
       if (rowProps.datum.isPending) return null
 
-      return <DocumentActions document={rowProps.datum} releaseTitle={release.metadata.title} />
+      return (
+        <DocumentActions
+          document={rowProps.datum}
+          releaseTitle={release.metadata.title}
+          versionType={rowVersionType}
+        />
+      )
     },
-    [release.metadata.title, release.state],
+    [release.metadata.title, release.state, rowVersionType],
   )
 
   const documentTableColumnDefs = useMemo(
@@ -199,7 +214,6 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     [tableData, activeFilter],
   )
 
-  const isCardinalityOne = isCardinalityOneRelease(release)
   const hasNoDocuments = !isLoading && documents.length === 0
 
   if (isCardinalityOne && hasNoDocuments) {

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -11,7 +11,11 @@ import {
 import {route, RouterProvider} from 'sanity/router'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {getAllByDataUi, getByDataUi} from '../../../../../../test/setup/customQueries'
+import {
+  getAllByDataUi,
+  getByDataUi,
+  queryByDataUi,
+} from '../../../../../../test/setup/customQueries'
 import {setupVirtualListEnv} from '../../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {type DocumentActionsResolver} from '../../../../config/types'
@@ -173,6 +177,20 @@ const renderTest = async (
   )
 }
 
+const publishOnly: DocumentActionsResolver = (prev) =>
+  prev.filter(({action}) => action === 'publish')
+
+// Every row keeps its menu mounted, and closed ones are hidden with `display: none`. Runtime
+// styles are disabled in jsdom, so the open menu does not read as visible to `getByRole` either,
+// which is why it is picked by the absence of that hidden style.
+const getOpenRowMenu = () => {
+  const [openMenu] = getAllByDataUi(document.body, 'MenuButton__popover').filter(
+    (popover) => popover.style.display !== 'none',
+  )
+
+  return openMenu
+}
+
 describe('ReleaseSummary', () => {
   setupVirtualListEnv()
 
@@ -201,15 +219,8 @@ describe('ReleaseSummary', () => {
 
       await userEvent.click(getByDataUi(firstDocumentRow, 'MenuButton'))
 
-      // Every row keeps its menu mounted, and closed ones are hidden with `display: none`.
-      // Runtime styles are disabled in jsdom, so the open menu does not read as visible to
-      // `getByRole` either, which is why it is picked by the absence of that hidden style.
-      const [openMenu] = getAllByDataUi(document.body, 'MenuButton__popover').filter(
-        (popover) => popover.style.display !== 'none',
-      )
-
       await userEvent.click(
-        within(openMenu).getByRole('menuitem', {name: 'Discard version', hidden: true}),
+        within(getOpenRowMenu()).getByRole('menuitem', {name: 'Discard version', hidden: true}),
       )
 
       expect(await screen.findByRole('dialog')).toBeInTheDocument()
@@ -374,7 +385,7 @@ describe('ReleaseSummary', () => {
       await screen.findByTestId('document-table-card')
 
       const [firstDocumentRow] = screen.getAllByTestId('table-row')
-      return firstDocumentRow.querySelector('[data-ui="MenuButton"]')
+      return queryByDataUi(firstDocumentRow, 'MenuButton')
     }
 
     it('renders while discardVersion and unpublishVersion are configured', async () => {
@@ -382,10 +393,24 @@ describe('ReleaseSummary', () => {
     })
 
     it('is gone once both action ids are omitted from document.actions', async () => {
-      const publishOnly: DocumentActionsResolver = (prev) =>
-        prev.filter(({action}) => action === 'publish')
-
       expect(await findFirstRowMenuButton(publishOnly)).not.toBeInTheDocument()
+    })
+
+    it('drops unpublish for a cardinality-one release row', async () => {
+      await renderTest({release: activeCardinalityOneRelease}, {variantsEnabled})
+      await screen.findByTestId('document-table-card')
+
+      const [firstDocumentRow] = screen.getAllByTestId('table-row')
+      await userEvent.click(getByDataUi(firstDocumentRow, 'MenuButton'))
+
+      const openMenu = getOpenRowMenu()
+
+      expect(
+        within(openMenu).getByRole('menuitem', {name: 'Discard version', hidden: true}),
+      ).toBeInTheDocument()
+      expect(
+        within(openMenu).queryByRole('menuitem', {name: 'Unpublish', hidden: true}),
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -14,6 +14,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {getAllByDataUi, getByDataUi} from '../../../../../../test/setup/customQueries'
 import {setupVirtualListEnv} from '../../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentActionsResolver} from '../../../../config/types'
 import type * as ConnectionStatusStoreMod from '../../../../store/connection-status/connection-status-store'
 import {
   activeASAPRelease,
@@ -144,11 +145,14 @@ const ScrollContainer: FC<PropsWithChildren> = ({children}) => {
 
 const renderTest = async (
   props: Partial<ReleaseSummaryProps>,
-  options?: {variantsEnabled?: boolean},
+  options?: {variantsEnabled?: boolean; documentActions?: DocumentActionsResolver},
 ) => {
   const wrapper = await createTestProvider({
     resources: [releasesUsEnglishLocaleBundle],
-    ...(options?.variantsEnabled ? {config: {beta: {variants: {enabled: true}}}} : undefined),
+    config: {
+      ...(options?.variantsEnabled ? {beta: {variants: {enabled: true}}} : undefined),
+      ...(options?.documentActions ? {document: {actions: options.documentActions}} : undefined),
+    },
   })
 
   return render(
@@ -356,6 +360,32 @@ describe('ReleaseSummary', () => {
       expect(screen.queryAllByTestId('table-row')).toHaveLength(0)
       expect(screen.getByRole('tab', {name: /all/i})).toBeInTheDocument()
       expect(searchInput).toHaveFocus()
+    })
+  })
+
+  // Both table shapes share one `renderRowActions`, so the document.actions gate has to hold for
+  // the default table and the beta.variants DocumentTable alike.
+  describe.each([
+    {tableShape: 'default table', variantsEnabled: false},
+    {tableShape: 'variants DocumentTable', variantsEnabled: true},
+  ])('row action menu in the $tableShape', ({variantsEnabled}) => {
+    const findFirstRowMenuButton = async (documentActions?: DocumentActionsResolver) => {
+      await renderTest({}, {variantsEnabled, documentActions})
+      await screen.findByTestId('document-table-card')
+
+      const [firstDocumentRow] = screen.getAllByTestId('table-row')
+      return firstDocumentRow.querySelector('[data-ui="MenuButton"]')
+    }
+
+    it('renders while discardVersion and unpublishVersion are configured', async () => {
+      expect(await findFirstRowMenuButton()).toBeInTheDocument()
+    })
+
+    it('is gone once both action ids are omitted from document.actions', async () => {
+      const publishOnly: DocumentActionsResolver = (prev) =>
+        prev.filter(({action}) => action === 'publish')
+
+      expect(await findFirstRowMenuButton(publishOnly)).not.toBeInTheDocument()
     })
   })
 

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -8,6 +8,7 @@ import {Box} from 'ui5'
 import {MenuButton} from '../../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {ContextMenuButton} from '../../../../components/contextMenuButton/ContextMenuButton'
+import {useConfiguredDocumentActionIds} from '../../../../config/document/useConfiguredDocumentActionIds'
 import {useSchema} from '../../../../hooks/useSchema'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useDocumentPairPermissions} from '../../../../store/grants/documentPairPermissions'
@@ -79,6 +80,18 @@ const DocumentActionsInner = memo(
     const isUnpublishActionDisabled =
       noPermissionToUnpublish || !document.document.publishedDocumentExists || isAlreadyUnpublished
 
+    const configuredActionIds = useConfiguredDocumentActionIds({
+      schemaType: type,
+      documentId: publishedId,
+      versionType: 'version',
+      releaseId: version,
+    })
+    const showDiscardVersion = configuredActionIds.has('discardVersion')
+    const showUnpublish = configuredActionIds.has('unpublishVersion')
+    const hasConfiguredMenuItems = showDiscardVersion || showUnpublish
+
+    if (!hasConfiguredMenuItems) return null
+
     return (
       <>
         <Card tone="default" display="flex">
@@ -87,30 +100,36 @@ const DocumentActionsInner = memo(
             button={<ContextMenuButton />}
             menu={
               <Menu>
-                <MenuItem
-                  text={coreT('release.action.discard-version')}
-                  icon={CloseIcon}
-                  onClick={() => setShowDiscardDialog(true)}
-                  disabled={isDiscardVersionActionDisabled}
-                  tooltipProps={{
-                    disabled: !isDiscardVersionActionDisabled,
-                    content: t('permissions.error.discard-version'),
-                  }}
-                />
-                <MenuDivider />
-                <Box padding={3} paddingBottom={2}>
-                  <Label size={1}>{t('menu.group.when-releasing')}</Label>
-                </Box>
-                <MenuItem
-                  text={t('action.unpublish')}
-                  icon={UnpublishIcon}
-                  disabled={isUnpublishActionDisabled}
-                  tooltipProps={{
-                    disabled: !isUnpublishActionDisabled,
-                    content: unPublishTooltipContent,
-                  }}
-                  onClick={() => setShowUnpublishDialog(true)}
-                />
+                {showDiscardVersion && (
+                  <MenuItem
+                    text={coreT('release.action.discard-version')}
+                    icon={CloseIcon}
+                    onClick={() => setShowDiscardDialog(true)}
+                    disabled={isDiscardVersionActionDisabled}
+                    tooltipProps={{
+                      disabled: !isDiscardVersionActionDisabled,
+                      content: t('permissions.error.discard-version'),
+                    }}
+                  />
+                )}
+                {showUnpublish && (
+                  <>
+                    {showDiscardVersion && <MenuDivider />}
+                    <Box padding={3} paddingBottom={2}>
+                      <Label size={1}>{t('menu.group.when-releasing')}</Label>
+                    </Box>
+                    <MenuItem
+                      text={t('action.unpublish')}
+                      icon={UnpublishIcon}
+                      disabled={isUnpublishActionDisabled}
+                      tooltipProps={{
+                        disabled: !isUnpublishActionDisabled,
+                        content: unPublishTooltipContent,
+                      }}
+                      onClick={() => setShowUnpublishDialog(true)}
+                    />
+                  </>
+                )}
               </Menu>
             }
           />

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -156,7 +156,10 @@ const DocumentActionsInner = memo(
       </>
     )
   },
-  (prev, next) => prev.document.memoKey === next.document.memoKey,
+  (prev, next) =>
+    prev.document.memoKey === next.document.memoKey &&
+    prev.versionType === next.versionType &&
+    prev.releaseTitle === next.releaseTitle,
 )
 
 export const DocumentActions = memo(function GuardedDocumentActions(props: {

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -23,10 +23,12 @@ import {type BundleDocumentRow} from '../ReleaseSummary'
 const DocumentActionsInner = memo(
   function DocumentActionsInner({
     document,
+    releaseId,
     releaseTitle,
     versionType,
   }: {
     document: BundleDocumentRow
+    releaseId: string
     releaseTitle: string | undefined
     versionType: DocumentActionsVersionType
   }) {
@@ -38,9 +40,7 @@ const DocumentActionsInner = memo(
 
     const publishedId = getPublishedId(document.document._id)
     const type = document.document._type
-    // No `getTargetScopeId(useTargetDocumentState())` here: the version is derived from the table row's own
-    // document id (the release being viewed), in a variant release version this will also work because the scopeId
-    // is the same as the version from id.
+    // Permission checks address the row's own version, keyed by the scope segment of its id.
     const version = getVersionFromId(document.document._id)
 
     const [discardVersionPermission, isDiscardVersionPermissionsLoading] =
@@ -87,7 +87,7 @@ const DocumentActionsInner = memo(
       schemaType: type,
       documentId: publishedId,
       versionType,
-      releaseId: version,
+      releaseId,
     })
     const showDiscardVersion = configuredActionIds.has('discardVersion')
     const showUnpublish = configuredActionIds.has('unpublishVersion')
@@ -159,11 +159,13 @@ const DocumentActionsInner = memo(
   (prev, next) =>
     prev.document.memoKey === next.document.memoKey &&
     prev.versionType === next.versionType &&
+    prev.releaseId === next.releaseId &&
     prev.releaseTitle === next.releaseTitle,
 )
 
 export const DocumentActions = memo(function GuardedDocumentActions(props: {
   document: BundleDocumentRow
+  releaseId: string
   releaseTitle: string | undefined
   versionType: DocumentActionsVersionType
 }) {

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -9,6 +9,7 @@ import {MenuButton} from '../../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {ContextMenuButton} from '../../../../components/contextMenuButton/ContextMenuButton'
 import {useConfiguredDocumentActionIds} from '../../../../config/document/useConfiguredDocumentActionIds'
+import {type DocumentActionsVersionType} from '../../../../config/types'
 import {useSchema} from '../../../../hooks/useSchema'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useDocumentPairPermissions} from '../../../../store/grants/documentPairPermissions'
@@ -23,9 +24,11 @@ const DocumentActionsInner = memo(
   function DocumentActionsInner({
     document,
     releaseTitle,
+    versionType,
   }: {
     document: BundleDocumentRow
     releaseTitle: string | undefined
+    versionType: DocumentActionsVersionType
   }) {
     const [showDiscardDialog, setShowDiscardDialog] = useState(false)
     const [showUnpublishDialog, setShowUnpublishDialog] = useState(false)
@@ -83,7 +86,7 @@ const DocumentActionsInner = memo(
     const configuredActionIds = useConfiguredDocumentActionIds({
       schemaType: type,
       documentId: publishedId,
-      versionType: 'version',
+      versionType,
       releaseId: version,
     })
     const showDiscardVersion = configuredActionIds.has('discardVersion')
@@ -159,6 +162,7 @@ const DocumentActionsInner = memo(
 export const DocumentActions = memo(function GuardedDocumentActions(props: {
   document: BundleDocumentRow
   releaseTitle: string | undefined
+  versionType: DocumentActionsVersionType
 }) {
   const schema = useSchema()
   const type = schema.get(props.document.document._type)

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
@@ -32,7 +32,10 @@ describe('DocumentActions', () => {
   it('renders discard version and unpublish when document.actions is unfiltered', async () => {
     const wrapper = await createTestProvider({resources: localeResources})
 
-    render(<DocumentActions document={documentRow} releaseTitle="Release 1" />, {wrapper})
+    render(
+      <DocumentActions document={documentRow} releaseTitle="Release 1" versionType="version" />,
+      {wrapper},
+    )
     await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.getByText('Discard version')).toBeInTheDocument()
@@ -49,10 +52,32 @@ describe('DocumentActions', () => {
       },
     })
 
-    render(<DocumentActions document={documentRow} releaseTitle="Release 1" />, {wrapper})
+    render(
+      <DocumentActions document={documentRow} releaseTitle="Release 1" versionType="version" />,
+      {wrapper},
+    )
     await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
+    expect(screen.queryByText('Unpublish')).not.toBeInTheDocument()
+  })
+
+  // A cardinality-one release row is a scheduled draft, and that plugin's action list has no
+  // `unpublishVersion`, so the row must not offer Unpublish where the footer cannot.
+  it('drops unpublish on a scheduled draft row', async () => {
+    const wrapper = await createTestProvider({resources: localeResources})
+
+    render(
+      <DocumentActions
+        document={documentRow}
+        releaseTitle="Release 1"
+        versionType="scheduled-draft"
+      />,
+      {wrapper},
+    )
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.getByText('Discard version')).toBeInTheDocument()
     expect(screen.queryByText('Unpublish')).not.toBeInTheDocument()
   })
 
@@ -66,7 +91,10 @@ describe('DocumentActions', () => {
       },
     })
 
-    render(<DocumentActions document={documentRow} releaseTitle="Release 1" />, {wrapper})
+    render(
+      <DocumentActions document={documentRow} releaseTitle="Release 1" versionType="version" />,
+      {wrapper},
+    )
     await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.queryByText('Discard version')).not.toBeInTheDocument()

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
@@ -4,6 +4,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {useDocumentPairPermissionsMockReturn} from '../../../../../../../test/mocks/useDocumentPairPermissions.mock'
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {type DocumentActionsResolver} from '../../../../../config/types'
 import {studioDefaultLocaleResources} from '../../../../../i18n/bundles/studio'
 import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
 import {type BundleDocumentRow} from '../../ReleaseSummary'
@@ -33,7 +34,12 @@ describe('DocumentActions', () => {
     const wrapper = await createTestProvider({resources: localeResources})
 
     render(
-      <DocumentActions document={documentRow} releaseTitle="Release 1" versionType="version" />,
+      <DocumentActions
+        document={documentRow}
+        releaseId="release1"
+        releaseTitle="Release 1"
+        versionType="version"
+      />,
       {wrapper},
     )
     await flushMicrotasksThisIsACodeSmell()
@@ -53,7 +59,12 @@ describe('DocumentActions', () => {
     })
 
     render(
-      <DocumentActions document={documentRow} releaseTitle="Release 1" versionType="version" />,
+      <DocumentActions
+        document={documentRow}
+        releaseId="release1"
+        releaseTitle="Release 1"
+        versionType="version"
+      />,
       {wrapper},
     )
     await flushMicrotasksThisIsACodeSmell()
@@ -70,6 +81,7 @@ describe('DocumentActions', () => {
     render(
       <DocumentActions
         document={documentRow}
+        releaseId="release1"
         releaseTitle="Release 1"
         versionType="scheduled-draft"
       />,
@@ -92,12 +104,47 @@ describe('DocumentActions', () => {
     })
 
     render(
-      <DocumentActions document={documentRow} releaseTitle="Release 1" versionType="version" />,
+      <DocumentActions
+        document={documentRow}
+        releaseId="release1"
+        releaseTitle="Release 1"
+        versionType="version"
+      />,
       {wrapper},
     )
     await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
     expect(screen.getByText('Unpublish')).toBeInTheDocument()
+  })
+
+  // A variant row's id carries a scope hash, not the release id the document footer resolves against.
+  it('resolves row actions for the release id on a variant row', async () => {
+    const documentActions = vi.fn<DocumentActionsResolver>((prev) => prev)
+    const wrapper = await createTestProvider({
+      resources: localeResources,
+      config: {document: {actions: documentActions}},
+    })
+
+    const variantDocumentRow = {
+      ...documentRow,
+      document: {...documentRow.document, _id: 'versions.k7fh2qzs9m.doc1'},
+    } as unknown as BundleDocumentRow
+
+    render(
+      <DocumentActions
+        document={variantDocumentRow}
+        releaseId="release1"
+        releaseTitle="Release 1"
+        versionType="version"
+      />,
+      {wrapper},
+    )
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(documentActions).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({releaseId: 'release1'}),
+    )
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
@@ -1,0 +1,75 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {useDocumentPairPermissionsMockReturn} from '../../../../../../../test/mocks/useDocumentPairPermissions.mock'
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../../../test/testUtils/flushMicrotasks'
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {studioDefaultLocaleResources} from '../../../../../i18n/bundles/studio'
+import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
+import {type BundleDocumentRow} from '../../ReleaseSummary'
+import {DocumentActions} from '../DocumentActions'
+
+vi.mock('../../../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(() => useDocumentPairPermissionsMockReturn),
+}))
+
+const documentRow = {
+  memoKey: 'memo-1',
+  validation: {validation: [], hasError: false, isValidating: false},
+  document: {
+    _id: 'versions.release1.doc1',
+    _type: 'author',
+    _rev: 'rev1',
+    _createdAt: '',
+    _updatedAt: '',
+    publishedDocumentExists: true,
+  },
+} as unknown as BundleDocumentRow
+
+const localeResources = [studioDefaultLocaleResources, releasesUsEnglishLocaleBundle]
+
+describe('DocumentActions', () => {
+  it('renders discard version and unpublish when document.actions is unfiltered', async () => {
+    const wrapper = await createTestProvider({resources: localeResources})
+
+    render(<DocumentActions document={documentRow} releaseTitle="Release 1" />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.getByText('Discard version')).toBeInTheDocument()
+    expect(screen.getByText('Unpublish')).toBeInTheDocument()
+  })
+
+  it('hides discard version and unpublish when both action ids are omitted', async () => {
+    const wrapper = await createTestProvider({
+      resources: localeResources,
+      config: {
+        document: {
+          actions: (prev) => prev.filter((action) => action.action === 'publish'),
+        },
+      },
+    })
+
+    render(<DocumentActions document={documentRow} releaseTitle="Release 1" />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
+    expect(screen.queryByText('Unpublish')).not.toBeInTheDocument()
+  })
+
+  it('keeps unpublish when only discardVersion is omitted', async () => {
+    const wrapper = await createTestProvider({
+      resources: localeResources,
+      config: {
+        document: {
+          actions: (prev) => prev.filter((action) => action.action !== 'discardVersion'),
+        },
+      },
+    })
+
+    render(<DocumentActions document={documentRow} releaseTitle="Release 1" />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+
+    expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
+    expect(screen.getByText('Unpublish')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
@@ -8,6 +8,10 @@ import {useRouter} from 'sanity/router'
 import {Button} from '../../../../ui-components/button/Button'
 import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'
 import {Popover} from '../../../../ui-components/popover/Popover'
+import {
+  getVersionContextMenuActionsContext,
+  useConfiguredDocumentActionIds,
+} from '../../../config/document/useConfiguredDocumentActionIds'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useScheduledDraftDocument} from '../../../singleDocRelease/hooks/useScheduledDraftDocument'
 import {useScheduledDraftMenuActions} from '../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
@@ -42,27 +46,50 @@ export const ScheduledDraftMenuButtonWrapper = ({release}: {release: ReleaseDocu
     onActionComplete: handleActionComplete,
   })
 
+  const configuredActionIds = useConfiguredDocumentActionIds(
+    scheduledDraftDocument
+      ? getVersionContextMenuActionsContext({
+          schemaType: scheduledDraftDocument._type,
+          documentGroupId: getPublishedId(scheduledDraftDocument._id),
+          fromRelease: getReleaseIdFromReleaseDocumentId(release._id),
+          isScheduledDraft: true,
+        })
+      : null,
+  )
+  const showPublishNow = configuredActionIds.has('publish')
+  const showSchedule = configuredActionIds.has('schedule')
+  const showDeleteSchedule = configuredActionIds.has('discardVersion')
+
   const displayedMenuItems = useMemo(() => {
+    const deleteSchedule = showDeleteSchedule
+      ? [<MenuItem key={'delete-schedule'} {...actions.deleteSchedule} />]
+      : []
+
     if (release.state === 'archived' || release.state === 'published') {
-      return [<MenuItem key={'delete-schedule'} {...actions.deleteSchedule} />]
+      return deleteSchedule
     }
+
+    const publishNow = showPublishNow
+      ? [<MenuItem key={'publish-now'} {...actions.publishNow} />]
+      : []
 
     if (isPausedCardinalityOneRelease(release)) {
-      return [
-        <MenuItem key={'publish-now'} {...actions.publishNow} />,
-        <MenuItem key={'schedule-publish'} {...actions.schedulePublish} />,
-        <MenuItem key={'delete-schedule'} {...actions.deleteSchedule} />,
-      ]
+      const schedulePublish = showSchedule
+        ? [<MenuItem key={'schedule-publish'} {...actions.schedulePublish} />]
+        : []
+
+      return [...publishNow, ...schedulePublish, ...deleteSchedule]
     }
 
-    return [
-      <MenuItem key={'publish-now'} {...actions.publishNow} />,
-      <MenuItem key={'edit-schedule'} {...actions.editSchedule} />,
-      <MenuItem key={'delete-schedule'} {...actions.deleteSchedule} />,
-    ]
-  }, [release, actions])
+    const editSchedule = showSchedule
+      ? [<MenuItem key={'edit-schedule'} {...actions.editSchedule} />]
+      : []
+
+    return [...publishNow, ...editSchedule, ...deleteSchedule]
+  }, [release, actions, showPublishNow, showSchedule, showDeleteSchedule])
 
   const canPerformActions = Boolean(scheduledDraftDocument)
+  const hasConfiguredMenuItems = displayedMenuItems.length > 0
 
   const handleOnButtonClick = useCallback(() => {
     setOpenPopover((prev) => !prev)
@@ -73,7 +100,7 @@ export const ScheduledDraftMenuButtonWrapper = ({release}: {release: ReleaseDocu
     () => [popoverRef.current, scheduledDraftMenuRef.current],
   )
 
-  if (!canPerformActions) {
+  if (!canPerformActions || !hasConfiguredMenuItems) {
     return null
   }
 

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ScheduledDraftMenuButtonWrapper.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ScheduledDraftMenuButtonWrapper.test.tsx
@@ -1,0 +1,56 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentActionsResolver} from '../../../../config/types'
+import {activeCardinalityOneRelease} from '../../../__fixtures__/release.fixture'
+import {releasesUsEnglishLocaleBundle} from '../../../i18n'
+import {ScheduledDraftMenuButtonWrapper} from '../ScheduledDraftMenuButtonWrapper'
+
+const scheduledDraftDocument = {
+  _id: 'versions.rSchedule.doc1',
+  _type: 'author',
+  _rev: 'rev1',
+  _createdAt: '',
+  _updatedAt: '',
+}
+
+vi.mock('../../../../singleDocRelease/hooks/useScheduledDraftDocument', () => ({
+  useScheduledDraftDocument: vi.fn(() => ({
+    firstDocument: scheduledDraftDocument,
+    firstDocumentPreview: undefined,
+    firstDocumentValidation: undefined,
+    loading: false,
+  })),
+}))
+
+const renderMenu = async (documentActions?: DocumentActionsResolver) => {
+  const wrapper = await createTestProvider({
+    resources: [releasesUsEnglishLocaleBundle],
+    config: documentActions ? {document: {actions: documentActions}} : undefined,
+  })
+
+  render(<ScheduledDraftMenuButtonWrapper release={activeCardinalityOneRelease} />, {wrapper})
+  await flushMicrotasksThisIsACodeSmell()
+}
+
+describe('ScheduledDraftMenuButtonWrapper', () => {
+  it('renders the menu button while the scheduled draft actions are configured', async () => {
+    await renderMenu()
+
+    expect(screen.getByTestId('scheduled-draft-menu-button')).toBeInTheDocument()
+  })
+
+  it('renders nothing when every scheduled draft action is omitted from document.actions', async () => {
+    await renderMenu((prev) => prev.filter(({action}) => action === 'duplicate'))
+
+    expect(screen.queryByTestId('scheduled-draft-menu-button')).not.toBeInTheDocument()
+  })
+
+  it('keeps the menu button when only publish survives', async () => {
+    await renderMenu((prev) => prev.filter(({action}) => action === 'publish'))
+
+    expect(screen.getByTestId('scheduled-draft-menu-button')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes [SAPP-4330](https://linear.app/sanity/issue/SAPP-4330/right-clicking-the-content-release-pill-provides-access-to-unexpected). Filtering `document.actions` down to `publish` removed Delete schedule / Discard version from the document footer, but the version chip, the document group inventory rows, and the release detail documents table still offered them on right-click.

Those menus now resolve `document.actions` for their own perspective and hide items whose action id is no longer configured. `useConfiguredDocumentActionIds` is a new internal hook for that, reading the same resolver instance the document pane reads, so the menus and the footer never disagree. The ids are what the plugins declare rather than hand-invented - `PublishScheduledDraftAction.action = 'publish'`, `EditScheduledDraftAction.action = 'schedule'`, `DeleteScheduledDraftAction.action = 'discardVersion'`, `useDiscardVersionAction.action = 'discardVersion'`, `useUnpublishVersionAction.action = 'unpublishVersion'` - and `keyof DocumentActionKeys` is closed over the Sanity-defined ids, so renaming a built-in fails type checking at every gate. Plugins widen that union by declaration merging; these gates check built-in literals, so a widened union leaves them intact.

Covered: version chip, document group inventory rows, both shapes of the release detail documents table, and the Scheduled drafts overview row menu. `ReleaseSummary` renders the default `Table` or, behind `beta.variants`, the shared `DocumentTable`, but both take the same `renderRowActions`, so gating `DocumentActions` once covers both screens.

The test studio filter sits at workspace level because that is the only position that survives. Both `releases` and `singleDocRelease` replace the action list rather than composing over it, and the root config resolves last, so a plugin-level filter is discarded before it reaches those version types.

`useConfiguredDocumentActionIds` accepts a null context and resolves nothing. `ScheduledDraftMenuButtonWrapper` reads its schema type from a document that loads asynchronously and hooks run before its loading guard, so without this a resolver reading `ctx.schemaType.startsWith(...)` would throw a `ConfigPropertyError`.

Two known limits. The gate is presence-only: it sees config-array omission and nothing else. An action that stays in the array but returns `null` from its hook for a given document or state keeps its id in the set, so the menu renders a live item while the footer renders nothing - the same symptom as SAPP-4330 through a different mechanism. Every built-in has such a path: `EditScheduledDraftAction` returns `null` on a paused release, `useUnpublishVersionAction` without a release or a version. A config that replaces an action but keeps its id lands in the same place, wired to the built-in handler. And `useSchedulePublishAction` and `EditScheduledDraftAction` share the id `schedule`, so a Set of ids cannot tell them apart; the paused-release check already separates them in the UI.

Rejected alternatives. Invoking each action hook at the gate to read what it returns: the gate holds config context only (`schemaType`, `documentId`, `versionType`, `releaseId`), while a `DocumentActionComponent` takes the pane's edit state (`draft`, `published`, `version`, `liveEdit`, `revision`) and the six built-ins in `src/structure/documentActions` call `useDocumentPane`, which throws outside the provider. `document.actions` answers availability and rendering with a single value, and only the render site holds what the rendering half needs, so splitting the two is a public API change and out of scope here. Reusing the pane's `getDocumentVersionType`: the chip's `releases` prop is `notCurrentReleases`, so every scheduled-draft chip would downgrade to `version`.

Follow-ups under the `Honour disabled document actions studio wide` milestone: document panel banners (SAPP-4340), bulk operations (SAPP-4341), the deprecated scheduled publishing menus (SAPP-4342), the `versionType` derivations (SAPP-4339) and the invariant itself (SAPP-4338).

### What to review

- `useConfiguredDocumentActionIds` and the two chip helpers, and whether `core/config/document` is the right home for helpers that name a UI surface
- `VersionContextMenu` gating Publish now / Edit schedule / Delete schedule / Discard version from one resolved id set
- `DocumentActions` in the release detail table: the row menu returns `null` when neither `discardVersion` nor `unpublishVersion` is configured, rather than opening a menu containing only a group label. The row's version type comes from `isCardinalityOneRelease(release)`, so a cardinality-one release row resolves against the scheduled-draft action list. `releaseId` arrives as a prop from `ReleaseSummary` rather than being read off the row id, because a variant-of-release row id is `versions.<scopeId>.<groupId>` with an opaque hash in the bundle segment - resolving from the id would hand the resolver a hash where the document footer hands it `selectedReleaseId`. `version` stays derived from the row id and feeds only the two `useDocumentPairPermissions` calls, which is what pair checkout keys off
- `DocumentActions`' memo comparator previously gated only on `document.memoKey`. That key is a fresh `uuid()` per document emission, so it carries no information about sibling props. It now also compares `versionType`, `releaseId` and `releaseTitle`. `versionType` is defensive: it cannot change for a mounted row, since a release's cardinality is write-once and a release switch remounts every row. `releaseTitle` fixes a real pre-existing bug - `useReleaseDocuments` compares only `state` and `finalDocumentStates`, so a title-only edit emits no new `memoKey`, the inner memo bails, and `fromPerspective` renders the pre-edit title in the Discard dialog. Cosmetic, but wrong
- `ScheduledDraftMenuButtonWrapper` returns `null` when none of `publish`, `schedule` or `discardVersion` is configured
- `VariantDocumentActions` needs nothing: it already returns `null` pending FH-113
- Test studio type `restrictedVersionActionsTest` plus the workspace-level `document.actions` filter, inherited by every workspace that spreads `defaultWorkspace`

### Testing

Unit tests cover both directions, so no assertion passes by the items simply never rendering: scheduled draft actions all present unfiltered then each hidden under omission; draft chip Discard version present while `discardChanges` is configured then hidden without it; release detail table items present unfiltered, both hidden, and unpublish surviving alone.

`ReleaseSummary` gets a matched set per table shape via `describe.each`, so every gate is proven for the default table and the `beta.variants` `DocumentTable` independently. That includes `drops unpublish for a cardinality-one release row`, which pins the `scheduled-draft` version type at the table level rather than only as a `DocumentActions` prop. Mutation-checked: flipping that one word leaves the rest of the suite green but fails this test in both shapes.

A variant-shaped row (`versions.<hash>.<groupId>`) in a release whose id differs from the hash pins the resolver's `releaseId` to the release id. Mutation-checked: resolving from the row id again fails that test alone and leaves the other four green.

Also fixed a pre-existing bug in `VersionContextMenu.test.tsx`: `calls onCreateVersion when a release is clicked` asserted `onCreateRelease` and only passed because an earlier test had already called that shared mock, so it failed when run alone. It now asserts `onCreateVersion` with the target release id, and a `beforeEach` clears the shared mocks so no test can pass on another's call.

Verified in the test studio that the workspace filter reaches `document.actions` for real: `restrictedVersionActionsTest` renders `action-publish` and no overflow menu, while `removeRestoreActionTest` renders publish plus Duplicate, Delete and an overflow menu.

oxfmt and oxlint are clean on the changed files, and the unit suite across `core/releases` and `core/config` is green (63 files, 687 tests). CI runs the full gates.

### Notes for release

Version chip, document inventory, release detail table and Scheduled drafts overview menus now respect `document.actions` filters, so actions removed from config such as Discard version, Delete schedule, Publish now and Unpublish no longer appear.

<!-- CURSOR_AGENT_PR_BODY_END -->

---
<div><a href="https://cursor.com/agents/bc-eecda808-2ef7-44bd-aa99-d88007bda06f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eecda808-2ef7-44bd-aa99-d88007bda06f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



