### PR TITLE
chore(core): moves diffValue and JsonStream into store/events folder

### DIFF
--- a/packages/sanity/src/core/store/events/calculateDiff.ts
+++ b/packages/sanity/src/core/store/events/calculateDiff.ts
@@ -1,95 +1,13 @@
-import {diffInput} from '@sanity/diff'
 import {type SanityDocument, type TransactionLogEventWithEffects} from '@sanity/types'
 import {applyPatch, incremental} from 'mendoza'
 
-import {type Annotation, type ObjectDiff} from '../../field/types'
-import {wrapValue} from '../history/history/diffValue'
+import {type ObjectDiff} from '../../field/types'
+import {diffValue, type EventMeta} from './diffValue'
 import {type DocumentGroupEvent, isEditDocumentVersionEvent} from './types'
-
-type EventMeta = {
-  transactionIndex: number
-  event?: DocumentGroupEvent
-} | null
 
 function omitRev(document: SanityDocument): Omit<SanityDocument, '_rev'> {
   const {_rev, ...doc} = document
   return doc
-}
-
-function annotationForTransactionIndex(
-  transactions: TransactionLogEventWithEffects[],
-  idx: number,
-  event?: DocumentGroupEvent,
-) {
-  const tx = transactions[idx]
-  if (!tx) return null
-
-  return {
-    timestamp: tx.timestamp,
-    author: tx.author,
-    event: event,
-  }
-}
-
-function extractAnnotationForFromInput(
-  transactions: TransactionLogEventWithEffects[],
-  meta: EventMeta,
-): Annotation {
-  if (meta) {
-    // The next transaction is where it disappeared:
-    return annotationForTransactionIndex(transactions, meta.transactionIndex + 1, meta.event)
-  }
-
-  // Fallback: if meta is null, the value existed initially and was changed/removed
-  // by the first transaction in our range
-  if (transactions.length > 0) {
-    return annotationForTransactionIndex(transactions, 0)
-  }
-
-  return null
-}
-function extractAnnotationForToInput(
-  transactions: TransactionLogEventWithEffects[],
-  meta: EventMeta,
-): Annotation {
-  if (meta) {
-    return annotationForTransactionIndex(transactions, meta.transactionIndex, meta.event)
-  }
-
-  return null
-}
-
-function diffValue({
-  transactions,
-  fromValue,
-  fromRaw,
-  toValue,
-  toRaw,
-}: {
-  transactions: TransactionLogEventWithEffects[]
-  fromValue: incremental.Value<EventMeta>
-  fromRaw: Omit<SanityDocument, '_rev'>
-  toValue: incremental.Value<EventMeta>
-  toRaw: Omit<SanityDocument, '_rev'>
-}) {
-  const fromInput = wrapValue<EventMeta>(fromValue, fromRaw, {
-    fromValue(value) {
-      return extractAnnotationForFromInput(transactions, value.endMeta)
-    },
-    fromMeta(meta) {
-      return extractAnnotationForFromInput(transactions, meta)
-    },
-  })
-
-  const toInput = wrapValue<EventMeta>(toValue, toRaw, {
-    fromValue(value) {
-      return extractAnnotationForToInput(transactions, value.startMeta)
-    },
-    fromMeta(meta) {
-      return extractAnnotationForToInput(transactions, meta)
-    },
-  })
-  return diffInput(fromInput, toInput)
 }
 
 export function calculateDiff({

--- a/packages/sanity/src/core/store/events/diffValue.ts
+++ b/packages/sanity/src/core/store/events/diffValue.ts
@@ -1,0 +1,275 @@
+import {
+  type ArrayInput,
+  diffInput,
+  type Input,
+  type ObjectInput,
+  type StringInput,
+  wrap,
+} from '@sanity/diff'
+import {type SanityDocument, type TransactionLogEventWithEffects} from '@sanity/types'
+import {type incremental} from 'mendoza'
+
+import {type Annotation} from '../../field/types'
+import {type DocumentGroupEvent} from './types'
+
+export type EventMeta = {
+  transactionIndex: number
+  event?: DocumentGroupEvent
+} | null
+
+function isSameAnnotation(a: Annotation, b: Annotation): boolean {
+  if (a && b) {
+    return a.author === b.author && a.timestamp === b.timestamp
+  }
+
+  if (!a && !b) {
+    return true
+  }
+
+  return false
+}
+
+export type AnnotationExtractor<T> = {
+  fromValue(value: incremental.Value<T>): Annotation
+  fromMeta(meta: T): Annotation
+}
+
+class ArrayContentWrapper<T> implements ArrayInput<Annotation> {
+  type = 'array' as const
+  value: unknown[]
+  length: number
+  annotation: Annotation
+  extractor: AnnotationExtractor<T>
+
+  private content: incremental.ArrayContent<T>
+  private elements: Input<Annotation>[] = []
+
+  constructor(
+    content: incremental.ArrayContent<T>,
+    value: unknown[],
+    annotation: Annotation,
+    extractor: AnnotationExtractor<T>,
+  ) {
+    this.content = content
+    this.value = value
+    this.annotation = annotation
+    this.extractor = extractor
+    this.length = content.elements.length
+  }
+
+  at(idx: number) {
+    if (idx >= this.length) throw new Error('out of bounds')
+    const input = this.elements[idx]
+    if (input) {
+      return input
+    }
+    return (this.elements[idx] = wrapValue(
+      this.content.elements[idx],
+      this.value[idx],
+      this.extractor,
+    ))
+  }
+
+  annotationAt(idx: number): Annotation {
+    const meta = this.content.metas[idx]
+    return this.extractor.fromMeta(meta)
+  }
+}
+
+class ObjectContentWrapper<T> implements ObjectInput<Annotation> {
+  type = 'object' as const
+  value: Record<string, unknown>
+  keys: string[]
+  annotation: Annotation
+  extractor: AnnotationExtractor<T>
+
+  private content: incremental.ObjectContent<T>
+  private fields: Record<string, Input<Annotation>> = {}
+
+  constructor(
+    content: incremental.ObjectContent<T>,
+    value: Record<string, unknown>,
+    annotation: Annotation,
+    extractor: AnnotationExtractor<T>,
+  ) {
+    this.content = content
+    this.value = value
+    this.annotation = annotation
+    this.extractor = extractor
+    this.keys = Object.keys(content.fields)
+  }
+
+  get(key: string) {
+    const input = this.fields[key]
+    if (input) {
+      return input
+    }
+    const value = this.content.fields[key]
+    if (!value) return undefined
+    return (this.fields[key] = wrapValue(value, this.value[key], this.extractor))
+  }
+}
+
+class StringContentWrapper<T> implements StringInput<Annotation> {
+  type = 'string' as const
+  value: string
+  annotation: Annotation
+  extractor: AnnotationExtractor<T>
+
+  private content: incremental.StringContent<T>
+
+  constructor(
+    content: incremental.StringContent<T>,
+    value: string,
+    annotation: Annotation,
+    extractor: AnnotationExtractor<T>,
+  ) {
+    this.content = content
+    this.value = value
+    this.annotation = annotation
+    this.extractor = extractor
+  }
+
+  sliceAnnotation(start: number, end: number): {text: string; annotation: Annotation}[] {
+    const result: {text: string; annotation: Annotation}[] = []
+    let idx = 0
+
+    function push(text: string, annotation: Annotation) {
+      if (result.length > 0) {
+        const lst = result[result.length - 1]
+        if (isSameAnnotation(lst.annotation, annotation)) {
+          lst.text += text
+          return
+        }
+      }
+
+      result.push({text, annotation})
+    }
+
+    for (const part of this.content.parts) {
+      const length = part.value.length
+
+      const subStart = Math.max(0, start - idx)
+      if (subStart < length) {
+        // The start of the slice is inside this part somewhere.
+
+        // Figure out where the end is:
+        const subEnd = Math.min(length, end - idx)
+
+        // If the end of the slice is before this part, then we're guaranteed
+        // that there are no more parts.
+        if (subEnd <= 0) break
+
+        push(part.value.slice(subStart, subEnd), this.extractor.fromValue(part))
+      }
+
+      idx += length
+    }
+
+    return result
+  }
+}
+
+export function wrapValue<T>(
+  value: incremental.Value<T>,
+  raw: unknown,
+  extractor: AnnotationExtractor<T>,
+): Input<Annotation> {
+  const annotation = extractor.fromValue(value)
+
+  if (value.content) {
+    switch (value.content.type) {
+      case 'array':
+        return new ArrayContentWrapper<T>(value.content, raw as unknown[], annotation, extractor)
+      case 'object':
+        return new ObjectContentWrapper<T>(
+          value.content,
+          raw as Record<string, unknown>,
+          annotation,
+          extractor,
+        )
+      case 'string':
+        return new StringContentWrapper<T>(value.content, raw as string, annotation, extractor)
+      default:
+      // do nothing
+    }
+  }
+
+  return wrap(raw, annotation)
+}
+
+function extractAnnotationForFromInput(
+  transactions: TransactionLogEventWithEffects[],
+  meta: EventMeta,
+): Annotation {
+  if (meta) {
+    // The next transaction is where it disappeared:
+    return annotationForTransactionIndex(transactions, meta.transactionIndex + 1, meta.event)
+  }
+
+  // Fallback: if meta is null, the value existed initially and was changed/removed
+  // by the first transaction in our range
+  if (transactions.length > 0) {
+    return annotationForTransactionIndex(transactions, 0)
+  }
+
+  return null
+}
+function extractAnnotationForToInput(
+  transactions: TransactionLogEventWithEffects[],
+  meta: EventMeta,
+): Annotation {
+  if (meta) {
+    return annotationForTransactionIndex(transactions, meta.transactionIndex, meta.event)
+  }
+
+  return null
+}
+
+function annotationForTransactionIndex(
+  transactions: TransactionLogEventWithEffects[],
+  idx: number,
+  event?: DocumentGroupEvent,
+) {
+  const tx = transactions[idx]
+  if (!tx) return null
+
+  return {
+    event: event,
+    timestamp: tx.timestamp,
+    author: tx.author,
+  }
+}
+
+export function diffValue({
+  transactions,
+  fromValue,
+  fromRaw,
+  toValue,
+  toRaw,
+}: {
+  transactions: TransactionLogEventWithEffects[]
+  fromValue: incremental.Value<EventMeta>
+  fromRaw: Omit<SanityDocument, '_rev'>
+  toValue: incremental.Value<EventMeta>
+  toRaw: Omit<SanityDocument, '_rev'>
+}) {
+  const fromInput = wrapValue<EventMeta>(fromValue, fromRaw, {
+    fromValue(value) {
+      return extractAnnotationForFromInput(transactions, value.endMeta)
+    },
+    fromMeta(meta) {
+      return extractAnnotationForFromInput(transactions, meta)
+    },
+  })
+
+  const toInput = wrapValue<EventMeta>(toValue, toRaw, {
+    fromValue(value) {
+      return extractAnnotationForToInput(transactions, value.startMeta)
+    },
+    fromMeta(meta) {
+      return extractAnnotationForToInput(transactions, meta)
+    },
+  })
+  return diffInput(fromInput, toInput)
+}

--- a/packages/sanity/src/core/store/events/getJsonStream.ts
+++ b/packages/sanity/src/core/store/events/getJsonStream.ts
@@ -3,7 +3,7 @@ import {
   type TransactionLogEventWithEffects,
 } from '@sanity/types'
 
-import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../../studioClient'
+import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../studioClient'
 
 type StreamResult =
   | (TransactionLogEventWithEffects & TransactionLogEventWithMutations)

--- a/packages/sanity/src/core/store/history/history/TimelineController.ts
+++ b/packages/sanity/src/core/store/history/history/TimelineController.ts
@@ -4,8 +4,8 @@ import {type Diff, type ObjectDiff} from '@sanity/diff'
 
 import {type Annotation, type Chunk} from '../../../field/types'
 import {type RemoteSnapshotVersionEvent} from '../../document/document-pair/checkoutPair'
+import {getJsonStream} from '../../events/getJsonStream'
 import {Aligner} from './Aligner'
-import {getJsonStream} from './getJsonStream'
 import {Reconstruction} from './Reconstruction'
 import {type ParsedTimeRef, type Timeline} from './Timeline'
 

--- a/packages/sanity/src/core/store/history/history/diffValue.ts
+++ b/packages/sanity/src/core/store/history/history/diffValue.ts
@@ -1,191 +1,17 @@
-import {
-  type ArrayInput,
-  type Diff,
-  diffInput,
-  type Input,
-  type ObjectInput,
-  type StringInput,
-  wrap,
-} from '@sanity/diff'
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
+import {type Diff, diffInput} from '@sanity/diff'
 import {type incremental} from 'mendoza'
 
 import {type Annotation, type Chunk} from '../../../field/types'
+import {wrapValue} from '../../events/diffValue'
 import {type Timeline} from './Timeline'
-import {isSameAnnotation} from './utils'
 
+/**
+ * @deprecated
+ */
 export type Meta = {chunk: Chunk; transactionIndex: number} | null
 
-export type AnnotationExtractor<T> = {
-  fromValue(value: incremental.Value<T>): Annotation
-  fromMeta(meta: T): Annotation
-}
-
-class ArrayContentWrapper<T> implements ArrayInput<Annotation> {
-  type = 'array' as const
-  value: unknown[]
-  length: number
-  annotation: Annotation
-  extractor: AnnotationExtractor<T>
-
-  private content: incremental.ArrayContent<T>
-  private elements: Input<Annotation>[] = []
-
-  constructor(
-    content: incremental.ArrayContent<T>,
-    value: unknown[],
-    annotation: Annotation,
-    extractor: AnnotationExtractor<T>,
-  ) {
-    this.content = content
-    this.value = value
-    this.annotation = annotation
-    this.extractor = extractor
-    this.length = content.elements.length
-  }
-
-  at(idx: number) {
-    if (idx >= this.length) throw new Error('out of bounds')
-    const input = this.elements[idx]
-    if (input) {
-      return input
-    }
-    return (this.elements[idx] = wrapValue(
-      this.content.elements[idx],
-      this.value[idx],
-      this.extractor,
-    ))
-  }
-
-  annotationAt(idx: number): Annotation {
-    const meta = this.content.metas[idx]
-    return this.extractor.fromMeta(meta)
-  }
-}
-
-class ObjectContentWrapper<T> implements ObjectInput<Annotation> {
-  type = 'object' as const
-  value: Record<string, unknown>
-  keys: string[]
-  annotation: Annotation
-  extractor: AnnotationExtractor<T>
-
-  private content: incremental.ObjectContent<T>
-  private fields: Record<string, Input<Annotation>> = {}
-
-  constructor(
-    content: incremental.ObjectContent<T>,
-    value: Record<string, unknown>,
-    annotation: Annotation,
-    extractor: AnnotationExtractor<T>,
-  ) {
-    this.content = content
-    this.value = value
-    this.annotation = annotation
-    this.extractor = extractor
-    this.keys = Object.keys(content.fields)
-  }
-
-  get(key: string) {
-    const input = this.fields[key]
-    if (input) {
-      return input
-    }
-    const value = this.content.fields[key]
-    if (!value) return undefined
-    return (this.fields[key] = wrapValue(value, this.value[key], this.extractor))
-  }
-}
-
-class StringContentWrapper<T> implements StringInput<Annotation> {
-  type = 'string' as const
-  value: string
-  annotation: Annotation
-  extractor: AnnotationExtractor<T>
-
-  private content: incremental.StringContent<T>
-
-  constructor(
-    content: incremental.StringContent<T>,
-    value: string,
-    annotation: Annotation,
-    extractor: AnnotationExtractor<T>,
-  ) {
-    this.content = content
-    this.value = value
-    this.annotation = annotation
-    this.extractor = extractor
-  }
-
-  sliceAnnotation(start: number, end: number): {text: string; annotation: Annotation}[] {
-    const result: {text: string; annotation: Annotation}[] = []
-    let idx = 0
-
-    function push(text: string, annotation: Annotation) {
-      if (result.length > 0) {
-        const lst = result[result.length - 1]
-        if (isSameAnnotation(lst.annotation, annotation)) {
-          lst.text += text
-          return
-        }
-      }
-
-      result.push({text, annotation})
-    }
-
-    for (const part of this.content.parts) {
-      const length = part.value.length
-
-      const subStart = Math.max(0, start - idx)
-      if (subStart < length) {
-        // The start of the slice is inside this part somewhere.
-
-        // Figure out where the end is:
-        const subEnd = Math.min(length, end - idx)
-
-        // If the end of the slice is before this part, then we're guaranteed
-        // that there are no more parts.
-        if (subEnd <= 0) break
-
-        push(part.value.slice(subStart, subEnd), this.extractor.fromValue(part))
-      }
-
-      idx += length
-    }
-
-    return result
-  }
-}
-
-export function wrapValue<T>(
-  value: incremental.Value<T>,
-  raw: unknown,
-  extractor: AnnotationExtractor<T>,
-): Input<Annotation> {
-  const annotation = extractor.fromValue(value)
-
-  if (value.content) {
-    switch (value.content.type) {
-      case 'array':
-        return new ArrayContentWrapper<T>(value.content, raw as unknown[], annotation, extractor)
-      case 'object':
-        return new ObjectContentWrapper<T>(
-          value.content,
-          raw as Record<string, unknown>,
-          annotation,
-          extractor,
-        )
-      case 'string':
-        return new StringContentWrapper<T>(value.content, raw as string, annotation, extractor)
-      default:
-      // do nothing
-    }
-  }
-
-  return wrap(raw, annotation)
-}
-
 function extractAnnotationForFromInput(
-  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   timeline: Timeline,
   firstChunk: Chunk | null,
   meta: Meta,
@@ -224,6 +50,9 @@ function annotationForTransactionIndex(timeline: Timeline, idx: number, chunkIdx
   }
 }
 
+/**
+ * @deprecated use the events api diff value with support for transactions instead.
+ */
 export function diffValue(
   // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   timeline: Timeline,

--- a/packages/sanity/src/core/store/history/history/utils.ts
+++ b/packages/sanity/src/core/store/history/history/utils.ts
@@ -1,18 +1,5 @@
 /* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
-import {type Annotation} from '../../../field/types'
 import {type CombinedDocument} from './types'
-
-export function isSameAnnotation(a: Annotation, b: Annotation): boolean {
-  if (a && b) {
-    return a.author === b.author && a.timestamp === b.timestamp
-  }
-
-  if (!a && !b) {
-    return true
-  }
-
-  return false
-}
 
 export function getAttrs(doc: CombinedDocument): Record<string, unknown> | null {
   return doc.draft || doc.published

--- a/packages/sanity/src/core/store/translog/getTransactionsLogs.test.ts
+++ b/packages/sanity/src/core/store/translog/getTransactionsLogs.test.ts
@@ -1,10 +1,10 @@
 import {type SanityClient} from '@sanity/client'
 import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
-import {getJsonStream} from '../history/history/getJsonStream'
+import {getJsonStream} from '../events/getJsonStream'
 import {getTransactionsLogs} from './getTransactionsLogs'
 
-vi.mock('../history/history/getJsonStream', () => ({
+vi.mock('../events/getJsonStream', () => ({
   getJsonStream: vi.fn(),
 }))
 

--- a/packages/sanity/src/core/store/translog/getTransactionsLogs.ts
+++ b/packages/sanity/src/core/store/translog/getTransactionsLogs.ts
@@ -4,7 +4,7 @@ import {
   type TransactionLogEventWithEffects,
 } from '@sanity/types'
 
-import {getJsonStream} from '../history/history/getJsonStream'
+import {getJsonStream} from '../events/getJsonStream'
 
 /**
  * Fetches transaction logs for the specified document IDs from the translog


### PR DESCRIPTION
### Description
diffValue and jsonStream are used by the events store.
The events store is the store we use to display the history events in the documents, it was introduced with content releases and the old store was marked as legacy and deprecated.
This moves this functions into the events folder because https://github.com/sanity-io/sanity/pull/13545 will remove everything in the legacy store for the next major.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal changes 
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Import-path refactor with logic moved as-is; legacy timeline now depends on events modules but behavior is unchanged.
> 
> **Overview**
> Relocates **`diffValue`** and **`getJsonStream`** from the deprecated `history/history` tree into **`store/events`**, where the events store already depends on them for document history and translog streaming.
> 
> **`calculateDiff`** now imports **`wrapValue`** from the local `./diffValue` module. Legacy **`Timeline`** / **`TimelineController`** and **`getTransactionsLogs`** (plus its tests) are updated to import from **`../../events/...`** instead of the history folder. **`isSameAnnotation`** is removed from history **`utils`** and inlined in **`events/diffValue.ts`** so annotation merging stays with the moved diff helpers.
> 
> No intended behavior change—this prepares for dropping the legacy history store in a follow-up major release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9008f9cb0041cea63e6af4ba3fe3a397adf4fb9c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->