### PR TITLE
chore(deps): drop tsdown rolldown version override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,7 @@ The `sanity` package tsdown build can emit a Rolldown [bundle analyzer](https://
 pnpm analyze:sanity
 ```
 
-The report is written to `packages/sanity/lib/analyze-data.md` (gitignored with `lib/`). The flag is opt-in because analysis adds work to the package build; it is declared in `packages/sanity/turbo.json` so turbo-cached builds are invalidated when it changes. Wiring is `@sanity/tsdown-config`'s `bundleAnalyzer` option (`true` selects markdown). `pnpm-workspace.yaml` pins `tsdown>rolldown` to the same rolldown that `@sanity/tsdown-config` uses, so the analyzer BuiltinPlugin actually runs.
+The report is written to `packages/sanity/lib/analyze-data.md` (gitignored with `lib/`). The flag is opt-in because analysis adds work to the package build; it is declared in `packages/sanity/turbo.json` so turbo-cached builds are invalidated when it changes. Wiring is `@sanity/tsdown-config`'s `bundleAnalyzer` option (`true` selects markdown).
 
 ### Studio performance benchmarks (perf/bench — No Auth Required)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,6 @@ catalogs:
 
 overrides:
   vitest: ^4.1.11
-  tsdown>rolldown: ~1.2.4
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -129,10 +129,6 @@ minimumReleaseAgeExclude:
 
 overrides:
   vitest: 'catalog:'
-  # @sanity/tsdown-config's `bundleAnalyzer` constructs a Rolldown BuiltinPlugin from
-  # `rolldown/experimental`. That instance must be the same rolldown tsdown runs
-  # (`~1.2.0` currently resolves 1.2.3; tsdown-config depends on ~1.2.4).
-  'tsdown>rolldown': ~1.2.4
 
 preferWorkspacePackages: true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`#14106` pinned `tsdown>rolldown` to `~1.2.4` so `@sanity/tsdown-config`'s `bundleAnalyzer` BuiltinPlugin and the rolldown tsdown actually runs were the same copy. tsdown's `~1.2.0` had resolved 1.2.3 at the time; mixing those versions registered the plugin but never wrote `analyze-data.md`.

Both now resolve a single `rolldown@1.2.4` without the pin, so the override is leftover workaround. The analyzer stays on the built-in `bundleAnalyzer` option from [`@sanity/tsdown-config@0.25.0`](https://github.com/sanity-io/pkg-utils/blob/main/packages/%40sanity/tsdown-config/CHANGELOG.md#0250).

Keeping the pin would fight tsdown's own range and bitrot on every rolldown patch. Reintroducing hand-rolled `rolldown/experimental` + `mergeConfig` wiring is what the first-class option replaced.

### What to review

- `pnpm-workspace.yaml` / `pnpm-lock.yaml`: only the `tsdown>rolldown` override is gone
- `AGENTS.md` no longer documents that pin
- `packages/sanity/tsdown.config.ts` is unchanged: `bundleAnalyzer: process.env.ENABLE_BUNDLE_ANALYZER === 'true'`

### Testing

No unit test — this is lockfile / plugin-resolution wiring.

- `pnpm why rolldown` reports one version (`1.2.4`) for both `tsdown` and `@sanity/tsdown-config`; both `import.meta.resolve` to the same `rolldown` and `rolldown/experimental` files
- Resolved plugins: flag off is `vite:react-compiler`, `vanilla-extract`; flag on adds `builtin:bundle-analyzer`
- `ENABLE_BUNDLE_ANALYZER=true pnpm exec tsdown` in `packages/sanity` emitted `lib/analyze-data.md` (5.09 MB) among 349 outputs
- Default `pnpm exec tsdown` emitted 348 outputs and removed the report
- CI: format, oxlint, unit tests, export tests, depcheck, knip, bundle stats, and Chromatic passed. Playwright e2e shards failed with `formView.waitFor` timeouts across unrelated specs (comments, navbar, document actions, vision, variants). The same e2e suite is currently failing on `main` and several other open PRs; this change does not touch studio runtime.

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20f3a50d-cb6c-474f-b2e7-98d1fbd1ab9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20f3a50d-cb6c-474f-b2e7-98d1fbd1ab9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

