### PR TITLE
feat(metrics): collect git history, release tags + npm metadata

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -169,6 +169,23 @@ jobs:
             sleep 15
           done
 
+  sync-git-metrics:
+    # Mirror the new tag + npm data into the metrics dataset. After
+    # npm-publish so the registry already knows the version. Nothing
+    # downstream depends on it; a failure alerts Slack via the called
+    # workflow's alert job.
+    needs: [git-operations, npm-publish]
+    # always(): also sync on publish-only dispatch runs, where
+    # git-operations is skipped
+    if: always() && needs.npm-publish.result == 'success'
+    permissions:
+      contents: read
+      deployments: read
+    uses: ./.github/workflows/sync-git-metrics.yml
+    secrets:
+      BENCH_METRICS_WRITE_TOKEN: ${{ secrets.BENCH_METRICS_WRITE_TOKEN }}
+      SLACK_WEBHOOK_URL_CI_ALERTS: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
+
   publish-releases:
     # Publish sanity.io Changelog & github release
     needs: [build-and-validate, npm-publish]

--- a/.github/workflows/sync-git-metrics.yml
+++ b/.github/workflows/sync-git-metrics.yml
@@ -1,0 +1,125 @@
+name: Sync git metrics
+permissions: {}
+
+# Mirror git history into the metrics-studio dataset as gitCommit / gitTag
+# documents — the join surface for repo-health metrics (see
+# dev/metrics-studio/SPEC.md). Every push upserts a trailing window
+# idempotently; a gap larger than the window needs one backfill dispatch.
+# The sync fails loudly on API errors, before anything is written, and
+# alerts Slack — "Re-run failed jobs" is always safe.
+#
+# Trusted contexts only, never pull_request: the sync step holds the dataset
+# write token, which must never run PR-authored code (same stance as
+# bench.yml's store jobs).
+on:
+  push:
+    branches: [main]
+    # Manually pushed tags only: release-latest.yml pushes its tag with the
+    # default GITHUB_TOKEN, whose events never trigger workflows — releases
+    # reach the sync by calling this workflow instead (same pattern as typedoc).
+    tags: ["v*"]
+  workflow_call:
+    inputs:
+      release:
+        description: "Collect npm data for the freshly published release"
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      BENCH_METRICS_WRITE_TOKEN:
+        required: true
+      SLACK_WEBHOOK_URL_CI_ALERTS:
+        required: true
+  schedule:
+    # Daily floor for the npm enrichment: dist-tags can move and download
+    # counts roll without any commit being pushed
+    - cron: "30 5 * * *"
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: "Full backfill since v5.0.0 (instead of the incremental window)"
+        required: false
+        type: boolean
+        default: false
+      patch_bench_run_refs:
+        description: "One-off: patch existing benchRun docs with the weak git.commit reference"
+        required: false
+        type: boolean
+        default: false
+
+# Serialize runs — not for correctness (upserts are idempotent) but to keep
+# a burst of pushes from hammering the API concurrently
+concurrency:
+  group: sync-git-metrics
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Read Vercel's per-commit deployments (test-studio deploy URLs)
+      deployments: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Always run current main's code: a tag push would otherwise check
+          # out the tag's tree, which for a release-branch tag may predate
+          # this workflow entirely. The script reads origin/main and
+          # refs/tags explicitly, not HEAD.
+          ref: main
+          # Full commit graph and all tags, but no file contents beyond
+          # main's tree — the sync reads only commit/tag metadata
+          fetch-depth: 0
+          filter: tree:0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Sync git history to metrics dataset
+        env:
+          BENCH_METRICS_WRITE_TOKEN: ${{ secrets.BENCH_METRICS_WRITE_TOKEN }}
+          # For deploy URL collection. A push-triggered run usually precedes
+          # its own Vercel build; that commit's URL lands on the next sync.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BACKFILL: ${{ inputs.backfill }}
+          # npm data moves on releases and daily, not on every main push —
+          # collect it only when it can have changed. `inputs.release` is the
+          # release-workflow call; the github context is the caller's push
+          # event there, so the event name can't tell a release from a push.
+          COLLECT_NPM: ${{ github.event_name != 'push' || inputs.release == true || startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          ARGS=""
+          if [ "$BACKFILL" = "true" ]; then ARGS="--all"; fi
+          if [ "$COLLECT_NPM" = "true" ]; then ARGS="$ARGS --npm"; fi
+          pnpm --filter metrics-studio sync-git $ARGS
+
+      # One-off migration (idempotent): links pre-existing benchRun docs to
+      # their gitCommit docs. Runs after the sync so the commit docs exist.
+      - name: Patch benchRun git.commit references
+        if: inputs.patch_bench_run_refs
+        env:
+          BENCH_METRICS_WRITE_TOKEN: ${{ secrets.BENCH_METRICS_WRITE_TOKEN }}
+        run: pnpm --filter metrics-studio backfill-benchrun-refs
+
+  # Nothing goes red on a PR for this workflow and nobody watches its runs —
+  # alert the CI channel instead (same pattern as bench.yml). `cancelled`
+  # included because job timeouts conclude as cancelled, not failure.
+  alert-failure:
+    needs: [sync]
+    if: >-
+      always() &&
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":alert-dot: \"${{ github.workflow }}\" (${{ github.event_name }}) failed — git/npm metrics are not syncing to the metrics dataset (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>)"
+            }

--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -25,6 +25,37 @@ secondary: leads scanning health weekly.
   principle.
 - PR A/B runs are _not_ stored (by design). The dashboard is main-branch
   health; PR verdicts live in PR comments.
+- **Git history as data.** One `gitCommit` document per main-branch commit
+  and one `gitTag` document per `v*` release tag, coverage starting at
+  v5.0.0.
+
+  Commit documents are metadata only: sha, first-parent sha (the exact
+  mainline chain — `committedAt` ordering has tie/rebase hazards), author,
+  dates, subject, and a best-effort conventional-commit parse plus PR
+  number. Tag documents carry the dereferenced sha, a weak reference to
+  their commit, and parsed semver so interleaved release lines group by
+  major. Tags also carry npm data (`publishedAt`, `distTags`,
+  `weeklyDownloads`), collected on releases, the daily cron, and dispatches
+  — the cron is the floor because dist-tags re-point and download counts
+  roll without commits.
+
+  Sync (scripts/syncGitHistory.ts via sync-git-metrics.yml): every push to
+  main re-upserts the last 50 commits — deterministic ids + createOrReplace
+  make that stateless and self-healing; a larger gap takes one `backfill`
+  dispatch. Documents are replaced whole, so a run never writes what it
+  could not collect: an API error aborts before anything is written (the
+  workflow alerts Slack; re-running is always safe), and tags are written
+  only on npm-collecting runs.
+
+  This is the join surface for future health metrics; joins are by value
+  (`sha`, `committedAt`, `tag`). Two enrichments exist today: `benchRun`
+  documents carry `git.commit`, a weak reference to their commit (written by
+  perf/bench's storeShape.ts, backfilled once via the `patch_bench_run_refs`
+  dispatch; dangles for PR-branch runs, `git.sha` stays the source of
+  truth), and each `gitCommit` records `testStudioUrl`, the immutable Vercel
+  deploy of dev/test-studio built at that commit — collected from GitHub
+  deployment statuses, landing one sync late since the Vercel build outlives
+  the sync run.
 
 ## Views
 
@@ -136,5 +167,8 @@ secondary: leads scanning health weekly.
 - **P2:** run detail view + drift feed (both baselines).
 - **Later:** Slack alerting (a Sanity Function on `benchRun` create running
   the drift computation — event-driven, no cron); broader health metrics
-  (coverage reports from CI's `json-summary`, flake rates) as sibling
-  document types with their own trends tabs.
+  (coverage reports from CI's `json-summary`, flake rates, version stability,
+  error rates) as sibling document types with their own trends tabs — the
+  `gitCommit`/`gitTag` documents (landed Aug 2026) are the join surface these
+  build on; release markers / commit subjects in the Trends charts are the
+  first consumer to build.

--- a/dev/metrics-studio/package.json
+++ b/dev/metrics-studio/package.json
@@ -5,13 +5,18 @@
   "description": "Studio presenting repo health metrics (perf benchmark runs from perf/bench, and friends)",
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",
+  "type": "module",
   "scripts": {
+    "backfill-benchrun-refs": "node --conditions=monorepo --import tsx scripts/backfillBenchRunCommitRefs.ts",
     "build": "sanity build",
     "clean": "rimraf .sanity dist",
     "dev": "sanity dev --port 3399",
-    "start": "sanity preview --port 3399"
+    "start": "sanity preview --port 3399",
+    "sync-git": "node --conditions=monorepo --import tsx scripts/syncGitHistory.ts"
   },
   "dependencies": {
+    "@repo/utils": "workspace:*",
+    "@sanity/client": "catalog:",
     "@sanity/icons": "^5.2.1",
     "@sanity/ui": "catalog:",
     "@visx/axis": "^4.0.0",
@@ -34,6 +39,7 @@
     "@sanity/vanilla-extract-vite-plugin": "catalog:",
     "@types/react": "catalog:",
     "rimraf": "catalog:",
+    "tsx": "^4.23.12",
     "vitest": "catalog:"
   }
 }

--- a/dev/metrics-studio/sanity.config.ts
+++ b/dev/metrics-studio/sanity.config.ts
@@ -27,6 +27,20 @@ export default defineConfig({
                   .title('Benchmark runs')
                   .defaultOrdering([{field: 'startedAt', direction: 'desc'}]),
               ),
+            S.listItem()
+              .title('Commits')
+              .child(
+                S.documentTypeList('gitCommit')
+                  .title('Commits')
+                  .defaultOrdering([{field: 'committedAt', direction: 'desc'}]),
+              ),
+            S.listItem()
+              .title('Releases')
+              .child(
+                S.documentTypeList('gitTag')
+                  .title('Releases')
+                  .defaultOrdering([{field: 'taggedAt', direction: 'desc'}]),
+              ),
           ]),
     }),
   ],

--- a/dev/metrics-studio/schemaTypes/benchRun.ts
+++ b/dev/metrics-studio/schemaTypes/benchRun.ts
@@ -295,6 +295,14 @@ const benchRun = defineType({
       type: 'object',
       fields: [
         defineField({name: 'sha', type: 'string'}),
+        defineField({
+          name: 'commit',
+          type: 'reference',
+          to: [{type: 'gitCommit'}],
+          weak: true,
+          description:
+            'Weak link to the measured commit\u2019s gitCommit document \u2014 dangles for PR-branch runs and pre-sync history. git.sha is the source of truth.',
+        }),
         defineField({name: 'branch', type: 'string'}),
         defineField({
           name: 'committedAt',

--- a/dev/metrics-studio/schemaTypes/gitCommit.ts
+++ b/dev/metrics-studio/schemaTypes/gitCommit.ts
@@ -1,0 +1,82 @@
+import {DotIcon} from '@sanity/icons/Dot'
+import {defineField, defineType} from 'sanity'
+
+/**
+ * One commit on main, metadata only — written by scripts/syncGitHistory.ts
+ * with deterministic id `gitCommit-<sha>`, covering v5.0.0 onward. The
+ * conventional-commit fields are best-effort parses of the subject, absent
+ * where it doesn't conform. Joins are by value: `benchRun.git.sha` ↔ `sha`,
+ * time axes on `committedAt`.
+ */
+export const gitCommit = defineType({
+  name: 'gitCommit',
+  title: 'Commit',
+  type: 'document',
+  icon: DotIcon,
+  // Machine-written: browsable but not editable, no draft workflow
+  readOnly: true,
+  liveEdit: true,
+  fields: [
+    defineField({name: 'schemaVersion', type: 'number'}),
+    defineField({
+      name: 'sha',
+      description: 'Full 40-char commit sha (also in _id)',
+      type: 'string',
+    }),
+    defineField({
+      name: 'parentSha',
+      description:
+        'First-parent sha — the linear mainline chain link. Points outside the synced set at the v5.0.0 cutoff.',
+      type: 'string',
+    }),
+    defineField({name: 'authorName', type: 'string'}),
+    defineField({name: 'authorEmail', type: 'string'}),
+    defineField({
+      name: 'authorLogin',
+      description: 'GitHub account the author email maps to — absent when GitHub has no mapping',
+      type: 'string',
+    }),
+    defineField({
+      name: 'authorAvatarUrl',
+      description:
+        'GitHub\u2019s avatar URL for that account (bot avatars are not derivable from the login)',
+      type: 'url',
+    }),
+    defineField({name: 'authoredAt', type: 'datetime'}),
+    defineField({
+      name: 'committedAt',
+      description: 'Committer date — the time-axis join key (matches benchRun.git.committedAt)',
+      type: 'datetime',
+    }),
+    defineField({name: 'subject', description: 'Raw first line of the message', type: 'string'}),
+    defineField({
+      name: 'commitType',
+      description: 'Parsed conventional-commit type (feat/fix/chore/…) — absent if unparseable',
+      type: 'string',
+    }),
+    defineField({name: 'scope', description: 'Parsed conventional-commit scope', type: 'string'}),
+    defineField({
+      name: 'breaking',
+      description: 'Conventional-commit “!” marker — only set when true',
+      type: 'boolean',
+    }),
+    defineField({
+      name: 'prNumber',
+      description: 'From the squash-merge subject’s trailing “(#1234)”',
+      type: 'number',
+    }),
+    defineField({
+      name: 'testStudioUrl',
+      description:
+        'Immutable Vercel deploy of dev/test-studio built at this commit. Absent when the build was skipped or had not finished when last synced.',
+      type: 'url',
+    }),
+  ],
+  preview: {
+    select: {subject: 'subject', sha: 'sha', committedAt: 'committedAt'},
+    prepare: ({subject, sha, committedAt}) => ({
+      title: subject,
+      subtitle: `${sha?.slice(0, 10)} · ${committedAt?.slice(0, 10)}`,
+    }),
+  },
+})

--- a/dev/metrics-studio/schemaTypes/gitTag.ts
+++ b/dev/metrics-studio/schemaTypes/gitTag.ts
@@ -1,0 +1,75 @@
+import {TagIcon} from '@sanity/icons/Tag'
+import {defineField, defineType} from 'sanity'
+
+/**
+ * One `v*` release tag (major >= 5) — written by scripts/syncGitHistory.ts
+ * with deterministic id `gitTag-<tagName>`.
+ *
+ * `commit` is a weak reference: ingestion order isn't guaranteed, and tags
+ * cut from release branches point at commits that never get a gitCommit
+ * document. `sha` stays alongside as a plain string for by-value joins. The
+ * parsed semver fields exist because release lines interleave in time
+ * (v5.31.2 shipped after v6.10.1) — grouping by `major` reconstructs a line
+ * in GROQ.
+ */
+export const gitTag = defineType({
+  name: 'gitTag',
+  title: 'Release tag',
+  type: 'document',
+  icon: TagIcon,
+  // Machine-written: browsable but not editable, no draft workflow
+  readOnly: true,
+  liveEdit: true,
+  fields: [
+    defineField({name: 'schemaVersion', type: 'number'}),
+    defineField({name: 'tag', description: 'Tag name, e.g. v6.10.1', type: 'string'}),
+    defineField({
+      name: 'sha',
+      description: 'Dereferenced commit sha the tag points at (plain string for by-value joins)',
+      type: 'string',
+    }),
+    defineField({
+      name: 'commit',
+      description: 'Weak: dangles (resolves to null) for tags cut off-main',
+      type: 'reference',
+      to: [{type: 'gitCommit'}],
+      weak: true,
+    }),
+    defineField({
+      name: 'taggedAt',
+      description: 'Tag creation date (committer date for lightweight tags)',
+      type: 'datetime',
+    }),
+    defineField({name: 'major', type: 'number'}),
+    defineField({name: 'minor', type: 'number'}),
+    defineField({name: 'patch', type: 'number'}),
+    defineField({
+      name: 'prerelease',
+      description: 'Prerelease identifier, e.g. rc.1 — absent on stable releases',
+      type: 'string',
+    }),
+    defineField({
+      name: 'npm',
+      description:
+        'npm registry data for the matching sanity@<version> — absent when npm does not know it',
+      type: 'object',
+      fields: [
+        defineField({name: 'publishedAt', type: 'datetime'}),
+        defineField({
+          name: 'distTags',
+          description: 'Dist-tags currently pointing at this version (latest, stable, …)',
+          type: 'array',
+          of: [{type: 'string'}],
+        }),
+        defineField({name: 'weeklyDownloads', type: 'number'}),
+      ],
+    }),
+  ],
+  preview: {
+    select: {tag: 'tag', taggedAt: 'taggedAt', sha: 'sha'},
+    prepare: ({tag, taggedAt, sha}) => ({
+      title: tag,
+      subtitle: `${taggedAt?.slice(0, 10)} · ${sha?.slice(0, 10)}`,
+    }),
+  },
+})

--- a/dev/metrics-studio/schemaTypes/index.ts
+++ b/dev/metrics-studio/schemaTypes/index.ts
@@ -1,4 +1,6 @@
 import {benchRunTypes} from './benchRun'
 import {driftAck} from './driftAck'
+import {gitCommit} from './gitCommit'
+import {gitTag} from './gitTag'
 
-export const schemaTypes = [...benchRunTypes, driftAck]
+export const schemaTypes = [...benchRunTypes, driftAck, gitCommit, gitTag]

--- a/dev/metrics-studio/scripts/backfillBenchRunCommitRefs.ts
+++ b/dev/metrics-studio/scripts/backfillBenchRunCommitRefs.ts
@@ -1,0 +1,72 @@
+// oxlint-disable no-console
+/**
+ * One-off backfill: patch existing `benchRun` documents with the weak
+ * `git.commit` reference that perf/bench/report/storeShape.ts now writes at
+ * store time. Idempotent — only touches docs missing the field. Run via the
+ * sync-git-metrics.yml `patch_bench_run_refs` dispatch input, or locally:
+ *
+ *   pnpm --filter metrics-studio backfill-benchrun-refs --dry-run
+ *
+ * --dry-run still needs BENCH_METRICS_WRITE_TOKEN — finding the docs to
+ * patch requires querying the dataset. Docs without a full 40-char sha are
+ * skipped; PR-branch shas get the reference and dangle by design, both
+ * matching the write-time rules.
+ */
+import process from 'node:process'
+import {parseArgs} from 'node:util'
+
+import {readEnv} from '@repo/utils'
+import {createClient} from '@sanity/client'
+
+const METRICS_PROJECT_ID = 'mhfozd0z'
+const METRICS_DATASET = 'bench'
+
+const FULL_SHA_RE = /^[0-9a-f]{40}$/
+
+async function main(): Promise<void> {
+  const {values} = parseArgs({
+    // pnpm forwards a `--` separator verbatim; see syncGitHistory.ts
+    args: process.argv.slice(2).filter((arg) => arg !== '--'),
+    options: {'dry-run': {type: 'boolean', default: false}},
+  })
+
+  const client = createClient({
+    projectId: METRICS_PROJECT_ID,
+    dataset: METRICS_DATASET,
+    apiVersion: '2025-02-19',
+    token: readEnv('BENCH_METRICS_WRITE_TOKEN'),
+    useCdn: false,
+  })
+
+  const docs = await client.fetch<{_id: string; sha: string | null}[]>(
+    '*[_type == "benchRun" && !defined(git.commit)]{_id, "sha": git.sha}',
+  )
+  const patchable = docs.filter((doc) => doc.sha && FULL_SHA_RE.test(doc.sha))
+  const skipped = docs.length - patchable.length
+  console.log(
+    `${docs.length} benchRun doc(s) missing git.commit; ${patchable.length} patchable` +
+      (skipped ? `, ${skipped} skipped (no full sha)` : ''),
+  )
+
+  if (values['dry-run']) {
+    for (const doc of patchable.slice(0, 5))
+      console.log(`  would patch ${doc._id} -> gitCommit-${doc.sha}`)
+    return
+  }
+  if (patchable.length === 0) return
+
+  // Same 300-mutation batching as the sync, to stay under request limits
+  const BATCH = 300
+  for (let offset = 0; offset < patchable.length; offset += BATCH) {
+    let transaction = client.transaction()
+    for (const doc of patchable.slice(offset, offset + BATCH)) {
+      transaction = transaction.patch(doc._id, {
+        set: {'git.commit': {_type: 'reference', _ref: `gitCommit-${doc.sha}`, _weak: true}},
+      })
+    }
+    await transaction.commit()
+  }
+  console.log(`Patched ${patchable.length} doc(s)`)
+}
+
+await main()

--- a/dev/metrics-studio/scripts/gitHistory.test.ts
+++ b/dev/metrics-studio/scripts/gitHistory.test.ts
@@ -1,0 +1,284 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  assembleSyncDocuments,
+  commitDocument,
+  commitDocumentId,
+  parseCommitRecords,
+  parseConventionalSubject,
+  parsePrNumber,
+  parseTagRefs,
+  tagDocument,
+} from './gitHistory'
+
+const FS = '\x1f'
+const RS = '\x1e'
+
+const SHA_A = 'a'.repeat(40)
+const SHA_B = 'b'.repeat(40)
+const SHA_C = 'c'.repeat(40)
+const SHA_D = 'd'.repeat(40)
+
+function commitRecord(subject: string, sha = SHA_A, parents = SHA_C): string {
+  return [
+    sha,
+    'Ada Lovelace',
+    'ada@example.com',
+    '2026-08-20T10:10:34+01:00',
+    '2026-08-20T11:10:34+02:00',
+    subject,
+    parents,
+  ].join(FS)
+}
+
+describe('parseCommitRecords', () => {
+  it('parses git log output into commit infos', () => {
+    const raw = `${commitRecord('feat(form): add thing (#123)')}${RS}\n${commitRecord('plain subject', SHA_B)}${RS}\n`
+    expect(parseCommitRecords(raw)).toEqual([
+      {
+        sha: SHA_A,
+        authorName: 'Ada Lovelace',
+        authorEmail: 'ada@example.com',
+        authoredAt: '2026-08-20T10:10:34+01:00',
+        committedAt: '2026-08-20T11:10:34+02:00',
+        subject: 'feat(form): add thing (#123)',
+        parentSha: SHA_C,
+      },
+      expect.objectContaining({sha: SHA_B, subject: 'plain subject'}),
+    ])
+  })
+
+  it('takes the first parent of a merge commit and omits parentSha on a root commit', () => {
+    const merge = parseCommitRecords(`${commitRecord('merge', SHA_A, `${SHA_C} ${SHA_D}`)}${RS}`)
+    expect(merge[0].parentSha).toBe(SHA_C)
+    const root = parseCommitRecords(`${commitRecord('initial commit', SHA_A, '')}${RS}`)
+    expect(root[0]).not.toHaveProperty('parentSha')
+  })
+
+  it('keeps subjects containing pipes and parens intact', () => {
+    const raw = `${commitRecord('fix(x): handle `a | b` case (really) (#9)')}${RS}`
+    expect(parseCommitRecords(raw)[0].subject).toBe('fix(x): handle `a | b` case (really) (#9)')
+  })
+
+  it('returns no records for empty output', () => {
+    expect(parseCommitRecords('')).toEqual([])
+    expect(parseCommitRecords('\n')).toEqual([])
+  })
+
+  it('throws on a record with the wrong field count instead of mis-attributing', () => {
+    const raw = `${SHA_A}${FS}only-three${FS}fields${RS}`
+    expect(() => parseCommitRecords(raw)).toThrow(/Malformed commit record \(3 fields/)
+  })
+})
+
+describe('parseConventionalSubject', () => {
+  it('parses type, scope and breaking marker', () => {
+    expect(parseConventionalSubject('feat(form): add array input')).toEqual({
+      commitType: 'feat',
+      scope: 'form',
+    })
+    expect(parseConventionalSubject('feat(sanity)!: drop node 18')).toEqual({
+      commitType: 'feat',
+      scope: 'sanity',
+      breaking: true,
+    })
+    expect(parseConventionalSubject('chore: bump deps')).toEqual({commitType: 'chore'})
+  })
+
+  it('returns {} for non-conforming subjects (about half the history)', () => {
+    expect(parseConventionalSubject('Merge pull request #100 from sanity-io/x')).toEqual({})
+    expect(parseConventionalSubject('Revert "feat(form): add array input"')).toEqual({})
+    expect(parseConventionalSubject('[form] add array input')).toEqual({})
+    // Colon without the required following space
+    expect(parseConventionalSubject('fix:no space')).toEqual({})
+  })
+})
+
+describe('parsePrNumber', () => {
+  it('parses the trailing squash-merge PR number', () => {
+    expect(parsePrNumber('feat(form): add thing (#14197)')).toBe(14197)
+    expect(parsePrNumber('feat(form): add thing (#14197) ')).toBe(14197)
+  })
+
+  it('ignores mid-subject references and bare numbers', () => {
+    expect(parsePrNumber('fix(#123): odd scope')).toBeUndefined()
+    expect(parsePrNumber('revert (#123) then more words')).toBeUndefined()
+    expect(parsePrNumber('fix issue #123')).toBeUndefined()
+    expect(parsePrNumber('no pr here')).toBeUndefined()
+  })
+})
+
+function tagLine(tag: string, dereferencedSha: string, objectSha: string): string {
+  return [tag, '2026-08-18T15:10:53Z', dereferencedSha, objectSha].join(FS)
+}
+
+describe('parseTagRefs', () => {
+  it('parses annotated release tags via the dereferenced sha', () => {
+    expect(parseTagRefs(tagLine('v6.10.0', SHA_A, SHA_B))).toEqual([
+      {tag: 'v6.10.0', taggedAt: '2026-08-18T15:10:53Z', sha: SHA_A, major: 6, minor: 10, patch: 0},
+    ])
+  })
+
+  it('falls back to the object sha for lightweight tags', () => {
+    expect(parseTagRefs(tagLine('v5.31.2', '', SHA_B))[0].sha).toBe(SHA_B)
+  })
+
+  it('parses prerelease identifiers', () => {
+    expect(parseTagRefs(tagLine('v6.0.0-rc.1', SHA_A, SHA_B))[0]).toMatchObject({
+      major: 6,
+      minor: 0,
+      patch: 0,
+      prerelease: 'rc.1',
+    })
+  })
+
+  it('filters junk refs and pre-cutoff majors', () => {
+    const raw = [
+      tagLine('backup/graceful-errors-rebase2', '', SHA_B),
+      tagLine('test-tag', '', SHA_B),
+      tagLine('sanity-v3.86.0', SHA_A, SHA_B),
+      tagLine('v3.86.0', SHA_A, SHA_B),
+      tagLine('v4.10.1', SHA_A, SHA_B),
+      tagLine('v0.144.3', SHA_A, SHA_B),
+      tagLine('v6.10.1', SHA_A, SHA_B),
+    ].join('\n')
+    expect(parseTagRefs(raw).map((t) => t.tag)).toEqual(['v6.10.1'])
+  })
+
+  it('throws on a structurally broken record', () => {
+    expect(() => parseTagRefs(`v6.10.1${FS}2026-08-18`)).toThrow(/Malformed tag record \(2 fields/)
+  })
+})
+
+describe('commitDocument', () => {
+  it('builds a deterministic id and merges parsed fields', () => {
+    const doc = commitDocument({
+      sha: SHA_A,
+      parentSha: SHA_C,
+      authorName: 'Ada Lovelace',
+      authorEmail: 'ada@example.com',
+      authoredAt: '2026-08-20T10:10:34+01:00',
+      committedAt: '2026-08-20T11:10:34+02:00',
+      subject: 'feat(form)!: add thing (#123)',
+    })
+    expect(doc).toEqual({
+      _id: `gitCommit-${SHA_A}`,
+      _type: 'gitCommit',
+      schemaVersion: 1,
+      sha: SHA_A,
+      parentSha: SHA_C,
+      authorName: 'Ada Lovelace',
+      authorEmail: 'ada@example.com',
+      authoredAt: '2026-08-20T10:10:34+01:00',
+      committedAt: '2026-08-20T11:10:34+02:00',
+      subject: 'feat(form)!: add thing (#123)',
+      commitType: 'feat',
+      scope: 'form',
+      breaking: true,
+      prNumber: 123,
+    })
+  })
+
+  it('omits optional fields for non-conforming subjects', () => {
+    const doc = commitDocument({
+      sha: SHA_A,
+      authorName: 'Ada Lovelace',
+      authorEmail: 'ada@example.com',
+      authoredAt: '2026-08-20T10:10:34+01:00',
+      committedAt: '2026-08-20T11:10:34+02:00',
+      subject: 'Update README',
+    })
+    expect(doc).not.toHaveProperty('commitType')
+    expect(doc).not.toHaveProperty('scope')
+    expect(doc).not.toHaveProperty('breaking')
+    expect(doc).not.toHaveProperty('prNumber')
+    expect(doc).not.toHaveProperty('parentSha')
+  })
+})
+
+describe('tagDocument', () => {
+  it('builds a deterministic id and a weak reference matching the commit doc id', () => {
+    const doc = tagDocument({
+      tag: 'v6.10.1',
+      taggedAt: '2026-08-18T21:56:56Z',
+      sha: SHA_A,
+      major: 6,
+      minor: 10,
+      patch: 1,
+    })
+    expect(doc._id).toBe('gitTag-v6.10.1')
+    expect(doc.commit).toEqual({_type: 'reference', _ref: commitDocumentId(SHA_A), _weak: true})
+    expect(doc).toMatchObject({tag: 'v6.10.1', sha: SHA_A, major: 6, minor: 10, patch: 1})
+    expect(doc).not.toHaveProperty('prerelease')
+  })
+})
+
+describe('assembleSyncDocuments', () => {
+  const commit = (sha: string) =>
+    commitDocument({
+      sha,
+      authorName: 'Ada Lovelace',
+      authorEmail: 'ada@example.com',
+      authoredAt: '2026-08-20T10:10:34+01:00',
+      committedAt: '2026-08-20T11:10:34+02:00',
+      subject: 'fix: thing',
+    })
+  const tag = tagDocument({
+    tag: 'v6.0.0',
+    taggedAt: '2026-08-18T00:00:00Z',
+    sha: SHA_C,
+    major: 6,
+    minor: 0,
+    patch: 0,
+  })
+
+  it('omits commits whose GitHub lookup did not run — writing them would erase enrichment', () => {
+    const result = assembleSyncDocuments({
+      commits: [commit(SHA_A), commit(SHA_B)],
+      tags: [],
+      github: {
+        info: new Map([[SHA_A, {testStudioUrl: 'https://a.sanity.dev', authorLogin: 'ada'}]]),
+        queriedShas: new Set([SHA_A]), // SHA_B's batch failed
+      },
+    })
+    expect(result.commitCount).toBe(1)
+    expect(result.skippedCommitCount).toBe(1)
+    expect(result.urlCount).toBe(1)
+    expect(result.documents[0]).toMatchObject({
+      sha: SHA_A,
+      testStudioUrl: 'https://a.sanity.dev',
+      authorLogin: 'ada',
+    })
+  })
+
+  it('writes queried commits without enrichment as-is (legit absence, not erasure)', () => {
+    const result = assembleSyncDocuments({
+      commits: [commit(SHA_A)],
+      tags: [],
+      github: {info: new Map(), queriedShas: new Set([SHA_A])},
+    })
+    expect(result.commitCount).toBe(1)
+    expect(result.documents[0]).not.toHaveProperty('testStudioUrl')
+  })
+
+  it('skips ALL tags when npmInfo is absent — a plain upsert would clobber npm enrichment', () => {
+    const result = assembleSyncDocuments({
+      commits: [],
+      tags: [tag],
+      github: {info: new Map(), queriedShas: new Set()},
+    })
+    expect(result.tagCount).toBe(0)
+    expect(result.documents).toEqual([])
+  })
+
+  it('writes tags with npm enrichment on npm runs', () => {
+    const result = assembleSyncDocuments({
+      commits: [],
+      tags: [tag],
+      github: {info: new Map(), queriedShas: new Set()},
+      npmInfo: new Map([['v6.0.0', {distTags: ['latest'], weeklyDownloads: 7}]]),
+    })
+    expect(result.tagCount).toBe(1)
+    expect(result.documents[0]).toMatchObject({tag: 'v6.0.0', npm: {distTags: ['latest']}})
+  })
+})

--- a/dev/metrics-studio/scripts/gitHistory.ts
+++ b/dev/metrics-studio/scripts/gitHistory.ts
@@ -1,0 +1,283 @@
+/**
+ * Pure parsing for the git-history sync (I/O lives in syncGitHistory.ts):
+ * `git log` / `git for-each-ref` output → `gitCommit` / `gitTag` documents
+ * with deterministic ids, so every run can `createOrReplace` idempotently.
+ *
+ * Delimiters are control characters: subjects can contain any printable
+ * character, and git permits `|` even in refnames. A wrong field count
+ * throws rather than silently mis-attributing fields.
+ */
+
+/** `git log --format=` value producing one \x1e-terminated record per commit. */
+export const COMMIT_LOG_FORMAT = '%H%x1f%an%x1f%ae%x1f%aI%x1f%cI%x1f%s%x1f%P%x1e'
+
+/**
+ * `git for-each-ref refs/tags --format=` value; %(*objectname) is the
+ * dereferenced commit for annotated tags. `lstrip=2`, not `:short` — a
+ * branch named like the tag makes `:short` print `tags/v5.0.1`, silently
+ * failing the semver match.
+ */
+export const TAG_REF_FORMAT =
+  '%(refname:lstrip=2)%1f%(creatordate:iso-strict)%1f%(*objectname)%1f%(objectname)'
+
+/** The dataset covers v5.0.0 onward — same cutoff the commit backfill uses. */
+export const MIN_TAG_MAJOR = 5
+
+const FIELD_SEPARATOR = '\x1f'
+const RECORD_SEPARATOR = '\x1e'
+
+/** Strict `vMAJOR.MINOR.PATCH[-prerelease]` — anything else is not a release tag. */
+const SEMVER_TAG_RE = /^v(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/
+
+export interface CommitInfo {
+  sha: string
+  authorName: string
+  authorEmail: string
+  authoredAt: string
+  committedAt: string
+  subject: string
+  /** First parent — the linear mainline chain link. Absent on a root commit. */
+  parentSha?: string
+}
+
+export interface TagInfo {
+  tag: string
+  taggedAt: string
+  /** Dereferenced commit sha (annotated tags point at a tag object first). */
+  sha: string
+  major: number
+  minor: number
+  patch: number
+  prerelease?: string
+}
+
+export interface GitCommitDocument {
+  _id: string
+  _type: 'gitCommit'
+  schemaVersion: number
+  sha: string
+  /** First-parent sha — the linear mainline chain link (Bisect walks it). */
+  parentSha?: string
+  authorName: string
+  authorEmail: string
+  authoredAt: string
+  committedAt: string
+  subject: string
+  commitType?: string
+  scope?: string
+  breaking?: boolean
+  prNumber?: number
+  // The three fields below are merged in by syncGitHistory.ts from the
+  // GitHub API (see githubDeployments.ts), not set by commitDocument().
+  /** Immutable Vercel deploy of dev/test-studio built at this commit. */
+  testStudioUrl?: string
+  /** GitHub account the author email maps to. */
+  authorLogin?: string
+  /** GitHub's avatar URL — not derivable: bot avatars live under /in/<app-id>. */
+  authorAvatarUrl?: string
+}
+
+export interface GitTagDocument {
+  _id: string
+  _type: 'gitTag'
+  schemaVersion: number
+  tag: string
+  sha: string
+  /** Merged in by syncGitHistory.ts on npm-collecting runs (see npmVersions.ts). */
+  npm?: {publishedAt?: string; distTags?: string[]; weeklyDownloads?: number}
+  /** Weak: the commit may be off-main (release-branch tags) or not ingested yet. */
+  commit: {_type: 'reference'; _ref: string; _weak: true}
+  taggedAt: string
+  major: number
+  minor: number
+  patch: number
+  prerelease?: string
+}
+
+export function parseCommitRecords(raw: string): CommitInfo[] {
+  return raw
+    .split(RECORD_SEPARATOR)
+    .map((record) => record.trim())
+    .filter((record) => record.length > 0)
+    .map((record) => {
+      const fields = record.split(FIELD_SEPARATOR)
+      if (fields.length !== 7) {
+        throw new Error(
+          `Malformed commit record (${fields.length} fields, expected 7): ${JSON.stringify(record)}`,
+        )
+      }
+      const [sha, authorName, authorEmail, authoredAt, committedAt, subject, parents] = fields
+      // %P is space-separated parents; the first is the mainline link
+      const parentSha = parents.split(' ')[0] || undefined
+      return {
+        sha,
+        authorName,
+        authorEmail,
+        authoredAt,
+        committedAt,
+        subject,
+        ...(parentSha ? {parentSha} : {}),
+      }
+    })
+}
+
+/**
+ * Best-effort conventional-commit parse. Only ~half the history conforms, so
+ * a non-match is `{}`, not an error; the raw subject is always stored too.
+ */
+export function parseConventionalSubject(subject: string): {
+  commitType?: string
+  scope?: string
+  breaking?: boolean
+} {
+  const match = /^(\w+)(?:\(([^)]*)\))?(!)?:\s/.exec(subject)
+  if (!match) return {}
+  const [, commitType, scope, breaking] = match
+  return {
+    commitType,
+    ...(scope ? {scope} : {}),
+    ...(breaking ? {breaking: true} : {}),
+  }
+}
+
+/** PR number from a squash-merge subject's trailing `(#1234)` — mid-subject mentions don't count. */
+export function parsePrNumber(subject: string): number | undefined {
+  const match = /\(#(\d+)\)\s*$/.exec(subject)
+  return match ? Number(match[1]) : undefined
+}
+
+/**
+ * Parse `for-each-ref` output down to release tags: strict semver match plus
+ * the major cutoff. Junk refs are filtered; a broken record still throws.
+ */
+export function parseTagRefs(raw: string): TagInfo[] {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .flatMap((line) => {
+      const fields = line.split(FIELD_SEPARATOR)
+      if (fields.length !== 4) {
+        throw new Error(
+          `Malformed tag record (${fields.length} fields, expected 4): ${JSON.stringify(line)}`,
+        )
+      }
+      const [tag, taggedAt, dereferencedSha, objectSha] = fields
+      const match = SEMVER_TAG_RE.exec(tag)
+      if (!match) return []
+      const [, major, minor, patch, prerelease] = match
+      if (Number(major) < MIN_TAG_MAJOR) return []
+      return [
+        {
+          tag,
+          taggedAt,
+          // Annotated tags dereference to their commit; lightweight tags ARE the commit.
+          sha: dereferencedSha || objectSha,
+          major: Number(major),
+          minor: Number(minor),
+          patch: Number(patch),
+          ...(prerelease ? {prerelease} : {}),
+        },
+      ]
+    })
+}
+
+export function commitDocumentId(sha: string): string {
+  return `gitCommit-${sha}`
+}
+
+export function commitDocument(info: CommitInfo): GitCommitDocument {
+  const {commitType, scope, breaking} = parseConventionalSubject(info.subject)
+  const prNumber = parsePrNumber(info.subject)
+  return {
+    _id: commitDocumentId(info.sha),
+    _type: 'gitCommit',
+    schemaVersion: 1,
+    sha: info.sha,
+    ...(info.parentSha ? {parentSha: info.parentSha} : {}),
+    authorName: info.authorName,
+    authorEmail: info.authorEmail,
+    authoredAt: info.authoredAt,
+    committedAt: info.committedAt,
+    subject: info.subject,
+    ...(commitType ? {commitType} : {}),
+    ...(scope ? {scope} : {}),
+    ...(breaking ? {breaking} : {}),
+    ...(typeof prNumber === 'number' ? {prNumber} : {}),
+  }
+}
+
+export function tagDocument(info: TagInfo): GitTagDocument {
+  return {
+    // Dots in ids make path segments (invisible to unauthenticated queries)
+    // — fine here, every reader authenticates
+    _id: `gitTag-${info.tag}`,
+    _type: 'gitTag',
+    schemaVersion: 1,
+    tag: info.tag,
+    sha: info.sha,
+    commit: {_type: 'reference', _ref: commitDocumentId(info.sha), _weak: true},
+    taggedAt: info.taggedAt,
+    major: info.major,
+    minor: info.minor,
+    patch: info.patch,
+    ...(info.prerelease ? {prerelease: info.prerelease} : {}),
+  }
+}
+
+export interface GitHubCollection {
+  /** Resolved enrichment per sha (deploy URL, author login). */
+  info: Map<string, {testStudioUrl?: string; authorLogin?: string; authorAvatarUrl?: string}>
+  /**
+   * Shas the GitHub lookup covered. An uncovered sha (no GITHUB_TOKEN — API
+   * errors abort instead) must not be written: documents are replaced whole,
+   * so writing it would erase stored enrichment.
+   */
+  queriedShas: Set<string>
+}
+
+/**
+ * Decide what a sync run writes — pure, so the erasure rules are testable:
+ * commits whose GitHub lookup didn't run are omitted (the next run covers
+ * them), and tags are written only on npm-collecting runs (a tag upsert
+ * without npm data would clobber the enrichment).
+ */
+export function assembleSyncDocuments(input: {
+  commits: GitCommitDocument[]
+  tags: GitTagDocument[]
+  github: GitHubCollection
+  /** Present only on npm-collecting runs. */
+  npmInfo?: Map<string, {publishedAt?: string; distTags?: string[]; weeklyDownloads?: number}>
+}): {
+  documents: (GitCommitDocument | GitTagDocument)[]
+  commitCount: number
+  skippedCommitCount: number
+  urlCount: number
+  tagCount: number
+} {
+  const commits = input.commits
+    .filter((commit) => input.github.queriedShas.has(commit.sha))
+    .map((commit) => {
+      const enrichment = input.github.info.get(commit.sha)
+      if (!enrichment) return commit
+      return {
+        ...commit,
+        ...(enrichment.testStudioUrl ? {testStudioUrl: enrichment.testStudioUrl} : {}),
+        ...(enrichment.authorLogin ? {authorLogin: enrichment.authorLogin} : {}),
+        ...(enrichment.authorAvatarUrl ? {authorAvatarUrl: enrichment.authorAvatarUrl} : {}),
+      }
+    })
+  const tags = input.npmInfo
+    ? input.tags.map((tag) => {
+        const npm = input.npmInfo!.get(tag.tag)
+        return npm ? {...tag, npm} : tag
+      })
+    : []
+  return {
+    documents: [...commits, ...tags],
+    commitCount: commits.length,
+    skippedCommitCount: input.commits.length - commits.length,
+    urlCount: commits.filter((commit) => 'testStudioUrl' in commit).length,
+    tagCount: tags.length,
+  }
+}

--- a/dev/metrics-studio/scripts/githubDeployments.test.ts
+++ b/dev/metrics-studio/scripts/githubDeployments.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'vitest'
+
+import {buildDeploymentsQuery, parseCommitGitHubInfo} from './githubDeployments'
+
+const SHA_A = 'a'.repeat(40)
+const SHA_B = 'b'.repeat(40)
+
+describe('buildDeploymentsQuery', () => {
+  it('emits one alias per sha with both environments and the author login', () => {
+    const query = buildDeploymentsQuery([SHA_A, SHA_B])
+    expect(query).toContain(`c0: object(oid: "${SHA_A}")`)
+    expect(query).toContain(`c1: object(oid: "${SHA_B}")`)
+    expect(query).toContain('Production – test-studio')
+    expect(query).toContain('Preview – test-studio')
+    expect(query).toContain('author { user { login avatarUrl(size: 132) } }')
+    expect(query).toContain('repository(owner: "sanity-io", name: "sanity")')
+  })
+
+  it('rejects anything that is not a full lowercase hex sha', () => {
+    expect(() => buildDeploymentsQuery(['unknown'])).toThrow(/Not a full lowercase sha/)
+    expect(() => buildDeploymentsQuery([SHA_A.slice(0, 12)])).toThrow(/Not a full lowercase sha/)
+    expect(() => buildDeploymentsQuery(['A'.repeat(40)])).toThrow(/Not a full lowercase sha/)
+    // Injection shape: quote/brace smuggling must throw, never embed
+    expect(() => buildDeploymentsQuery(['"] } evil { ["'])).toThrow(/Not a full lowercase sha/)
+  })
+})
+
+function response(commits: Record<string, unknown>) {
+  return {repository: commits}
+}
+
+describe('parseCommitGitHubInfo', () => {
+  it('maps shas to the first successful deploy URL and the author login', () => {
+    const info = parseCommitGitHubInfo(
+      response({
+        c0: {
+          author: {user: {login: 'ada', avatarUrl: 'https://avatars.githubusercontent.com/u/1'}},
+          deployments: {
+            nodes: [{latestStatus: {state: 'SUCCESS', environmentUrl: 'https://a.sanity.dev'}}],
+          },
+        },
+        c1: {
+          author: {user: null}, // email GitHub can't map
+          deployments: {
+            nodes: [
+              {latestStatus: {state: 'ERROR', environmentUrl: 'https://broken.sanity.dev'}},
+              {latestStatus: {state: 'SUCCESS', environmentUrl: 'https://b.sanity.dev'}},
+            ],
+          },
+        },
+      }),
+      [SHA_A, SHA_B],
+    )
+    expect(info.get(SHA_A)).toEqual({
+      testStudioUrl: 'https://a.sanity.dev',
+      authorLogin: 'ada',
+      authorAvatarUrl: 'https://avatars.githubusercontent.com/u/1',
+    })
+    expect(info.get(SHA_B)).toEqual({testStudioUrl: 'https://b.sanity.dev'})
+  })
+
+  it('keeps the login for commits whose build was skipped, and vice versa', () => {
+    const info = parseCommitGitHubInfo(
+      response({
+        c0: {author: {user: {login: 'ada'}}, deployments: {nodes: []}},
+        c1: {author: null, deployments: {nodes: [{latestStatus: {state: 'IN_PROGRESS'}}]}},
+      }),
+      [SHA_A, SHA_B],
+    )
+    expect(info.get(SHA_A)).toEqual({authorLogin: 'ada'})
+    expect(info.has(SHA_B)).toBe(false)
+  })
+
+  it('resolves nothing for unknown oids and unfinished deploys', () => {
+    const info = parseCommitGitHubInfo(
+      response({
+        c0: null, // oid not found
+        c1: {deployments: {nodes: [{latestStatus: null}]}},
+        c2: {deployments: {nodes: [{latestStatus: {state: 'SUCCESS', environmentUrl: null}}]}},
+      }),
+      [SHA_A, SHA_B, 'c'.repeat(40)],
+    )
+    expect(info.size).toBe(0)
+  })
+
+  it('tolerates a missing repository payload', () => {
+    expect(parseCommitGitHubInfo(null, [SHA_A]).size).toBe(0)
+    expect(parseCommitGitHubInfo({}, [SHA_A]).size).toBe(0)
+  })
+})

--- a/dev/metrics-studio/scripts/githubDeployments.ts
+++ b/dev/metrics-studio/scripts/githubDeployments.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure builders/parsers for collecting test-studio deploy URLs from GitHub
+ * (I/O lives in syncGitHistory.ts). Vercel builds dev/test-studio for every
+ * commit and records a GitHub deployment whose latest status carries the
+ * immutable URL — we only collect. The lookup asks each *commit* for its
+ * deployments (one alias per sha, batched) rather than paging the repo's
+ * tens of thousands of deployments.
+ */
+
+/**
+ * GitHub environment names Vercel writes for the test-studio project — note
+ * the en-dash. Renaming the Vercel project silently breaks this match; watch
+ * the sync's deploy-URL count.
+ */
+export const DEPLOYMENT_ENVIRONMENTS = ['Production – test-studio', 'Preview – test-studio']
+
+/** Aliases per GraphQL query — one call per incremental sync, backfill ≈ 42. */
+export const GITHUB_DEPLOYMENTS_BATCH_SIZE = 50
+
+const FULL_SHA_RE = /^[0-9a-f]{40}$/
+
+/**
+ * One query, one `c<index>` alias per sha. Shas are interpolated into the
+ * query text, so anything but a full lowercase hex sha throws.
+ */
+export function buildDeploymentsQuery(shas: string[]): string {
+  const environments = JSON.stringify(DEPLOYMENT_ENVIRONMENTS)
+  const fields = shas
+    .map((sha, index) => {
+      if (!FULL_SHA_RE.test(sha)) {
+        throw new Error(`Not a full lowercase sha: ${JSON.stringify(sha)}`)
+      }
+      return (
+        `c${index}: object(oid: "${sha}") { ... on Commit { ` +
+        `author { user { login avatarUrl(size: 132) } } ` +
+        `deployments(environments: ${environments}, first: 5) { ` +
+        `nodes { latestStatus { state environmentUrl } } } } }`
+      )
+    })
+    .join(' ')
+  return `query { repository(owner: "sanity-io", name: "sanity") { ${fields} } }`
+}
+
+interface DeploymentNode {
+  latestStatus?: {state?: string; environmentUrl?: string | null} | null
+}
+
+export interface CommitGitHubInfo {
+  /** First SUCCESS deployment URL — absent for skipped/unfinished builds. */
+  testStudioUrl?: string
+  /** GitHub account the author email maps to — absent for unmapped emails. */
+  authorLogin?: string
+  /** GitHub's avatar URL — not derivable: bot avatars live under /in/<app-id>. */
+  authorAvatarUrl?: string
+}
+
+/**
+ * Map each sha to its enrichment. Unknown oids, skipped builds,
+ * failed/in-progress deploys and unmapped author emails simply resolve
+ * nothing for that part.
+ */
+export function parseCommitGitHubInfo(
+  data: unknown,
+  shas: string[],
+): Map<string, CommitGitHubInfo> {
+  const repository = (data as {repository?: Record<string, unknown>} | null)?.repository
+  const info = new Map<string, CommitGitHubInfo>()
+  if (!repository) return info
+  shas.forEach((sha, index) => {
+    const commit = repository[`c${index}`] as
+      | {
+          author?: {user?: {login?: string | null; avatarUrl?: string | null} | null} | null
+          deployments?: {nodes?: (DeploymentNode | null)[] | null} | null
+        }
+      | null
+      | undefined
+    if (!commit) return
+    const entry: CommitGitHubInfo = {}
+    for (const node of commit.deployments?.nodes ?? []) {
+      const status = node?.latestStatus
+      if (status?.state === 'SUCCESS' && status.environmentUrl) {
+        entry.testStudioUrl = status.environmentUrl
+        break
+      }
+    }
+    const login = commit.author?.user?.login
+    if (login) entry.authorLogin = login
+    const avatarUrl = commit.author?.user?.avatarUrl
+    if (avatarUrl) entry.authorAvatarUrl = avatarUrl
+    if (entry.testStudioUrl || entry.authorLogin || entry.authorAvatarUrl) info.set(sha, entry)
+  })
+  return info
+}

--- a/dev/metrics-studio/scripts/npmVersions.test.ts
+++ b/dev/metrics-studio/scripts/npmVersions.test.ts
@@ -1,0 +1,58 @@
+import {expect, test} from 'vitest'
+
+import {npmInfoForTags} from './npmVersions'
+
+const DATA = {
+  distTags: {
+    'latest': '6.10.1',
+    'stable': '6.7.0',
+    'maintenance-v5': '5.31.2',
+    'next': '6.11.0-next.49',
+  },
+  time: {
+    'created': '2015-01-01T00:00:00Z',
+    'modified': '2026-08-20T00:00:00Z',
+    '6.10.1': '2026-08-18T22:00:00Z',
+    '6.7.0': '2026-07-20T10:00:00Z',
+    '6.0.0-rc.1': '2026-05-01T09:00:00Z',
+  },
+  downloads: {'6.10.1': 12345, '6.7.0': 65888},
+}
+
+test('maps vX.Y.Z tags to their npm version info', () => {
+  const info = npmInfoForTags(['v6.10.1', 'v6.7.0'], DATA)
+  expect(info.get('v6.10.1')).toEqual({
+    publishedAt: '2026-08-18T22:00:00Z',
+    distTags: ['latest'],
+    weeklyDownloads: 12345,
+  })
+  expect(info.get('v6.7.0')).toEqual({
+    publishedAt: '2026-07-20T10:00:00Z',
+    distTags: ['stable'],
+    weeklyDownloads: 65888,
+  })
+})
+
+test('prerelease tags map through unchanged', () => {
+  expect(npmInfoForTags(['v6.0.0-rc.1'], DATA).get('v6.0.0-rc.1')).toEqual({
+    publishedAt: '2026-05-01T09:00:00Z',
+  })
+})
+
+test('several dist-tags on one version are all kept, sorted', () => {
+  const info = npmInfoForTags(['v6.7.0'], {
+    distTags: {stable: '6.7.0', pinned: '6.7.0'},
+  })
+  expect(info.get('v6.7.0')).toEqual({distTags: ['pinned', 'stable']})
+})
+
+test('versions npm does not know resolve nothing', () => {
+  const info = npmInfoForTags(['v9.9.9'], DATA)
+  expect(info.has('v9.9.9')).toBe(false)
+  expect(npmInfoForTags(['v6.10.1'], {}).size).toBe(0)
+})
+
+test('a zero download count is kept (zero is data, not absence)', () => {
+  const info = npmInfoForTags(['v6.7.0'], {downloads: {'6.7.0': 0}})
+  expect(info.get('v6.7.0')).toEqual({weeklyDownloads: 0})
+})

--- a/dev/metrics-studio/scripts/npmVersions.ts
+++ b/dev/metrics-studio/scripts/npmVersions.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure mapping of npm registry responses onto git tags (I/O lives in
+ * syncGitHistory.ts). Tag `vX.Y.Z` = `sanity@X.Y.Z`; npm adds what git can't
+ * know: publish time, current dist-tags, and last week's downloads (the
+ * blast radius of a regression). Versions npm doesn't know get no
+ * enrichment.
+ */
+
+export interface NpmVersionInfo {
+  publishedAt?: string
+  distTags?: string[]
+  weeklyDownloads?: number
+}
+
+export function npmInfoForTags(
+  tagNames: string[],
+  data: {
+    /** `/-/package/sanity/dist-tags`: dist-tag name → version */
+    distTags?: Record<string, string>
+    /** packument `time`: version → publish timestamp (plus created/modified) */
+    time?: Record<string, string>
+    /** `api.npmjs.org/versions/sanity/last-week` `downloads`: version → count */
+    downloads?: Record<string, number>
+  },
+): Map<string, NpmVersionInfo> {
+  const tagsByVersion = new Map<string, string[]>()
+  for (const [distTag, version] of Object.entries(data.distTags ?? {})) {
+    tagsByVersion.set(version, [...(tagsByVersion.get(version) ?? []), distTag])
+  }
+
+  const info = new Map<string, NpmVersionInfo>()
+  for (const tagName of tagNames) {
+    const version = tagName.replace(/^v/, '')
+    const publishedAt = data.time?.[version]
+    const distTags = tagsByVersion.get(version)
+    const weeklyDownloads = data.downloads?.[version]
+    if (publishedAt === undefined && distTags === undefined && weeklyDownloads === undefined) {
+      continue
+    }
+    info.set(tagName, {
+      ...(publishedAt ? {publishedAt} : {}),
+      ...(distTags ? {distTags: distTags.toSorted()} : {}),
+      ...(weeklyDownloads === undefined ? {} : {weeklyDownloads}),
+    })
+  }
+  return info
+}

--- a/dev/metrics-studio/scripts/syncGitHistory.ts
+++ b/dev/metrics-studio/scripts/syncGitHistory.ts
@@ -1,0 +1,239 @@
+// oxlint-disable no-console
+/**
+ * Sync git history into the metrics dataset as `gitCommit` / `gitTag`
+ * documents. Run by .github/workflows/sync-git-metrics.yml on pushes to main
+ * and after releases; `--all` backfills from the v5.0.0 cutoff.
+ *
+ * Stateless and idempotent: deterministic ids + createOrReplace mean every
+ * run blindly re-upserts its window — overlap is free, a failed run is
+ * repaired by the next one. Collection is fail-loud: a GitHub or npm API
+ * error aborts before anything is written (failing the workflow, which
+ * alerts Slack). Documents are replaced whole, so a run never writes what it
+ * could not collect — see assembleSyncDocuments for the rules.
+ *
+ *   pnpm --filter metrics-studio sync-git -- --dry-run        # preview, nothing written
+ *   pnpm --filter metrics-studio sync-git -- --all --dry-run  # backfill preview
+ *   pnpm --filter metrics-studio sync-git                     # last 50 commits
+ *
+ * Requires BENCH_METRICS_WRITE_TOKEN (same secret `bench store` uses) unless
+ * --dry-run. Without GITHUB_TOKEN even a preview assembles zero commits —
+ * every commit the GitHub lookup did not cover is filtered out.
+ */
+import {execFileSync} from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {parseArgs} from 'node:util'
+
+import {readEnv} from '@repo/utils'
+import {createClient, type IdentifiedSanityDocumentStub} from '@sanity/client'
+
+import {
+  assembleSyncDocuments,
+  COMMIT_LOG_FORMAT,
+  commitDocument,
+  type GitCommitDocument,
+  type GitHubCollection,
+  type GitTagDocument,
+  parseCommitRecords,
+  parseTagRefs,
+  TAG_REF_FORMAT,
+  tagDocument,
+} from './gitHistory'
+import {
+  buildDeploymentsQuery,
+  type CommitGitHubInfo,
+  GITHUB_DEPLOYMENTS_BATCH_SIZE,
+  parseCommitGitHubInfo,
+} from './githubDeployments'
+import {npmInfoForTags, type NpmVersionInfo} from './npmVersions'
+
+/** The metrics-studio project — same constants as perf/bench/report/storeToSanity.ts. */
+const METRICS_PROJECT_ID = 'mhfozd0z'
+const METRICS_DATASET = 'bench'
+
+/** Backfill start: the dataset deliberately covers v5.0.0 (2025-12-16) onward. */
+const BACKFILL_CUTOFF_TAG = 'v5.0.0'
+
+/**
+ * Incremental window: one GitHub GraphQL batch, ~2 days of main. Failures
+ * alert Slack the same day; a longer gap takes one `--all` dispatch.
+ */
+const DEFAULT_MAX_COUNT = 50
+
+/** ~300 sub-400-byte docs per transaction ≈ 100 KB bodies, ~7 requests on backfill. */
+const MUTATIONS_PER_TRANSACTION = 300
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+/** Fail-loud git — a bad ref or shallow clone must abort, not store a partial window. */
+function git(args: string[]): string {
+  return execFileSync('git', args, {cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024})
+}
+
+function collectDocuments(options: {all: boolean; maxCount: number; ref: string}): {
+  commits: GitCommitDocument[]
+  tags: GitTagDocument[]
+} {
+  // ^.. includes the cutoff commit itself (gitTag-v5.0.0's reference would
+  // otherwise dangle); --first-parent is the chain parentSha promises.
+  // Refs go after --end-of-options so a hostile --ref can't become a flag.
+  const logArgs = options.all
+    ? [
+        'log',
+        '--first-parent',
+        `--format=${COMMIT_LOG_FORMAT}`,
+        '--end-of-options',
+        `${BACKFILL_CUTOFF_TAG}^..${options.ref}`,
+      ]
+    : [
+        'log',
+        '--first-parent',
+        `--max-count=${options.maxCount}`,
+        `--format=${COMMIT_LOG_FORMAT}`,
+        '--end-of-options',
+        options.ref,
+      ]
+  const commits = parseCommitRecords(git(logArgs)).map(commitDocument)
+  const tags = parseTagRefs(git(['for-each-ref', 'refs/tags', `--format=${TAG_REF_FORMAT}`])).map(
+    tagDocument,
+  )
+  return {commits, tags}
+}
+
+/**
+ * Per-commit GitHub enrichment: test-studio deploy URL (from deployment
+ * statuses — Vercel builds every commit, we only collect) and the author's
+ * GitHub login/avatar. An API error aborts the run; a commit with no
+ * deployment is NOT an error — the push-triggered run usually precedes its
+ * own Vercel build, and the trailing window fills the URL in next run. The
+ * one fail-soft path is a missing GITHUB_TOKEN (deliberate local mode):
+ * commits are then skipped entirely, since writing them would erase
+ * enrichment.
+ */
+async function collectGitHubInfo(shas: string[]): Promise<GitHubCollection> {
+  const token = process.env.GITHUB_TOKEN
+  const info = new Map<string, CommitGitHubInfo>()
+  const queriedShas = new Set<string>()
+  if (!token) {
+    console.warn(
+      'GITHUB_TOKEN not set — commits are skipped entirely (writing them would erase enrichment)',
+    )
+    return {info, queriedShas}
+  }
+  for (let offset = 0; offset < shas.length; offset += GITHUB_DEPLOYMENTS_BATCH_SIZE) {
+    const batch = shas.slice(offset, offset + GITHUB_DEPLOYMENTS_BATCH_SIZE)
+    const response = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {'authorization': `bearer ${token}`, 'content-type': 'application/json'},
+      body: JSON.stringify({query: buildDeploymentsQuery(batch)}),
+    })
+    if (!response.ok) throw new Error(`GitHub GraphQL responded ${response.status}`)
+    const payload = (await response.json()) as {data?: unknown; errors?: {message: string}[]}
+    if (payload.errors?.length) throw new Error(payload.errors[0].message)
+    for (const [sha, entry] of parseCommitGitHubInfo(payload.data, batch)) info.set(sha, entry)
+    for (const sha of batch) queriedShas.add(sha)
+  }
+  return {info, queriedShas}
+}
+
+/**
+ * npm enrichment for the release tags (publish time, current dist-tags,
+ * weekly downloads). Only runs with --npm — the workflow requests it on
+ * releases, the daily cron, and dispatches, not on every main push. npm
+ * being down aborts the run before anything is written.
+ */
+async function collectNpmInfo(tagNames: string[]): Promise<Map<string, NpmVersionInfo>> {
+  const get = async (url: string) => {
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`${url} responded ${response.status}`)
+    return response.json()
+  }
+  try {
+    const [distTags, packument, downloads] = await Promise.all([
+      get('https://registry.npmjs.org/-/package/sanity/dist-tags') as Promise<
+        Record<string, string>
+      >,
+      get('https://registry.npmjs.org/sanity') as Promise<{time?: Record<string, string>}>,
+      get('https://api.npmjs.org/versions/sanity/last-week') as Promise<{
+        downloads?: Record<string, number>
+      }>,
+    ])
+    return npmInfoForTags(tagNames, {
+      distTags,
+      time: packument.time,
+      downloads: downloads.downloads,
+    })
+  } catch (error) {
+    // Name the culprit subsystem; the `cause` chain keeps undici's
+    // network-level reason visible
+    throw new Error('npm enrichment failed', {cause: error})
+  }
+}
+
+async function main(): Promise<void> {
+  const {values} = parseArgs({
+    // pnpm forwards the `--` separator verbatim, and parseArgs would demote
+    // everything after it to (disallowed) positionals
+    args: process.argv.slice(2).filter((arg) => arg !== '--'),
+    options: {
+      'all': {type: 'boolean', default: false},
+      'max-count': {type: 'string', default: String(DEFAULT_MAX_COUNT)},
+      'ref': {type: 'string', default: 'origin/main'},
+      'npm': {type: 'boolean', default: false},
+      'dry-run': {type: 'boolean', default: false},
+    },
+  })
+
+  const collected = collectDocuments({
+    all: values.all,
+    maxCount: Number(values['max-count']),
+    ref: values.ref,
+  })
+  const github = await collectGitHubInfo(collected.commits.map((commit) => commit.sha))
+  const npmInfo = values.npm
+    ? await collectNpmInfo(collected.tags.map((tag) => tag.tag))
+    : undefined
+  const assembled = assembleSyncDocuments({
+    commits: collected.commits,
+    tags: collected.tags,
+    github,
+    ...(npmInfo ? {npmInfo} : {}),
+  })
+  const documents: IdentifiedSanityDocumentStub[] = assembled.documents
+  console.log(
+    `Assembled ${assembled.commitCount} commit(s) (${values.all ? `${BACKFILL_CUTOFF_TAG}^..${values.ref}` : `last ${values['max-count']} on ${values.ref}`}` +
+      (assembled.skippedCommitCount > 0
+        ? `, ${assembled.skippedCommitCount} skipped: GitHub lookup missing`
+        : '') +
+      `) and ${assembled.tagCount} tag(s)` +
+      (values.npm ? ` with npm info for ${npmInfo?.size ?? 0}` : ' (tags need --npm)') +
+      `; deploy URLs on ${assembled.urlCount} commit(s)`,
+  )
+
+  if (values['dry-run']) {
+    const samples = [documents[0], documents.at(-1)].filter(Boolean)
+    console.log(`Dry run — would upsert ${documents.length} document(s). Samples:`)
+    for (const sample of samples) console.log(JSON.stringify(sample, null, 2))
+    return
+  }
+
+  const client = createClient({
+    projectId: METRICS_PROJECT_ID,
+    dataset: METRICS_DATASET,
+    apiVersion: '2025-02-19',
+    token: readEnv('BENCH_METRICS_WRITE_TOKEN'),
+    useCdn: false,
+  })
+
+  for (let offset = 0; offset < documents.length; offset += MUTATIONS_PER_TRANSACTION) {
+    const batch = documents.slice(offset, offset + MUTATIONS_PER_TRANSACTION)
+    let transaction = client.transaction()
+    for (const doc of batch) transaction = transaction.createOrReplace(doc)
+    await transaction.commit()
+    console.log(`Upserted ${Math.min(offset + batch.length, documents.length)}/${documents.length}`)
+  }
+  console.log(`Synced ${assembled.commitCount} commit(s) + ${assembled.tagCount} tag(s)`)
+}
+
+await main()

--- a/dev/metrics-studio/vitest.config.mts
+++ b/dev/metrics-studio/vitest.config.mts
@@ -2,9 +2,10 @@ import {defineConfig} from '@repo/test-config/vitest'
 
 export default defineConfig({
   test: {
-    // The pure trend-math modules (drift detection, ack expiry) — the UI
-    // itself is exercised via the debug data sources, not unit tests
-    include: ['./tools/**/*.test.ts'],
+    // The pure trend-math modules (drift detection, ack expiry) and the
+    // git-history parsers — the UI itself is exercised via the debug data
+    // sources, not unit tests
+    include: ['./tools/**/*.test.ts', './scripts/**/*.test.ts'],
     exclude: ['./dist/**', './node_modules/**'],
   },
 })

--- a/perf/bench/report/__tests__/storeShape.test.ts
+++ b/perf/bench/report/__tests__/storeShape.test.ts
@@ -145,4 +145,23 @@ describe('toStorableRun', () => {
     toStorableRun(RUN)
     expect(RUN).toEqual(before)
   })
+
+  it('adds a weak gitCommit reference for a full sha', () => {
+    const sha = 'a'.repeat(40)
+    const stored = toStorableRun({...RUN, git: {...RUN.git, sha}})
+    expect(stored.git.commit).toEqual({
+      _type: 'reference',
+      _ref: `gitCommit-${sha}`,
+      _weak: true,
+    })
+    expect(stored.git.sha).toBe(sha)
+  })
+
+  it('omits the commit reference when the sha is not a full sha', () => {
+    // RUN's sha is 16 chars; collect.ts also emits 'unknown' outside a repo
+    expect(toStorableRun(RUN).git).not.toHaveProperty('commit')
+    expect(toStorableRun({...RUN, git: {...RUN.git, sha: 'unknown'}}).git).not.toHaveProperty(
+      'commit',
+    )
+  })
 })

--- a/perf/bench/report/storeShape.ts
+++ b/perf/bench/report/storeShape.ts
@@ -14,13 +14,25 @@ import {
  * - `byClass` is an arbitrary-key record, which a studio schema can't
  *   declare either — stored as a keyed `{endpointClass, count}` array
  * - every object in an array gets a `_key`
+ * - `git.commit` is added as a weak reference to the run's `gitCommit`
+ *   document, derived from the deterministic id `gitCommit-<sha>` — no
+ *   lookup. Weak because the target may not exist (PR-branch commits are
+ *   never synced; a fresh main run can beat the sync). `git.sha` stays the
+ *   source of truth.
  *
  * The artifact/report JSON keeps the raw shape; only the stored document
  * differs. The metrics-studio schema mirrors THIS shape — keep them in sync.
  */
 export function toStorableRun(document: BenchRunDocument) {
+  const isFullSha = /^[0-9a-f]{40}$/.test(document.git.sha)
   return {
     ...document,
+    git: {
+      ...document.git,
+      ...(isFullSha
+        ? {commit: {_type: 'reference', _ref: `gitCommit-${document.git.sha}`, _weak: true}}
+        : {}),
+    },
     scenarios: document.scenarios.map((scenario) => ({
       ...scenario,
       _key: `${scenario.mode ?? scenario.kind}-${scenario.scenario}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,12 @@ importers:
 
   dev/metrics-studio:
     dependencies:
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../packages/@repo/utils
+      '@sanity/client':
+        specifier: 'catalog:'
+        version: 8.2.0(vitest@4.1.11)
       '@sanity/icons':
         specifier: ^5.2.1
         version: 5.2.1(react@19.2.8)
@@ -407,6 +413,9 @@ importers:
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1)(vite@8.2.2)


### PR DESCRIPTION
### Description

Stores repo history in the metrics dataset: one `gitCommit` document per main-branch commit and one `gitTag` document per `v*` release tag (starting from v5.0.0), synced by a new workflow on every push. Commit docs also get the Vercel test-studio deploy URL and the author's GitHub login/avatar; tag docs get npm data (publish time, dist-tags, weekly downloads). This is the base for release markers in Trends, a bisect tool over preview builds, and later health metrics. A second commit adds a weak reference from `benchRun` docs to their commit.

### What to review

- `gitHistory.ts`: the write rules in `assembleSyncDocuments`.
- `sync-git-metrics.yml` and the new job in `release-latest.yml`: runs only in trusted contexts, `ref: main`, `persist-credentials: false`, minimal permissions.
- Injection guards: `--end-of-options` for git argv, full-sha regex for GraphQL interpolation.

### Testing

- 32 unit tests for the parsers, GraphQL query builder, npm mapping, and each write rule; 8 storeShape tests for the weak reference.

### Notes for release

N/A – Internal only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a trusted-context CI workflow that writes to the live metrics dataset using BENCH_METRICS_WRITE_TOKEN and GitHub GraphQL. Fail-loud upserts and no PR-triggered runs limit blast radius, but a bad sync can replace stored enrichment.
> 
> **Overview**
> Mirrors repo history into the metrics dataset as `gitCommit` / `gitTag` documents (from v5.0.0), so later health views can join on sha/tag instead of scraping git.
> 
> A new `sync-git-metrics` workflow upserts the last 50 main commits on every push (idempotent `createOrReplace`), collects test-studio deploy URLs and author login/avatar from GitHub, and on releases/cron/dispatch also writes tags with npm publish time, dist-tags, and weekly downloads. API errors abort before any write; tags are skipped on non-npm runs so enrichment is not clobbered. Release-latest calls the same workflow after npm publish. The studio schema and structure lists expose Commits and Releases as read-only types.
> 
> `bench store` now stamps a weak `git.commit` reference from a full sha (source of truth remains `git.sha`); a one-off dispatch backfills existing runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e7a61aec08509a634f52d04d5c6766cc77876a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->