### PR TITLE
docs(agents): include linear issue id in cursor cloud branch names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -716,17 +716,7 @@ These notes cover non-obvious gotchas for running in the Cursor Cloud VM. The st
 
 ### Git branch naming
 
-Cursor Cloud already requires lowercase branches of the form `cursor/<descriptive-name>-<hash>` (`cursor/` prefix, session hash suffix).
-
-When the session is working from a Linear issue — an identifier in the prompt, a `linear.app` URL, or Linear MCP context — put that identifier, lowercased, immediately after `cursor/`:
-
-```
-cursor/<linear-id>-<descriptive-name>-<hash>
-```
-
-Example: working on `SAPP-1234` becomes `cursor/sapp-1234-some-thing-hash`.
-
-Do not invent an identifier. If no Linear issue is provided during the session, keep `cursor/<descriptive-name>-<hash>`.
+When a Linear issue is provided during the session, include its lowercased id in the branch name: `cursor/<linear-id>-<descriptive-name>-<hash>` (e.g. `cursor/sapp-1234-some-thing-hash`).
 
 ### Services
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -714,6 +714,20 @@ See `turbo.json` for full list of environment variables that affect builds.
 
 These notes cover non-obvious gotchas for running in the Cursor Cloud VM. The startup update script already runs `pnpm install`.
 
+### Git branch naming
+
+Cursor Cloud already requires lowercase branches of the form `cursor/<descriptive-name>-<hash>` (`cursor/` prefix, session hash suffix).
+
+When the session is working from a Linear issue — an identifier in the prompt, a `linear.app` URL, or Linear MCP context — put that identifier, lowercased, immediately after `cursor/`:
+
+```
+cursor/<linear-id>-<descriptive-name>-<hash>
+```
+
+Example: working on `SAPP-1234` becomes `cursor/sapp-1234-some-thing-hash`.
+
+Do not invent an identifier. If no Linear issue is provided during the session, keep `cursor/<descriptive-name>-<hash>`.
+
 ### Services
 
 | Service                                           | Port | Purpose                                          |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Cursor Cloud branches are currently `cursor/some-thing-hash`, so PRs started from Linear issues are hard to find. If a session has a Linear issue, the branch should include that id: `cursor/sapp-1234-some-thing-hash`.

### What to review

The new **Git branch naming** subsection in `AGENTS.md`. One sentence; no other files.

### Testing

N/A: documentation-only.

### Notes for release

N/A: Internal only

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5c58b11-6f95-4565-9ebb-bff792a7f054?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5c58b11-6f95-4565-9ebb-bff792a7f054&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

