### PR TITLE
fix(core): report array items whose type is not an allowed type

### DIFF
--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -89,10 +89,14 @@ export function resolveTypeForArrayItem(
   item: unknown,
   candidates: SchemaType[],
 ): SchemaType | undefined {
-  // if there is only one type available, assume that it's the correct one
-  if (candidates.length === 1) return candidates[0]
-
   const itemType = isTypedObject(item) && item._type
+
+  // Infer the sole candidate only when the item does not declare a type of its own.
+  // An explicit `_type` still has to match a candidate: inferring it here would
+  // validate the item's remaining fields against a type the array does not allow,
+  // and report nothing at all.
+  if (candidates.length === 1 && !itemType) return candidates[0]
+
   const primitive =
     item === undefined || item === null || (!itemType && typeString(item).toLowerCase())
 
@@ -490,18 +494,36 @@ function validateItemObservable({
 
   if (shouldRunNestedValidationForArrays) {
     nestedChecks = nestedChecks.concat(
-      value.map((item, index) =>
-        validateItemObservable({
+      value.map((item, index) => {
+        const itemPath = path.concat(isKeyedObject(item) ? {_key: item._key} : index)
+        const itemType = resolveTypeForArrayItem(item, type.of)
+
+        // An item declaring a `_type` that no candidate matches cannot be validated
+        // against anything: an unresolved type normalizes to zero rules, so without a
+        // marker here the item would pass validation silently.
+        if (!itemType && isTypedObject(item)) {
+          return of([
+            {
+              level: 'error' as const,
+              message: `Array item type "${item._type}" is not allowed here. Allowed types: ${type.of
+                .map((candidate) => `"${candidate.name}"`)
+                .join(', ')}`,
+              path: itemPath,
+            },
+          ])
+        }
+
+        return validateItemObservable({
           ...restOfContext,
           hidden,
           parent: value,
           value: item,
-          path: path.concat(isKeyedObject(item) ? {_key: item._key} : index),
-          type: resolveTypeForArrayItem(item, type.of),
+          path: itemPath,
+          type: itemType,
           environment,
           customValidationConcurrencyLimiter,
-        }),
-      ),
+        })
+      }),
     )
   }
 

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -94,6 +94,35 @@ describe('resolveTypeForArrayItem', () => {
 
     expect(resolved).toBe(fooType)
   })
+
+  it('does not assume the sole candidate when the item declares a mismatched _type', () => {
+    // Regression test for SAPP-4206. Returning the sole candidate before looking at
+    // `_type` validated the item's other fields against a type the array does not
+    // allow, and reported nothing.
+    const resolved = resolveTypeForArrayItem(
+      {
+        _type: 'notAllowed',
+        _key: 'exampleKey',
+        title: 5,
+      },
+      [fooType!],
+    )
+
+    expect(resolved).toBeUndefined()
+  })
+
+  it('still resolves the sole candidate when the item declares a matching _type', () => {
+    const resolved = resolveTypeForArrayItem(
+      {
+        _type: 'foo',
+        _key: 'exampleKey',
+        title: 5,
+      },
+      [fooType!],
+    )
+
+    expect(resolved).toBe(fooType)
+  })
 })
 
 describe('validateDocument', () => {
@@ -144,6 +173,89 @@ describe('validateDocument', () => {
         path: ['title'],
       },
     ])
+  })
+
+  it('reports an array item whose _type is not among the allowed types', async () => {
+    // Repro from SAPP-4206: a single-candidate array silently accepted an item
+    // declaring a type it does not allow, because the sole candidate was inferred
+    // before `_type` was ever consulted. The remaining fields are deliberately
+    // valid for `foo`, so this only produced a marker once the type mismatch was
+    // reported in its own right.
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        {
+          name: 'foo',
+          type: 'object',
+          fields: [{name: 'title', type: 'string'}],
+        },
+        {
+          name: 'arrayDoc',
+          type: 'document',
+          fields: [{name: 'items', type: 'array', of: [{type: 'foo'}]}],
+        },
+      ],
+    })
+
+    const document: SanityDocument = {
+      _id: 'testId',
+      _createdAt: '2021-08-27T14:48:51.650Z',
+      _rev: 'exampleRev',
+      _type: 'arrayDoc',
+      _updatedAt: '2021-08-27T14:48:51.650Z',
+      items: [{_key: 'a', _type: 'notAllowed', title: 'valid for foo'}],
+    }
+
+    const result = await validateDocument({
+      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
+      getClient,
+      document,
+      workspace: {schema} as Workspace,
+    })
+
+    expect(result).toMatchObject([
+      {
+        level: 'error',
+        message: 'Array item type "notAllowed" is not allowed here. Allowed types: "foo"',
+        path: ['items', {_key: 'a'}],
+      },
+    ])
+  })
+
+  it('does not report an array item whose _type matches an allowed type', async () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        {
+          name: 'foo',
+          type: 'object',
+          fields: [{name: 'title', type: 'string'}],
+        },
+        {
+          name: 'arrayDoc',
+          type: 'document',
+          fields: [{name: 'items', type: 'array', of: [{type: 'foo'}]}],
+        },
+      ],
+    })
+
+    const document: SanityDocument = {
+      _id: 'testId',
+      _createdAt: '2021-08-27T14:48:51.650Z',
+      _rev: 'exampleRev',
+      _type: 'arrayDoc',
+      _updatedAt: '2021-08-27T14:48:51.650Z',
+      items: [{_key: 'a', _type: 'foo', title: 'valid'}],
+    }
+
+    const result = await validateDocument({
+      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
+      getClient,
+      document,
+      workspace: {schema} as Workspace,
+    })
+
+    expect(result).toEqual([])
   })
 })
 


### PR DESCRIPTION
### Description

`resolveTypeForArrayItem` returned the sole candidate before ever looking at the item's `_type`, so a single-candidate array accepted an item declaring a type it does not allow. The item's remaining fields were then validated against the wrong type — and when they happened to be valid for it, validation reported nothing at all. Fixes [SAPP-4206](https://linear.app/sanity/issue/SAPP-4206) (inherited Studio behaviour, surfaced by headless/MCP validation).

Repro from the issue — schema `{type: 'array', of: [{type: 'foo'}]}`, value `[{_key: 'a', _type: 'notAllowed'}]`, no marker produced.

The part worth knowing is that **the one-line fix isn't sufficient on its own.** Making the resolver return `undefined` for a mismatch just trades a wrong-type pass for silence: `normalizeValidationRules(undefined)` returns `[]`, so an unresolved type yields no rules and therefore no markers. That's the same silent hole multi-candidate arrays already had — a bogus `_type` in an array with two or more candidates has always resolved to `undefined` and validated to nothing.

So this does two things: stops inferring the sole candidate when `_type` is present, and emits an error marker at the array call site for any item declaring a `_type` no candidate matches. The second half is what actually closes the issue, and it fixes the multi-candidate case too.

### What to review

One file plus its tests. Two judgement calls I'd like a second opinion on:

- **Severity.** I used `error`. The nearest precedent, `unknownFieldsValidator`, is a `warning` — but an unknown *field* is milder than an item whose type the array doesn't permit, and the form already treats these as incompatible (`IncompatibleItemType`). Easy to downgrade if you'd rather.
- **Breadth.** The marker fires for every unresolvable explicit `_type`, not only the single-candidate case in the issue. That's the consistent reading of "report an invalid array-item type" and closes the multi-candidate silence, but it is a wider behaviour change than the issue strictly asks for.

Inference is unchanged when `_type` is absent — the existing `assumes the type if there is only one possible candidate` test covers exactly that and still passes untouched. I also walked the matching fallbacks for the shapes that rely on them (named array members resolving via `candidate.type?.name`, `image`/`reference`/`block` members resolving via `candidate.name`) since those now go through the matching path instead of the shortcut.

### Testing

`pnpm vitest run --project=sanity packages/sanity/test/validation packages/sanity/src/core/validation` — 124 passed, 1 skipped, no type errors. Lint clean.

Four tests added: two unit tests on the resolver (mismatched `_type` no longer infers; matching `_type` still resolves) and two end-to-end through `validateDocument` — the issue's exact repro asserting a marker at `['items', {_key: 'a'}]`, and a matching-`_type` document asserting no markers so the new marker can't fire on valid content.

Both new failing-path tests were verified red against the unpatched file.

### Notes for release

Fixed document validation silently accepting array items whose `_type` is not one of the array's allowed types. Previously, an array declaring a single member type would infer that type for every item regardless of the item's own `_type`, validate the rest of the item against it, and report no error when those fields happened to be valid.

Such items now produce a validation error naming the offending type and the allowed types.

Note this can surface new validation errors on existing content that was previously passing — content whose array items carry a `_type` the schema does not list (for example left behind by a partial migration or a schema rename) will now be reported rather than silently accepted.

---