### PR TITLE
feat(form): make the useFormValue path optional

### DIFF
--- a/packages/sanity/src/core/form/contexts/FormValue.tsx
+++ b/packages/sanity/src/core/form/contexts/FormValue.tsx
@@ -27,17 +27,22 @@ export function FormValueProvider(props: {
   return <FormValueContext.Provider value={value}>{props.children}</FormValueContext.Provider>
 }
 
+const ROOT_PATH: Path = []
+
 /**
- * React hook that returns the value of the field specified by a path.
+ * React hook that returns the value of the field specified by a path, or the whole
+ * document when called without one.
  * @public
  *
- * @param path - An array notation with segments that are either strings representing field names, index integers for arrays with simple values, or objects with a _key for arrays containing objects
+ * @param path - An array notation with segments that are either strings representing field names, index integers for arrays with simple values, or objects with a _key for arrays containing objects. Defaults to the document root.
  *
- * @returns The value of the field specified by the path
+ * @returns The value of the field specified by the path, or the whole document if no path is given
  *
  * @example Using the `useFormValue` hook
  * ```ts
  * function MyComponent() {
+ *    // get the whole document
+ *    const document = useFormValue()
  *    // get value of field 'name' in object 'author'
  *    const authorName = useFormValue(['author', 'name'])
  *    // get value of the second item in array 'tags' of type 'string'
@@ -49,7 +54,7 @@ export function FormValueProvider(props: {
  * ```
  */
 
-export function useFormValue(path: Path): unknown {
+export function useFormValue(path: Path = ROOT_PATH): unknown {
   const uniquePath = pathFor(path)
   const ctx = useContext(FormValueContext)
   if (!ctx) {

--- a/packages/sanity/src/core/form/contexts/__tests__/FormValue.test.tsx
+++ b/packages/sanity/src/core/form/contexts/__tests__/FormValue.test.tsx
@@ -1,0 +1,58 @@
+import {renderHook} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {describe, expect, it} from 'vitest'
+
+import {type FormDocumentValue} from '../../types/formDocumentValue'
+import {FormValueProvider, useFormValue} from '../FormValue'
+
+const document = {
+  _id: 'drafts.doc1',
+  _type: 'author',
+  name: 'Ada',
+  address: {city: 'London'},
+  tags: ['a', 'b'],
+  books: [{_key: 'k1', title: 'First'}],
+} as unknown as FormDocumentValue
+
+function wrapper({children}: {children: ReactNode}) {
+  return <FormValueProvider value={document}>{children}</FormValueProvider>
+}
+
+describe('useFormValue', () => {
+  it('returns the whole document when called without a path', () => {
+    const {result} = renderHook(() => useFormValue(), {wrapper})
+
+    expect(result.current).toBe(document)
+  })
+
+  it('returns the whole document when called with an empty path', () => {
+    // The documented workaround before the path became optional — it must keep working.
+    const {result} = renderHook(() => useFormValue([]), {wrapper})
+
+    expect(result.current).toBe(document)
+  })
+
+  it('resolves a nested field path', () => {
+    const {result} = renderHook(() => useFormValue(['address', 'city']), {wrapper})
+
+    expect(result.current).toBe('London')
+  })
+
+  it('resolves an indexed path into an array of primitives', () => {
+    const {result} = renderHook(() => useFormValue(['tags', 1]), {wrapper})
+
+    expect(result.current).toBe('b')
+  })
+
+  it('resolves a keyed path into an array of objects', () => {
+    const {result} = renderHook(() => useFormValue(['books', {_key: 'k1'}, 'title']), {wrapper})
+
+    expect(result.current).toBe('First')
+  })
+
+  it('throws when used outside a FormValueProvider', () => {
+    expect(() => renderHook(() => useFormValue())).toThrow(
+      'useFormValue must be used within a FormValueProvider',
+    )
+  })
+})


### PR DESCRIPTION
### Description

`useFormValue` required a path, so reading the whole document meant calling `useFormValue([])`. That workaround is common enough that the customer on the linked ticket wrapped it in their own helper (`const useDocumentValue = () => useFormValue([]) as T`) and asked whether there was a reason not to. Implements [SAPP-1403](https://linear.app/sanity/issue/SAPP-1403) ("Easy Wins" milestone).

The path now defaults to the document root, so `useFormValue()` returns the whole document. `useFormValue([])` keeps working — the default *is* the same root path rather than a separate branch, so there is one code path, not two.

**The issue's second ask is deliberately not implemented.** It also wants a parent value ("if you pass in parent it will give you the value of the parent"). That isn't implementable as a context-only hook: there is no ambient current-field-path context in the form (`FormValueContext` carries the document value only), so a zero-argument `useParentValue()` would mean threading a new path context through every input — not an easy win, and a design decision beyond this ticket. The customer's own workaround needs the input's props for exactly this reason:

```ts
const useParentValue = (props: ObjectInputProps) => useFormValue(props.path.slice(0, -1))
```

Since the caller must supply its own path either way, that half is better handled as its own issue. Happy to write it up if you want it tracked.

### What to review

One file plus a new test file. The change itself is a default parameter; the thing worth a glance is that `ROOT_PATH` is a module-level constant rather than an inline `[]` default, so every no-argument call passes the same reference into `pathFor` instead of a fresh array each render.

### Testing

New `contexts/__tests__/FormValue.test.tsx` — there was no test file for this hook before. Six cases: no-argument returning the whole document, the `[]` workaround still returning it, nested field paths, indexed paths into primitive arrays, keyed paths into object arrays, and the outside-provider throw.

The nested/indexed/keyed cases are there to pin that adding a default didn't disturb normal path resolution; they pass both before and after. The no-argument case was verified failing against the unpatched hook.

`pnpm vitest run --project=sanity packages/sanity/src/core/form/contexts` — 6 passed, no type errors. Lint clean.

### Notes for release

`useFormValue` can now be called without a path to get the whole document:

```ts
// before
const document = useFormValue([])

// now
const document = useFormValue()
```

Passing an explicit path — including `[]` — behaves exactly as before, so this is purely additive.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single optional-parameter change on a public form hook with backward-compatible behavior and new unit tests only.
> 
> **Overview**
> **`useFormValue`** no longer requires a path to read the full document: calling it with no arguments returns the whole form document, replacing the common **`useFormValue([])`** workaround.
> 
> The default is a shared **`ROOT_PATH`** constant (empty path), so no-arg calls reuse the same reference through **`pathFor`** instead of allocating a new **`[]`** each render. Explicit paths—including **`[]`**—behave unchanged, and JSDoc/examples now document the no-argument usage.
> 
> Adds **`FormValue.test.tsx`** with six cases covering no-arg and **`[]`** document reads, nested/indexed/keyed paths, and the outside-provider error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c71a33405b4a71affec1ce00e04bde63053b9983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->