### PR TITLE
feat(form): support options columns for arrays with grid layout

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -632,6 +632,39 @@ export default defineType({
       ],
     },
     {
+      name: 'gridArrayTwoColumns',
+      title: 'Image grid, columns: 2',
+      description: 'options: {layout: "grid", columns: 2} — narrower than the default of 4',
+      type: 'array',
+      options: {
+        layout: 'grid',
+        columns: 2,
+      },
+      of: [{type: 'image'}],
+    },
+    {
+      name: 'gridArraySixColumns',
+      title: 'Image grid, columns: 6',
+      description: 'options: {layout: "grid", columns: 6} — wider than the default of 4',
+      type: 'array',
+      options: {
+        layout: 'grid',
+        columns: 6,
+      },
+      of: [{type: 'image'}],
+    },
+    {
+      name: 'gridArrayOfStringsTwoColumns',
+      title: 'String grid, columns: 2',
+      description: 'Primitive array with options: {layout: "grid", columns: 2}',
+      type: 'array',
+      options: {
+        layout: 'grid',
+        columns: 2,
+      },
+      of: [{type: 'string'}],
+    },
+    {
       name: 'polymorphicGridArray',
       title: 'Polymorphic grid array',
       description: 'An array of multiple types. options: {layout: "grid"}',

--- a/packages/@sanity/types/src/schema/definition/type/array.ts
+++ b/packages/@sanity/types/src/schema/definition/type/array.ts
@@ -88,6 +88,24 @@ export interface ArrayOptions<V = unknown> extends SearchConfiguration, BaseSche
   // inferring the array.of value for ArrayDefinition cause too much code-noise and was removed.
   // Since we don't have the type-info needed here, we allow values
   layout?: 'list' | 'tags' | 'grid'
+  /**
+   * The number of columns to render when `layout` is `'grid'`. Has no effect for
+   * other layouts. Defaults to `4`.
+   *
+   * The value applies at the widest breakpoint and steps down on narrower ones, so
+   * the grid stays readable on small screens. Values below `1` are ignored.
+   *
+   * @example
+   * ```ts
+   * defineField({
+   *   name: 'gallery',
+   *   type: 'array',
+   *   of: [{type: 'image'}],
+   *   options: {layout: 'grid', columns: 2},
+   * })
+   * ```
+   */
+  columns?: number
   /** @deprecated This option does not have any effect anymore */
   direction?: 'horizontal' | 'vertical'
   sortable?: boolean

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -7,6 +7,7 @@ import {type ArrayOfObjectsInputProps} from '../../../../types/inputProps'
 import {type ObjectItem, type ObjectItemProps} from '../../../../types/itemProps'
 import {UploadTargetCard} from '../../../files/common/uploadTarget/UploadTargetCard'
 import {ArrayValidationProvider} from '../../common/ArrayValidationContext'
+import {resolveGridTemplateColumns} from '../../common/gridColumns'
 import {Item, List} from '../../common/list'
 import {ArrayOfObjectsFunctions} from '../ArrayOfObjectsFunctions'
 import {createProtoArrayValue} from '../createProtoArrayValue'
@@ -43,6 +44,7 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
   const errorTone: CardTone | undefined = hasErrors ? 'critical' : undefined
 
   const sortable = schemaType.options?.sortable !== false
+  const gridTemplateColumns = resolveGridTemplateColumns(schemaType.options?.columns)
 
   const renderItem = useCallback((itemProps: Omit<ObjectItemProps, 'renderDefault'>) => {
     // todo: consider using a different item component for references
@@ -74,7 +76,7 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
             {members?.length > 0 && (
               <Card border radius={1} tone={errorTone}>
                 <List
-                  gridTemplateColumns={[2, 3, 4]}
+                  gridTemplateColumns={gridTemplateColumns}
                   gap={3}
                   padding={1}
                   margin={1}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfObjectOptionsInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfObjectOptionsInput.tsx
@@ -8,6 +8,7 @@ import {ChangeIndicator} from '../../../../changeIndicators/ChangeIndicator'
 import {IncompatibleItemType} from '../../../members/array/IncompatibleItemType'
 import {set, unset} from '../../../patch/patch'
 import {type ArrayOfObjectsInputProps} from '../../../types/inputProps'
+import {DEFAULT_GRID_COLUMNS} from '../common/gridColumns'
 
 function isEqual(item: any, otherItem: any): boolean {
   if (item === otherItem) {
@@ -105,15 +106,13 @@ export function ArrayOfObjectOptionsInput(props: ArrayOfObjectsInputProps) {
   )
 
   const isGrid = schemaType.options?.layout === 'grid'
+  // A checkbox grid never needs more tracks than it has options, so an explicit
+  // `columns` narrows the grid but cannot stretch it past the option count.
+  const gridColumns = Math.min(options.length, schemaType.options?.columns ?? DEFAULT_GRID_COLUMNS)
 
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={false}>
-      <Grid
-        gap={2}
-        gridTemplateColumns={isGrid ? Math.min(options.length, 4) : 1}
-        tabIndex={0}
-        {...elementProps}
-      >
+      <Grid gap={2} gridTemplateColumns={isGrid ? gridColumns : 1} tabIndex={0} {...elementProps}>
         {options.map((option, index) => {
           const optionType = getMemberTypeOfItem(schemaType, option)
           const checked = inArray(value, option)

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfPrimitiveOptionsInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfPrimitiveOptionsInput.tsx
@@ -9,6 +9,7 @@ import {ChangeIndicator} from '../../../../changeIndicators/ChangeIndicator'
 import {set, unset} from '../../../patch/patch'
 import {type ArrayOfPrimitivesInputProps} from '../../../types/inputProps'
 import {IncompatibleItemType} from '../ArrayOfObjectsInput/List/IncompatibleItemType'
+import {DEFAULT_GRID_COLUMNS} from '../common/gridColumns'
 
 function isPrimitiveOption(option: unknown): option is NormalizedPrimitiveOption {
   return Boolean(option && typeof option === 'object' && 'title' in option && 'value' in option)
@@ -75,14 +76,13 @@ export function ArrayOfPrimitiveOptionsInput(props: ArrayOfPrimitivesInputProps)
   }
 
   const isGrid = schemaType.options?.layout === 'grid'
+  // A checkbox grid never needs more tracks than it has options, so an explicit
+  // `columns` narrows the grid but cannot stretch it past the option count.
+  const gridColumns = Math.min(options.length, schemaType.options?.columns ?? DEFAULT_GRID_COLUMNS)
 
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={false}>
-      <Grid
-        gap={2}
-        gridTemplateColumns={isGrid ? Math.min(options.length, 4) : 1}
-        {...elementProps}
-      >
+      <Grid gap={2} gridTemplateColumns={isGrid ? gridColumns : 1} {...elementProps}>
         {options.map((option, index) => {
           const optionType = getMemberTypeOfItem(schemaType, option)
           const checked = value.includes(option.value)

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -8,6 +8,7 @@ import {type ArrayOfPrimitivesInputProps} from '../../../types/inputProps'
 import {type PrimitiveItemProps} from '../../../types/itemProps'
 import {ErrorItem} from '../ArrayOfObjectsInput/List/ErrorItem'
 import {ArrayValidationProvider} from '../common/ArrayValidationContext'
+import {resolveGridTemplateColumns} from '../common/gridColumns'
 import {Item, List} from '../common/list'
 import {ArrayOfPrimitivesFunctions} from './ArrayOfPrimitivesFunctions'
 import {UploadTargetCard} from './arrayOfPrimitiveUploadTarget'
@@ -163,6 +164,7 @@ export class ArrayOfPrimitivesInput extends PureComponent<ArrayOfPrimitivesInput
 
     const isSortable = !readOnly && get(schemaType, 'options.sortable') !== false
     const isGrid = schemaType.options?.layout === 'grid'
+    const gridTemplateColumns = resolveGridTemplateColumns(schemaType.options?.columns)
 
     // Compute tone for array container based on validation errors
     const hasErrors = validation?.some((v) => v.level === 'error')
@@ -197,7 +199,7 @@ export class ArrayOfPrimitivesInput extends PureComponent<ArrayOfPrimitivesInput
                     items={membersWithSortIds.map((m) => m.id)}
                     sortable={isSortable}
                     gap={isGrid ? 3 : 1}
-                    gridTemplateColumns={isGrid ? [2, 3, 4] : 1}
+                    gridTemplateColumns={isGrid ? gridTemplateColumns : 1}
                     padding={isGrid ? 1 : undefined}
                     margin={isGrid ? 1 : undefined}
                   >

--- a/packages/sanity/src/core/form/inputs/arrays/common/gridColumns.test.ts
+++ b/packages/sanity/src/core/form/inputs/arrays/common/gridColumns.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest'
+
+import {DEFAULT_GRID_COLUMNS, resolveGridTemplateColumns} from './gridColumns'
+
+describe('resolveGridTemplateColumns', () => {
+  it('reproduces the historical default when columns is not set', () => {
+    // `[2, 3, 4]` is what grid arrays rendered at before `columns` existed, so an
+    // unset value must keep producing exactly that.
+    expect(resolveGridTemplateColumns(undefined)).toEqual([2, 3, 4])
+    expect(resolveGridTemplateColumns(DEFAULT_GRID_COLUMNS)).toEqual([2, 3, 4])
+  })
+
+  it('never exceeds the requested count at any breakpoint', () => {
+    expect(resolveGridTemplateColumns(1)).toEqual([1, 1, 1])
+    expect(resolveGridTemplateColumns(2)).toEqual([2, 2, 2])
+    expect(resolveGridTemplateColumns(3)).toEqual([2, 3, 3])
+  })
+
+  it('steps up to the requested count on wider breakpoints', () => {
+    expect(resolveGridTemplateColumns(6)).toEqual([2, 3, 6])
+    expect(resolveGridTemplateColumns(12)).toEqual([2, 3, 12])
+  })
+
+  it('falls back to the default for values that cannot describe a grid', () => {
+    // `columns` comes from userland schema config, so it is not necessarily sane.
+    expect(resolveGridTemplateColumns(0)).toEqual([2, 3, 4])
+    expect(resolveGridTemplateColumns(-3)).toEqual([2, 3, 4])
+    expect(resolveGridTemplateColumns(Number.NaN)).toEqual([2, 3, 4])
+    expect(resolveGridTemplateColumns(Number.POSITIVE_INFINITY)).toEqual([2, 3, 4])
+  })
+
+  it('truncates fractional counts rather than emitting a fractional track count', () => {
+    expect(resolveGridTemplateColumns(3.7)).toEqual([2, 3, 3])
+  })
+})

--- a/packages/sanity/src/core/form/inputs/arrays/common/gridColumns.ts
+++ b/packages/sanity/src/core/form/inputs/arrays/common/gridColumns.ts
@@ -1,0 +1,26 @@
+/**
+ * The number of columns a `layout: 'grid'` array renders at when `options.columns`
+ * is not set. Chosen so the default stays exactly what it has always been: the
+ * responsive ramp below expands `4` to `[2, 3, 4]`.
+ */
+export const DEFAULT_GRID_COLUMNS = 4
+
+/**
+ * Resolves `options.columns` to a Sanity UI responsive `gridTemplateColumns` value.
+ *
+ * The requested count applies at the widest breakpoint and steps down on narrower
+ * ones, so a wide grid stays usable on small screens rather than producing columns
+ * too thin to read. The ramp never exceeds the requested count, so asking for fewer
+ * columns than the default is honoured at every breakpoint (`2` -> `[2, 2, 2]`).
+ *
+ * Non-finite, zero and negative values fall back to the default rather than
+ * producing an invalid grid — `columns` comes from userland schema config.
+ */
+export function resolveGridTemplateColumns(columns: number | undefined): number[] {
+  const requested =
+    typeof columns === 'number' && Number.isFinite(columns) && columns >= 1
+      ? Math.floor(columns)
+      : DEFAULT_GRID_COLUMNS
+
+  return [Math.min(2, requested), Math.min(3, requested), requested]
+}


### PR DESCRIPTION
### Description

Grid arrays hardcoded a responsive `[2, 3, 4]` column ramp, so a gallery of small thumbnails and one of large cards were stuck at the same width with no way to influence it.

`options.columns` now sets the column count at the widest breakpoint:

```ts
defineField({
  name: 'gallery',
  type: 'array',
  of: [{type: 'image'}],
  options: {layout: 'grid', columns: 2},
})
```

The design point worth checking is the default. `columns` defaults to `4`, and the ramp expands `4` back to `[2, 3, 4]` — so today's behaviour *is* the default rather than a special case sitting beside it, and there is no separate "unset" code path to keep in sync.

The ramp is `[min(2, n), min(3, n), n]`. It steps down on narrower breakpoints so a wide grid stays usable on a phone, and it never exceeds the requested count, so `columns: 2` gives two columns everywhere instead of being widened at small sizes.

Rejected: applying the number flat at every breakpoint. `columns: 8` would then render eight tracks on a phone, and the responsive behaviour that already exists is the reason grid arrays are usable on small screens today.

### What to review

The main judgement call is the ramp formula in `common/gridColumns.ts` — whether stepping down on narrow breakpoints is the right call versus honouring the number literally.

Applied to all four renderers that respect `layout: 'grid'`, so the option behaves the same wherever it is set:

- `ArrayOfObjectsInput/Grid/GridArrayInput.tsx` and `ArrayOfPrimitivesInput.tsx` — both previously hardcoded `[2, 3, 4]`
- `ArrayOfOptionsInput/ArrayOf{Object,Primitive}OptionsInput.tsx` — the checkbox grids. These are the odd ones out: they previously used `Math.min(options.length, 4)` and are **not** responsive. They keep the `options.length` cap (a grid cannot usefully have more tracks than checkboxes) and just take the count from `columns`. Worth confirming that's the behaviour you want rather than making them responsive too.

Also confirmed no validator change is needed — unlike block styles, array `options` are not checked against an allow-list, so `columns` passes schema validation as-is.

### Testing

`resolveGridTemplateColumns` is a pure function, so it's unit tested directly (5 cases): the default reproducing `[2, 3, 4]` exactly, never exceeding the requested count, stepping up on wider breakpoints, and falling back to the default for values that cannot describe a grid (zero, negative, non-finite, fractional) — `columns` is userland config and is not validated, so those are reachable.

`pnpm vitest run --project=sanity packages/sanity/src/core/form/inputs/arrays` — 34 passed, no type errors. Lint clean.

Three fields added to the test studio (`Arrays` document) for visual verification: image grids at `columns: 2` and `columns: 6`, and a primitive string grid at `columns: 2`.

### Notes for release

Arrays using `layout: 'grid'` now accept a `columns` option to control how many columns are rendered:

```ts
defineField({
  name: 'gallery',
  title: 'Gallery',
  type: 'array',
  of: [{type: 'image'}],
  options: {layout: 'grid', columns: 2},
})
```

The count applies at the widest breakpoint and steps down on narrower ones so the grid stays readable on small screens. It defaults to `4`, which matches how grid arrays have always rendered, so existing schemas are unaffected.

---