### PR TITLE
refactor(core): prefer `data-pt-editor` over `.pt-editable`

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -78,7 +78,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
     height: 100%;
   }
 
-  & .pt-editable {
+  & [data-pt-editor] {
     display: block;
     width: 100%;
     height: 100%;
@@ -122,7 +122,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
     & > [data-pt-block] {
       /* Positioning context for the absolutely-positioned drop indicator so it
          sizes to the block (the centred text column) instead of the full-width
-         .pt-editable, which overshoots the block in fullscreen. */
+         [data-pt-editor], which overshoots the block in fullscreen. */
       position: relative;
       margin: 0 auto;
       max-width: ${(props) => getTheme_v2(props.theme).container[1]}px;

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/DragAndDrop.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/DragAndDrop.browser.test.tsx
@@ -58,7 +58,10 @@ describe('Portable Text Input', () => {
       await getFocusedPortableTextEditor('field-body')
 
       // Drag and drop the 'Hello world' block to the position of 'Baz'
-      await dragAndDrop('.pt-editable [draggable="true"]', '[data-pt-block="text"]:nth-child(3)')
+      await dragAndDrop(
+        '[data-pt-editor] [draggable="true"]',
+        '[data-pt-block="text"]:nth-child(3)',
+      )
 
       // NOTE: `document` is shadowed by the SanityDocument fixture above, so
       // reach for the DOM via `window.document`.
@@ -80,7 +83,7 @@ describe('Portable Text Input', () => {
 
       // Drag and drop the 'Hello world' block to the position of 'Baz' without dropping it
       await dragWithoutDrop(
-        '.pt-editable [draggable="true"]',
+        '[data-pt-editor] [draggable="true"]',
         '[data-pt-block="text"]:nth-child(3)',
       )
 

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/ImageArrayDrag.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/ImageArrayDrag.browser.test.tsx
@@ -53,7 +53,7 @@ describe('Portable Text Input - ImageArrayDrag', () => {
     await expect.element(page.getByTestId('pte-block-object')).toBeVisible()
 
     // Drag the block to a different position
-    await dragAndDrop('.pt-editable [draggable="true"]', '[data-testid="text-block"]')
+    await dragAndDrop('[data-pt-editor] [draggable="true"]', '[data-testid="text-block"]')
 
     // Check that no error toast appeared (the range-out-of-bounds toast)
     await expect.element(page.getByRole('alert')).not.toBeInTheDocument()


### PR DESCRIPTION
### Description

PTE will stop emitting the `pt-editable` class in the next major version. This PR migrates to its replacement, a `data-pt-editor` attribute.

### What to review

The swapped selectors must resolve to the same element as before; the fullscreen padding and drop-indicator sizing styles in `Editor.styles.tsx` are the affected surface.

### Testing

The existing drag-and-drop and image-drag browser tests exercise the new selectors and pass.

### Notes for release

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and test selector swaps with no logic changes; risk is limited to a wrong target element, which the existing browser tests are meant to catch.
> 
> **Overview**
> Portable Text **styles and drag-and-drop browser tests** now target the editor root via the **`data-pt-editor`** attribute instead of the **`pt-editable`** class.
> 
> In `Editor.styles.tsx`, the same rules apply (layout, list counters, fullscreen padding, drop-indicator positioning on `[data-pt-block]`). The selector change is meant to match the element the class used today and to stay valid when the editor drops `pt-editable` in its next major.
> 
> `DragAndDrop.browser.test.tsx` and `ImageArrayDrag.browser.test.tsx` use **`[data-pt-editor] [draggable="true"]`** for drag sources so test DOM queries align with the new styling hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb536c4ed504941a11103110fec8895d62ca44a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->