### PR TITLE
fix(core): build comment and task notification links for the dashboard

### DIFF
--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TaskNotificationTarget.test.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TaskNotificationTarget.test.tsx
@@ -42,4 +42,31 @@ describe('getTaskURL', () => {
       'http://test-studio.com/anotherpath/structure/?sidebar=tasks&selectedTask=task-id-456&viewMode=edit',
     )
   })
+
+  it('builds on an explicit origin instead of window.location.origin', () => {
+    const url = getTaskURL(
+      'task-id-123',
+      '/basepath',
+      'structure',
+      'https://www.sanity.io/@org/studio/app-id/default',
+    )
+    expect(url).toBe(
+      'https://www.sanity.io/@org/studio/app-id/default/basepath/structure/?sidebar=tasks&selectedTask=task-id-123&viewMode=edit',
+    )
+  })
+
+  it('omits the basePath when the dashboard URL already identifies the workspace', () => {
+    // Regression test for SAPP-3134. In the dashboard the workspace is addressed by the
+    // dashboard path, so the caller passes no basePath — repeating it yields a path the
+    // dashboard cannot resolve, dropping the user on Structure instead of the task.
+    const url = getTaskURL(
+      'task-id-123',
+      undefined,
+      'structure',
+      'https://www.sanity.io/@org/studio/app-id/default',
+    )
+    expect(url).toBe(
+      'https://www.sanity.io/@org/studio/app-id/default/structure/?sidebar=tasks&selectedTask=task-id-123&viewMode=edit',
+    )
+  })
 })

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
@@ -9,6 +9,7 @@ import {useFormValue} from '../../../../form/contexts/FormValue'
 import {set} from '../../../../form/patch/patch'
 import {type ObjectFieldProps} from '../../../../form/types/fieldProps'
 import {useClient} from '../../../../hooks/useClient'
+import {useStudioUrl} from '../../../../hooks/useStudioUrl'
 import {usePerspective} from '../../../../perspective/usePerspective'
 import {useWorkspace} from '../../../../studio/workspace'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../studioClient'
@@ -21,8 +22,13 @@ import {useDocumentPreviewValues} from '../../../hooks/useDocumentPreviewValues'
 import {type TaskContext, type TaskDocument} from '../../../types'
 import {CurrentWorkspaceProvider} from '../CurrentWorkspaceProvider'
 
-export function getTaskURL(taskId: string, basePath?: string, toolName: string = ''): string {
-  let path = window.location.origin
+export function getTaskURL(
+  taskId: string,
+  basePath?: string,
+  toolName: string = '',
+  origin: string = window.location.origin,
+): string {
+  let path = origin
   if (basePath) path += basePath
   if (toolName) path += `/${toolName}`
 
@@ -45,6 +51,7 @@ function TasksNotificationTargetInner(props: ObjectFieldProps<TaskDocument>) {
   )
   const {target, _id, context, _rev} = useFormValue([]) as TaskDocument
   const {title: workspaceTitle, basePath, name: workspaceName} = useWorkspace()
+  const {buildStudioUrl} = useStudioUrl()
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const imageBuilder = useMemo(() => createImageUrlBuilder(client), [client])
   const documentId = target?.document?._ref ?? ''
@@ -66,7 +73,15 @@ function TasksNotificationTargetInner(props: ObjectFieldProps<TaskDocument>) {
     const contextUrl = context?.notification?.url
     const studioUrl =
       // Avoid updating the contextURL in dev mode if it already exists, persist the deployed one.
-      contextUrl && isDev ? contextUrl : getTaskURL(_id, basePath, activeToolName)
+      contextUrl && isDev
+        ? contextUrl
+        : buildStudioUrl({
+            // In the dashboard the studio URL already identifies the workspace, so
+            // repeating the workspace basePath produces a path the dashboard cannot
+            // resolve and it falls back to Structure instead of opening the task.
+            coreUi: (base) => getTaskURL(_id, undefined, activeToolName, base),
+            studio: (base) => getTaskURL(_id, basePath, activeToolName, base),
+          })
 
     return {
       url: studioUrl,
@@ -80,6 +95,7 @@ function TasksNotificationTargetInner(props: ObjectFieldProps<TaskDocument>) {
     _id,
     basePath,
     activeToolName,
+    buildStudioUrl,
     workspaceTitle,
     workspaceName,
     imageUrl,

--- a/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/CommentsWrapper.tsx
@@ -6,6 +6,7 @@ import {
   useCommentsEnabled,
   getTargetScopeId,
   usePerspective,
+  useStudioUrl,
 } from 'sanity'
 import {useRouter} from 'sanity/router'
 
@@ -44,6 +45,7 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
   const {selectedReleaseId, selectedVariantName} = usePerspective()
   const {params, setParams} = usePaneRouter()
   const {resolveIntentLink} = useRouter()
+  const {buildIntentUrl} = useStudioUrl()
 
   // The scope of the document targeted by the selected perspective (undefined when the target is
   // still resolving or the draft/published pair applies). While resolving, reverting is disabled
@@ -78,9 +80,15 @@ function CommentsProviderWrapper(props: CommentsWrapperProps) {
         },
         searchParams,
       )
-      return `${window.location.origin}${intentLink}`
+      // Not `window.location.origin + intentLink`: when the Studio runs inside the
+      // dashboard, the workspace is identified by the dashboard path rather than the
+      // workspace basePath, so a link carrying the basePath cannot be resolved there.
+      // `buildIntentUrl` swaps the basePath for the dashboard path in that context and
+      // is a no-op in a standalone Studio.
+      return buildIntentUrl(intentLink)
     },
     [
+      buildIntentUrl,
       documentId,
       documentType,
       resolveIntentLink,

--- a/packages/sanity/src/structure/panes/document/comments/__tests__/CommentsWrapper.test.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/__tests__/CommentsWrapper.test.tsx
@@ -7,6 +7,11 @@ import {useDocumentPane} from '../../useDocumentPane'
 import {CommentsWrapper} from '../CommentsWrapper'
 
 const mockResolveIntentLink = vi.hoisted(() => vi.fn(() => '/mock-intent-link'))
+// Mirrors the real hook: in a standalone Studio the intent link is appended to the
+// origin unchanged. Overridden per-test to cover the dashboard (coreUi) behaviour.
+const mockBuildIntentUrl = vi.hoisted(() =>
+  vi.fn((intentLink: string) => `${window.location.origin}${intentLink}`),
+)
 
 let capturedCommentsProviderProps: Record<string, unknown> | undefined
 
@@ -19,6 +24,11 @@ vi.mock('sanity', () => ({
   },
   getTargetScopeId: vi.fn(() => undefined),
   useCommentsEnabled: vi.fn(() => ({enabled: true})),
+  useStudioUrl: vi.fn(() => ({
+    buildIntentUrl: mockBuildIntentUrl,
+    buildStudioUrl: vi.fn(),
+    studioUrl: window.location.origin,
+  })),
   usePerspective: vi.fn(() => ({
     selectedPerspectiveName: undefined,
     selectedReleaseId: undefined,
@@ -266,7 +276,7 @@ describe('CommentsWrapper', () => {
       expect(mockResolveIntentLink.mock.calls[0][2]).toEqual([])
     })
 
-    it('returns a URL combining window.location.origin with the resolved intent link', () => {
+    it('builds the comment URL from the resolved intent link via buildIntentUrl', () => {
       mockResolveIntentLink.mockReturnValue('/intent/edit/id=doc-789;type=page')
 
       render(
@@ -280,7 +290,35 @@ describe('CommentsWrapper', () => {
 
       const result = getCommentLink('comment-123')
 
+      expect(mockBuildIntentUrl).toHaveBeenCalledWith('/intent/edit/id=doc-789;type=page')
       expect(result).toBe(`${window.location.origin}/intent/edit/id=doc-789;type=page`)
+    })
+
+    it('uses the dashboard URL rather than the origin when running in the dashboard', () => {
+      // Regression test for SAPP-3134: a Studio hosted in the dashboard is addressed by
+      // its dashboard path, not by the workspace basePath. Building the link from
+      // `window.location.origin` kept the basePath in the URL, which the dashboard could
+      // not resolve — it dropped the user on Structure instead of the commented document.
+      mockResolveIntentLink.mockReturnValue('/default/intent/edit/id=doc-789;type=page')
+      mockBuildIntentUrl.mockReturnValueOnce(
+        'https://www.sanity.io/@org/studio/app-id/default/intent/edit/id=doc-789;type=page',
+      )
+
+      render(
+        <CommentsWrapper documentId="doc-789" documentType="page">
+          <div>children</div>
+        </CommentsWrapper>,
+      )
+
+      const getCommentLink = capturedCommentsProviderProps!.getCommentLink as (id: string) => string
+
+      const result = getCommentLink('comment-123')
+
+      expect(mockBuildIntentUrl).toHaveBeenCalledWith('/default/intent/edit/id=doc-789;type=page')
+      expect(result).toBe(
+        'https://www.sanity.io/@org/studio/app-id/default/intent/edit/id=doc-789;type=page',
+      )
+      expect(result).not.toContain(window.location.origin)
     })
   })
 


### PR DESCRIPTION
### Description

Comment and task notification emails built their URLs as `window.location.origin` + the workspace-relative path. In a Studio hosted in the dashboard, the workspace is addressed by its dashboard path (`/@org/studio/<appId>/<workspaceName>`), not by the `basePath` from the workspace config — so the generated link carried a `basePath` segment the dashboard couldn't resolve, and the recipient landed on Structure instead of the commented document. Fixes [SAPP-3134](https://linear.app/sanity/issue/SAPP-3134), which has four linked customer threads.

This is why the bug only appears when a workspace declares a non-`/` basePath. From the issue, the two reported links differ by exactly one segment:

```
works:  /@oX0az1z9b/studio/hzow9lelgkjzyw9heiz4zjna/studio-b/intent/edit/...
breaks: /@oX0az1z9b/studio/hzow9lelgkjzyw9heiz4zjna/Defaultv1/default/intent/edit/...
                                                              ^^^^^^^ workspace basePath
```

With `basePath: '/'` the origin-relative path and the dashboard path coincide, which is why single-default-workspace studios never hit it.

No new URL-building logic was needed: `useStudioUrl` already solves this for release copy-links, and its `buildIntentUrl` was the only consumer. It swaps the basePath for the dashboard path under `coreUi` and is a no-op in a standalone Studio — its existing tests already pin exactly this ("strips basePath from intent link in coreUi context"). Comments now route through it.

Tasks needed a slightly different shape because a task URL is a tool URL with search params, not an intent link, so `buildIntentUrl` doesn't apply. `getTaskURL` takes an explicit origin (defaulting to `window.location.origin`, so existing callers and tests are unaffected) and the caller goes through `buildStudioUrl`, which already picks a `coreUi`/`studio` branch for us — omitting the basePath in the dashboard.

Rejected: teaching the dashboard to tolerate the extra segment. The Studio is producing a URL for a context it knows it's in, and the helper for that already exists.

### What to review

One package (`sanity`), two independent call sites:

- `structure/panes/document/comments/CommentsWrapper.tsx` — one-line swap to `buildIntentUrl`
- `core/tasks/.../TasksNotificationTarget.tsx` — the new `origin` parameter and the `buildStudioUrl` branching

Worth confirming the tasks branching is right, since it's the part not already covered by an existing helper: in `coreUi` the basePath is deliberately dropped (the dashboard path already names the workspace), and in a standalone Studio it's kept.

Note this fixes link *generation* only. Links already stored on existing task/comment documents keep their old value — tasks persist `context.notification.url` on the document, so previously-created tasks are not retroactively corrected.

### Testing

`pnpm vitest run --project=sanity` over `core/tasks`, `core/comments`, `structure/panes/document/comments` and `useStudioUrl`: 118 passed, 3 skipped, no type errors. Lint clean.

Added regression coverage at both call sites:

- `CommentsWrapper.test.tsx` — asserts the link is built via `buildIntentUrl`, plus a dashboard case asserting the result is the dashboard URL and not `window.location.origin`. Both verified failing against the unpatched component.
- `TaskNotificationTarget.test.tsx` — an explicit-origin case and a dashboard case pinning that the basePath is omitted.

The existing `CommentsWrapper` test asserting `window.location.origin + intentLink` was updated, since that assertion encoded the bug.

### Notes for release

Fixed comment and task notification links in Studios hosted in the dashboard. When a workspace defined a `basePath` other than `/` (including any studio with multiple workspaces), the link in the notification email opened the Studio's Structure view instead of the document the comment was made on. Links are now built against the dashboard's workspace URL.

This affects newly created comments and tasks. Tasks store their notification URL on the task document, so links on tasks created before this fix are unchanged.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how comment and task notification URLs are generated (including persisted task URLs). Wrong branching would send users to the wrong studio location, but existing standalone behavior is preserved via useStudioUrl.
> 
> **Overview**
> Fixes comment and task notification links for Studios hosted in the dashboard (SAPP-3134). Links used `window.location.origin` plus the workspace `basePath`, which the dashboard cannot resolve when `basePath` is not `/`, so recipients landed on Structure instead of the document or task.
> 
> Comment links now go through `buildIntentUrl` from `useStudioUrl`, which swaps the workspace path for the dashboard path in coreUi and is a no-op in a standalone Studio.
> 
> Task notification URLs are built with `buildStudioUrl`: dashboard (`coreUi`) omits `basePath` because the dashboard path already names the workspace; standalone Studio still includes it. `getTaskURL` accepts an optional origin so existing callers stay unchanged.
> 
> **Note:** only newly generated links are fixed. Task documents already storing `context.notification.url` keep the old value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38114d8155c6382be2c815f7f7ed6d39554350f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->