### PR TITLE
fix(search): exclude content agent versions from raw perspective search

### DIFF
--- a/packages/sanity/src/core/search/common/types.ts
+++ b/packages/sanity/src/core/search/common/types.ts
@@ -121,6 +121,11 @@ export type SearchStrategyFactory<TResult extends WeightedSearchResults | Groq20
 export type SearchOptions = {
   maxDepth?: number
   comments?: string[]
+  /**
+   * GROQ constraint AND-ed into the search query. Takes precedence over a filter passed as a
+   * factory option (`SearchFactoryOptions.filter`), matching how the strategies merge options.
+   */
+  filter?: string
   skipSortByScore?: boolean
   sort?: SearchSort[]
   cursor?: string

--- a/packages/sanity/src/core/search/constants.ts
+++ b/packages/sanity/src/core/search/constants.ts
@@ -1,2 +1,18 @@
+import {AGENT_BUNDLE_PREFIX} from '../store/agent/createAgentBundlesStore'
+import {VERSION_FOLDER} from '../util/draftUtils'
+
 // Findability version, prepended to every search query for future measurement
 export const FINDABILITY_MVI = 4
+
+/**
+ * GROQ constraint matching every document except Content Agent versions, identified by a
+ * `versions.agent-*.*` id or by an agent `_system.bundleId` (variant-scoped versions carry the
+ * bundle in `_system` because their ids use opaque scope hashes).
+ *
+ * `_system.bundleId` is unset on most documents, and `string::startsWith(null, …)` returns
+ * `null` — which would poison the negation under GROQ's three-valued logic (`!(false || null)`
+ * is `null`, and filters only keep `true`). Comparing with `== true` keeps the clause boolean.
+ *
+ * @internal
+ */
+export const EXCLUDE_AGENT_VERSIONS_FILTER = `!(string::startsWith(_id, "${VERSION_FOLDER}.${AGENT_BUNDLE_PREFIX}") || string::startsWith(_system.bundleId, "${AGENT_BUNDLE_PREFIX}") == true)`

--- a/packages/sanity/src/core/search/search.test.ts
+++ b/packages/sanity/src/core/search/search.test.ts
@@ -1,0 +1,86 @@
+import {type SanityClient} from '@sanity/client'
+import {Schema} from '@sanity/schema'
+import {lastValueFrom, of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getSearchableTypes} from './common/getSearchableTypes'
+import {EXCLUDE_AGENT_VERSIONS_FILTER} from './constants'
+import {createSearch} from './search'
+
+const mockSchema = Schema.compile({
+  name: 'default',
+  types: [
+    {name: 'book', title: 'Book', type: 'document', fields: [{name: 'title', type: 'string'}]},
+  ],
+})
+
+const searchableTypes = getSearchableTypes(mockSchema)
+
+const fetch = vi.fn()
+const withConfig = vi.fn()
+const client = {observable: {fetch}, withConfig} as unknown as SanityClient
+withConfig.mockReturnValue(client)
+
+beforeEach(() => {
+  fetch.mockClear()
+  fetch.mockReturnValue(of([]))
+})
+
+/** The main search query is the last fetch; groq2024 may run a reference-resolve query first. */
+function lastFetchedQuery(): string {
+  return fetch.mock.calls.at(-1)?.[0]
+}
+
+describe.each(['groqLegacy', 'groq2024'] as const)('createSearch (%s)', (strategy) => {
+  it('excludes agent versions when searching with the raw perspective', async () => {
+    const search = createSearch(searchableTypes, client, {strategy})
+
+    await lastValueFrom(search({query: 'term', types: []}, {perspective: 'raw'}))
+
+    expect(lastFetchedQuery()).toContain(EXCLUDE_AGENT_VERSIONS_FILTER)
+  })
+
+  it('excludes agent versions when raw is set as a factory option', async () => {
+    const search = createSearch(searchableTypes, client, {strategy, perspective: 'raw'})
+
+    await lastValueFrom(search({query: 'term', types: []}))
+
+    expect(lastFetchedQuery()).toContain(EXCLUDE_AGENT_VERSIONS_FILTER)
+  })
+
+  it('ANDs the agent version exclusion with an existing filter', async () => {
+    const search = createSearch(searchableTypes, client, {
+      strategy,
+      filter: 'customFilter == $customParam',
+    })
+
+    await lastValueFrom(search({query: 'term', types: []}, {perspective: 'raw'}))
+
+    expect(lastFetchedQuery()).toContain(
+      `((customFilter == $customParam) && ${EXCLUDE_AGENT_VERSIONS_FILTER})`,
+    )
+  })
+
+  it('does not exclude agent versions for other perspectives', async () => {
+    const search = createSearch(searchableTypes, client, {strategy})
+
+    await lastValueFrom(search({query: 'term', types: []}, {perspective: ['r123', 'drafts']}))
+    await lastValueFrom(search({query: 'term', types: []}, {perspective: 'drafts'}))
+    await lastValueFrom(search({query: 'term', types: []}))
+
+    for (const [query] of fetch.mock.calls) {
+      expect(query).not.toContain(EXCLUDE_AGENT_VERSIONS_FILTER)
+    }
+  })
+})
+
+describe('EXCLUDE_AGENT_VERSIONS_FILTER', () => {
+  it('stays boolean for documents without _system.bundleId', () => {
+    // `string::startsWith(null, …)` is `null` and `!(false || null)` is `null`, which a GROQ
+    // filter treats as excluded — silently dropping every published and classic draft document.
+    // The `== true` comparison guards against that regression.
+    expect(EXCLUDE_AGENT_VERSIONS_FILTER).toContain(
+      'string::startsWith(_system.bundleId, "agent-") == true',
+    )
+  })
+})

--- a/packages/sanity/src/core/search/search.ts
+++ b/packages/sanity/src/core/search/search.ts
@@ -8,6 +8,7 @@ import {
   type SearchStrategyFactory,
   type WeightedSearchResults,
 } from './common/types'
+import {EXCLUDE_AGENT_VERSIONS_FILTER} from './constants'
 import {createGroq2024Search} from './groq2024'
 import {createWeightedSearch} from './weighted'
 
@@ -36,5 +37,24 @@ export const createSearch: SearchStrategyFactory<WeightedSearchResults | Groq202
       : undefined,
   )
 
-  return factory(searchableTypes, versionedClient(client, apiVersion), options)
+  const search = factory(searchableTypes, versionedClient(client, apiVersion), options)
+
+  return (searchTerms, searchOptions) => {
+    const {perspective, filter} = {...options, ...searchOptions}
+
+    // The `raw` perspective returns every version of every document, including Content Agent
+    // versions. Those are only readable by their author, so for everyone else they surface as
+    // duplicate search hits that open an empty document. No studio search should show them, so
+    // they are excluded here — the one place every search strategy and caller passes through.
+    if (perspective !== 'raw') {
+      return search(searchTerms, searchOptions)
+    }
+
+    return search(searchTerms, {
+      ...searchOptions,
+      filter: filter
+        ? `(${filter}) && ${EXCLUDE_AGENT_VERSIONS_FILTER}`
+        : EXCLUDE_AGENT_VERSIONS_FILTER,
+    })
+  }
 }

--- a/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
+++ b/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
@@ -13,7 +13,8 @@ import {
   switchMap,
 } from 'rxjs'
 
-const AGENT_BUNDLE_PREFIX = 'agent-'
+/** @internal */
+export const AGENT_BUNDLE_PREFIX = 'agent-'
 
 /**
  * A single active agent bundle as reported by the SSE endpoint.

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -233,6 +233,9 @@ export function SearchProvider({
           skipSortByScore: ordering.ignoreScore,
           ...(ordering.sort ? {sort: [ordering.sort]} : {}),
           cursor: cursor || undefined,
+          // Raw so drafts, published, and release versions are all findable. Content Agent
+          // versions are excluded by `createSearch` — they are only readable by their author
+          // and would otherwise appear as duplicate hits that open an empty document.
           perspective: 'raw',
         },
         terms: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Global search queries with `perspective=raw` so drafts, published documents, and release versions are all findable — but raw also returns Content Agent versions, which are only readable by their author. For everyone else they surface as duplicate hits that open an empty document ([SAPP-3895](https://linear.app/sanity/issue/SAPP-3895/search-shows-duplicate-inaccessible-agent-documents)).

Third take on #14194 / #14232. Those threaded a new perspective-conditional helper into both strategy query builders. This one instead wires the exclusion once in `createSearch` — the single factory every search strategy and caller (global search, incoming references, document lists, reference inputs) passes through — by AND-ing a GROQ constant into the existing `filter` option both query builders already support. The query builders are untouched.

Alternatives rejected:

- Filtering per query builder (the previous takes) — two insertion points, new option threading, and each raw caller silently misses the fix unless the builder covers it
- Keeping the current user's own agent versions — they still duplicate the draft/published hit, and wiring ownership through the agent-bundles SSE would re-run search as bundles load
- Client-side hit filtering — opaque-id agent versions are only identifiable via `_system.bundleId`, which is not in the search projection, and dropping hits after the fact skews pagination

GROQ notes, verified against a live dataset (50542 docs = 50521 kept + 21 agent versions; 18 matched by id, 3 variant-scoped versions matched only by `_system.bundleId`):

- `path()` segment patterns do not support prefixes (`versions.agent-*.*` matches nothing), so the id leg uses `string::startsWith`
- `string::startsWith(_system.bundleId, …)` is `null` on the ~all documents that have no `_system.bundleId`, and `!(false || null)` is `null`, which a filter drops — the `== true` comparison keeps the clause boolean (this is the bug Bugbot found on both prior takes)

### What to review

- `packages/sanity/src/core/search/search.ts` — the wrapper in `createSearch`, and whether excluding agent versions for *every* raw search (not just global search) is the right scope
- `packages/sanity/src/core/search/constants.ts` — `EXCLUDE_AGENT_VERSIONS_FILTER`, especially the null-safety of the `_system.bundleId` leg
- `SearchOptions.filter` in `packages/sanity/src/core/search/common/types.ts` is a type-only addition: both query builders already read `filter` from the merged factory + per-call options

Affected package: `sanity`.

### Testing

`packages/sanity/src/core/search/search.test.ts` covers both strategies through `createSearch`: raw perspective (per-call and factory-level) injects the exclusion, an existing factory `filter` is AND-ed rather than replaced, and non-raw perspectives are untouched. The filter's set arithmetic and null semantics were verified against the live `ppsg7ml5/test` dataset.

Manually verified in the test studio against real data — that dataset contains an agent version (`versions.agent-12334.…`) whose title is the only document matching the term "draftts":

Before (`main`) — searching "draftts" returns a false hit:

[before_main_search_shows_false_agent_version_hit.mp4](https://cursor.com/agents/bc-05a015b5-cfcd-4539-b315-32538799dd7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_main_search_shows_false_agent_version_hit.mp4)

After (this branch) — "draftts" returns no results, and a normal search ("Foo 668") still works:

[after_fix_agent_version_hit_gone_normal_search_works.mp4](https://cursor.com/agents/bc-05a015b5-cfcd-4539-b315-32538799dd7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_agent_version_hit_gone_normal_search_works.mp4)

### Notes for release

Studio search no longer lists Content Agent document versions when querying across all versions. Those versions were often duplicates of the real document and opened as an empty document for anyone who was not the author.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05a015b5-cfcd-4539-b315-32538799dd7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05a015b5-cfcd-4539-b315-32538799dd7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

