### PR TITLE
feat(form): name the field in the invalid data type warning

### DIFF
--- a/packages/sanity/src/core/form/inputs/InvalidValueInput/InvalidValueInput.tsx
+++ b/packages/sanity/src/core/form/inputs/InvalidValueInput/InvalidValueInput.tsx
@@ -39,10 +39,14 @@ interface InvalidValueProps {
   validTypes: string[]
   value?: unknown
   onChange: (event: PatchEvent) => void
+  /** The schema name of the field this value belongs to, shown under developer info. */
+  fieldName?: string
+  /** The human-readable title of the field, used to say which field is affected. */
+  fieldTitle?: string
 }
 
 export function InvalidValueInput(props: InvalidValueProps & RefAttributes<{focus: () => void}>) {
-  const {ref, value, actualType, validTypes, onChange} = props
+  const {ref, value, actualType, validTypes, onChange, fieldName, fieldTitle} = props
 
   useImperativeHandle(ref, () => ({
     // @todo
@@ -87,14 +91,31 @@ export function InvalidValueInput(props: InvalidValueProps & RefAttributes<{focu
     </Stack>
   )
 
+  // Name the affected field in the title where we know it — the alert renders inline
+  // with the field, but a document with several of these is otherwise a wall of
+  // identical "Invalid property value" headings.
+  const title = fieldTitle
+    ? t('inputs.invalid-value.title-with-field', {fieldTitle})
+    : t('inputs.invalid-value.title')
+
   return (
-    <Alert status="error" suffix={suffix} title={t('inputs.invalid-value.title')}>
+    <Alert status="error" suffix={suffix} title={title}>
       <Text as="p" muted size={1}>
         {t('inputs.invalid-value.description')}
       </Text>
 
       <Details marginTop={4} open={isDev} title={t('inputs.invalid-value.details.title')}>
         <Stack gap={3}>
+          {fieldName && (
+            <Text as="p" muted size={1}>
+              <Translate
+                t={t}
+                i18nKey="inputs.invalid-value.details.field-name"
+                values={{fieldName}}
+              />
+            </Text>
+          )}
+
           {validTypes.length === 1 && (
             <Text as="p" muted size={1}>
               <Translate

--- a/packages/sanity/src/core/form/inputs/InvalidValueInput/__tests__/InvalidValueInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/InvalidValueInput/__tests__/InvalidValueInput.test.tsx
@@ -1,0 +1,65 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {InvalidValueInput} from '../InvalidValueInput'
+
+const baseProps = {
+  actualType: 'string',
+  validTypes: ['number'],
+  value: 'not a number',
+  onChange: vi.fn(),
+}
+
+describe('InvalidValueInput', () => {
+  it('names the affected field in the title when a field title is given', async () => {
+    const TestProvider = await createTestProvider({})
+
+    render(
+      <TestProvider>
+        <InvalidValueInput {...baseProps} fieldName="rating" fieldTitle="Rating" />
+      </TestProvider>,
+    )
+
+    expect(screen.getByText('Invalid data for Rating')).toBeInTheDocument()
+  })
+
+  it('falls back to the generic title when no field title is given', async () => {
+    // Not every caller knows a title — an untitled schema type has none.
+    const TestProvider = await createTestProvider({})
+
+    render(
+      <TestProvider>
+        <InvalidValueInput {...baseProps} fieldName="rating" />
+      </TestProvider>,
+    )
+
+    expect(screen.getByText('Invalid property value')).toBeInTheDocument()
+  })
+
+  it('shows the schema field name under developer info', async () => {
+    const TestProvider = await createTestProvider({})
+
+    render(
+      <TestProvider>
+        <InvalidValueInput {...baseProps} fieldName="rating" fieldTitle="Rating" />
+      </TestProvider>,
+    )
+
+    expect(screen.getByText(/Field name:/)).toBeInTheDocument()
+    expect(screen.getByText('rating')).toBeInTheDocument()
+  })
+
+  it('labels the destructive action as unsetting rather than resetting', async () => {
+    // The button dispatches `unset()`, so "Reset value" described the wrong operation.
+    const TestProvider = await createTestProvider({})
+
+    render(
+      <TestProvider>
+        <InvalidValueInput {...baseProps} fieldName="rating" fieldTitle="Rating" />
+      </TestProvider>,
+    )
+
+    expect(screen.getByRole('button', {name: 'Unset value'})).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/form/members/object/MemberFieldError.tsx
+++ b/packages/sanity/src/core/form/members/object/MemberFieldError.tsx
@@ -31,6 +31,8 @@ export function MemberFieldError(props: {member: FieldError}) {
         onChange={handleChange}
         actualType={member.error.resolvedValueType}
         validTypes={[member.error.expectedSchemaType.name]}
+        fieldName={member.fieldName}
+        fieldTitle={member.error.expectedSchemaType.title}
       />
     )
   }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1005,12 +1005,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'inputs.invalid-value.convert-button.text': 'Convert to {{targetType}}',
   /** The current value (<code>`{{actualType}}`</code>) */
   'inputs.invalid-value.current-type': 'The current value (<code>{{actualType}}</code>)',
-  /** The property value is stored as a value type that does not match the expected type. */
+  /** This field has content in a data type that is different from this field's configuration in the Studio schema. */
   'inputs.invalid-value.description':
-    'The property value is stored as a value type that does not match the expected type.',
+    "This field has content in a data type that is different from this field's configuration in the Studio schema.",
   /** The value of this property must be of type <code>`{{validType}}`</code> according to the schema. */
   'inputs.invalid-value.details.description':
     'The value of this property must be of type <code>{{validType}}</code> according to the schema.',
+  /** Field name: <code>`{{fieldName}}`</code> */
+  'inputs.invalid-value.details.field-name': 'Field name: <code>{{fieldName}}</code>',
   /** Only the following types are valid here according to schema: */
   'inputs.invalid-value.details.multi-type-description':
     'Only the following types are valid here according to schema:',
@@ -1020,10 +1022,12 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Developer info */
   'inputs.invalid-value.details.title': 'Developer info',
   /** -- Invalid Value Input -- */
-  /** Reset value */
-  'inputs.invalid-value.reset-button.text': 'Reset value',
+  /** Unset value */
+  'inputs.invalid-value.reset-button.text': 'Unset value',
   /** Invalid property value */
   'inputs.invalid-value.title': 'Invalid property value',
+  /** Invalid data for `{{fieldTitle}}` */
+  'inputs.invalid-value.title-with-field': 'Invalid data for {{fieldTitle}}',
   /** Title for the "All fields" field group */
   'inputs.object.field-group-tabs.all-fields-title': 'All fields',
   /** Aria label for the "Field groups" select control on smaller screens */


### PR DESCRIPTION
### Description

Knut's feedback on this warning ([SAPP-1407](https://linear.app/sanity/issue/SAPP-1407), "Easy Wins"): the verbiage is hard to parse, it never says *which* field is affected, and it calls the action "Reset" when the button actually dispatches `unset()`.

This addresses the mechanical parts of that proposal:

- **The alert names the field** when a title is known. Previously a document with several invalid values rendered a wall of identical "Invalid property value" headings with nothing distinguishing them.
- **Developer info gains the schema field name** — the piece you actually need to find the field in the schema. It was already available at the call site (`member.fieldName`), just never passed down.
- **"Reset value" becomes "Unset value"**, matching both the patch it dispatches and the terminology used elsewhere.
- The description adopts Knut's wording, which drops "property value ... value type" in favour of language that matches the docs.

**Deliberately not implemented**, because each needs input this PR can't supply:

- the "Learn about field migrations" link needs a real docs URL
- "Contact an admin on this project" needs the manage project path and a product decision on whether to surface it
- making the action harder to trigger accidentally (a confirmation step) is a design call
- hinting that unsetting can be reverted is a factual claim I'd want confirmed before putting it in the UI

Happy to follow up on any of those with the URLs/decisions.

### What to review

Mostly a copy change; the structural part is two new optional props on `InvalidValueInput` (`fieldName`, `fieldTitle`) threaded from `MemberFieldError`.

Both are optional and the component falls back to the existing generic title when no title is given — `expectedSchemaType.title` is not guaranteed, so an untitled schema type still renders sensibly rather than "Invalid data for undefined".

Copy under review, since this is a UX ticket and the wording is the substance:

| key | before | after |
| --- | --- | --- |
| `title-with-field` (new) | — | `Invalid data for {{fieldTitle}}` |
| `description` | The property value is stored as a value type that does not match the expected type. | This field has content in a data type that is different from this field's configuration in the Studio schema. |
| `details.field-name` (new) | — | `Field name: <code>{{fieldName}}</code>` |
| `reset-button.text` | Reset value | Unset value |

Only English strings in `bundles/studio.ts` change here; translations live in the locale packages and fall back until updated.

### Testing

New `InvalidValueInput/__tests__/InvalidValueInput.test.tsx` — the component had no tests. Four cases: the field-named title, the fallback title when no title is given, the field name under developer info, and the button labelled "Unset value".

Three of the four were verified failing against the unpatched component and bundle; the fallback-title case passes both before and after by design, since it pins the behaviour that must not regress.

`pnpm vitest run --project=sanity` over `InvalidValueInput`, `form/members` and `core/i18n` — 46 passed, 1 skipped, no type errors. Lint clean.

### Notes for release

The warning shown when a field's stored value doesn't match its schema type is clearer:

- it now names the affected field in the heading, rather than showing an identical "Invalid property value" heading for every affected field
- developer info includes the schema field name
- the action is labelled "Unset value" instead of "Reset value", matching what it does
- the explanation has been reworded to match the language used in the docs

---