### PR TITLE
chore(core): export byId map from useActiveReleases

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -41,18 +41,18 @@ import {
  */
 export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: string}) {
   const {t} = useTranslation()
-  const {data: releases} = useActiveReleases()
+  const {byId: releasesById} = useActiveReleases()
   const {byId: variantsById} = useAllVariants()
   const {loading, versions} = useDocumentVersions({documentId: documentGroupId})
   const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
 
   const versionGroups = useMemo(
     () =>
-      groupDocumentVersionsForStatus(versions, releases ?? [], variantsById, {
+      groupDocumentVersionsForStatus(versions, releasesById, variantsById, {
         variantsEnabled,
         showAgentVersions: SHOW_AGENT_VERSIONS_IN_STATUS,
       }),
-    [releases, variantsById, variantsEnabled, versions],
+    [releasesById, variantsById, variantsEnabled, versions],
   )
 
   if (loading) {

--- a/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/DocumentVersionsStatus.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../../../releases/hooks/useDocumentVersions', () => ({
 vi.mock('../../../releases/store/useActiveReleases', () => ({
   useActiveReleases: vi.fn(() => ({
     data: [],
+    byId: new Map(),
     error: undefined,
     loading: false,
     dispatch: vi.fn(),
@@ -134,6 +135,7 @@ describe('DocumentVersionsStatus', () => {
     })
     mockUseActiveReleases.mockReturnValue({
       data: [],
+      byId: new Map(),
       error: undefined,
       loading: false,
       dispatch: vi.fn(),

--- a/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
@@ -1,3 +1,4 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {describe, expect, it} from 'vitest'
 
 import {type VersionInfoDocumentStub} from '../../../releases/store/types'
@@ -70,7 +71,7 @@ const releaseSummer = {
     releaseType: 'scheduled',
   },
   state: 'active',
-} as const
+} as const satisfies ReleaseDocument
 
 const releaseHalloween = {
   _id: '_.releases.rHalloween',
@@ -84,7 +85,7 @@ const releaseHalloween = {
     releaseType: 'scheduled',
   },
   state: 'active',
-} as const
+} as const satisfies ReleaseDocument
 
 const releaseAsap = {
   _id: '_.releases.rASAP',
@@ -98,7 +99,7 @@ const releaseAsap = {
     releaseType: 'asap',
   },
   state: 'active',
-} as const
+} as const satisfies ReleaseDocument
 
 describe('groupDocumentVersionsForStatus', () => {
   it('groups default variant first, then sorts variants by id', () => {
@@ -124,7 +125,7 @@ describe('groupDocumentVersionsForStatus', () => {
           variantRef: variantReturning._id,
         }),
       ],
-      [],
+      new Map(),
       new Map([
         [variantReturning._id, variantReturning],
         [variantFirstTime._id, variantFirstTime],
@@ -178,7 +179,11 @@ describe('groupDocumentVersionsForStatus', () => {
           variantRef: variantReturning._id,
         }),
       ],
-      [releaseSummer, releaseHalloween, releaseAsap],
+      new Map<string, ReleaseDocument>([
+        [releaseSummer._id, releaseSummer],
+        [releaseHalloween._id, releaseHalloween],
+        [releaseAsap._id, releaseAsap],
+      ]),
       new Map([
         [variantReturning._id, variantReturning],
         [variantFirstTime._id, variantFirstTime],
@@ -211,7 +216,7 @@ describe('groupDocumentVersionsForStatus', () => {
           updatedAt: '2025-06-02T00:00:00Z',
         }),
       ],
-      [],
+      new Map(),
       new Map(),
     )
 
@@ -246,7 +251,7 @@ describe('groupDocumentVersionsForStatus', () => {
           releaseRef: releaseSummer._id,
         }),
       ],
-      [releaseSummer],
+      new Map([[releaseSummer._id, releaseSummer]]),
       new Map(),
       {showAgentVersions: true},
     )
@@ -289,7 +294,7 @@ describe('groupDocumentVersionsForStatus', () => {
           variantRef: variantReturning._id,
         }),
       ],
-      [releaseSummer],
+      new Map([[releaseSummer._id, releaseSummer]]),
       new Map([[variantReturning._id, variantReturning]]),
       {variantsEnabled: false},
     )

--- a/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
+++ b/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
@@ -133,15 +133,15 @@ function compareDocumentVersionsForStatus(
  */
 export function groupDocumentVersionsForStatus(
   versions: VersionInfoDocumentStub[],
-  releases: ReleaseDocument[],
+  releasesById: Map<string, ReleaseDocument>,
   variantsById: Map<string, SystemVariant>,
   {
     variantsEnabled = true,
     showAgentVersions = SHOW_AGENT_VERSIONS_IN_STATUS,
   }: GroupDocumentVersionsForStatusOptions = {},
 ): DocumentVersionStatusGroup[] {
+  const releases = Array.from(releasesById.values())
   const sortedReleases = sortReleases(releases)
-  const releasesById = new Map(sortedReleases.map((release) => [release._id, release]))
   const visibleVersions = versions.filter((version) => {
     if (!variantsEnabled && version._system.variant?._ref) {
       return false

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/ReleaseForm.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/ReleaseForm.test.tsx
@@ -100,6 +100,7 @@ describe('ReleaseForm', () => {
       ]
       mockUseActiveReleases.mockReturnValue({
         data: mockData,
+        byId: new Map(mockData.map((release) => [release._id, release])),
         loading: false,
         dispatch: vi.fn(),
         error: undefined,
@@ -209,6 +210,7 @@ describe('ReleaseForm', () => {
       const mockData: ReleaseDocument[] = []
       mockUseActiveReleases.mockReturnValue({
         data: mockData,
+        byId: new Map(mockData.map((release) => [release._id, release])),
         loading: false,
         dispatch: vi.fn(),
         error: undefined,
@@ -315,6 +317,7 @@ describe('ReleaseForm', () => {
       ]
       mockUseActiveReleases.mockReturnValue({
         data: mockData,
+        byId: new Map(mockData.map((release) => [release._id, release])),
         loading: false,
         dispatch: vi.fn(),
         error: undefined,

--- a/packages/sanity/src/core/releases/store/__tests__/__mocks/useActiveReleases.mock.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/__mocks/useActiveReleases.mock.ts
@@ -5,6 +5,7 @@ import {useActiveReleases} from '../../useActiveReleases'
 
 export const useActiveReleasesMockReturn = {
   data: [] as ReleaseDocument[],
+  byId: new Map<string, ReleaseDocument>(),
   error: undefined as Error | undefined,
   loading: false,
   dispatch: vi.fn(),

--- a/packages/sanity/src/core/releases/store/__tests__/useActiveReleases.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/useActiveReleases.test.ts
@@ -47,6 +47,7 @@ describe('useActiveReleases', () => {
     expect(result.current).toEqual({
       loading: true,
       data: [],
+      byId: new Map(),
       error: undefined,
       dispatch: mockDispatch,
     })
@@ -69,6 +70,7 @@ describe('useActiveReleases', () => {
       expect(result.current).toEqual({
         loading: false,
         data: [],
+        byId: new Map(),
         error: testError,
         dispatch: mockDispatch,
       })
@@ -93,6 +95,7 @@ describe('useActiveReleases', () => {
       expect(result.current).toEqual({
         loading: false,
         data: [activeASAPRelease],
+        byId: new Map([[activeASAPRelease._id, activeASAPRelease]]),
         error: undefined,
         dispatch: mockDispatch,
       })
@@ -117,6 +120,7 @@ describe('useActiveReleases', () => {
       expect(result.current).toEqual({
         loading: false,
         data: mockReleases,
+        byId: new Map(mockReleases.map((release) => [release._id, release])),
         error: undefined,
         dispatch: mockDispatch,
       })
@@ -130,6 +134,7 @@ describe('useActiveReleases', () => {
     expect(result.current).toEqual({
       loading: true,
       data: [],
+      byId: new Map(),
       error: undefined,
       dispatch: mockDispatch,
     })

--- a/packages/sanity/src/core/releases/store/useActiveReleases.ts
+++ b/packages/sanity/src/core/releases/store/useActiveReleases.ts
@@ -15,6 +15,7 @@ interface ReleasesState {
   error?: Error
   loading: boolean
   dispatch: (event: ReleasesReducerAction) => void
+  byId: Map<string, ReleaseDocument>
 }
 
 /**
@@ -39,13 +40,19 @@ export function useActiveReleases(): ReleasesState {
     [state.releases],
   )
 
+  const byId = useMemo(
+    () => new Map(releasesAsArray.map((release) => [release._id, release])),
+    [releasesAsArray],
+  )
+
   return useMemo(
     () => ({
       data: releasesAsArray,
       dispatch,
       error: state.error,
+      byId,
       loading: ['loading', 'initialising'].includes(state.state),
     }),
-    [releasesAsArray, state.error, state.state, dispatch],
+    [releasesAsArray, state.error, state.state, dispatch, byId],
   )
 }

--- a/packages/sanity/src/core/singleDocRelease/hooks/useHasCardinalityOneReleaseVersions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useHasCardinalityOneReleaseVersions.test.tsx
@@ -29,6 +29,7 @@ const mockActiveReleasesReturn = {
   loading: false,
   error: undefined,
   dispatch: vi.fn(),
+  byId: new Map<string, ReleaseDocument>(),
 }
 
 const mockDocumentVersionsReturn = {
@@ -63,6 +64,7 @@ describe('useHasCardinalityOneReleaseVersions', () => {
     useActiveReleases.mockReturnValue({
       ...mockActiveReleasesReturn,
       data: [activeASAPRelease], // This has cardinality 'many'
+      byId: new Map([[activeASAPRelease._id, activeASAPRelease]]),
     })
     // @ts-expect-error -- pre-existing, fix later
     useDocumentVersions.mockReturnValue({
@@ -79,6 +81,7 @@ describe('useHasCardinalityOneReleaseVersions', () => {
     useActiveReleases.mockReturnValue({
       ...mockActiveReleasesReturn,
       data: [cardinalityOneRelease],
+      byId: new Map([[cardinalityOneRelease._id, cardinalityOneRelease]]),
     })
     // @ts-expect-error -- pre-existing, fix later
     useDocumentVersions.mockReturnValue({
@@ -95,6 +98,7 @@ describe('useHasCardinalityOneReleaseVersions', () => {
     useActiveReleases.mockReturnValue({
       ...mockActiveReleasesReturn,
       data: [cardinalityOneRelease],
+      byId: new Map([[cardinalityOneRelease._id, cardinalityOneRelease]]),
     })
     // @ts-expect-error -- pre-existing, fix later
     useDocumentVersions.mockReturnValue({

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -27,11 +27,7 @@ export function VariantDocumentsTable({
 }): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const [activeLane, setActiveLane] = useState<string>(RELEASE_LANE_ALL)
-  const {data: releases} = useActiveReleases()
-  const releasesById = useMemo(
-    () => new Map(releases.map((release) => [release._id, release])),
-    [releases],
-  )
+  const {byId: releasesById} = useActiveReleases()
 
   const segments = useMemo(
     () => computeReleaseLaneSegments(rows, releasesById),

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../../../../components/documentTable/EditedByCell', () => ({
 vi.mock('../../../../releases/store/useActiveReleases', () => ({
   useActiveReleases: vi.fn(() => ({
     data: [],
+    byId: new Map(),
     loading: false,
     error: null,
   })),

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DeletedDocumentBanners.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DeletedDocumentBanners.test.tsx
@@ -46,6 +46,7 @@ describe('DeletedDocumentBanners', () => {
     >)
     mockUseActiveReleases.mockReturnValue({
       data: [],
+      byId: new Map(),
       dispatch: vi.fn(),
       loading: false,
     })
@@ -74,6 +75,7 @@ describe('DeletedDocumentBanners', () => {
     >)
     mockUseActiveReleases.mockReturnValue({
       data: [mockReleaseDocument],
+      byId: new Map([[mockReleaseDocument._id, mockReleaseDocument]]),
       dispatch: vi.fn(),
       loading: false,
     })
@@ -104,6 +106,7 @@ describe('DeletedDocumentBanners', () => {
 
     mockUseActiveReleases.mockReturnValue({
       data: [mockBundleDocument],
+      byId: new Map([[mockBundleDocument._id, mockBundleDocument]]),
       dispatch: vi.fn(),
       loading: false,
     })

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/OpenReleaseToEditBanner.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/OpenReleaseToEditBanner.test.tsx
@@ -70,6 +70,7 @@ describe('OpenReleaseToEditbanner', () => {
   it('does not show when is draft', async () => {
     mockUseActiveReleases.mockReturnValue({
       data: [],
+      byId: new Map(),
       dispatch: vi.fn(),
       loading: false,
     })
@@ -87,6 +88,7 @@ describe('OpenReleaseToEditbanner', () => {
   it('does not show when is published', async () => {
     mockUseActiveReleases.mockReturnValue({
       data: [],
+      byId: new Map(),
       dispatch: vi.fn(),
       loading: false,
     })
@@ -105,6 +107,7 @@ describe('OpenReleaseToEditbanner', () => {
 
     mockUseActiveReleases.mockReturnValue({
       data: [release1],
+      byId: new Map([[release1._id, release1]]),
       dispatch: vi.fn(),
       loading: false,
     })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentHeaderTitle.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentHeaderTitle.test.tsx
@@ -88,6 +88,7 @@ describe('DocumentHeaderTitle', () => {
     mockUseDocumentVersions.mockReturnValue({data: [], loading: false, error: undefined})
     mockUseActiveReleases.mockReturnValue({
       data: [],
+      byId: new Map(),
       loading: false,
       dispatch: vi.fn(),
     })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/__tests__/DocumentPerspectiveList.test.tsx
@@ -43,7 +43,7 @@ vi.mock('sanity', async (importOriginal) => ({
     loading: true,
     versions: [],
   }),
-  useActiveReleases: vi.fn().mockReturnValue({data: [], loading: false}),
+  useActiveReleases: vi.fn().mockReturnValue({data: [], byId: new Map(), loading: false}),
   useAllVariants: vi.fn().mockReturnValue({
     data: [],
     byId: new Map(),
@@ -212,6 +212,7 @@ describe('DocumentPerspectiveList', () => {
     mockUseActiveReleases.mockReturnValue({
       loading: false,
       data: [mockCurrent],
+      byId: new Map([[mockCurrent._id, mockCurrent]]),
       dispatch: vi.fn(),
     })
 


### PR DESCRIPTION
### Description
This PR extends the internal `useActiveReleases` hook to expose a `byId` map (mirroring the useAllVariants pattern), and updates call sites/tests to consume that memoized map instead of rebuilding Maps inline.

Replaces local new Map(releases.map(...)) constructions with useActiveReleases().byId where applicable.




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Internal API shape change for an already-internal hook, with tests updated. No auth, data, or user-facing behavior changes.
> 
> **Overview**
> Adds a memoized `byId` map on `useActiveReleases`, matching `useAllVariants`.
> 
> Call sites that previously built `new Map(releases.map(...))` now consume `byId` directly. `groupDocumentVersionsForStatus` takes that map instead of a release array.
> 
> Mocks and unit tests are updated to include `byId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb54d49be2a9ee8be42dab42ff7461b6f2d16fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->