### PR TITLE
feat(structure): add pause to edit for scheduled drafts

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -1678,6 +1678,7 @@ import type {
   useParseErrorForPath,
   useParseErrors,
   usePausedScheduledDraft,
+  usePauseToEditScheduledDraft,
   usePerspective,
   usePresenceStore,
   usePreviewCard,
@@ -6875,6 +6876,9 @@ describe('sanity', () => {
   })
   test('usePausedScheduledDraft', () => {
     expectTypeOf<typeof usePausedScheduledDraft>().toBeFunction()
+  })
+  test('usePauseToEditScheduledDraft', () => {
+    expectTypeOf<typeof usePauseToEditScheduledDraft>().toBeFunction()
   })
   test('usePerspective', () => {
     expectTypeOf<typeof usePerspective>().toBeFunction()

--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -1160,6 +1160,7 @@ export {
   useSingleDocRelease,
 } from '../core/singleDocRelease/context/SingleDocReleaseProvider'
 export {usePausedScheduledDraft} from '../core/singleDocRelease/hooks/usePausedScheduledDraft'
+export {usePauseToEditScheduledDraft} from '../core/singleDocRelease/hooks/usePauseToEditScheduledDraft'
 export {useScheduledDraftDocument} from '../core/singleDocRelease/hooks/useScheduledDraftDocument'
 export {useScheduledDraftsEnabled} from '../core/singleDocRelease/hooks/useScheduledDraftsEnabled'
 export {isAgentBundleName} from '../core/store/agent/createAgentBundlesStore'

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1574,6 +1574,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.action.new-release.limit-reached': 'This workspace is limited to {{count}} release',
   'release.action.new-release.limit-reached_other':
     'This workspace is limited to {{count}} releases',
+  /** Action message for pausing a scheduled draft so it can be edited */
+  'release.action.pause-to-edit': 'Pause to edit',
   /** Tooltip message for not having permissions for creating new releases */
   'release.action.permission.error': 'You do not have permission to perform this action',
   /** Action message for running a scheduled draft immediately */

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
@@ -68,7 +68,7 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
   return (
     <Menu>
       {showPublishNow && <MenuItem {...actions.publishNow} />}
-      {showEditScheduleItem && <MenuItem {...actions.editSchedule} />}
+      {showEditScheduleItem && <MenuItem {...actions.pauseToEdit} />}
       <IntentLink
         intent={RELEASES_SCHEDULED_DRAFTS_INTENT}
         params={{view: 'drafts'}}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -277,7 +277,7 @@ describe('VersionContextMenu', () => {
     await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.getByTestId('publish-now-menu-item')).toBeInTheDocument()
-    expect(screen.getByTestId('edit-schedule-menu-item')).toBeInTheDocument()
+    expect(screen.getByTestId('pause-to-edit-menu-item')).toBeInTheDocument()
     expect(screen.getByTestId('delete-schedule-menu-item')).toBeInTheDocument()
   })
 
@@ -307,7 +307,7 @@ describe('VersionContextMenu', () => {
     await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.queryByTestId('publish-now-menu-item')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('edit-schedule-menu-item')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pause-to-edit-menu-item')).not.toBeInTheDocument()
     expect(screen.queryByTestId('delete-schedule-menu-item')).not.toBeInTheDocument()
   })
 
@@ -337,7 +337,7 @@ describe('VersionContextMenu', () => {
     await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.getByTestId('publish-now-menu-item')).toBeInTheDocument()
-    expect(screen.queryByTestId('edit-schedule-menu-item')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pause-to-edit-menu-item')).not.toBeInTheDocument()
     expect(screen.queryByTestId('delete-schedule-menu-item')).not.toBeInTheDocument()
   })
 

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -45,13 +45,13 @@ const createScheduledDraftMenuActions = () => ({
       'disabled': false,
       'data-testid': 'publish-now-menu-item',
     },
-    editSchedule: {
+    pauseToEdit: {
       'icon': undefined,
-      'text': 'Edit schedule',
+      'text': 'Pause to edit',
       'tone': 'default' as const,
       'onClick': vi.fn(),
       'disabled': false,
-      'data-testid': 'edit-schedule-menu-item',
+      'data-testid': 'pause-to-edit-menu-item',
     },
     schedulePublish: {
       'icon': undefined,

--- a/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
@@ -83,7 +83,7 @@ export const ScheduledDraftMenuButtonWrapper = ({release}: {release: ReleaseDocu
     }
 
     const editSchedule = showSchedule
-      ? [<MenuItem key={'edit-schedule'} {...actions.editSchedule} />]
+      ? [<MenuItem key={'pause-to-edit'} {...actions.pauseToEdit} />]
       : []
 
     return [...publishNow, ...editSchedule, ...deleteSchedule]

--- a/packages/sanity/src/core/singleDocRelease/hooks/usePauseToEditScheduledDraft.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/usePauseToEditScheduledDraft.test.tsx
@@ -1,0 +1,47 @@
+import {act, renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../test/testUtils/TestProvider'
+import {usePauseToEditScheduledDraft} from './usePauseToEditScheduledDraft'
+import {useScheduleDraftOperations} from './useScheduleDraftOperations'
+
+vi.mock('./useScheduleDraftOperations', () => ({
+  useScheduleDraftOperations: vi.fn(),
+}))
+
+const mockOperations = {
+  publishScheduledDraft: vi.fn(),
+  rescheduleScheduledDraft: vi.fn(),
+  deleteScheduledDraft: vi.fn(),
+  createScheduledDraft: vi.fn(),
+  pauseScheduledDraft: vi.fn(),
+}
+
+const mockUseScheduleDraftOperations = useScheduleDraftOperations as MockedFunction<
+  typeof useScheduleDraftOperations
+>
+
+describe('usePauseToEditScheduledDraft', () => {
+  let TestProvider: React.ComponentType<{children: React.ReactNode}>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    mockUseScheduleDraftOperations.mockReturnValue(mockOperations)
+    mockOperations.pauseScheduledDraft.mockResolvedValue(undefined)
+
+    TestProvider = await createTestProvider()
+  })
+
+  it('does not call the operation when release is undefined', async () => {
+    const {result} = renderHook(() => usePauseToEditScheduledDraft({release: undefined}), {
+      wrapper: TestProvider,
+    })
+
+    await act(async () => {
+      await result.current.pauseToEdit()
+    })
+
+    expect(mockOperations.pauseScheduledDraft).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/singleDocRelease/hooks/usePauseToEditScheduledDraft.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/usePauseToEditScheduledDraft.tsx
@@ -1,0 +1,71 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {useToast} from '@sanity/ui/toast'
+import {useCallback, useState} from 'react'
+
+import {useTranslation} from '../../i18n/hooks/useTranslation'
+import {Translate} from '../../i18n/Translate'
+import {getErrorMessage} from '../../util/getErrorMessage'
+import {useScheduleDraftOperations} from './useScheduleDraftOperations'
+
+export interface UsePauseToEditScheduledDraftOptions {
+  release: ReleaseDocument | undefined
+  documentTitle?: string
+  onComplete?: () => void
+}
+
+export interface UsePauseToEditScheduledDraftValue {
+  pauseToEdit: () => Promise<void>
+  isPausing: boolean
+}
+
+/**
+ * Hook that pauses a scheduled draft so it can be edited.
+ *
+ * @internal
+ */
+export function usePauseToEditScheduledDraft(
+  options: UsePauseToEditScheduledDraftOptions,
+): UsePauseToEditScheduledDraftValue {
+  const {release, documentTitle, onComplete} = options
+
+  const {t} = useTranslation()
+  const toast = useToast()
+  const operations = useScheduleDraftOperations()
+  const [isPausing, setIsPausing] = useState(false)
+
+  const pauseToEdit = useCallback(async () => {
+    if (!release) return
+
+    setIsPausing(true)
+    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
+    const run = async () => {
+      await operations.pauseScheduledDraft(release)
+      onComplete?.()
+    }
+    try {
+      await run()
+    } catch (error) {
+      console.error('Failed to pause scheduled draft:', error)
+      toast.push({
+        closable: true,
+        status: 'error',
+        description: (
+          <Translate
+            t={t}
+            i18nKey="release.toast.pause-scheduled-draft.error"
+            values={{
+              title: documentTitle || t('preview.default.title-fallback'),
+              error: getErrorMessage(error),
+            }}
+          />
+        ),
+      })
+    }
+    setIsPausing(false)
+  }, [release, operations, onComplete, toast, t, documentTitle])
+
+  return {
+    pauseToEdit,
+    isPausing,
+  }
+}

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -86,7 +86,7 @@ function TestComponent({options}: TestComponentProps) {
       <Menu>
         <div data-testid="menu-items">
           <MenuItem {...actions.publishNow} />
-          <MenuItem {...actions.editSchedule} />
+          <MenuItem {...actions.pauseToEdit} />
           <MenuItem {...actions.deleteSchedule} />
         </div>
       </Menu>
@@ -95,9 +95,9 @@ function TestComponent({options}: TestComponentProps) {
           <span data-testid="publish-now-text">{actions.publishNow.text}</span>
           <span data-testid="publish-now-disabled">{String(actions.publishNow.disabled)}</span>
         </div>
-        <div data-testid="edit-schedule-props">
-          <span data-testid="edit-schedule-text">{actions.editSchedule.text}</span>
-          <span data-testid="edit-schedule-disabled">{String(actions.editSchedule.disabled)}</span>
+        <div data-testid="pause-to-edit-props">
+          <span data-testid="pause-to-edit-text">{actions.pauseToEdit.text}</span>
+          <span data-testid="pause-to-edit-disabled">{String(actions.pauseToEdit.disabled)}</span>
         </div>
         <div data-testid="delete-schedule-props">
           <span data-testid="delete-schedule-text">{actions.deleteSchedule.text}</span>
@@ -192,14 +192,14 @@ describe('useScheduledDraftMenuActions', () => {
     // Should have exactly 3 menu items
     expect(menuItems).toHaveLength(3)
 
-    // Check the order: Publish Now -> Edit Schedule -> Delete Schedule
+    // Check the order: Publish Now -> Pause to edit -> Delete Schedule
     expect(menuItems[0]).toHaveAttribute('data-testid', 'publish-now-menu-item')
-    expect(menuItems[1]).toHaveAttribute('data-testid', 'edit-schedule-menu-item')
+    expect(menuItems[1]).toHaveAttribute('data-testid', 'pause-to-edit-menu-item')
     expect(menuItems[2]).toHaveAttribute('data-testid', 'delete-schedule-menu-item')
 
     // Verify all items are present
     expect(screen.getByTestId('publish-now-menu-item')).toBeInTheDocument()
-    expect(screen.getByTestId('edit-schedule-menu-item')).toBeInTheDocument()
+    expect(screen.getByTestId('pause-to-edit-menu-item')).toBeInTheDocument()
     expect(screen.getByTestId('delete-schedule-menu-item')).toBeInTheDocument()
   })
 
@@ -211,7 +211,7 @@ describe('useScheduledDraftMenuActions', () => {
     )
 
     expect(screen.getByTestId('publish-now-text')).toHaveTextContent('Publish now')
-    expect(screen.getByTestId('edit-schedule-text')).toHaveTextContent('Edit schedule')
+    expect(screen.getByTestId('pause-to-edit-text')).toHaveTextContent('Pause to edit')
     expect(screen.getByTestId('delete-schedule-text')).toHaveTextContent('Delete schedule')
   })
 
@@ -259,7 +259,7 @@ describe('useScheduledDraftMenuActions', () => {
     })
   })
 
-  describe('edit schedule action', () => {
+  describe('pause to edit action', () => {
     it('should call pauseScheduledDraft operation on success', async () => {
       render(
         <TestProvider>
@@ -268,7 +268,7 @@ describe('useScheduledDraftMenuActions', () => {
       )
 
       // Click menu item to trigger pause operation
-      await userEvent.click(screen.getByTestId('edit-schedule-menu-item'))
+      await userEvent.click(screen.getByTestId('pause-to-edit-menu-item'))
 
       await waitFor(() => {
         expect(mockOperations.pauseScheduledDraft).toHaveBeenCalledWith(scheduledRelease)
@@ -286,7 +286,7 @@ describe('useScheduledDraftMenuActions', () => {
         </TestProvider>,
       )
 
-      await userEvent.click(screen.getByTestId('edit-schedule-menu-item'))
+      await userEvent.click(screen.getByTestId('pause-to-edit-menu-item'))
 
       await waitFor(() => {
         expect(mockToastPush).toHaveBeenCalledWith(

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -8,19 +8,15 @@ import {type ComponentProps, useCallback, useMemo, useState} from 'react'
 
 import {type MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
-import {Translate} from '../../i18n/Translate'
 import {getErrorMessage} from '../../util/getErrorMessage'
 import {DeleteScheduledDraftDialog} from '../components/DeleteScheduledDraftDialog'
 import {PublishScheduledDraftDialog} from '../components/PublishScheduledDraftDialog'
 import {ScheduleDraftDialog} from '../components/ScheduleDraftDialog'
+import {usePauseToEditScheduledDraft} from './usePauseToEditScheduledDraft'
 import {useScheduledDraftDocument} from './useScheduledDraftDocument'
 import {useScheduleDraftOperations} from './useScheduleDraftOperations'
 
-export type ScheduledDraftAction =
-  | 'publish-now'
-  | 'edit-schedule'
-  | 'delete-schedule'
-  | 'schedule-publish'
+export type ScheduledDraftAction = 'publish-now' | 'delete-schedule' | 'schedule-publish'
 
 export interface UseScheduledDraftMenuActionsOptions {
   release: ReleaseDocument | undefined
@@ -41,7 +37,7 @@ interface ScheduledDraftActionProps {
 
 export interface UseScheduledDraftMenuActionsReturn {
   actions: Record<
-    'publishNow' | 'editSchedule' | 'deleteSchedule' | 'schedulePublish',
+    'publishNow' | 'pauseToEdit' | 'deleteSchedule' | 'schedulePublish',
     ScheduledDraftActionProps
   >
   dialogs: React.ReactNode
@@ -71,55 +67,27 @@ export function useScheduledDraftMenuActions(
   const toast = useToast()
   const operations = useScheduleDraftOperations()
   const [selectedAction, setSelectedAction] = useState<ScheduledDraftAction | null>(null)
-  const [isPerformingOperation, setIsPerformingOperation] = useState(false)
   const [isScheduling, setIsScheduling] = useState(false)
 
   // Safely handle undefined release by passing undefined to the hook
   const {firstDocumentPreview, loading: documentLoading} = useScheduledDraftDocument(release?._id, {
     includePreview: true,
   })
-
-  const handleEditSchedule = useCallback(async () => {
-    if (!release) return
-
-    setIsPerformingOperation(true)
-    // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
-    const run = async () => {
-      await operations.pauseScheduledDraft(release)
-      onActionComplete?.()
-    }
-    try {
-      await run()
-    } catch (error) {
-      console.error('Failed to pause scheduled draft:', error)
-      toast.push({
-        closable: true,
-        status: 'error',
-        description: (
-          <Translate
-            t={t}
-            i18nKey="release.toast.pause-scheduled-draft.error"
-            values={{
-              title: firstDocumentPreview?.title || t('preview.default.title-fallback'),
-              error: getErrorMessage(error),
-            }}
-          />
-        ),
-      })
-    }
-    setIsPerformingOperation(false)
-    setSelectedAction(null)
-  }, [release, operations, onActionComplete, toast, t, firstDocumentPreview?.title])
+  const {pauseToEdit, isPausing} = usePauseToEditScheduledDraft({
+    release,
+    documentTitle: firstDocumentPreview?.title,
+    onComplete: onActionComplete,
+  })
 
   const handleMenuItemClick = useCallback((action: ScheduledDraftAction) => {
     setSelectedAction(action)
   }, [])
 
   const handleDialogClose = useCallback(() => {
-    if (!isPerformingOperation) {
+    if (!isPausing) {
       setSelectedAction(null)
     }
-  }, [isPerformingOperation])
+  }, [isPausing])
 
   const handleSchedulePublish = useCallback(
     async (publishAt: Date) => {
@@ -153,7 +121,7 @@ export function useScheduledDraftMenuActions(
   )
 
   const actions = useMemo(() => {
-    const baseDisabled = disabled || isPerformingOperation || documentLoading
+    const baseDisabled = disabled || isPausing || documentLoading
 
     return {
       publishNow: {
@@ -164,13 +132,13 @@ export function useScheduledDraftMenuActions(
         'disabled': baseDisabled,
         'data-testid': 'publish-now-menu-item',
       },
-      editSchedule: {
+      pauseToEdit: {
         'icon': EditIcon,
-        'text': t('release.action.edit-schedule'),
+        'text': t('release.action.pause-to-edit'),
         'tone': 'default' as const,
-        'onClick': handleEditSchedule,
+        'onClick': pauseToEdit,
         'disabled': baseDisabled,
-        'data-testid': 'edit-schedule-menu-item',
+        'data-testid': 'pause-to-edit-menu-item',
       },
       schedulePublish: {
         'icon': CalendarIcon,
@@ -189,7 +157,7 @@ export function useScheduledDraftMenuActions(
         'data-testid': 'delete-schedule-menu-item',
       },
     }
-  }, [t, handleMenuItemClick, handleEditSchedule, disabled, isPerformingOperation, documentLoading])
+  }, [t, handleMenuItemClick, pauseToEdit, disabled, isPausing, documentLoading])
 
   const dialogs = useMemo(() => {
     if (!selectedAction || !release) return null
@@ -242,7 +210,7 @@ export function useScheduledDraftMenuActions(
   return {
     actions,
     dialogs,
-    isPerformingOperation,
+    isPerformingOperation: isPausing,
     selectedAction,
     handleDialogClose,
   }

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
@@ -88,7 +88,7 @@ export const PublishScheduledDraftAction = createScheduledDraftAction('publishNo
  * Only visible when the draft is NOT paused
  * @internal
  */
-export const EditScheduledDraftAction = createScheduledDraftAction(
+export const PauseToEditScheduledDraftAction = createScheduledDraftAction(
   'pauseToEdit',
   (release) => !isPausedCardinalityOneRelease(release), // Hide when paused
 )
@@ -101,6 +101,6 @@ export const DeleteScheduledDraftAction = createScheduledDraftAction('deleteSche
 
 PublishScheduledDraftAction.action = 'publish'
 
-EditScheduledDraftAction.action = 'schedule'
+PauseToEditScheduledDraftAction.action = 'schedule'
 
 DeleteScheduledDraftAction.action = 'discardVersion'

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
@@ -84,12 +84,12 @@ const createScheduledDraftAction = (
 export const PublishScheduledDraftAction = createScheduledDraftAction('publishNow')
 
 /**
- * Document action for editing schedule of a scheduled draft
+ * Document action for pausing a scheduled draft so it can be edited.
  * Only visible when the draft is NOT paused
  * @internal
  */
 export const EditScheduledDraftAction = createScheduledDraftAction(
-  'editSchedule',
+  'pauseToEdit',
   (release) => !isPausedCardinalityOneRelease(release), // Hide when paused
 )
 

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
@@ -13,7 +13,7 @@ export default function resolveDocumentActions(
 ): DocumentActionComponent[] {
   if (context.versionType === 'scheduled-draft') {
     // For paused scheduled drafts: Schedule (primary), Publish Now, Delete Schedule
-    // For active scheduled drafts: Publish Now (primary), Edit Schedule, Delete Schedule
+    // For active scheduled drafts: Publish Now (primary), Pause to edit, Delete Schedule
     return [
       useSchedulePublishAction, // Shows only when paused
       PublishScheduledDraftAction, // Always shows

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/index.ts
@@ -2,7 +2,7 @@ import {type DocumentActionComponent} from '../../../config/document/actions'
 import {type DocumentActionsContext} from '../../../config/types'
 import {
   DeleteScheduledDraftAction,
-  EditScheduledDraftAction,
+  PauseToEditScheduledDraftAction,
   PublishScheduledDraftAction,
 } from './ScheduledDraftDocumentActions'
 import {useSchedulePublishAction} from './SchedulePublishAction'
@@ -17,7 +17,7 @@ export default function resolveDocumentActions(
     return [
       useSchedulePublishAction, // Shows only when paused
       PublishScheduledDraftAction, // Always shows
-      EditScheduledDraftAction, // Shows only when NOT paused
+      PauseToEditScheduledDraftAction, // Shows only when NOT paused
       DeleteScheduledDraftAction, // Always shows
     ]
   }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
@@ -2,13 +2,16 @@ import {LockIcon} from '@sanity/icons/Lock'
 import {Text} from '@sanity/ui'
 import {
   getReleaseTone,
+  isCardinalityOneRelease,
   LATEST,
   type ReleaseDocument,
   Translate,
   useFormatRelativeLocalePublishDate,
+  usePauseToEditScheduledDraft,
   useTranslation,
 } from 'sanity'
 
+import {useDocumentTitle} from '../../useDocumentTitle'
 import {Banner} from './Banner'
 
 export function ScheduledReleaseBanner({
@@ -20,11 +23,18 @@ export function ScheduledReleaseBanner({
 
   const {t: tCore} = useTranslation()
   const formatPublishDate = useFormatRelativeLocalePublishDate()
+  const {title} = useDocumentTitle()
+  const isCardinalityOne = isCardinalityOneRelease(currentRelease)
+  const {pauseToEdit, isPausing} = usePauseToEditScheduledDraft({
+    release: isCardinalityOne ? currentRelease : undefined,
+    documentTitle: title,
+  })
 
   return (
     <Banner
       tone={tone}
       icon={LockIcon}
+      data-testid="scheduled-release-banner"
       content={
         <Text size={1}>
           <Translate
@@ -35,6 +45,17 @@ export function ScheduledReleaseBanner({
             }}
           />
         </Text>
+      }
+      action={
+        isCardinalityOne
+          ? {
+              text: tCore('release.action.pause-to-edit'),
+              onClick: pauseToEdit,
+              disabled: isPausing,
+              mode: 'default',
+              tone: tone,
+            }
+          : undefined
       }
     />
   )

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/ScheduledReleaseBanner.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/ScheduledReleaseBanner.test.tsx
@@ -1,0 +1,98 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {type ReleaseDocument, usePauseToEditScheduledDraft} from 'sanity'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {ScheduledReleaseBanner} from '../ScheduledReleaseBanner'
+
+vi.mock('../../../useDocumentTitle', () => ({
+  useDocumentTitle: () => ({title: 'Test document'}),
+}))
+
+vi.mock('sanity', async () => {
+  const actual = await vi.importActual('sanity')
+  return {
+    ...actual,
+    usePauseToEditScheduledDraft: vi.fn(),
+  }
+})
+
+const mockUsePauseToEditScheduledDraft = usePauseToEditScheduledDraft as Mock<
+  typeof usePauseToEditScheduledDraft
+>
+
+const pauseToEdit = vi.fn()
+
+// Matches `scheduledRelease` in core/releases/__fixtures__/release.fixture.ts
+const scheduledRelease: ReleaseDocument = {
+  _rev: 'scheduledRev',
+  _id: '_.releases.rScheduled',
+  name: 'rScheduled',
+  _type: 'system.release',
+  _createdAt: '2023-10-10T08:00:00Z',
+  _updatedAt: '2023-10-10T09:00:00Z',
+  state: 'scheduled',
+  publishAt: '2023-10-10T10:00:00Z',
+  metadata: {
+    title: 'scheduled Release',
+    releaseType: 'scheduled',
+    intendedPublishAt: '2023-10-10T10:00:00Z',
+    description: 'scheduled Release description',
+    cardinality: undefined,
+  },
+}
+
+const scheduledCardinalityOneRelease: ReleaseDocument = {
+  ...scheduledRelease,
+  metadata: {
+    ...scheduledRelease.metadata,
+    cardinality: 'one',
+  },
+}
+
+async function renderBanner(currentRelease: ReleaseDocument) {
+  const wrapper = await createTestProvider()
+  return render(<ScheduledReleaseBanner currentRelease={currentRelease} />, {wrapper})
+}
+
+describe('ScheduledReleaseBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUsePauseToEditScheduledDraft.mockReturnValue({
+      pauseToEdit,
+      isPausing: false,
+    })
+  })
+
+  it('shows a Pause to edit button for a cardinality-one scheduled release', async () => {
+    await renderBanner(scheduledCardinalityOneRelease)
+
+    expect(screen.getByTestId('scheduled-release-banner')).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Pause to edit'})).toBeInTheDocument()
+    expect(mockUsePauseToEditScheduledDraft).toHaveBeenCalledWith({
+      release: scheduledCardinalityOneRelease,
+      documentTitle: 'Test document',
+    })
+  })
+
+  it('does not show a Pause to edit button for a multi-doc scheduled release', async () => {
+    await renderBanner(scheduledRelease)
+
+    expect(screen.getByTestId('scheduled-release-banner')).toBeInTheDocument()
+    expect(screen.getByText(/scheduled to be published/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: 'Pause to edit'})).not.toBeInTheDocument()
+    expect(mockUsePauseToEditScheduledDraft).toHaveBeenCalledWith({
+      release: undefined,
+      documentTitle: 'Test document',
+    })
+  })
+
+  it('calls pauseToEdit when Pause to edit is clicked', async () => {
+    await renderBanner(scheduledCardinalityOneRelease)
+
+    await userEvent.click(screen.getByRole('button', {name: 'Pause to edit'}))
+
+    expect(pauseToEdit).toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -677,6 +677,7 @@ exports[`exports snapshot 1`] = `
     "useOnlyHasVersions": "function",
     "useParseErrorForPath": "function",
     "useParseErrors": "function",
+    "usePauseToEditScheduledDraft": "function",
     "usePausedScheduledDraft": "function",
     "usePerspective": "function",
     "usePresenceStore": "function",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Customers could not find how to unlock a scheduled draft. The overflow item was labelled Edit schedule but it already called `pauseScheduledDraft` — no date dialog — and the lock banner had no CTA. Jordan endorsed Pause to edit on the banner, so this restores that treatment on top of #14273.

The pause hook takes `documentTitle` from the caller instead of fetching it. `useScheduledDraftDocument` / `useReleaseDocuments` stay at main's count on the menu path; the banner uses the pane's already-loaded `useDocumentTitle()`.

`EditScheduledDraftAction` is renamed to `PauseToEditScheduledDraftAction` (and its `displayName`) so action lists and telemetry match the pause behaviour. `.action` stays `'schedule'` so `document.actions` resolvers that key off that token still match.

Known follow-up, not changed here: `documentInScheduledRelease` uses `isReleaseScheduledOrScheduling`, so the CTA can render while a release is in `scheduling`. An unschedule can be rejected mid-transition and the user gets the existing error toast. The three overflow surfaces already have that exposure; making the action discoverable hits the path more often. A human should decide whether to tighten the gate to `state === 'scheduled'`.

Stacked on #14273 (dead-code dialog removal; that PR no longer touches `studio.ts`). This PR's `studio.ts` change is only the additive `release.action.pause-to-edit` key.

Fixes [SAPP-3494](https://linear.app/sanity/issue/SAPP-3494).

### What to review

- Banner CTA is cardinality-one only; both `action: undefined` and `release: undefined` gates stay. `DocumentPanel` shows this banner for any `documentInScheduledRelease`.
- Menu path still has a single `useScheduledDraftDocument({includePreview: true})` and passes `firstDocumentPreview?.title` into the hook.
- i18n: add `release.action.pause-to-edit` after `new-release.limit-reached_other`. Do not delete or restore `release.action.edit-schedule`.
- `PauseToEditScheduledDraftAction` replaces `EditScheduledDraftAction`; `.action` remains `'schedule'`.

### Testing

- `useScheduledDraftMenuActions` covers the relabel and pause operation/error toast.
- `usePauseToEditScheduledDraft` only asserts the undefined-release gate (the P0's second gate). Success/error toast cases stay on the menu-actions suite.
- `ScheduledReleaseBanner` covers cardinality-one vs multi-doc and the click.

**Before** — lock banner has no CTA; overflow is still labelled Edit schedule; clicking it pauses with no date dialog.

[Before: lock banner with no CTA](https://cursor.com/agents/bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsapp3494_before_lock_banner_no_cta.webp)
[Before: kebab only Edit schedule](https://cursor.com/agents/bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsapp3494_before_kebab_edit_schedule.webp)
[Before: kebab Edit schedule pauses the schedule](https://cursor.com/agents/bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsapp3494_before_after_kebab_pauses.webp)

**After** — Pause to edit on the banner; same label in the overflow; click pauses and the form becomes writable.

[sapp3494 after pause to edit banner.mp4](https://cursor.com/agents/bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsapp3494%20after%20pause%20to%20edit%20banner.mp4)

[After: lock banner Pause to edit CTA](https://cursor.com/agents/bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsapp3494_after_banner_pause_to_edit.webp)
[Knock-on: multi-doc scheduled release has no Pause to edit](https://cursor.com/agents/bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsapp3494_knockon_multidoc_no_pause_cta.webp)

### Notes for release

Scheduled drafts now show a Pause to edit button on the locked document banner allowing for the document to be unlocked for edits to take place.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-843b5c7d-b927-4c25-9311-1a1ab98f9f59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

