### PR TITLE
chore(metrics): use ui5 flexBasis/flexGrow on trends chart card

### DIFF
--- a/dev/metrics-studio/tools/trends/TrendChart.tsx
+++ b/dev/metrics-studio/tools/trends/TrendChart.tsx
@@ -4,7 +4,6 @@ import {Group} from '@visx/group'
 import {scaleLinear, scaleTime} from '@visx/scale'
 import {Area, LinePath} from '@visx/shape'
 import {useRef, useState} from 'react'
-import {Box} from 'ui5'
 
 import {
   CALIBRATION_EXPLAINER,

--- a/dev/metrics-studio/tools/trends/TrendsTool.tsx
+++ b/dev/metrics-studio/tools/trends/TrendsTool.tsx
@@ -374,7 +374,7 @@ function SeriesCard(props: {
             percentage it contextualizes instead of floating top-right while
             the badge wraps under a long title. */}
         <Flex align="center" justify="space-between" gap={3}>
-          <Box flex={1} style={{minWidth: 0}}>
+          <Box flexBasis="0%" flexGrow={1} style={{minWidth: 0}}>
             {/* Clicking the title deep-links to this chart (shareable focus) */}
             {onFocus ? (
               <Box


### PR DESCRIPTION
### Description
Box in TrendsTool comes from ui5 (@sanity/ui@alpha, now 5.0.0-alpha.4), which dropped the flex shorthand. Changed `flex={1}` → `flexBasis="0%" flexGrow={1}`, matching the other migrated files. Also removed an unused Box import in  TrendChart.tsx.

### What to review

### Testing


### Notes for release
n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Layout-prop and unused-import cleanup only; no behavior or data-path changes.
> 
> **Overview**
> Replaces the dropped ui5 `flex` shorthand on the trends chart-card title `Box` with `flexBasis="0%"` and `flexGrow={1}`, matching the rest of the metrics studio migration.
> 
> Also removes an unused `Box` import from `TrendChart.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949825abce2b84de6b99d39e24044553523aa21e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->