### PR TITLE
fix(core): skip invite grants via useObservable disabled option

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.test.tsx
@@ -55,4 +55,33 @@ describe('useCanInviteProjectMembers', () => {
     rerender(view('visible'))
     expect(subscribes.count).toBe(1)
   })
+
+  it('does not subscribe while disabled, then subscribes once when enabled', async () => {
+    const subscribes = {count: 0}
+    const getGrants = vi.fn(() =>
+      defer(() => {
+        subscribes.count += 1
+        return of(grants)
+      }),
+    )
+    vi.mocked(useProjectStore).mockReturnValue({getGrants} as unknown as ProjectStore)
+
+    function CanInvite({enabled}: {enabled: boolean}) {
+      return <span data-testid="can-invite">{String(useCanInviteProjectMembers({enabled}))}</span>
+    }
+
+    const {rerender} = render(<CanInvite enabled={false} />)
+    expect(screen.getByTestId('can-invite')).toHaveTextContent('false')
+    rerender(<CanInvite enabled={false} />)
+    expect(subscribes.count).toBe(0)
+
+    rerender(<CanInvite enabled={true} />)
+    await waitFor(() => expect(screen.getByTestId('can-invite')).toHaveTextContent('true'))
+    expect(subscribes.count).toBe(1)
+
+    // `disabled` unsubscribes without replacing the observable, so a
+    // disabled re-render must not add another grants request.
+    rerender(<CanInvite enabled={false} />)
+    expect(subscribes.count).toBe(1)
+  })
 })

--- a/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.test.tsx
@@ -79,9 +79,10 @@ describe('useCanInviteProjectMembers', () => {
     await waitFor(() => expect(screen.getByTestId('can-invite')).toHaveTextContent('true'))
     expect(subscribes.count).toBe(1)
 
-    // `disabled` unsubscribes without replacing the observable, so a
-    // disabled re-render must not add another grants request.
+    // `disabled` keeps the last emission, but the hook's contract is: if we
+    // are not checking grants, assume no access.
     rerender(<CanInvite enabled={false} />)
+    expect(screen.getByTestId('can-invite')).toHaveTextContent('false')
     expect(subscribes.count).toBe(1)
   })
 })

--- a/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.ts
+++ b/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.ts
@@ -1,6 +1,6 @@
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {map, of} from 'rxjs'
+import {map} from 'rxjs'
 
 import {useProjectStore} from '../../../store/datastores'
 
@@ -25,17 +25,7 @@ export function useCanInviteProjectMembers(opts?: UseCanInviteProjectMembersOpti
   const {enabled = true} = opts || {}
   const projectStore = useProjectStore()
 
-  // Keep the observable identity stable across renders.
-  //
-  // Why it matters: once this hook has received an emission, react-rx
-  // re-subscribes *replacement* observables during render (that is what
-  // lets rebuild-every-render consumers converge instead of looping).
-  // Stable identity = exactly one subscription for the hook's lifetime.
-  //
-  // The React Compiler usually memoizes this expression already. The
-  // explicit `useMemo` keeps the guarantee even where the compiler bails.
   const canInvite$ = useMemo(() => {
-    if (!enabled) return of(false)
     return projectStore.getGrants().pipe(
       map((grants) => {
         const permission = grants[PERMISSION_NAME]
@@ -43,7 +33,7 @@ export function useCanInviteProjectMembers(opts?: UseCanInviteProjectMembersOpti
         return !!permission?.some((p) => p.grants.some((g) => g.name === GRANT_NAME))
       }),
     )
-  }, [enabled, projectStore])
+  }, [projectStore])
 
-  return useObservable(canInvite$, false)
+  return useObservable(canInvite$, false, {disabled: !enabled})
 }

--- a/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.ts
+++ b/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.ts
@@ -35,5 +35,6 @@ export function useCanInviteProjectMembers(opts?: UseCanInviteProjectMembersOpti
     )
   }, [projectStore])
 
-  return useObservable(canInvite$, false, {disabled: !enabled})
+  const value = useObservable(canInvite$, false, {disabled: !enabled})
+  return enabled ? value : false
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to #14234. Putting `enabled` in the grants observable memo meant a closed-then-opened presence menu replaced the observable after the first emission, which is the identity react-rx 6 re-subscribes during render.

`useObservable(..., {disabled: !enabled})` skips the subscription without swapping in `of(false)`, so the memo only needs `[projectStore]`. `disabled` keeps the last emission, so the hook still returns `false` when not checking — if we are not asking the server, assume no access.

### What to review

- `useCanInviteProjectMembers` — `disabled: !enabled` plus `enabled ? value : false`. Presence menu still gates the grants request on open.
- Tests: zero subscriptions while hidden or `enabled: false`; after a `true` result, disabling returns `false` without another subscribe.

### Testing

- Existing hidden-`<Activity>` subscription test kept
- `enabled` flag test now also asserts the reset-to-false contract

### Notes for release

N/A – Internal only (same deferred grants request as #14234, cleaner implementation)

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3459151f-4d64-4e7a-ac4d-b788e1995196?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3459151f-4d64-4e7a-ac4d-b788e1995196&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

