### PR TITLE
feat(validation): add cancellation support

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.types.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.types.test-d.ts
@@ -1421,6 +1421,7 @@ describe('@sanity/types', () => {
   })
   test('ValidationContext', () => {
     expectTypeOf<ValidationContext>().toBeObject()
+    expectTypeOf<ValidationContext['signal']>().toEqualTypeOf<AbortSignal | undefined>()
   })
   test('ValidationError', () => {
     expectTypeOf<ValidationError>().toBeObject()

--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation._internal.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation._internal.test-d.ts
@@ -4,6 +4,8 @@
 
 import type {
   convertToValidationMarker,
+  evaluateDocumentInternal,
+  evaluateDocumentObservable,
   getFallbackLocaleSource,
   getTypeChain,
   hasValidationContext,
@@ -20,6 +22,7 @@ import type {
   validateDocumentObservable,
   ValidateDocumentObservableOptions,
   validateItem,
+  ValidateItemOptions,
   ValidationContext,
   validationLocaleStrings,
 } from '@sanity/validation/_internal'
@@ -28,6 +31,12 @@ import {describe, expectTypeOf, test} from 'vitest'
 describe('@sanity/validation/_internal', () => {
   test('convertToValidationMarker', () => {
     expectTypeOf<typeof convertToValidationMarker>().toBeFunction()
+  })
+  test('evaluateDocumentInternal', () => {
+    expectTypeOf<typeof evaluateDocumentInternal>().toBeFunction()
+  })
+  test('evaluateDocumentObservable', () => {
+    expectTypeOf<typeof evaluateDocumentObservable>().toBeFunction()
   })
   test('getFallbackLocaleSource', () => {
     expectTypeOf<typeof getFallbackLocaleSource>().toBeFunction()
@@ -68,15 +77,24 @@ describe('@sanity/validation/_internal', () => {
   })
   test('ValidateDocumentInternalOptions', () => {
     expectTypeOf<ValidateDocumentInternalOptions>().toBeObject()
+    expectTypeOf<ValidateDocumentInternalOptions['signal']>().toEqualTypeOf<
+      AbortSignal | undefined
+    >()
   })
   test('validateDocumentObservable', () => {
     expectTypeOf<typeof validateDocumentObservable>().toBeFunction()
   })
   test('ValidateDocumentObservableOptions', () => {
     expectTypeOf<ValidateDocumentObservableOptions>().toBeObject()
+    expectTypeOf<ValidateDocumentObservableOptions['signal']>().toEqualTypeOf<
+      AbortSignal | undefined
+    >()
   })
   test('validateItem', () => {
     expectTypeOf<typeof validateItem>().toBeFunction()
+  })
+  test('ValidateItemOptions', () => {
+    expectTypeOf<ValidateItemOptions['signal']>().toEqualTypeOf<AbortSignal | undefined>()
   })
   test('ValidationContext', () => {
     // This export has 2 declarations, run `TEST_DTS_EXPORTS_DIAGNOSTICS=duplicates pnpm generate:dts-exports` to see where each declaration is coming from

--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
@@ -37,12 +37,16 @@ describe('@sanity/validation', () => {
   })
   test('ValidateDocumentOptions', () => {
     expectTypeOf<ValidateDocumentOptions>().toBeObject()
+    expectTypeOf<ValidateDocumentOptions['signal']>().toEqualTypeOf<AbortSignal | undefined>()
   })
   test('validateDocumentWithWorkspace', () => {
     expectTypeOf<typeof validateDocumentWithWorkspace>().toBeFunction()
   })
   test('ValidateDocumentWorkspaceOptions', () => {
     expectTypeOf<ValidateDocumentWorkspaceOptions>().toBeObject()
+    expectTypeOf<ValidateDocumentWorkspaceOptions['signal']>().toEqualTypeOf<
+      AbortSignal | undefined
+    >()
   })
   test('ValidationClient', () => {
     expectTypeOf<ValidationClient>().toBeObject()

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -266,8 +266,10 @@ export interface ValidationContext {
   type?: SchemaType
   document?: SanityDocument
   path?: Path
-  getDocumentExists?: (options: {id: string}) => Promise<boolean>
+  getDocumentExists?: (options: {id: string; signal?: AbortSignal}) => Promise<boolean>
   environment: 'cli' | 'studio'
+  /** Signal used to cancel validation and any work it starts. */
+  signal?: AbortSignal
   /**
    * Whether this field is hidden for any reason (either itself or any of its ancestors).
    */

--- a/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
@@ -1,7 +1,7 @@
 import {types} from 'node:util'
 
 import {createClient, type SanityClient} from '@sanity/client'
-import {firstValueFrom, from, of} from 'rxjs'
+import {firstValueFrom, from, NEVER, Observable, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createClientConcurrencyLimiter} from '../createClientConcurrencyLimiter'
@@ -150,5 +150,136 @@ describe('createConcurrencyLimitedClient', () => {
     deferredPromise.resolve()
     await active
     expect(mockClient.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases an active Observable fetch when its signal is aborted', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    const unsubscribe = vi.fn()
+    const mockClient = {
+      observable: {
+        fetch: vi
+          .fn()
+          .mockImplementationOnce(
+            (_query: string, _params: object, {signal}: {signal: AbortSignal}) =>
+              new Observable((subscriber) => {
+                const onAbort = () => subscriber.error(signal.reason)
+                signal.addEventListener('abort', onAbort, {once: true})
+                return () => {
+                  signal.removeEventListener('abort', onAbort)
+                  unsubscribe()
+                }
+              }),
+          )
+          .mockImplementationOnce(() => of('next')),
+      },
+    } as unknown as SanityClient
+    const client = createClientConcurrencyLimiter(1)(mockClient)
+    const active = firstValueFrom(
+      client.observable.fetch('active', {}, {signal: controller.signal}),
+    )
+    await vi.waitFor(() => expect(mockClient.observable.fetch).toHaveBeenCalledOnce())
+
+    controller.abort(reason)
+
+    await expect(active).rejects.toBe(reason)
+    await expect(firstValueFrom(client.observable.fetch('next'))).resolves.toBe('next')
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('releases an active Observable fetch when unsubscribed', async () => {
+    const fetch = vi
+      .fn()
+      .mockImplementationOnce(() => NEVER)
+      .mockImplementationOnce(() => of('next'))
+    const client = createClientConcurrencyLimiter(1)({
+      observable: {fetch},
+    } as unknown as SanityClient)
+    const active = client.observable.fetch('active').subscribe()
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+
+    active.unsubscribe()
+
+    await expect(firstValueFrom(client.observable.fetch('next'))).resolves.toBe('next')
+  })
+
+  it('adds a default signal to promise and Observable fetches', async () => {
+    const controller = new AbortController()
+    const mockClient = {
+      fetch: vi.fn(async () => 'promise result'),
+      observable: {fetch: vi.fn(() => of('observable result'))},
+    } as unknown as SanityClient
+    const client = createClientConcurrencyLimiter(1, controller.signal)(mockClient)
+
+    await expect(client.fetch('promise')).resolves.toBe('promise result')
+    await expect(firstValueFrom(client.observable.fetch('observable'))).resolves.toBe(
+      'observable result',
+    )
+
+    expect(mockClient.fetch).toHaveBeenCalledWith(
+      'promise',
+      undefined,
+      expect.objectContaining({signal: controller.signal}),
+    )
+    expect(mockClient.observable.fetch).toHaveBeenCalledWith(
+      'observable',
+      undefined,
+      expect.objectContaining({signal: controller.signal}),
+    )
+  })
+
+  it('combines a default signal with a fetch signal', async () => {
+    const defaultController = new AbortController()
+    const fetchController = new AbortController()
+    const reason = new Error('validation cancelled')
+    const mockClient = {
+      fetch: vi.fn(
+        (_query: string, _params: object, {signal}: {signal: AbortSignal}) =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+          }),
+      ),
+    } as unknown as SanityClient
+    const client = createClientConcurrencyLimiter(1, defaultController.signal)(mockClient)
+    const result = client.fetch('query', {}, {signal: fetchController.signal})
+    await vi.waitFor(() => expect(mockClient.fetch).toHaveBeenCalledOnce())
+
+    defaultController.abort(reason)
+
+    await expect(result).rejects.toBe(reason)
+    expect(fetchController.signal.aborted).toBe(false)
+  })
+
+  it('combines a default signal with an Observable fetch signal', async () => {
+    const defaultController = new AbortController()
+    const fetchController = new AbortController()
+    const reason = new Error('validation cancelled')
+    const unsubscribe = vi.fn()
+    const mockClient = {
+      observable: {
+        fetch: vi.fn(
+          (_query: string, _params: object, {signal}: {signal: AbortSignal}) =>
+            new Observable((subscriber) => {
+              const onAbort = () => subscriber.error(signal.reason)
+              signal.addEventListener('abort', onAbort, {once: true})
+              return () => {
+                signal.removeEventListener('abort', onAbort)
+                unsubscribe()
+              }
+            }),
+        ),
+      },
+    } as unknown as SanityClient
+    const client = createClientConcurrencyLimiter(1, defaultController.signal)(mockClient)
+    const result = firstValueFrom(
+      client.observable.fetch('query', {}, {signal: fetchController.signal}),
+    )
+    await vi.waitFor(() => expect(mockClient.observable.fetch).toHaveBeenCalledOnce())
+
+    defaultController.abort(reason)
+
+    await expect(result).rejects.toBe(reason)
+    expect(fetchController.signal.aborted).toBe(false)
+    expect(unsubscribe).toHaveBeenCalledOnce()
   })
 })

--- a/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
@@ -88,4 +88,26 @@ describe('createConcurrencyLimitedClient', () => {
     expect(types.isProxy(client.observable.withConfig().withConfig()))
     expect(types.isProxy(client.observable.config({}).config({})))
   })
+
+  it('does not start a queued fetch after its signal is aborted', async () => {
+    const deferredPromise = (() => {
+      let resolve!: () => void
+      const promise = new Promise<void>((thisResolve) => (resolve = thisResolve))
+      return Object.assign(promise, {resolve})
+    })()
+    const mockClient = {fetch: vi.fn(() => deferredPromise)} as unknown as SanityClient
+    const client = createClientConcurrencyLimiter(1)(mockClient)
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+
+    const active = client.fetch('active')
+    const queued = client.fetch('queued', {}, {signal: controller.signal})
+    await tick()
+    controller.abort(reason)
+
+    await expect(queued).rejects.toBe(reason)
+    deferredPromise.resolve()
+    await active
+    expect(mockClient.fetch).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
@@ -68,6 +68,33 @@ describe('createConcurrencyLimitedClient', () => {
     expect(mockClient.observable.fetch).toHaveBeenCalledTimes(2)
   })
 
+  it('does not acquire an observable slot before subscription', async () => {
+    const mockClient = {
+      observable: {fetch: vi.fn(() => of('result'))},
+    } as unknown as SanityClient
+    const client = createClientConcurrencyLimiter(1)(mockClient)
+    const controller = new AbortController()
+
+    void client.observable.fetch('unused')
+    const active = firstValueFrom(
+      client.observable.fetch('active', {}, {signal: controller.signal}),
+    )
+    const outcome = await Promise.race([active, tick().then(() => 'timed out')])
+
+    controller.abort()
+    await active.catch(() => undefined)
+
+    expect(outcome).toBe('result')
+    expect(mockClient.observable.fetch).toHaveBeenCalledOnce()
+    expect(mockClient.observable.fetch).toHaveBeenCalledWith(
+      'active',
+      {},
+      {
+        signal: controller.signal,
+      },
+    )
+  })
+
   it('returns a wrapped client that limits the observable client fetch', () => {
     const mockClient = createClient({
       projectId: 'project-id',

--- a/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
@@ -1,7 +1,7 @@
 import {types} from 'node:util'
 
 import {createClient, type SanityClient} from '@sanity/client'
-import {firstValueFrom, from} from 'rxjs'
+import {firstValueFrom, from, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createClientConcurrencyLimiter} from '../createClientConcurrencyLimiter'
@@ -87,6 +87,20 @@ describe('createConcurrencyLimitedClient', () => {
     expect(types.isProxy(client.observable.clone().clone()))
     expect(types.isProxy(client.observable.withConfig().withConfig()))
     expect(types.isProxy(client.observable.config({}).config({})))
+  })
+
+  it('releases an observable slot when unsubscribed before the fetch starts', async () => {
+    const mockClient = {
+      observable: {fetch: vi.fn(() => of('result'))},
+    } as unknown as SanityClient
+    const client = createClientConcurrencyLimiter(1)(mockClient)
+
+    const cancelled = client.observable.fetch('cancelled').subscribe()
+    cancelled.unsubscribe()
+
+    await expect(firstValueFrom(client.observable.fetch('next'))).resolves.toBe('result')
+    expect(mockClient.observable.fetch).toHaveBeenCalledOnce()
+    expect(mockClient.observable.fetch).toHaveBeenCalledWith('next')
   })
 
   it('does not start a queued fetch after its signal is aborted', async () => {

--- a/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
@@ -1,5 +1,5 @@
 import {type ObservableSanityClient, type SanityClient} from '@sanity/client'
-import {defer, finalize, from, switchMap} from 'rxjs'
+import {defer, finalize, from, switchMap, tap} from 'rxjs'
 
 import {ConcurrencyLimiter} from '../../concurrency-limiter'
 
@@ -70,13 +70,27 @@ export function createClientConcurrencyLimiter(
           case 'fetch': {
             return (...args: Parameters<ObservableSanityClient['fetch']>) => {
               const signal = args[2]?.signal
-              return from(limiter.ready(signal)).pipe(
+              const ready = limiter.ready(signal)
+              let acquired = false
+
+              return from(ready).pipe(
+                tap(() => {
+                  acquired = true
+                }),
                 switchMap(() =>
                   defer(() => {
                     signal?.throwIfAborted()
                     return target.fetch(...args)
-                  }).pipe(finalize(() => limiter.release())),
+                  }),
                 ),
+                finalize(() => {
+                  if (acquired) {
+                    limiter.release()
+                    return
+                  }
+
+                  void ready.then(limiter.release, () => undefined)
+                }),
               )
             }
           }

--- a/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
@@ -1,7 +1,46 @@
 import {type ObservableSanityClient, type SanityClient} from '@sanity/client'
-import {defer, finalize, from, switchMap, tap} from 'rxjs'
+import {defer, finalize, Observable, switchMap} from 'rxjs'
 
 import {ConcurrencyLimiter} from '../../concurrency-limiter'
+
+function acquireSlot(limiter: ConcurrencyLimiter, signal?: AbortSignal): Observable<() => void> {
+  return new Observable((subscriber) => {
+    const subscriptionController = new AbortController()
+    const waitSignal = signal
+      ? AbortSignal.any([signal, subscriptionController.signal])
+      : subscriptionController.signal
+
+    void limiter.ready(waitSignal).then(
+      () => {
+        if (subscriber.closed) {
+          limiter.release()
+          return
+        }
+
+        subscriber.next(limiter.release)
+        subscriber.complete()
+      },
+      (error) => subscriber.error(error),
+    )
+
+    return () => subscriptionController.abort()
+  })
+}
+
+function runObservable<T>(
+  limiter: ConcurrencyLimiter,
+  work: () => Observable<T>,
+  signal?: AbortSignal,
+): Observable<T> {
+  return acquireSlot(limiter, signal).pipe(
+    switchMap((release) =>
+      defer(() => {
+        signal?.throwIfAborted()
+        return work()
+      }).pipe(finalize(release)),
+    ),
+  )
+}
 
 /**
  * Decorates a sanity client to limit the concurrency of `client.fetch`
@@ -10,25 +49,25 @@ import {ConcurrencyLimiter} from '../../concurrency-limiter'
  */
 export function createClientConcurrencyLimiter(
   maxConcurrency: number,
+  defaultSignal?: AbortSignal,
 ): (input: SanityClient) => SanityClient {
   const limiter = new ConcurrencyLimiter(maxConcurrency)
+
+  function resolveSignal(signal?: AbortSignal): AbortSignal | undefined {
+    if (!defaultSignal || defaultSignal === signal) return signal || defaultSignal
+    if (!signal) return defaultSignal
+    return AbortSignal.any([defaultSignal, signal])
+  }
 
   function wrapClient(client: SanityClient): SanityClient {
     return new Proxy(client, {
       get: (target, property) => {
         switch (property) {
           case 'fetch': {
-            return async (...args: Parameters<SanityClient['fetch']>) => {
-              const signal = args[2]?.signal
-              await limiter.ready(signal)
-              try {
-                signal?.throwIfAborted()
-                // note we want to await before we return so the finally block
-                // will run after the promise has been fulfilled or rejected
-                return await target.fetch(...args)
-              } finally {
-                limiter.release()
-              }
+            return (...args: Parameters<SanityClient['fetch']>) => {
+              const signal = resolveSignal(args[2]?.signal)
+              if (signal !== args[2]?.signal) args[2] = {...args[2], signal}
+              return limiter.run(() => target.fetch(...args), signal)
             }
           }
           case 'clone': {
@@ -69,32 +108,9 @@ export function createClientConcurrencyLimiter(
         switch (property) {
           case 'fetch': {
             return (...args: Parameters<ObservableSanityClient['fetch']>) => {
-              const signal = args[2]?.signal
-
-              return defer(() => {
-                const ready = limiter.ready(signal)
-                let acquired = false
-
-                return from(ready).pipe(
-                  tap(() => {
-                    acquired = true
-                  }),
-                  switchMap(() =>
-                    defer(() => {
-                      signal?.throwIfAborted()
-                      return target.fetch(...args)
-                    }),
-                  ),
-                  finalize(() => {
-                    if (acquired) {
-                      limiter.release()
-                      return
-                    }
-
-                    void ready.then(limiter.release, () => undefined)
-                  }),
-                )
-              })
+              const signal = resolveSignal(args[2]?.signal)
+              if (signal !== args[2]?.signal) args[2] = {...args[2], signal}
+              return runObservable(limiter, () => target.fetch(...args), signal)
             }
           }
           case 'clone': {

--- a/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
@@ -1,7 +1,7 @@
 import {type ObservableSanityClient, type SanityClient} from '@sanity/client'
-import {finalize, from, switchMap} from 'rxjs'
+import {defer, finalize, from, switchMap} from 'rxjs'
 
-import {ConcurrencyLimiter} from '../../concurrency-limiter'
+import {ConcurrencyLimiter, throwIfAborted} from '../../concurrency-limiter'
 
 /**
  * Decorates a sanity client to limit the concurrency of `client.fetch`
@@ -19,8 +19,10 @@ export function createClientConcurrencyLimiter(
         switch (property) {
           case 'fetch': {
             return async (...args: Parameters<SanityClient['fetch']>) => {
-              await limiter.ready()
+              const signal = args[2]?.signal
+              await limiter.ready(signal)
               try {
+                throwIfAborted(signal)
                 // note we want to await before we return so the finally block
                 // will run after the promise has been fulfilled or rejected
                 return await target.fetch(...args)
@@ -66,11 +68,17 @@ export function createClientConcurrencyLimiter(
       get: (target, property) => {
         switch (property) {
           case 'fetch': {
-            return (...args: Parameters<ObservableSanityClient['fetch']>) =>
-              from(limiter.ready()).pipe(
-                switchMap(() => target.fetch(...args)),
-                finalize(() => limiter.release()),
+            return (...args: Parameters<ObservableSanityClient['fetch']>) => {
+              const signal = args[2]?.signal
+              return from(limiter.ready(signal)).pipe(
+                switchMap(() =>
+                  defer(() => {
+                    throwIfAborted(signal)
+                    return target.fetch(...args)
+                  }).pipe(finalize(() => limiter.release())),
+                ),
               )
+            }
           }
           case 'clone': {
             return (...args: Parameters<ObservableSanityClient['clone']>) => {

--- a/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
@@ -70,28 +70,31 @@ export function createClientConcurrencyLimiter(
           case 'fetch': {
             return (...args: Parameters<ObservableSanityClient['fetch']>) => {
               const signal = args[2]?.signal
-              const ready = limiter.ready(signal)
-              let acquired = false
 
-              return from(ready).pipe(
-                tap(() => {
-                  acquired = true
-                }),
-                switchMap(() =>
-                  defer(() => {
-                    signal?.throwIfAborted()
-                    return target.fetch(...args)
+              return defer(() => {
+                const ready = limiter.ready(signal)
+                let acquired = false
+
+                return from(ready).pipe(
+                  tap(() => {
+                    acquired = true
                   }),
-                ),
-                finalize(() => {
-                  if (acquired) {
-                    limiter.release()
-                    return
-                  }
+                  switchMap(() =>
+                    defer(() => {
+                      signal?.throwIfAborted()
+                      return target.fetch(...args)
+                    }),
+                  ),
+                  finalize(() => {
+                    if (acquired) {
+                      limiter.release()
+                      return
+                    }
 
-                  void ready.then(limiter.release, () => undefined)
-                }),
-              )
+                    void ready.then(limiter.release, () => undefined)
+                  }),
+                )
+              })
             }
           }
           case 'clone': {

--- a/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
@@ -1,7 +1,7 @@
 import {type ObservableSanityClient, type SanityClient} from '@sanity/client'
 import {defer, finalize, from, switchMap} from 'rxjs'
 
-import {ConcurrencyLimiter, throwIfAborted} from '../../concurrency-limiter'
+import {ConcurrencyLimiter} from '../../concurrency-limiter'
 
 /**
  * Decorates a sanity client to limit the concurrency of `client.fetch`
@@ -22,7 +22,7 @@ export function createClientConcurrencyLimiter(
               const signal = args[2]?.signal
               await limiter.ready(signal)
               try {
-                throwIfAborted(signal)
+                signal?.throwIfAborted()
                 // note we want to await before we return so the finally block
                 // will run after the promise has been fulfilled or rejected
                 return await target.fetch(...args)
@@ -73,7 +73,7 @@ export function createClientConcurrencyLimiter(
               return from(limiter.ready(signal)).pipe(
                 switchMap(() =>
                   defer(() => {
-                    throwIfAborted(signal)
+                    signal?.throwIfAborted()
                     return target.fetch(...args)
                   }).pipe(finalize(() => limiter.release())),
                 ),

--- a/packages/@sanity/util/src/concurrency-limiter.ts
+++ b/packages/@sanity/util/src/concurrency-limiter.ts
@@ -40,6 +40,17 @@ export class ConcurrencyLimiter {
     })
   }
 
+  /** Runs an operation when a concurrency slot is available. */
+  run = async <T>(work: () => PromiseLike<T> | T, signal?: AbortSignal): Promise<T> => {
+    await this.ready(signal)
+    try {
+      signal?.throwIfAborted()
+      return await work()
+    } finally {
+      this.release()
+    }
+  }
+
   /**
    * Releases a slot, decrementing the current count of operations if nothing is in the queue.
    * If there are operations waiting, it allows the next one in the queue to proceed.

--- a/packages/@sanity/util/src/concurrency-limiter.ts
+++ b/packages/@sanity/util/src/concurrency-limiter.ts
@@ -20,7 +20,7 @@ export class ConcurrencyLimiter {
    * If under the limit, it resolves immediately; otherwise, it waits until a slot is free.
    */
   ready = (signal?: AbortSignal): Promise<void> => {
-    if (signal?.aborted) return Promise.reject(getAbortReason(signal))
+    if (signal?.aborted) return Promise.reject(signal.reason)
     if (this.max === Infinity) return Promise.resolve()
 
     if (this.current < this.max) {
@@ -33,7 +33,7 @@ export class ConcurrencyLimiter {
       pending.onAbort = () => {
         const index = this.resolvers.indexOf(pending)
         if (index !== -1) this.resolvers.splice(index, 1)
-        if (signal) reject(getAbortReason(signal))
+        if (signal) reject(signal.reason)
       }
       signal?.addEventListener('abort', pending.onAbort, {once: true})
       this.resolvers.push(pending)
@@ -51,7 +51,7 @@ export class ConcurrencyLimiter {
     while (next) {
       next.signal?.removeEventListener('abort', next.onAbort)
       if (next.signal?.aborted) {
-        next.reject(getAbortReason(next.signal))
+        next.reject(next.signal.reason)
         next = this.resolvers.shift()
         continue
       }
@@ -61,15 +61,4 @@ export class ConcurrencyLimiter {
 
     this.current = Math.max(0, this.current - 1)
   }
-}
-
-function getAbortReason(signal: AbortSignal): unknown {
-  return signal.reason === undefined
-    ? new DOMException('The operation was aborted', 'AbortError')
-    : signal.reason
-}
-
-/** @internal */
-export function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw getAbortReason(signal)
 }

--- a/packages/@sanity/util/src/concurrency-limiter.ts
+++ b/packages/@sanity/util/src/concurrency-limiter.ts
@@ -4,7 +4,12 @@
  */
 export class ConcurrencyLimiter {
   current = 0
-  resolvers: Array<() => void> = []
+  resolvers: Array<{
+    resolve: () => void
+    reject: (reason?: unknown) => void
+    signal?: AbortSignal
+    onAbort: () => void
+  }> = []
   public max: number
   constructor(max: number) {
     this.max = max
@@ -14,7 +19,8 @@ export class ConcurrencyLimiter {
    * Indicates when a slot for a new operation is ready.
    * If under the limit, it resolves immediately; otherwise, it waits until a slot is free.
    */
-  ready = (): Promise<void> => {
+  ready = (signal?: AbortSignal): Promise<void> => {
+    if (signal?.aborted) return Promise.reject(getAbortReason(signal))
     if (this.max === Infinity) return Promise.resolve()
 
     if (this.current < this.max) {
@@ -22,8 +28,15 @@ export class ConcurrencyLimiter {
       return Promise.resolve()
     }
 
-    return new Promise<void>((resolve) => {
-      this.resolvers.push(resolve)
+    return new Promise<void>((resolve, reject) => {
+      const pending = {resolve, reject, signal, onAbort: () => {}}
+      pending.onAbort = () => {
+        const index = this.resolvers.indexOf(pending)
+        if (index !== -1) this.resolvers.splice(index, 1)
+        if (signal) reject(getAbortReason(signal))
+      }
+      signal?.addEventListener('abort', pending.onAbort, {once: true})
+      this.resolvers.push(pending)
     })
   }
 
@@ -34,12 +47,29 @@ export class ConcurrencyLimiter {
   release = (): void => {
     if (this.max === Infinity) return
 
-    const nextResolver = this.resolvers.shift()
-    if (nextResolver) {
-      nextResolver()
+    let next = this.resolvers.shift()
+    while (next) {
+      next.signal?.removeEventListener('abort', next.onAbort)
+      if (next.signal?.aborted) {
+        next.reject(getAbortReason(next.signal))
+        next = this.resolvers.shift()
+        continue
+      }
+      next.resolve()
       return
     }
 
     this.current = Math.max(0, this.current - 1)
   }
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason === undefined
+    ? new DOMException('The operation was aborted', 'AbortError')
+    : signal.reason
+}
+
+/** @internal */
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw getAbortReason(signal)
 }

--- a/packages/@sanity/util/test/ConcurrencyLimiter.test.ts
+++ b/packages/@sanity/util/test/ConcurrencyLimiter.test.ts
@@ -39,4 +39,20 @@ describe('ConcurrencyLimiter', () => {
 
     await allDone
   })
+
+  it('removes aborted waiters without consuming a concurrency slot', async () => {
+    const limiter = new ConcurrencyLimiter(1)
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+
+    await limiter.ready()
+    const queued = limiter.ready(controller.signal)
+    controller.abort(reason)
+
+    await expect(queued).rejects.toBe(reason)
+    limiter.release()
+
+    await expect(limiter.ready()).resolves.toBeUndefined()
+    limiter.release()
+  })
 })

--- a/packages/@sanity/util/test/ConcurrencyLimiter.test.ts
+++ b/packages/@sanity/util/test/ConcurrencyLimiter.test.ts
@@ -55,4 +55,24 @@ describe('ConcurrencyLimiter', () => {
     await expect(limiter.ready()).resolves.toBeUndefined()
     limiter.release()
   })
+
+  it('releases a slot after an operation rejects', async () => {
+    const limiter = new ConcurrencyLimiter(1)
+    const error = new Error('failed')
+
+    await expect(limiter.run(() => Promise.reject(error))).rejects.toBe(error)
+    await expect(limiter.run(() => 'next')).resolves.toBe('next')
+  })
+
+  it('releases a slot when starting an operation throws', async () => {
+    const limiter = new ConcurrencyLimiter(1)
+    const error = new Error('failed')
+
+    await expect(
+      limiter.run(() => {
+        throw error
+      }),
+    ).rejects.toBe(error)
+    await expect(limiter.run(() => 'next')).resolves.toBe('next')
+  })
 })

--- a/packages/@sanity/validation/README.md
+++ b/packages/@sanity/validation/README.md
@@ -36,8 +36,12 @@ When a check cannot run, `result.status` is `notEvaluated`. Omitting `client` di
 callbacks and skips network checks. Pass `customValidation: false` to disable custom callbacks while
 still providing a client.
 
-Pass an `AbortSignal` to cancel validation and its pending network work. Cancellation rejects with
-the signal's reason (an `AbortError` when no custom reason was supplied).
+Pass one `AbortSignal` to cancel validation and its pending network work. Built-in checks and client
+requests made through a custom validator's `context.getClient()` inherit this signal. A custom
+`getDocumentExists` callback receives it as an argument; custom work using another API should pass
+`context.signal` to that API. Cancellation rejects with the signal's reason (an `AbortError` when
+no custom reason was supplied). Work that does not accept an abort signal cannot be stopped, even
+though validation itself rejects immediately.
 
 ```ts
 const controller = new AbortController()

--- a/packages/@sanity/validation/README.md
+++ b/packages/@sanity/validation/README.md
@@ -36,6 +36,17 @@ When a check cannot run, `result.status` is `notEvaluated`. Omitting `client` di
 callbacks and skips network checks. Pass `customValidation: false` to disable custom callbacks while
 still providing a client.
 
+Pass an `AbortSignal` to cancel validation and its pending network work. Cancellation rejects with
+the signal's reason (an `AbortError` when no custom reason was supplied).
+
+```ts
+const controller = new AbortController()
+const validation = validateDocument({document, schema, client, signal: controller.signal})
+
+controller.abort()
+await validation
+```
+
 The package does not apply mutations or decide whether a document may be edited or published.
 
 ## Migrating from `sanity`

--- a/packages/@sanity/validation/README.md
+++ b/packages/@sanity/validation/README.md
@@ -42,9 +42,14 @@ the signal's reason (an `AbortError` when no custom reason was supplied).
 ```ts
 const controller = new AbortController()
 const validation = validateDocument({document, schema, client, signal: controller.signal})
+const reason = new Error('Validation cancelled')
 
-controller.abort()
-await validation
+controller.abort(reason)
+try {
+  await validation
+} catch (error) {
+  if (error !== reason) throw error
+}
 ```
 
 The package does not apply mutations or decide whether a document may be edited or published.

--- a/packages/@sanity/validation/src/Rule.ts
+++ b/packages/@sanity/validation/src/Rule.ts
@@ -10,7 +10,6 @@ import {
 } from '@sanity/types'
 import get from 'lodash-es/get.js'
 
-import {getAbortReason} from './abortSignal'
 import {ClientUnavailableError} from './clientUnavailable'
 import {validationMarkerCodes} from './codes'
 import {isInternalValidator} from './internalValidators'
@@ -148,7 +147,7 @@ export const Rule: RuleClass = class Rule extends BaseRule implements IRule {
           specConstraint = async (...args: Parameters<CustomValidator>) => {
             await customValidationConcurrencyLimiter.ready(context.signal)
             try {
-              if (context.signal?.aborted) throw getAbortReason(context.signal)
+              context.signal?.throwIfAborted()
               return await customValidator(...args)
             } finally {
               customValidationConcurrencyLimiter.release()
@@ -166,7 +165,7 @@ export const Rule: RuleClass = class Rule extends BaseRule implements IRule {
             code: fallbackCodeForRule(curr.flag),
           })
         } catch (err) {
-          if (context.signal?.aborted) throw getAbortReason(context.signal)
+          context.signal?.throwIfAborted()
           if (err instanceof ClientUnavailableError) {
             markIncomplete?.()
             return []

--- a/packages/@sanity/validation/src/Rule.ts
+++ b/packages/@sanity/validation/src/Rule.ts
@@ -10,6 +10,7 @@ import {
 } from '@sanity/types'
 import get from 'lodash-es/get.js'
 
+import {getAbortReason} from './abortSignal'
 import {ClientUnavailableError} from './clientUnavailable'
 import {validationMarkerCodes} from './codes'
 import {isInternalValidator} from './internalValidators'
@@ -145,8 +146,9 @@ export const Rule: RuleClass = class Rule extends BaseRule implements IRule {
         ) {
           const customValidator = specConstraint as CustomValidator
           specConstraint = async (...args: Parameters<CustomValidator>) => {
-            await customValidationConcurrencyLimiter.ready()
+            await customValidationConcurrencyLimiter.ready(context.signal)
             try {
+              if (context.signal?.aborted) throw getAbortReason(context.signal)
               return await customValidator(...args)
             } finally {
               customValidationConcurrencyLimiter.release()
@@ -164,6 +166,7 @@ export const Rule: RuleClass = class Rule extends BaseRule implements IRule {
             code: fallbackCodeForRule(curr.flag),
           })
         } catch (err) {
+          if (context.signal?.aborted) throw getAbortReason(context.signal)
           if (err instanceof ClientUnavailableError) {
             markIncomplete?.()
             return []

--- a/packages/@sanity/validation/src/Rule.ts
+++ b/packages/@sanity/validation/src/Rule.ts
@@ -144,15 +144,8 @@ export const Rule: RuleClass = class Rule extends BaseRule implements IRule {
           !(specConstraint as CustomValidator)?.bypassConcurrencyLimit
         ) {
           const customValidator = specConstraint as CustomValidator
-          specConstraint = async (...args: Parameters<CustomValidator>) => {
-            await customValidationConcurrencyLimiter.ready(context.signal)
-            try {
-              context.signal?.throwIfAborted()
-              return await customValidator(...args)
-            } finally {
-              customValidationConcurrencyLimiter.release()
-            }
-          }
+          specConstraint = (...args: Parameters<CustomValidator>) =>
+            customValidationConcurrencyLimiter.run(() => customValidator(...args), context.signal)
         }
 
         const message = isLocalizedMessages(this._message)

--- a/packages/@sanity/validation/src/_internal.ts
+++ b/packages/@sanity/validation/src/_internal.ts
@@ -18,6 +18,7 @@ export {
   resolveTypeForArrayItem,
   validateDocumentInternal,
   type ValidateDocumentInternalOptions,
+  type ValidateItemOptions,
   validateDocumentObservable,
   type ValidateDocumentObservableOptions,
   validateItem,

--- a/packages/@sanity/validation/src/abortSignal.ts
+++ b/packages/@sanity/validation/src/abortSignal.ts
@@ -1,0 +1,24 @@
+import {Observable} from 'rxjs'
+
+export function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason === undefined
+    ? new DOMException('The operation was aborted', 'AbortError')
+    : signal.reason
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw getAbortReason(signal)
+}
+
+export function abortSignalAsObservable(signal: AbortSignal): Observable<never> {
+  return new Observable((subscriber) => {
+    const onAbort = () => subscriber.error(getAbortReason(signal))
+    if (signal.aborted) {
+      onAbort()
+      return undefined
+    }
+
+    signal.addEventListener('abort', onAbort, {once: true})
+    return () => signal.removeEventListener('abort', onAbort)
+  })
+}

--- a/packages/@sanity/validation/src/abortSignal.ts
+++ b/packages/@sanity/validation/src/abortSignal.ts
@@ -1,18 +1,8 @@
 import {Observable} from 'rxjs'
 
-export function getAbortReason(signal: AbortSignal): unknown {
-  return signal.reason === undefined
-    ? new DOMException('The operation was aborted', 'AbortError')
-    : signal.reason
-}
-
-export function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw getAbortReason(signal)
-}
-
 export function abortSignalAsObservable(signal: AbortSignal): Observable<never> {
   return new Observable((subscriber) => {
-    const onAbort = () => subscriber.error(getAbortReason(signal))
+    const onAbort = () => subscriber.error(signal.reason)
     if (signal.aborted) {
       onAbort()
       return undefined

--- a/packages/@sanity/validation/src/abortSignal.ts
+++ b/packages/@sanity/validation/src/abortSignal.ts
@@ -1,6 +1,6 @@
-import {Observable} from 'rxjs'
+import {type MonoTypeOperatorFunction, Observable, takeUntil} from 'rxjs'
 
-export function abortSignalAsObservable(signal: AbortSignal): Observable<never> {
+function abortSignalAsObservable(signal: AbortSignal): Observable<never> {
   return new Observable((subscriber) => {
     const onAbort = () => subscriber.error(signal.reason)
     if (signal.aborted) {
@@ -11,4 +11,8 @@ export function abortSignalAsObservable(signal: AbortSignal): Observable<never> 
     signal.addEventListener('abort', onAbort, {once: true})
     return () => signal.removeEventListener('abort', onAbort)
   })
+}
+
+export function cancelWith<T>(signal?: AbortSignal): MonoTypeOperatorFunction<T> {
+  return (source) => (signal ? source.pipe(takeUntil(abortSignalAsObservable(signal))) : source)
 }

--- a/packages/@sanity/validation/src/types.ts
+++ b/packages/@sanity/validation/src/types.ts
@@ -35,6 +35,7 @@ export interface InternalValidationContext extends BaseValidationContext {
     customValidationConcurrencyLimiter?: {
       ready: (signal?: AbortSignal) => Promise<void>
       release: () => void
+      run: <T>(work: () => PromiseLike<T> | T, signal?: AbortSignal) => Promise<T>
     }
     markIncomplete?: () => void
   }

--- a/packages/@sanity/validation/src/types.ts
+++ b/packages/@sanity/validation/src/types.ts
@@ -33,7 +33,7 @@ export interface InternalValidationContext extends BaseValidationContext {
   __internal?: {
     customValidation?: boolean
     customValidationConcurrencyLimiter?: {
-      ready: () => Promise<void>
+      ready: (signal?: AbortSignal) => Promise<void>
       release: () => void
     }
     markIncomplete?: () => void

--- a/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
+++ b/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {from, map, of} from 'rxjs'
+import {from, map, Observable, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {
@@ -90,5 +90,59 @@ describe('createBatchedGetDocumentExists', () => {
     const results = await resultsPromise
     expect(results.every((result) => result === true))
     expect(mockClient.observable.request).toHaveBeenCalledTimes(MAX_REQUEST_CONCURRENCY + 1)
+  })
+
+  it('does not abort unrelated checks before their requests start', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    const mockClient = {
+      getDataUrl: (operation: string, path?: string) => `https://example.com/${operation}/${path}`,
+      observable: {
+        request: vi.fn(() => of({omitted: []})),
+      },
+    }
+    const getDocumentExists = createBatchedGetDocumentExists(mockClient as unknown as SanityClient)
+
+    const cancelled = getDocumentExists({id: 'cancelled', signal: controller.signal})
+    const active = getDocumentExists({id: 'active'})
+    controller.abort(reason)
+
+    await expect(cancelled).rejects.toBe(reason)
+    await expect(active).resolves.toBe(true)
+    expect(mockClient.observable.request).toHaveBeenCalledOnce()
+    expect(mockClient.observable.request).toHaveBeenCalledWith(
+      expect.objectContaining({signal: undefined}),
+    )
+  })
+
+  it('does not abort unrelated checks when an active request is aborted', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    const mockClient = {
+      getDataUrl: (operation: string, path?: string) => `https://example.com/${operation}/${path}`,
+      observable: {
+        request: vi.fn(({signal}: {signal?: AbortSignal}) => {
+          if (!signal) return of({omitted: []})
+
+          return new Observable<{omitted: {id: string; reason: 'existence' | 'permission'}[]}>(
+            (subscriber) => {
+              const onAbort = () => subscriber.error(signal.reason)
+              signal.addEventListener('abort', onAbort, {once: true})
+              return () => signal.removeEventListener('abort', onAbort)
+            },
+          )
+        }),
+      },
+    }
+    const getDocumentExists = createBatchedGetDocumentExists(mockClient as unknown as SanityClient)
+
+    const cancelled = getDocumentExists({id: 'cancelled', signal: controller.signal})
+    const active = getDocumentExists({id: 'active'})
+    await vi.waitFor(() => expect(mockClient.observable.request).toHaveBeenCalledOnce())
+    controller.abort(reason)
+
+    await expect(cancelled).rejects.toBe(reason)
+    await expect(active).resolves.toBe(true)
+    expect(mockClient.observable.request).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
+++ b/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
@@ -92,6 +92,24 @@ describe('createBatchedGetDocumentExists', () => {
     expect(mockClient.observable.request).toHaveBeenCalledTimes(MAX_REQUEST_CONCURRENCY + 1)
   })
 
+  it('does not request an already-aborted check', async () => {
+    const reason = new Error('cancelled')
+    const mockClient = {
+      getDataUrl: (operation: string, path?: string) => `https://example.com/${operation}/${path}`,
+      observable: {
+        request: vi.fn(() => of({omitted: []})),
+      },
+    }
+    const getDocumentExists = createBatchedGetDocumentExists(mockClient as unknown as SanityClient)
+
+    await expect(
+      getDocumentExists({id: 'cancelled', signal: AbortSignal.abort(reason)}),
+    ).rejects.toBe(reason)
+    await timeout(300)
+
+    expect(mockClient.observable.request).not.toHaveBeenCalled()
+  })
+
   it('does not abort unrelated checks before their requests start', async () => {
     const controller = new AbortController()
     const reason = new Error('cancelled')

--- a/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
+++ b/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {from, map, Observable, of} from 'rxjs'
+import {from, map, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {
@@ -133,34 +133,21 @@ describe('createBatchedGetDocumentExists', () => {
     )
   })
 
-  it('does not abort unrelated checks when an active request is aborted', async () => {
-    const controller = new AbortController()
-    const reason = new Error('cancelled')
+  it('passes the default signal to requests', async () => {
+    const signal = new AbortController().signal
     const mockClient = {
       getDataUrl: (operation: string, path?: string) => `https://example.com/${operation}/${path}`,
       observable: {
-        request: vi.fn(({signal}: {signal?: AbortSignal}) => {
-          if (!signal) return of({omitted: []})
-
-          return new Observable<{omitted: {id: string; reason: 'existence' | 'permission'}[]}>(
-            (subscriber) => {
-              const onAbort = () => subscriber.error(signal.reason)
-              signal.addEventListener('abort', onAbort, {once: true})
-              return () => signal.removeEventListener('abort', onAbort)
-            },
-          )
-        }),
+        request: vi.fn(() => of({omitted: []})),
       },
     }
-    const getDocumentExists = createBatchedGetDocumentExists(mockClient as unknown as SanityClient)
+    const getDocumentExists = createBatchedGetDocumentExists(
+      mockClient as unknown as SanityClient,
+      signal,
+    )
 
-    const cancelled = getDocumentExists({id: 'cancelled', signal: controller.signal})
-    const active = getDocumentExists({id: 'active'})
-    await vi.waitFor(() => expect(mockClient.observable.request).toHaveBeenCalledOnce())
-    controller.abort(reason)
+    await expect(getDocumentExists({id: 'document'})).resolves.toBe(true)
 
-    await expect(cancelled).rejects.toBe(reason)
-    await expect(active).resolves.toBe(true)
-    expect(mockClient.observable.request).toHaveBeenCalledTimes(2)
+    expect(mockClient.observable.request).toHaveBeenCalledWith(expect.objectContaining({signal}))
   })
 })

--- a/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
+++ b/packages/@sanity/validation/src/util/__tests__/createBatchedGetDocumentExists.test.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {from, map, of} from 'rxjs'
+import {from, map, Observable, of, Subject} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {
@@ -133,21 +133,66 @@ describe('createBatchedGetDocumentExists', () => {
     )
   })
 
-  it('passes the default signal to requests', async () => {
-    const signal = new AbortController().signal
+  it('cancels one caller without aborting a shared request', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    const response$ = new Subject<{
+      omitted: {id: string; reason: 'existence' | 'permission'}[]
+    }>()
     const mockClient = {
       getDataUrl: (operation: string, path?: string) => `https://example.com/${operation}/${path}`,
       observable: {
-        request: vi.fn(() => of({omitted: []})),
+        request: vi.fn(() => response$),
+      },
+    }
+    const getDocumentExists = createBatchedGetDocumentExists(mockClient as unknown as SanityClient)
+
+    const cancelled = getDocumentExists({id: 'cancelled', signal: controller.signal})
+    const active = getDocumentExists({id: 'active'})
+    await vi.waitFor(() => expect(mockClient.observable.request).toHaveBeenCalledOnce())
+    controller.abort(reason)
+
+    await expect(cancelled).rejects.toBe(reason)
+    response$.next({omitted: []})
+    response$.complete()
+    await expect(active).resolves.toBe(true)
+    expect(mockClient.observable.request).toHaveBeenCalledOnce()
+    expect(mockClient.observable.request).toHaveBeenCalledWith(
+      expect.objectContaining({signal: undefined}),
+    )
+  })
+
+  it('cancels active and queued batches with the default signal', async () => {
+    const controller = new AbortController()
+    const reason = new Error('validation cancelled')
+    const unsubscribe = vi.fn()
+    const mockClient = {
+      getDataUrl: (operation: string, path?: string) => `https://example.com/${operation}/${path}`,
+      observable: {
+        request: vi.fn(
+          () =>
+            new Observable(() => {
+              return unsubscribe
+            }),
+        ),
       },
     }
     const getDocumentExists = createBatchedGetDocumentExists(
       mockClient as unknown as SanityClient,
-      signal,
+      controller.signal,
     )
+    const checks = Promise.all(
+      Array.from({length: MAX_BUFFER_SIZE + 1}, (_, index) =>
+        getDocumentExists({id: index.toString()}),
+      ),
+    )
+    await vi.waitFor(() => expect(mockClient.observable.request).toHaveBeenCalledOnce())
 
-    await expect(getDocumentExists({id: 'document'})).resolves.toBe(true)
+    controller.abort(reason)
 
-    expect(mockClient.observable.request).toHaveBeenCalledWith(expect.objectContaining({signal}))
+    await expect(checks).rejects.toBe(reason)
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    await timeout(300)
+    expect(mockClient.observable.request).toHaveBeenCalledOnce()
   })
 })

--- a/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
+++ b/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
@@ -7,6 +7,7 @@ import {
   EMPTY,
   filter,
   finalize,
+  firstValueFrom,
   from,
   map,
   mergeMap,
@@ -16,6 +17,8 @@ import {
   tap,
   throwError,
 } from 'rxjs'
+
+import {cancelWith} from '../abortSignal'
 
 interface AvailabilityResponse {
   omitted: {id: string; reason: 'existence' | 'permission'}[]
@@ -110,34 +113,19 @@ export function createBatchedGetDocumentExists(
     share(),
   )
 
-  return function getDocumentExists(options) {
+  return async function getDocumentExists(options) {
     const signal = options.signal || defaultSignal
-    return new Promise<boolean>((resolve, reject) => {
-      const onAbort = () => {
-        if (!signal) return
-        subscription.unsubscribe()
-        reject(signal.reason)
-      }
-      const subscription = existence$
-        .pipe(filter(({id, signal: resultSignal}) => id === options.id && resultSignal === signal))
-        .subscribe({
-          error: (error) => {
-            signal?.removeEventListener('abort', onAbort)
-            reject(error)
-          },
-          next: ({exists}) => {
-            signal?.removeEventListener('abort', onAbort)
-            subscription.unsubscribe()
-            resolve(exists)
-          },
-        })
+    signal?.throwIfAborted()
 
-      if (signal?.aborted) {
-        onAbort()
-        return
-      }
-      signal?.addEventListener('abort', onAbort, {once: true})
-      id$.next({id: options.id, signal})
-    })
+    const result = firstValueFrom(
+      existence$.pipe(
+        filter(({id, signal: resultSignal}) => id === options.id && resultSignal === signal),
+        map(({exists}) => exists),
+        cancelWith(signal),
+      ),
+    )
+
+    id$.next({id: options.id, signal})
+    return result
   }
 }

--- a/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
+++ b/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
@@ -2,9 +2,9 @@ import {type SanityClient} from '@sanity/client'
 import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import {
   bufferTime,
+  defer,
   filter,
   finalize,
-  firstValueFrom,
   from,
   map,
   mergeMap,
@@ -12,6 +12,8 @@ import {
   Subject,
   switchMap,
 } from 'rxjs'
+
+import {getAbortReason, throwIfAborted} from '../abortSignal'
 
 interface AvailabilityResponse {
   omitted: {id: string; reason: 'existence' | 'permission'}[]
@@ -39,28 +41,41 @@ export const MAX_REQUEST_CONCURRENCY = 1
 
 export function createBatchedGetDocumentExists(
   client: SanityClient,
-): (options: {id: string}) => Promise<boolean> {
-  const id$ = new Subject<string>()
+  defaultSignal?: AbortSignal,
+): (options: {id: string; signal?: AbortSignal}) => Promise<boolean> {
+  const id$ = new Subject<{id: string; signal?: AbortSignal}>()
   const limiter = new ConcurrencyLimiter(MAX_REQUEST_CONCURRENCY)
 
   const existence$ = id$.pipe(
     bufferTime(BUFFER_TIME, null, MAX_BUFFER_SIZE),
-    map((ids) => Array.from(new Set(ids))),
-    mergeMap((ids) =>
-      from(limiter.ready()).pipe(
+    mergeMap((entries) => {
+      const groups = new Map<AbortSignal | undefined, Set<string>>()
+      for (const {id, signal} of entries) {
+        const ids = groups.get(signal) || new Set<string>()
+        ids.add(id)
+        groups.set(signal, ids)
+      }
+      return from(Array.from(groups, ([signal, ids]) => ({ids: Array.from(ids), signal})))
+    }),
+    mergeMap(({ids, signal}) =>
+      from(limiter.ready(signal)).pipe(
         switchMap(() =>
-          client.observable
-            .request<AvailabilityResponse>({
+          defer(() => {
+            throwIfAborted(signal)
+            return client.observable.request<AvailabilityResponse>({
               url: client.getDataUrl('doc', ids.join(',')),
               query: {excludeContent: 'true'},
+              signal,
               tag: 'documents-availability',
             })
-            .pipe(map((availability) => ({availability, ids}))),
+          }).pipe(
+            map((availability) => ({availability, ids, signal})),
+            finalize(limiter.release),
+          ),
         ),
-        finalize(limiter.release),
       ),
     ),
-    mergeMap(({availability, ids}) =>
+    mergeMap(({availability, ids, signal}) =>
       ids.map((id) => {
         const omittedIds = availability.omitted.reduce<Record<string, 'existence' | 'permission'>>(
           (acc, next) => {
@@ -71,23 +86,44 @@ export function createBatchedGetDocumentExists(
         )
 
         // if not in the `omitted`, then it exists
-        if (!omittedIds[id]) return {id, exists: true}
+        if (!omittedIds[id]) return {id, exists: true, signal}
         // if in the `omitted` due to existence, then it does not exist
-        if (omittedIds[id] === 'existence') return {id, exists: false}
+        if (omittedIds[id] === 'existence') return {id, exists: false, signal}
         // otherwise, it must exist
-        return {id, exists: true}
+        return {id, exists: true, signal}
       }),
     ),
     share(),
   )
 
-  return async function getDocumentExists(options) {
-    // set up a promise/listener that waits for the result
-    const result = firstValueFrom(existence$.pipe(filter(({id}) => id === options.id)))
-    // send off the request to the stream for batching
-    id$.next(options.id)
+  return function getDocumentExists(options) {
+    const signal = options.signal || defaultSignal
+    return new Promise<boolean>((resolve, reject) => {
+      const onAbort = () => {
+        if (!signal) return
+        subscription.unsubscribe()
+        reject(getAbortReason(signal))
+      }
+      const subscription = existence$
+        .pipe(filter(({id, signal: resultSignal}) => id === options.id && resultSignal === signal))
+        .subscribe({
+          error: (error) => {
+            signal?.removeEventListener('abort', onAbort)
+            reject(error)
+          },
+          next: ({exists}) => {
+            signal?.removeEventListener('abort', onAbort)
+            subscription.unsubscribe()
+            resolve(exists)
+          },
+        })
 
-    const {exists} = await result
-    return exists
+      if (signal?.aborted) {
+        onAbort()
+        return
+      }
+      signal?.addEventListener('abort', onAbort, {once: true})
+      id$.next({id: options.id, signal})
+    })
   }
 }

--- a/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
+++ b/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
@@ -1,22 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
-import {
-  bufferTime,
-  catchError,
-  defer,
-  EMPTY,
-  filter,
-  finalize,
-  firstValueFrom,
-  from,
-  map,
-  mergeMap,
-  share,
-  Subject,
-  switchMap,
-  tap,
-  throwError,
-} from 'rxjs'
+import {bufferTime, filter, firstValueFrom, map, mergeMap, share, Subject} from 'rxjs'
 
 import {cancelWith} from '../abortSignal'
 
@@ -49,60 +32,29 @@ export function createBatchedGetDocumentExists(
   defaultSignal?: AbortSignal,
 ): (options: {id: string; signal?: AbortSignal}) => Promise<boolean> {
   const id$ = new Subject<string>()
-  const limiter = new ConcurrencyLimiter(MAX_REQUEST_CONCURRENCY)
 
   const existence$ = id$.pipe(
     bufferTime(BUFFER_TIME, null, MAX_BUFFER_SIZE),
     map((ids) => Array.from(new Set(ids))),
     filter((ids) => ids.length > 0),
-    mergeMap((ids) => {
-      const ready = limiter.ready(defaultSignal)
-      let acquired = false
-
-      return from(ready).pipe(
-        tap(() => {
-          acquired = true
-        }),
-        switchMap(() =>
-          defer(() => {
-            defaultSignal?.throwIfAborted()
-            return client.observable.request<AvailabilityResponse>({
-              url: client.getDataUrl('doc', ids.join(',')),
-              query: {excludeContent: 'true'},
-              signal: defaultSignal,
-              tag: 'documents-availability',
-            })
-          }).pipe(map((availability) => ({availability, ids}))),
-        ),
-        catchError((error) => (defaultSignal?.aborted ? EMPTY : throwError(() => error))),
-        finalize(() => {
-          if (acquired) {
-            limiter.release()
-            return
-          }
-
-          void ready.then(limiter.release, () => undefined)
-        }),
-      )
-    }),
-    mergeMap(({availability, ids}) =>
-      ids.map((id) => {
-        const omittedIds = availability.omitted.reduce<Record<string, 'existence' | 'permission'>>(
-          (acc, next) => {
-            acc[next.id] = next.reason
-            return acc
-          },
-          {},
-        )
-
-        // if not in the `omitted`, then it exists
-        if (!omittedIds[id]) return {id, exists: true}
-        // if in the `omitted` due to existence, then it does not exist
-        if (omittedIds[id] === 'existence') return {id, exists: false}
-        // otherwise, it must exist
-        return {id, exists: true}
-      }),
+    mergeMap(
+      (ids) =>
+        client.observable
+          .request<AvailabilityResponse>({
+            url: client.getDataUrl('doc', ids.join(',')),
+            query: {excludeContent: 'true'},
+            signal: defaultSignal,
+            tag: 'documents-availability',
+          })
+          .pipe(map((availability) => ({availability, ids}))),
+      MAX_REQUEST_CONCURRENCY,
     ),
+    mergeMap(({availability, ids}) => {
+      const missingIds = new Set(
+        availability.omitted.filter(({reason}) => reason === 'existence').map(({id}) => id),
+      )
+      return ids.map((id) => ({id, exists: !missingIds.has(id)}))
+    }),
     share(),
   )
 

--- a/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
+++ b/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
@@ -48,22 +48,15 @@ export function createBatchedGetDocumentExists(
   client: SanityClient,
   defaultSignal?: AbortSignal,
 ): (options: {id: string; signal?: AbortSignal}) => Promise<boolean> {
-  const id$ = new Subject<{id: string; signal?: AbortSignal}>()
+  const id$ = new Subject<string>()
   const limiter = new ConcurrencyLimiter(MAX_REQUEST_CONCURRENCY)
 
   const existence$ = id$.pipe(
     bufferTime(BUFFER_TIME, null, MAX_BUFFER_SIZE),
-    mergeMap((entries) => {
-      const groups = new Map<AbortSignal | undefined, Set<string>>()
-      for (const {id, signal} of entries) {
-        const ids = groups.get(signal) || new Set<string>()
-        ids.add(id)
-        groups.set(signal, ids)
-      }
-      return from(Array.from(groups, ([signal, ids]) => ({ids: Array.from(ids), signal})))
-    }),
-    mergeMap(({ids, signal}) => {
-      const ready = limiter.ready(signal)
+    map((ids) => Array.from(new Set(ids))),
+    filter((ids) => ids.length > 0),
+    mergeMap((ids) => {
+      const ready = limiter.ready(defaultSignal)
       let acquired = false
 
       return from(ready).pipe(
@@ -72,16 +65,16 @@ export function createBatchedGetDocumentExists(
         }),
         switchMap(() =>
           defer(() => {
-            signal?.throwIfAborted()
+            defaultSignal?.throwIfAborted()
             return client.observable.request<AvailabilityResponse>({
               url: client.getDataUrl('doc', ids.join(',')),
               query: {excludeContent: 'true'},
-              signal,
+              signal: defaultSignal,
               tag: 'documents-availability',
             })
-          }).pipe(map((availability) => ({availability, ids, signal}))),
+          }).pipe(map((availability) => ({availability, ids}))),
         ),
-        catchError((error) => (signal?.aborted ? EMPTY : throwError(() => error))),
+        catchError((error) => (defaultSignal?.aborted ? EMPTY : throwError(() => error))),
         finalize(() => {
           if (acquired) {
             limiter.release()
@@ -92,7 +85,7 @@ export function createBatchedGetDocumentExists(
         }),
       )
     }),
-    mergeMap(({availability, ids, signal}) =>
+    mergeMap(({availability, ids}) =>
       ids.map((id) => {
         const omittedIds = availability.omitted.reduce<Record<string, 'existence' | 'permission'>>(
           (acc, next) => {
@@ -103,11 +96,11 @@ export function createBatchedGetDocumentExists(
         )
 
         // if not in the `omitted`, then it exists
-        if (!omittedIds[id]) return {id, exists: true, signal}
+        if (!omittedIds[id]) return {id, exists: true}
         // if in the `omitted` due to existence, then it does not exist
-        if (omittedIds[id] === 'existence') return {id, exists: false, signal}
+        if (omittedIds[id] === 'existence') return {id, exists: false}
         // otherwise, it must exist
-        return {id, exists: true, signal}
+        return {id, exists: true}
       }),
     ),
     share(),
@@ -119,13 +112,13 @@ export function createBatchedGetDocumentExists(
 
     const result = firstValueFrom(
       existence$.pipe(
-        filter(({id, signal: resultSignal}) => id === options.id && resultSignal === signal),
+        filter(({id}) => id === options.id),
         map(({exists}) => exists),
         cancelWith(signal),
       ),
     )
 
-    id$.next({id: options.id, signal})
+    id$.next(options.id)
     return result
   }
 }

--- a/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
+++ b/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
@@ -2,7 +2,9 @@ import {type SanityClient} from '@sanity/client'
 import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import {
   bufferTime,
+  catchError,
   defer,
+  EMPTY,
   filter,
   finalize,
   from,
@@ -11,6 +13,7 @@ import {
   share,
   Subject,
   switchMap,
+  throwError,
 } from 'rxjs'
 
 interface AvailabilityResponse {
@@ -71,6 +74,7 @@ export function createBatchedGetDocumentExists(
             finalize(limiter.release),
           ),
         ),
+        catchError((error) => (signal?.aborted ? EMPTY : throwError(() => error))),
       ),
     ),
     mergeMap(({availability, ids, signal}) =>

--- a/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
+++ b/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
@@ -13,6 +13,7 @@ import {
   share,
   Subject,
   switchMap,
+  tap,
   throwError,
 } from 'rxjs'
 
@@ -58,8 +59,14 @@ export function createBatchedGetDocumentExists(
       }
       return from(Array.from(groups, ([signal, ids]) => ({ids: Array.from(ids), signal})))
     }),
-    mergeMap(({ids, signal}) =>
-      from(limiter.ready(signal)).pipe(
+    mergeMap(({ids, signal}) => {
+      const ready = limiter.ready(signal)
+      let acquired = false
+
+      return from(ready).pipe(
+        tap(() => {
+          acquired = true
+        }),
         switchMap(() =>
           defer(() => {
             signal?.throwIfAborted()
@@ -69,14 +76,19 @@ export function createBatchedGetDocumentExists(
               signal,
               tag: 'documents-availability',
             })
-          }).pipe(
-            map((availability) => ({availability, ids, signal})),
-            finalize(limiter.release),
-          ),
+          }).pipe(map((availability) => ({availability, ids, signal}))),
         ),
         catchError((error) => (signal?.aborted ? EMPTY : throwError(() => error))),
-      ),
-    ),
+        finalize(() => {
+          if (acquired) {
+            limiter.release()
+            return
+          }
+
+          void ready.then(limiter.release, () => undefined)
+        }),
+      )
+    }),
     mergeMap(({availability, ids, signal}) =>
       ids.map((id) => {
         const omittedIds = availability.omitted.reduce<Record<string, 'existence' | 'permission'>>(

--- a/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
+++ b/packages/@sanity/validation/src/util/createBatchedGetDocumentExists.ts
@@ -13,8 +13,6 @@ import {
   switchMap,
 } from 'rxjs'
 
-import {getAbortReason, throwIfAborted} from '../abortSignal'
-
 interface AvailabilityResponse {
   omitted: {id: string; reason: 'existence' | 'permission'}[]
 }
@@ -61,7 +59,7 @@ export function createBatchedGetDocumentExists(
       from(limiter.ready(signal)).pipe(
         switchMap(() =>
           defer(() => {
-            throwIfAborted(signal)
+            signal?.throwIfAborted()
             return client.observable.request<AvailabilityResponse>({
               url: client.getDataUrl('doc', ids.join(',')),
               query: {excludeContent: 'true'},
@@ -102,7 +100,7 @@ export function createBatchedGetDocumentExists(
       const onAbort = () => {
         if (!signal) return
         subscription.unsubscribe()
-        reject(getAbortReason(signal))
+        reject(signal.reason)
       }
       const subscription = existence$
         .pipe(filter(({id, signal: resultSignal}) => id === options.id && resultSignal === signal))

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -17,7 +17,7 @@ import flatten from 'lodash-es/flatten.js'
 import {concat, defer, from, lastValueFrom, merge, Observable, of, throwError} from 'rxjs'
 import {catchError, map, mergeAll, mergeMap, raceWith, switchMap, toArray} from 'rxjs/operators'
 
-import {abortSignalAsObservable, getAbortReason, throwIfAborted} from './abortSignal'
+import {abortSignalAsObservable} from './abortSignal'
 import {ClientUnavailableError} from './clientUnavailable'
 import {type DocumentValidationMarker, validationMarkerCodes} from './codes'
 import {getFallbackLocaleSource} from './i18n/fallback'
@@ -371,7 +371,7 @@ export function evaluateDocumentInternal({
   customValidation = true,
   signal,
 }: ValidateDocumentInternalOptions): Promise<DocumentValidationResult> {
-  if (signal?.aborted) return Promise.reject(getAbortReason(signal))
+  if (signal?.aborted) return Promise.reject(signal.reason)
   const limitConcurrency = createClientConcurrencyLimiter(
     maxFetchConcurrency ?? DEFAULT_MAX_FETCH_CONCURRENCY,
   )
@@ -433,7 +433,7 @@ export function evaluateDocumentObservable(
 ): Observable<DocumentValidationResult> {
   const {signal} = options
   return defer(() => {
-    throwIfAborted(signal)
+    signal?.throwIfAborted()
     const validation$ = evaluateDocumentObservableWithoutCancellation(options)
     return signal ? validation$.pipe(raceWith(abortSignalAsObservable(signal))) : validation$
   })
@@ -520,7 +520,7 @@ function evaluateDocumentObservableWithoutCancellation({
       switchMap(() => validateItemObservable(validationOptions)),
       map((markers) => createDocumentValidationResult(markers, complete)),
       catchError((err) => {
-        if (signal?.aborted) return throwError(() => getAbortReason(signal))
+        if (signal?.aborted) return throwError(() => signal.reason)
         console.error(err)
 
         const message = err?.message || 'Unknown error'
@@ -561,7 +561,7 @@ export type ValidateItemOptions = {
 export function validateItem(opts: ValidateItemOptions): Promise<ValidationMarker[]> {
   return lastValueFrom(
     defer(() => {
-      throwIfAborted(opts.signal)
+      opts.signal?.throwIfAborted()
       const validation$ = validateItemObservable(opts)
       return opts.signal
         ? validation$.pipe(raceWith(abortSignalAsObservable(opts.signal)))

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -14,9 +14,10 @@ import {createClientConcurrencyLimiter} from '@sanity/util/client'
 import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import {dequal as isEqual} from 'dequal/lite'
 import flatten from 'lodash-es/flatten.js'
-import {concat, defer, from, lastValueFrom, merge, Observable, of} from 'rxjs'
-import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/operators'
+import {concat, defer, from, lastValueFrom, merge, Observable, of, throwError} from 'rxjs'
+import {catchError, map, mergeAll, mergeMap, raceWith, switchMap, toArray} from 'rxjs/operators'
 
+import {abortSignalAsObservable, getAbortReason, throwIfAborted} from './abortSignal'
 import {ClientUnavailableError} from './clientUnavailable'
 import {type DocumentValidationMarker, validationMarkerCodes} from './codes'
 import {getFallbackLocaleSource} from './i18n/fallback'
@@ -114,6 +115,9 @@ interface ValidateDocumentBaseOptions {
   /** The compiled schema to validate against. */
   schema: ValidationSchema
 
+  /** Signal used to cancel validation and any work it starts. */
+  signal?: AbortSignal
+
   /**
    * Function used to check if referenced documents exists (and is published).
    *
@@ -123,7 +127,7 @@ interface ValidateDocumentBaseOptions {
    * If no function is provided a default one will be provided that will batch
    * call the `doc` endpoint to check for document existence.
    */
-  getDocumentExists?: (options: {id: string}) => Promise<boolean>
+  getDocumentExists?: (options: {id: string; signal?: AbortSignal}) => Promise<boolean>
 
   /**
    * The maximum amount of custom validation functions to be running
@@ -261,6 +265,7 @@ export function validateDocumentWithWorkspace({
   maxFetchConcurrency,
   currentUser,
   customValidation,
+  signal,
 }: ValidateDocumentWorkspaceOptions): Promise<DocumentValidationMarker[]> {
   return validateDocumentInternal({
     currentUser,
@@ -273,6 +278,7 @@ export function validateDocumentWithWorkspace({
     maxCustomValidationConcurrency,
     maxFetchConcurrency,
     schema: workspace.schema,
+    signal,
   })
 }
 
@@ -315,13 +321,14 @@ export interface ValidateDocumentInternalOptions {
   document: SanityDocument
   schema: Schema
   getClient: (clientOptions: {apiVersion: string}) => SanityClient
-  getDocumentExists?: (options: {id: string}) => Promise<boolean>
+  getDocumentExists?: (options: {id: string; signal?: AbortSignal}) => Promise<boolean>
   i18n?: LocaleSource
   environment: 'cli' | 'studio'
   maxCustomValidationConcurrency?: number
   maxFetchConcurrency?: number
   currentUser?: Omit<CurrentUser, 'role'> | null
   customValidation?: boolean
+  signal?: AbortSignal
 }
 
 function createDocumentValidationResult(
@@ -362,7 +369,9 @@ export function evaluateDocumentInternal({
   maxFetchConcurrency,
   currentUser,
   customValidation = true,
+  signal,
 }: ValidateDocumentInternalOptions): Promise<DocumentValidationResult> {
+  if (signal?.aborted) return Promise.reject(getAbortReason(signal))
   const limitConcurrency = createClientConcurrencyLimiter(
     maxFetchConcurrency ?? DEFAULT_MAX_FETCH_CONCURRENCY,
   )
@@ -377,11 +386,12 @@ export function evaluateDocumentInternal({
       schema,
       getDocumentExists:
         getDocumentExists ||
-        createBatchedGetDocumentExists(getClient(DEFAULT_VALIDATION_CLIENT_OPTIONS)),
+        createBatchedGetDocumentExists(getClient(DEFAULT_VALIDATION_CLIENT_OPTIONS), signal),
       environment,
       maxCustomValidationConcurrency,
       currentUser,
       customValidation,
+      signal,
     }),
   )
 }
@@ -391,7 +401,7 @@ export function evaluateDocumentInternal({
  */
 export interface ValidateDocumentObservableOptions extends Pick<
   ValidationContext,
-  'getDocumentExists' | 'i18n'
+  'getDocumentExists' | 'i18n' | 'signal'
 > {
   getClient: (options: {apiVersion: string}) => SanityClient
   document: SanityDocument
@@ -418,7 +428,18 @@ export function validateDocumentObservable(
  * Validates a document against the given schema, including completion status.
  * @internal
  */
-export function evaluateDocumentObservable({
+export function evaluateDocumentObservable(
+  options: ValidateDocumentObservableOptions,
+): Observable<DocumentValidationResult> {
+  const {signal} = options
+  return defer(() => {
+    throwIfAborted(signal)
+    const validation$ = evaluateDocumentObservableWithoutCancellation(options)
+    return signal ? validation$.pipe(raceWith(abortSignalAsObservable(signal))) : validation$
+  })
+}
+
+function evaluateDocumentObservableWithoutCancellation({
   document,
   getClient,
   i18n = getFallbackLocaleSource(),
@@ -428,6 +449,7 @@ export function evaluateDocumentObservable({
   maxCustomValidationConcurrency,
   currentUser,
   customValidation = true,
+  signal,
 }: ValidateDocumentObservableOptions): Observable<DocumentValidationResult> {
   if (typeof document?._type !== 'string') {
     throw new Error(`Tried to validate a value without a '_type'`)
@@ -486,6 +508,7 @@ export function evaluateDocumentObservable({
       customValidationConcurrencyLimiter,
       currentUser,
       customValidation,
+      signal,
       __internal: {
         markIncomplete: () => {
           complete = false
@@ -497,6 +520,7 @@ export function evaluateDocumentObservable({
       switchMap(() => validateItemObservable(validationOptions)),
       map((markers) => createDocumentValidationResult(markers, complete)),
       catchError((err) => {
+        if (signal?.aborted) return throwError(() => getAbortReason(signal))
         console.error(err)
 
         const message = err?.message || 'Unknown error'
@@ -525,7 +549,7 @@ type ExplicitUndefined<T> = {
   [P in keyof Required<T>]: Pick<T, P> extends Required<Pick<T, P>> ? T[P] : T[P] | undefined
 }
 
-type ValidateItemOptions = {
+export type ValidateItemOptions = {
   value: unknown
   customValidationConcurrencyLimiter?: ConcurrencyLimiter
   hidden?: boolean
@@ -535,7 +559,15 @@ type ValidateItemOptions = {
 } & ExplicitUndefined<Omit<ValidationContext, 'hidden'>>
 
 export function validateItem(opts: ValidateItemOptions): Promise<ValidationMarker[]> {
-  return lastValueFrom(validateItemObservable(opts))
+  return lastValueFrom(
+    defer(() => {
+      throwIfAborted(opts.signal)
+      const validation$ = validateItemObservable(opts)
+      return opts.signal
+        ? validation$.pipe(raceWith(abortSignalAsObservable(opts.signal)))
+        : validation$
+    }),
+  )
 }
 
 function validateRule(

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -15,9 +15,9 @@ import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import {dequal as isEqual} from 'dequal/lite'
 import flatten from 'lodash-es/flatten.js'
 import {concat, defer, from, lastValueFrom, merge, Observable, of, throwError} from 'rxjs'
-import {catchError, map, mergeAll, mergeMap, raceWith, switchMap, toArray} from 'rxjs/operators'
+import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/operators'
 
-import {abortSignalAsObservable} from './abortSignal'
+import {cancelWith} from './abortSignal'
 import {ClientUnavailableError} from './clientUnavailable'
 import {type DocumentValidationMarker, validationMarkerCodes} from './codes'
 import {getFallbackLocaleSource} from './i18n/fallback'
@@ -434,9 +434,8 @@ export function evaluateDocumentObservable(
   const {signal} = options
   return defer(() => {
     signal?.throwIfAborted()
-    const validation$ = evaluateDocumentObservableWithoutCancellation(options)
-    return signal ? validation$.pipe(raceWith(abortSignalAsObservable(signal))) : validation$
-  })
+    return evaluateDocumentObservableWithoutCancellation(options)
+  }).pipe(cancelWith(signal))
 }
 
 function evaluateDocumentObservableWithoutCancellation({
@@ -562,11 +561,8 @@ export function validateItem(opts: ValidateItemOptions): Promise<ValidationMarke
   return lastValueFrom(
     defer(() => {
       opts.signal?.throwIfAborted()
-      const validation$ = validateItemObservable(opts)
-      return opts.signal
-        ? validation$.pipe(raceWith(abortSignalAsObservable(opts.signal)))
-        : validation$
-    }),
+      return validateItemObservable(opts)
+    }).pipe(cancelWith(opts.signal)),
   )
 }
 

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -374,6 +374,7 @@ export function evaluateDocumentInternal({
   if (signal?.aborted) return Promise.reject(signal.reason)
   const limitConcurrency = createClientConcurrencyLimiter(
     maxFetchConcurrency ?? DEFAULT_MAX_FETCH_CONCURRENCY,
+    signal,
   )
   const getConcurrencyLimitedClient = (clientOptions: {apiVersion: string}) =>
     limitConcurrency(getClient(clientOptions))

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -554,8 +554,9 @@ export type ValidateItemOptions = {
   hidden?: boolean
   currentUser?: Omit<CurrentUser, 'role'> | null
   customValidation?: boolean
+  signal?: AbortSignal
   __internal?: InternalValidationContext['__internal']
-} & ExplicitUndefined<Omit<ValidationContext, 'hidden'>>
+} & ExplicitUndefined<Omit<ValidationContext, 'hidden' | 'signal'>>
 
 export function validateItem(opts: ValidateItemOptions): Promise<ValidationMarker[]> {
   return lastValueFrom(

--- a/packages/@sanity/validation/src/validators/objectValidator.ts
+++ b/packages/@sanity/validation/src/validators/objectValidator.ts
@@ -134,6 +134,7 @@ export const objectValidators: Validators = {
           {
             id: documentId,
           },
+          {signal: context.signal},
         )
       if (!asset) {
         console.warn(

--- a/packages/@sanity/validation/src/validators/objectValidator.ts
+++ b/packages/@sanity/validation/src/validators/objectValidator.ts
@@ -66,7 +66,7 @@ export const objectValidators: Validators = {
       // a document should be able to reference itself without first being published
       return true
     }
-    const exists = await getDocumentExists({id: value._ref})
+    const exists = await getDocumentExists({id: value._ref, signal: context.signal})
     if (!exists) {
       return {
         code: validationMarkerCodes.referenceNotPublished,

--- a/packages/@sanity/validation/src/validators/slugValidator.ts
+++ b/packages/@sanity/validation/src/validators/slugValidator.ts
@@ -73,7 +73,7 @@ const defaultIsUnique: SlugIsUniqueValidator = (slug, context) => {
         published: getPublishedId(document._id as DocumentId),
         slug,
       },
-      {tag: 'validation.slug-is-unique'},
+      {signal: context.signal, tag: 'validation.slug-is-unique'},
     )
 }
 

--- a/packages/@sanity/validation/test/infer.test.ts
+++ b/packages/@sanity/validation/test/infer.test.ts
@@ -234,6 +234,29 @@ describe('schema validation inference', () => {
         },
       ])
     })
+
+    test('passes cancellation to media asset fetches', async () => {
+      const controller = new AbortController()
+      client.fetch.mockResolvedValue({
+        _id: 'image-12345-67890-png',
+        assetType: 'sanity.imageAsset',
+        aspects: {season: 'summer'},
+      })
+
+      await validateDocument({
+        client: sanityClient,
+        document: mockDocument,
+        getDocumentExists: () => Promise.resolve(true),
+        schema,
+        signal: controller.signal,
+      })
+
+      expect(client.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        {id: 'def'},
+        {signal: controller.signal},
+      )
+    })
   })
 
   describe('slug validation', () => {

--- a/packages/@sanity/validation/test/validateDocument.test.ts
+++ b/packages/@sanity/validation/test/validateDocument.test.ts
@@ -83,6 +83,7 @@ describe('validateDocument', () => {
   it('passes cancellation to custom validators without creating exception markers', async () => {
     const controller = new AbortController()
     const reason = new Error('cancelled')
+    const {client} = createMockClient()
     const customValidator = vi.fn(
       (_value: unknown, context: ValidationContext) =>
         new Promise<true>((_resolve, reject) => {
@@ -102,6 +103,7 @@ describe('validateDocument', () => {
     ])
 
     const validation = validateDocument({
+      client,
       document: createDocument({_type: 'article', title: 'Hello'}),
       schema,
       signal: controller.signal,
@@ -116,6 +118,7 @@ describe('validateDocument', () => {
   it('does not start queued custom validators after cancellation and releases their slots', async () => {
     const controller = new AbortController()
     const reason = new Error('cancelled')
+    const {client} = createMockClient()
     let waitForCancellation = true
     const firstValidator = vi.fn((_value: unknown, context: ValidationContext) => {
       if (!waitForCancellation) return true
@@ -144,6 +147,7 @@ describe('validateDocument', () => {
     const document = createDocument({_type: 'article', first: 'one', second: 'two'})
 
     const validation = validateDocument({
+      client,
       document,
       maxCustomValidationConcurrency: 1,
       schema,
@@ -156,7 +160,7 @@ describe('validateDocument', () => {
     expect(queuedValidator).not.toHaveBeenCalled()
 
     await expect(
-      validateDocument({document, maxCustomValidationConcurrency: 1, schema}),
+      validateDocument({client, document, maxCustomValidationConcurrency: 1, schema}),
     ).resolves.toMatchObject({status: 'passed'})
     expect(queuedValidator).toHaveBeenCalledOnce()
   })

--- a/packages/@sanity/validation/test/validateDocument.test.ts
+++ b/packages/@sanity/validation/test/validateDocument.test.ts
@@ -115,6 +115,57 @@ describe('validateDocument', () => {
     await expect(validation).rejects.toBe(reason)
   })
 
+  it('adds cancellation to custom validator client fetches', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    const fetch = vi.fn(
+      (_query: string, _params: object, {signal}: {signal: AbortSignal}) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+        }),
+    )
+    const client = {
+      fetch,
+      getDataUrl: () => '/doc',
+      observable: {request: vi.fn(() => of({omitted: []}))},
+      withConfig: vi.fn(() => client),
+    } as unknown as SanityClient
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [
+          {
+            name: 'title',
+            type: 'string',
+            validation: (rule: Rule) =>
+              rule.custom(async (_value, context) => {
+                await context.getClient({apiVersion: '2025-02-19'}).fetch('query')
+                return true as const
+              }),
+          },
+        ],
+      },
+    ])
+
+    const validation = validateDocument({
+      client,
+      document: createDocument({_type: 'article', title: 'Hello'}),
+      schema,
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+    expect(fetch).toHaveBeenCalledWith(
+      'query',
+      undefined,
+      expect.objectContaining({signal: controller.signal}),
+    )
+
+    controller.abort(reason)
+
+    await expect(validation).rejects.toBe(reason)
+  })
+
   it('does not start queued custom validators after cancellation and releases their slots', async () => {
     const controller = new AbortController()
     const reason = new Error('cancelled')

--- a/packages/@sanity/validation/test/validateDocument.test.ts
+++ b/packages/@sanity/validation/test/validateDocument.test.ts
@@ -59,7 +59,7 @@ describe('validateDocument', () => {
   it('rejects pre-aborted validation with the abort reason', async () => {
     const schema = createSchema([{name: 'article', type: 'document', fields: []}])
     const reason = new Error('cancelled')
-    const client = {withConfig: vi.fn()}
+    const {client} = createMockClient()
 
     await expect(
       validateDocument({
@@ -197,10 +197,11 @@ describe('validateDocument', () => {
         }),
     )
     const client = {
+      fetch: vi.fn(async () => null),
       getDataUrl: () => '/data/doc',
       observable: {request},
       withConfig: () => client,
-    }
+    } as unknown as SanityClient
     const schema = createSchema([
       {
         name: 'article',

--- a/packages/@sanity/validation/test/validateDocument.test.ts
+++ b/packages/@sanity/validation/test/validateDocument.test.ts
@@ -7,7 +7,7 @@ import {
   type SchemaTypeDefinition,
   type ValidationContext,
 } from '@sanity/types'
-import {of} from 'rxjs'
+import {Observable, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {
@@ -56,6 +56,177 @@ function validateMarkers(options: ValidateDocumentOptions) {
 }
 
 describe('validateDocument', () => {
+  it('rejects pre-aborted validation with the abort reason', async () => {
+    const schema = createSchema([{name: 'article', type: 'document', fields: []}])
+    const reason = new Error('cancelled')
+    const client = {withConfig: vi.fn()}
+
+    await expect(
+      validateDocument({
+        client,
+        document: createDocument({_type: 'article'}),
+        schema,
+        signal: AbortSignal.abort(reason),
+      }),
+    ).rejects.toBe(reason)
+    expect(client.withConfig).not.toHaveBeenCalled()
+
+    await expect(
+      validateDocument({
+        document: createDocument({_type: 'article'}),
+        schema,
+        signal: AbortSignal.abort(),
+      }),
+    ).rejects.toMatchObject({name: 'AbortError'})
+  })
+
+  it('passes cancellation to custom validators without creating exception markers', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    const customValidator = vi.fn(
+      (_value: unknown, context: ValidationContext) =>
+        new Promise<true>((_resolve, reject) => {
+          const {signal} = context
+          if (!signal) throw new Error('Expected a validation signal')
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+        }),
+    )
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [
+          {name: 'title', type: 'string', validation: (rule: Rule) => rule.custom(customValidator)},
+        ],
+      },
+    ])
+
+    const validation = validateDocument({
+      document: createDocument({_type: 'article', title: 'Hello'}),
+      schema,
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(customValidator).toHaveBeenCalledOnce())
+    expect(customValidator.mock.calls[0][1].signal).toBe(controller.signal)
+    controller.abort(reason)
+
+    await expect(validation).rejects.toBe(reason)
+  })
+
+  it('does not start queued custom validators after cancellation and releases their slots', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    let waitForCancellation = true
+    const firstValidator = vi.fn((_value: unknown, context: ValidationContext) => {
+      if (!waitForCancellation) return true
+      waitForCancellation = false
+      return new Promise<true>((_resolve, reject) => {
+        context.signal?.addEventListener('abort', () => reject(context.signal?.reason), {
+          once: true,
+        })
+      })
+    })
+    const queuedValidator = vi.fn(() => true as const)
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [
+          {name: 'first', type: 'string', validation: (rule: Rule) => rule.custom(firstValidator)},
+          {
+            name: 'second',
+            type: 'string',
+            validation: (rule: Rule) => rule.custom(queuedValidator),
+          },
+        ],
+      },
+    ])
+    const document = createDocument({_type: 'article', first: 'one', second: 'two'})
+
+    const validation = validateDocument({
+      document,
+      maxCustomValidationConcurrency: 1,
+      schema,
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(firstValidator).toHaveBeenCalledOnce())
+    controller.abort(reason)
+
+    await expect(validation).rejects.toBe(reason)
+    expect(queuedValidator).not.toHaveBeenCalled()
+
+    await expect(
+      validateDocument({document, maxCustomValidationConcurrency: 1, schema}),
+    ).resolves.toMatchObject({status: 'passed'})
+    expect(queuedValidator).toHaveBeenCalledOnce()
+  })
+
+  it('passes cancellation to slug uniqueness fetches', async () => {
+    const controller = new AbortController()
+    const {client, fetch} = createMockClient()
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [{name: 'slug', type: 'slug'}],
+      },
+    ])
+
+    await validateDocument({
+      client,
+      document: createDocument({_type: 'article', slug: {current: 'hello'}}),
+      schema,
+      signal: controller.signal,
+    })
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({signal: controller.signal}),
+    )
+  })
+
+  it('aborts and unsubscribes active reference availability requests', async () => {
+    const controller = new AbortController()
+    const reason = new Error('cancelled')
+    const teardown = vi.fn()
+    const request = vi.fn(
+      () =>
+        new Observable(() => {
+          return teardown
+        }),
+    )
+    const client = {
+      getDataUrl: () => '/data/doc',
+      observable: {request},
+      withConfig: () => client,
+    }
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [{name: 'author', type: 'reference', to: [{type: 'author'}]}],
+      },
+      {name: 'author', type: 'document', fields: []},
+    ])
+
+    const validation = validateDocument({
+      client,
+      document: createDocument({
+        _type: 'article',
+        author: {_ref: 'author-id', _type: 'reference'},
+      }),
+      schema,
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce())
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({signal: controller.signal}))
+    controller.abort(reason)
+
+    await expect(validation).rejects.toBe(reason)
+    expect(teardown).toHaveBeenCalledOnce()
+  })
+
   it('reports passed, failed, and not-evaluated document outcomes', async () => {
     const schema = createSchema([
       {
@@ -333,7 +504,7 @@ describe('validateDocument', () => {
       schema,
     })
 
-    expect(getDocumentExists).toHaveBeenCalledWith({id: 'author-id'})
+    expect(getDocumentExists).toHaveBeenCalledWith(expect.objectContaining({id: 'author-id'}))
     expect(result).toEqual({
       status: 'notEvaluated',
       markers: [],
@@ -728,6 +899,7 @@ describe('validateDocument', () => {
   })
 
   it('uses an explicit reference existence lookup when provided', async () => {
+    const controller = new AbortController()
     const schema = createSchema([
       {
         name: 'article',
@@ -744,6 +916,7 @@ describe('validateDocument', () => {
       document: createDocument({_type: 'article', author: {_ref: 'author-id', _type: 'reference'}}),
       getDocumentExists,
       schema,
+      signal: controller.signal,
     })
 
     expect(markers).toEqual([
@@ -755,7 +928,10 @@ describe('validateDocument', () => {
         path: ['author'],
       }),
     ])
-    expect(getDocumentExists).toHaveBeenCalledWith({id: 'author-id'})
+    expect(getDocumentExists).toHaveBeenCalledWith({
+      id: 'author-id',
+      signal: controller.signal,
+    })
     expect(request).not.toHaveBeenCalled()
   })
 

--- a/packages/sanity/src/core/validation/validateDocumentWithReferences.ts
+++ b/packages/sanity/src/core/validation/validateDocumentWithReferences.ts
@@ -8,7 +8,7 @@ import {
   type ValidationMarker,
   type CurrentUser,
 } from '@sanity/types'
-import {validateDocumentObservable} from '@sanity/validation/_internal'
+import {evaluateDocumentObservable} from '@sanity/validation/_internal'
 import {reduce as reduceJSON} from 'json-reduce'
 import {
   asyncScheduler,
@@ -179,7 +179,7 @@ export function validateDocumentWithReferences(
         }
         return concat(
           of({isValidating: true, revision: document._rev}),
-          validateDocumentObservable({
+          evaluateDocumentObservable({
             document,
             getClient: ctx.getClient,
             getDocumentExists,
@@ -187,9 +187,7 @@ export function validateDocumentWithReferences(
             schema: ctx.schema,
             environment: 'studio',
             currentUser: ctx.currentUser,
-          }).pipe(
-            map((validationMarkers) => ({validation: validationMarkers, isValidating: false})),
-          ),
+          }).pipe(map((result) => ({validation: result.markers, isValidating: false}))),
         )
       })
     }),


### PR DESCRIPTION
### Description

Long-running headless validation must stop both active work and queued validators or fetches when callers cancel. Cancellation stays in the Observable chain so it rejects with the signal reason instead of becoming a validation marker; Studio scheduling remains unchanged.

### What to review

Focus on abort propagation and teardown, concurrency slot accounting, and the `result.markers` Studio mapping. This affects `@sanity/validation`, `@sanity/types`, `@sanity/util`, `sanity`, and DTS fixtures. It also includes a small lockfile normalization required by the inherited stack.

### Notes for release

Headless and workspace validation now accept `signal`. Aborting rejects with `signal.reason` (or `AbortError`) and cancels pending validation and network work.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared concurrency limiting and validation/network teardown paths used by Studio and headless callers; incorrect slot accounting or abort propagation could stall fetches or leave validation running after cancel.
> 
> **Overview**
> Adds **`AbortSignal`** support so headless and workspace validation can be cancelled and pending network work torn down. **`validateDocument`**, internal options, and **`ValidationContext`** now accept an optional **`signal`**; aborting rejects with **`signal.reason`** (or **`AbortError`**) instead of producing validation markers.
> 
> Cancellation is wired through the Observable pipeline (**`cancelWith`**, **`evaluateDocumentObservable`**) and into built-in checks: concurrency-limited **`getClient()`** fetches, batched **`getDocumentExists`**, slug uniqueness, reference existence, and custom validators ( **`context.signal`** on **`getDocumentExists`**). **`ConcurrencyLimiter`** and **`createClientConcurrencyLimiter`** gain signal-aware queuing, a **`run`** helper, optional default signals combined via **`AbortSignal.any`**, and fixes so observable fetches only hold slots after subscribe and release on abort/unsubscribe.
> 
> Studio reference validation switches to **`evaluateDocumentObservable`** and maps **`result.markers`**. Public types and DTS export tests document the new **`signal`** fields; **`@sanity/validation` README** describes usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7480a467694075cd22c1c02258a31abc170508dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->