### PR TITLE
chore(studio): remove unused scheduled draft dialog variant

### DIFF
--- a/packages/sanity/src/core/singleDocRelease/components/ScheduleDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/ScheduleDraftDialog.tsx
@@ -15,38 +15,15 @@ import {useTimeZone} from '../../hooks/useTimeZone'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {CONTENT_RELEASES_TIME_ZONE_SCOPE} from '../../studio/constants'
 
-type ScheduleDraftDialogVariant = 'schedule' | 'edit-schedule'
-
-interface ScheduleDraftDialogConfig {
-  headerI18nKey: string
-  descriptionI18nKey: string
-  confirmButtonTextI18nKey: string
-}
-
-const SCHEDULE_DRAFT_DIALOG_CONFIG: Record<ScheduleDraftDialogVariant, ScheduleDraftDialogConfig> =
-  {
-    'schedule': {
-      headerI18nKey: 'schedule-publish-dialog.header',
-      descriptionI18nKey: 'schedule-publish-dialog.description',
-      confirmButtonTextI18nKey: 'schedule-publish-dialog.confirm',
-    },
-    'edit-schedule': {
-      headerI18nKey: 'release.dialog.edit-schedule.header',
-      descriptionI18nKey: 'release.dialog.edit-schedule.body',
-      confirmButtonTextI18nKey: 'release.dialog.edit-schedule.confirm',
-    },
-  }
-
 interface ScheduleDraftDialogProps {
   onClose: () => void
   onSchedule: (publishAt: Date) => void
-  variant: ScheduleDraftDialogVariant
   loading?: boolean
   initialDate?: Date | string
 }
 
 export function ScheduleDraftDialog(props: ScheduleDraftDialogProps): React.JSX.Element {
-  const {onClose, onSchedule, variant, loading = false, initialDate} = props
+  const {onClose, onSchedule, loading = false, initialDate} = props
   const {t} = useTranslation()
 
   const [publishAt, setPublishAt] = useState<Date | undefined>(
@@ -58,9 +35,6 @@ export function ScheduleDraftDialog(props: ScheduleDraftDialogProps): React.JSX.
   const timeZoneAdjustedPublishAt = publishAt ? utcToCurrentZoneDate(publishAt) : undefined
 
   const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(t), [t])
-
-  // Get dialog configuration based on variant
-  const dialogConfig = SCHEDULE_DRAFT_DIALOG_CONFIG[variant]
 
   const isScheduledDateInPast = useCallback(() => {
     if (!publishAt) return true
@@ -97,13 +71,13 @@ export function ScheduleDraftDialog(props: ScheduleDraftDialogProps): React.JSX.
   return (
     <Dialog
       id="schedule-draft-dialog"
-      header={t(dialogConfig.headerI18nKey)}
+      header={t('schedule-publish-dialog.header')}
       onClose={loading ? undefined : onClose}
       width={0}
       padding={false}
       footer={{
         confirmButton: {
-          text: t(dialogConfig.confirmButtonTextI18nKey),
+          text: t('schedule-publish-dialog.confirm'),
           tone: 'primary',
           onClick: handleConfirmSchedule,
           loading: loading,
@@ -116,7 +90,7 @@ export function ScheduleDraftDialog(props: ScheduleDraftDialogProps): React.JSX.
     >
       <Stack gap={4} paddingX={4} paddingBottom={4} paddingTop={1}>
         <Text size={1} muted>
-          {t(dialogConfig.descriptionI18nKey)}
+          {t('schedule-publish-dialog.description')}
         </Text>
 
         <label>

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -220,7 +220,6 @@ export function useScheduledDraftMenuActions(
           <ScheduleDraftDialog
             onClose={handleDialogClose}
             onSchedule={handleSchedulePublish}
-            variant="schedule"
             loading={isScheduling}
             initialDate={release?.metadata?.intendedPublishAt}
           />

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
@@ -172,7 +172,6 @@ export const useSchedulePublishAction: DocumentActionComponent = (
         <ScheduleDraftDialog
           onClose={handleCloseDialog}
           onSchedule={handleSchedule}
-          variant="schedule"
           loading={isScheduling}
           initialDate={initialDate}
         />


### PR DESCRIPTION
### Description

The `edit-schedule` variant of `ScheduleDraftDialog` had no call sites. It was leftover from before pause-to-edit shipped, and it caused a false triage that a kebab menu item opened a "Change schedule" dialog.

This PR removes that dead code: the `ScheduleDraftDialogVariant` type, `ScheduleDraftDialogConfig`, the `SCHEDULE_DRAFT_DIALOG_CONFIG` record, and the `variant` prop. The dialog now always renders with the `schedule-publish-dialog.*` keys it already used for its one live variant. It does not add a banner CTA, rename "Edit schedule", or otherwise decide how scheduled-draft editing should be labelled - that is still open on [SAPP-3494](https://linear.app/sanity/issue/SAPP-3494/clarify-edit-schedule-for-content-release-process).

### What to review

- `ScheduleDraftDialog` no longer branches on variant
- `variant="schedule"` dropped at the two live call sites, `useScheduledDraftMenuActions.tsx` and `SchedulePublishAction.tsx`

### Testing

`useScheduledDraftMenuActions` and `useScheduleDraftOperations` tests still pass. No user-facing behaviour change.

### Notes for release

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Internal cleanup with no intended user-facing behavior change; scheduling dialog text and flows stay on the live `schedule` path only.
> 
> **Overview**
> Removes dead **variant** plumbing from `ScheduleDraftDialog`: the `ScheduleDraftDialogVariant` type, per-variant i18n config map, and the `variant` prop. The dialog now always uses the existing `schedule-publish-dialog.*` strings.
> 
> Call sites in `useScheduledDraftMenuActions` and `SchedulePublishAction` no longer pass `variant="schedule"`. The unused `edit-schedule` dialog variant (no call sites) is gone; **Edit schedule** in the menu still pauses the draft via `handleEditSchedule`, not this dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ae92de0df148b1985bb2cb5fd73a964623ba33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->