### PR TITLE
chore(metrics): mark releases in trend charts and benchmark release commits

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,6 +30,10 @@ on:
         description: "Backfill: build and measure this main-history commit instead of HEAD (full 40-char sha; requires run_suite, incompatible with self_test and ab_from/ab_to; result is stored under this sha, harness/scenarios come from HEAD)"
         required: false
         type: string
+      release_tag:
+        description: "Release: the tag whose commit is being measured (e.g. v6.10.1). Set together with backfill_sha (the tag's dereferenced sha) by release-latest.yml; marks the stored run as the measurement of a shipped version"
+        required: false
+        type: string
       ab_from:
         description: "A/B: reference commit to compare against (full 40-char sha; set together with ab_to; incompatible with backfill_sha and self_test; verdicts land in the run summary)"
         required: false
@@ -104,11 +108,13 @@ jobs:
       - name: Validate dispatch inputs
         if: >-
           github.event_name == 'workflow_dispatch' &&
-          (inputs.backfill_sha != '' || inputs.ab_from != '' || inputs.ab_to != '')
+          (inputs.backfill_sha != '' || inputs.ab_from != '' || inputs.ab_to != ''
+           || inputs.release_tag != '')
         env:
           RUN_SUITE: ${{ inputs.run_suite }}
           SELF_TEST: ${{ inputs.self_test }}
           BACKFILL_SHA: ${{ inputs.backfill_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
           AB_FROM: ${{ inputs.ab_from }}
           AB_TO: ${{ inputs.ab_to }}
         run: |
@@ -133,6 +139,30 @@ jobs:
             fi
             if [ "$SELF_TEST" = "true" ]; then
               echo "::error::backfill_sha cannot be combined with self_test"
+              exit 1
+            fi
+          fi
+          # A release run measures the tag's dereferenced sha via the backfill
+          # path. Without a sha the run would measure HEAD and be stored as the
+          # release's measurement — the exact false attribution release runs
+          # exist to prevent — so this is an error, not a warning.
+          if [ -n "$RELEASE_TAG" ] && [ -z "$BACKFILL_SHA" ]; then
+            echo "::error::release_tag requires backfill_sha (the tag's dereferenced commit)"
+            exit 1
+          fi
+          # ...and the sha must actually BE that commit. The pair is also set
+          # by hand (the recovery runbook in release-latest.yml), and a stale
+          # copy-paste would store numbers measured on some other commit as
+          # the release's measurement. The checkout above is fetch-depth 0
+          # whenever backfill_sha is set, so the tag is resolvable here.
+          if [ -n "$RELEASE_TAG" ]; then
+            TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}" 2>/dev/null || true)"
+            if [ -z "$TAG_SHA" ]; then
+              echo "::error::release_tag $RELEASE_TAG does not exist"
+              exit 1
+            fi
+            if [ "$TAG_SHA" != "$BACKFILL_SHA" ]; then
+              echo "::error::backfill_sha $BACKFILL_SHA is not the commit $RELEASE_TAG points at ($TAG_SHA)"
               exit 1
             fi
           fi
@@ -282,6 +312,11 @@ jobs:
       # report/collect.ts)
       BENCH_GIT_SHA: ${{ inputs.backfill_sha || inputs.ab_to }}
       BENCH_GIT_COMMITTED_AT: ${{ needs.build.outputs.backfill_committed_at }}
+      # Why this run happened. A release_tag means release-latest.yml dispatched
+      # this to measure a shipped version; otherwise collect.ts infers it from
+      # the event (empty string is not a valid trigger, so it falls through).
+      BENCH_TRIGGER: ${{ inputs.release_tag != '' && 'release' || '' }}
+      BENCH_RELEASE_TAG: ${{ inputs.release_tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -383,6 +418,9 @@ jobs:
       # See bench-interaction: stamps backfill runs with the measured sha
       BENCH_GIT_SHA: ${{ inputs.backfill_sha || inputs.ab_to }}
       BENCH_GIT_COMMITTED_AT: ${{ needs.build.outputs.backfill_committed_at }}
+      # See bench-interaction
+      BENCH_TRIGGER: ${{ inputs.release_tag != '' && 'release' || '' }}
+      BENCH_RELEASE_TAG: ${{ inputs.release_tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -785,6 +823,10 @@ jobs:
       # measured sha
       BENCH_GIT_SHA: ${{ inputs.backfill_sha || inputs.ab_to }}
       BENCH_GIT_COMMITTED_AT: ${{ needs.build.outputs.backfill_committed_at }}
+      # See bench-interaction. This is the job that stores the absolute-mode
+      # document, so this is where the trigger actually reaches the dataset.
+      BENCH_TRIGGER: ${{ inputs.release_tag != '' && 'release' || '' }}
+      BENCH_RELEASE_TAG: ${{ inputs.release_tag }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -186,6 +186,70 @@ jobs:
       BENCH_METRICS_WRITE_TOKEN: ${{ secrets.BENCH_METRICS_WRITE_TOKEN }}
       SLACK_WEBHOOK_URL_CI_ALERTS: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
 
+  bench-release:
+    name: Benchmark the released commit
+    # Measure the released commit. Without this, nothing in the metrics dataset
+    # ever measures a shipped version: the daily cron measures whatever main
+    # happens to be at 05:00, which landed on a release commit exactly once in
+    # the first 9 releases of the bench window. A release run is what makes
+    # "v6.10.1 regressed LCP" a statement about a release rather than an
+    # interpolation between two commits nobody shipped.
+    #
+    # Dispatched, not triggered by the tag push: git-operations pushes the tag
+    # with the default GITHUB_TOKEN, whose events never start workflows (the
+    # same reason sync-git-metrics is called rather than listening for tags).
+    #
+    # Runs through bench.yml's backfill path, which builds and measures a given
+    # commit with HEAD's harness — the release sha is just another commit to
+    # measure. Non-blocking by construction: nothing depends on this job, so a
+    # failed benchmark can never fail or delay a release.
+    #
+    # Requires git-operations to have actually run (not 'skipped', which
+    # npm-publish tolerates), so a publish-only rerun does not re-measure a
+    # release that was already measured. The flip side: if the original run's
+    # dispatch failed, a rerun will not retry it — measure it by hand with
+    # `gh workflow run bench.yml -f run_suite=true -f backfill_sha=<sha>
+    # -f release_tag=<tag>`, which is exactly what this job does.
+    needs: [build-and-validate, git-operations]
+    if: >
+      always() && needs.build-and-validate.result == 'success' &&
+      needs.git-operations.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          # The tag was pushed by git-operations; fetch it to dereference
+          fetch-depth: 0
+          ref: v${{ needs.build-and-validate.outputs.version }}
+
+      - name: Resolve the tag's commit
+        id: resolve
+        env:
+          VERSION: ${{ needs.build-and-validate.outputs.version }}
+        run: |
+          # The dereferenced commit, so an annotated tag yields the commit and
+          # not the tag object
+          sha=$(git rev-parse "v$VERSION^{commit}")
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Measuring v$VERSION at $sha"
+
+      - name: Dispatch the bench suite for this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.build-and-validate.outputs.version }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          gh workflow run bench.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f run_suite=true \
+            -f backfill_sha="$SHA" \
+            -f release_tag="v$VERSION"
+
   publish-releases:
     # Publish sanity.io Changelog & github release
     needs: [build-and-validate, npm-publish]

--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -155,9 +155,86 @@ secondary: leads scanning health weekly.
 
 4. **Layer toggles** — the chart legend doubles as a switchboard: clicking an
    entry shows/hides that layer (median, p75–p90 band, host calibration,
-   baseline overlay) across the whole grid, persisted as `?layers=-band` so a
-   stripped-back view is shareable. Global rather than per-card because the
-   grid is 40+ small multiples.
+   baseline overlay, release markers) across the whole grid, persisted as
+   `?layers=-band` so a stripped-back view is shareable. Global rather than
+   per-card because the grid is 40+ small multiples.
+
+5. **Release markers** — one dotted vertical rule per stable `v*` tag
+   (`gitTag`, rc tags excluded) inside the plotted window, so "did this step
+   land with a release?" is answerable without leaving the chart. The first
+   consumer of the git-history join surface.
+
+   **Main-branch releases only.** The charts only ever plot main (bench runs are
+   main-branch crons), so a release cut off main is a _false_ annotation — its
+   commits are not in the line being measured. `TAGS_QUERY` filters on the
+   existence of a `gitCommit` with the tag's sha, since those documents are
+   main-only by construction. This is not a filter on `major`: the v5 tags up to
+   the v6 cutover were cut from main and belong on a chart reaching back that
+   far, while v5.31.2 (a maintenance release that shipped mid-window from a
+   release branch) is correctly excluded. The tag's own weak `commit` reference
+   is deliberately not the test — a dangling weak ref means "not synced", which
+   is a different claim than "not on main".
+
+   **Markers anchor to release runs where they exist** (`resolveTagPositions`).
+   A run with `trigger: 'release'` built and measured the tagged commit, so its
+   point _is_ the release and the marker sits exactly on it. The two positions
+   genuinely differ — the tag date is when the release was cut, the run measured
+   it whenever CI got to it — so drawing on the tag date would put the rule
+   beside the point that measured it.
+
+   Releases with no run fall back to the tag's own date, which is what every
+   marker did before release runs existed. Both kinds render **identically**:
+   the distinction is carried by wording (the tooltip says "measured release"
+   vs "release"; the popover says "released as" vs an after/before bracket), not
+   by a second visual language that would need its own legend entry to explain a
+   difference only relevant once you are asking about a specific run. So a chart
+   mixes anchored and date-placed markers without looking inconsistent — which
+   it will for as long as history predating release runs is in range.
+
+   Why this matters: before release runs, **1 of the first 9 releases** in the
+   bench window had ever been benchmarked, and that one was a coincidence (a
+   cron happened to land on it). Every performance statement about a release was
+   an interpolation between commits nobody shipped. See `perf/bench`'s
+   `bench-release` job in `release-latest.yml`.
+
+   The fallback join is **by time**, not by sha, and stays deliberately hedged:
+   an unanchored marker claims only "this release shipped here", never "this run
+   measured this release".
+
+   The **run popover** states release context for every run. A release run says
+   "released as vX.Y.Z" — the one case where a number attributes to a shipped
+   version. Every other run gets the bracket (`releaseContextAt`): newest
+   release at or before it, and the next one after ("after v6.10.1 / not yet
+   released"). The bracket reads the full tag list rather than the visible
+   window, since a run's preceding release is often older than the plotted
+   range. It stays a by-date bound, hence "after"/"before" rather than "released
+   in": proving commit containment would need an ancestry walk over
+   `gitCommit.parentSha`.
+
+   Markers survive branch comparison, unlike the band and the baseline overlay:
+   a release is global context, identical for every line, so it cannot turn
+   into per-branch mud. They are suppressed only on soak latest-run charts,
+   whose x-axis is minutes within one run — a calendar-dated rule there would
+   claim a relationship between a release and a minute of runtime.
+
+   **Labels are size-dependent.** At grid-card width (~330px) a 90-day window
+   holds ~20 markers, one every ~15px, so resting text is guaranteed overlap:
+   cards draw unlabelled rules (each with a tick at the top so it still reads as
+   an anchor) and the hover tooltip names the release nearest the crosshair,
+   within half the median run gap. The maximized view has the room and draws
+   rotated labels, thinned so that a cluster keeps its last tag — releases
+   cluster on release days, and the last of a cluster is the one in effect for
+   the runs that follow.
+
+6. **Maximize a single chart** — the grid is built for scanning; reading one
+   chart closely needs room. An expand button on each card opens the same
+   `SeriesCard` in a dialog at `?max=<series key>` (shareable and reloadable,
+   pushed to history so Back closes it), where it draws labelled release
+   markers and shows its description as visible text instead of behind the ⓘ.
+   The dialog is a superset of the card: it gets the same drift, baseline and
+   ack props, so maximizing is never a downgrade. Fixed width rather than
+   full-viewport — stretching 90 days across a 2500px monitor reads as a flat
+   line no matter what the metric did.
 
 ## Architecture
 
@@ -171,8 +248,10 @@ secondary: leads scanning health weekly.
   stops being true.
 - **Dev debug sources** (dev-server only): deterministic synthetic datasets
   (`tools/trends/debugData.ts` — steady/drift/step/host-correlated shapes,
-  sparse/single/empty sets) selectable in the toolbar, so charts and the
-  future drift feed are testable without live data.
+  sparse/single/empty sets, plus synthetic release tags with two interleaved
+  majors and a deliberate label collision) selectable in the toolbar, so the
+  charts, the drift feed and every encoding layer are testable without live
+  data.
 - **Charts: visx** (`@visx/scale`, `@visx/shape`, `@visx/group`,
   `@visx/axis`, `@visx/responsive`) — low-level primitives, no chart-library
   opinions to fight inside `@sanity/ui` layout.
@@ -188,5 +267,5 @@ secondary: leads scanning health weekly.
   (coverage reports from CI's `json-summary`, flake rates, version stability,
   error rates) as sibling document types with their own trends tabs — the
   `gitCommit`/`gitTag` documents (landed Aug 2026) are the join surface these
-  build on; release markers / commit subjects in the Trends charts are the
-  first consumer to build.
+  build on. Release markers (above) are the first consumer, shipped; commit
+  subjects in the run popover are the obvious next one.

--- a/dev/metrics-studio/schemaTypes/benchRun.ts
+++ b/dev/metrics-studio/schemaTypes/benchRun.ts
@@ -296,6 +296,19 @@ const benchRun = defineType({
     defineField({name: 'schemaVersion', type: 'number'}),
     defineField({name: 'mode', type: 'string', options: {list: ['ab', 'absolute']}}),
     defineField({
+      name: 'trigger',
+      description:
+        'Why this run happened. Only `release` runs measure a tagged release commit, so they are the only ones whose numbers attribute to a shipped version. Absent on documents written before this field existed — treat as `cron`.',
+      type: 'string',
+      options: {list: ['cron', 'release', 'backfill', 'dispatch', 'pr']},
+    }),
+    defineField({
+      name: 'releaseTag',
+      description:
+        'Release runs only: the tag whose commit this run measured, e.g. v6.10.1 — lets a chart anchor a release marker on this run instead of guessing by date',
+      type: 'string',
+    }),
+    defineField({
       name: 'git',
       type: 'object',
       fields: [

--- a/dev/metrics-studio/tools/trends/ChartLegend.tsx
+++ b/dev/metrics-studio/tools/trends/ChartLegend.tsx
@@ -1,10 +1,16 @@
 import {Flex, Text} from '@sanity/ui'
 
-import {CALIBRATION_EXPLAINER, formatValue, type TrendSeries} from './data'
+import {CALIBRATION_EXPLAINER, formatValue, type TrendSeries, type TrendTag} from './data'
 import {baselineDetail, baselineLabel, type DriftResult} from './drift'
 import {ALL_LAYERS_VISIBLE, type Layer, type LayerState} from './layers'
 import {categoricalColor} from './palette'
-import {baselineToDraw, COLOR, seriesHasBand, seriesHasCalibration} from './TrendChart'
+import {
+  baselineToDraw,
+  COLOR,
+  seriesHasBand,
+  seriesHasCalibration,
+  seriesHasReleases,
+} from './TrendChart'
 
 function Swatch(props: {children: React.ReactNode; dimmed?: boolean}) {
   return (
@@ -77,8 +83,10 @@ export function ChartLegend(props: {
   series: TrendSeries
   drift?: DriftResult
   layers?: LayerState
+  /** Release tags available to this chart — gates the `releases` entry. */
+  tags?: TrendTag[]
 }) {
-  const {series, drift, layers = ALL_LAYERS_VISIBLE} = props
+  const {series, drift, layers = ALL_LAYERS_VISIBLE, tags = []} = props
   const comparing = series.lines.length > 1
   // Whether this chart *has* a baseline to explain — independent of whether the
   // layer is currently visible, so toggling it off doesn't remove the control
@@ -118,6 +126,37 @@ export function ChartLegend(props: {
     </Flex>
   )
 
+  // Releases are global context — identical for every line — so unlike the band
+  // and the baseline overlay the entry survives branch comparison. Gated on the
+  // same predicate the plot uses, so the legend never offers a layer that isn't
+  // drawn (see seriesHasReleases: minute-axis soak charts don't qualify).
+  const releasesItem = seriesHasReleases(series, tags) && (
+    <LegendItem
+      layer="releases"
+      layers={layers}
+      label="releases"
+      hint="Stable sanity release tags cut from main. A release that was benchmarked sits on the run that measured it; the rest are placed by tag date, where a marker near a run does not mean that run measured it. Hover a run to name the releases around it"
+      swatch={
+        // A short vertical tick sitting on a baseline — the same construction as
+        // the plot (a tick above the plot's top edge), and the only vertical
+        // glyph in the legend
+        <>
+          <line
+            x1={8}
+            y1={1}
+            x2={8}
+            y2={7}
+            stroke={COLOR.release}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            opacity={0.75}
+          />
+          <line x1={2} y1={7} x2={14} y2={7} stroke={COLOR.axis} strokeWidth={1} opacity={0.3} />
+        </>
+      }
+    />
+  )
+
   if (comparing) {
     return (
       <Flex gap={3} wrap="wrap" align="center">
@@ -131,6 +170,7 @@ export function ChartLegend(props: {
             </Text>
           </Flex>
         ))}
+        {releasesItem}
         {goodItem}
         {series.goal === 'lower' && (
           <Text size={0} muted>
@@ -239,6 +279,7 @@ export function ChartLegend(props: {
           }
         />
       )}
+      {releasesItem}
       {goodItem}
       {series.goal === 'lower' && (
         <Text size={0} muted>

--- a/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
+++ b/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
@@ -12,8 +12,10 @@ import {
   CALIBRATION_EXPLAINER,
   formatValue,
   INP_MIN_INTERACTIONS,
+  releaseContextAt,
   type TrendPoint,
   type TrendSeries,
+  type TrendTag,
 } from './data'
 import {buildInvestigationPrompt} from './investigationPrompt'
 import {backlinksFor, compareUrl, sourceFileUrl} from './links'
@@ -33,11 +35,25 @@ export function RunDetailPopover(props: {
   point: TrendPoint
   /** The nearest earlier point on the same line measuring a distinct commit. */
   previousPoint?: TrendPoint
+  /** Stable main-branch release tags — for this run's release context. */
+  tags?: TrendTag[]
   referenceElement: HTMLElement | null
   onClose: () => void
 }) {
-  const {series, point, previousPoint, referenceElement, onClose} = props
+  const {series, point, previousPoint, tags = [], referenceElement, onClose} = props
   const {host} = point
+  // Which releases this run sits between. Always stated when known, unlike the
+  // hover tooltip's proximity-based row: "which release is this run's code in?"
+  // is a question every run has an answer to. Meaningless on soak minute charts,
+  // whose x-axis is elapsed minutes rather than a calendar date.
+  // A release run measured the tagged commit itself, so it needs no bracket:
+  // its value *is* that release's number. The bracket stays for ordinary runs,
+  // where sitting between two releases is the strongest true statement.
+  const releaseContext =
+    series.xKind === 'minute' || point.releaseTag
+      ? {}
+      : releaseContextAt(tags, point.date.getTime())
+  const measuredTag = series.xKind === 'minute' ? undefined : point.releaseTag
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null)
   // "What landed between this point and the previous one?" — the GitHub
   // compare view answers it directly. Guarded by the full-sha shape so a
@@ -182,6 +198,74 @@ export function RunDetailPopover(props: {
                 </Badge>
               )}
             </Stack>
+
+            {/* Where this run sits in the release timeline. Stated for every
+                run (not only ones next to a marker), because "is this before or
+                after the release I care about?" is the question the markers
+                raise and the popover is where it gets answered.
+
+                Wording is careful: "released in" would claim commit containment,
+                which a by-date bound does not establish — so it says "after" /
+                "before", which is exactly what the dates support. */}
+            {/* This run built and measured the release commit — the one case
+                where a performance number attributes to a shipped version
+                rather than to "main around then". Stated plainly, and
+                deliberately distinct from the after/before bracket below. */}
+            {measuredTag && (
+              <Stack gap={2}>
+                <Text size={0} muted weight="medium">
+                  Release
+                </Text>
+                <Flex align="center" gap={2}>
+                  <Text size={1} muted>
+                    released as
+                  </Text>
+                  <Text size={1} weight="semibold">
+                    {measuredTag}
+                  </Text>
+                </Flex>
+                <Text size={0} muted>
+                  This run measured the release commit.
+                </Text>
+              </Stack>
+            )}
+
+            {(releaseContext.previous || releaseContext.next) && (
+              <Stack gap={2}>
+                <Text size={0} muted weight="medium">
+                  Release
+                </Text>
+                <Stack gap={2}>
+                  {releaseContext.previous && (
+                    <Flex align="center" gap={2}>
+                      <Text size={1} muted>
+                        after
+                      </Text>
+                      <Text size={1}>{releaseContext.previous.tag}</Text>
+                      {releaseContext.previous.distTags?.includes('latest') && (
+                        <Badge tone="primary" fontSize={0}>
+                          latest
+                        </Badge>
+                      )}
+                    </Flex>
+                  )}
+                  {releaseContext.next ? (
+                    <Flex align="center" gap={2}>
+                      <Text size={1} muted>
+                        before
+                      </Text>
+                      <Text size={1}>{releaseContext.next.tag}</Text>
+                    </Flex>
+                  ) : (
+                    // The common case for recent runs, and worth saying out
+                    // loud: silence here would read as missing data
+                    <Text size={1} muted>
+                      not yet released
+                    </Text>
+                  )}
+                </Stack>
+              </Stack>
+            )}
 
             {/* The machine that produced this run — the context every absolute
                 number depends on. cpuModel/image/browser exist on documents

--- a/dev/metrics-studio/tools/trends/TrendChart.tsx
+++ b/dev/metrics-studio/tools/trends/TrendChart.tsx
@@ -433,12 +433,12 @@ function labelFor(cluster: TagCluster): string {
  * the plotted window, so "did this step land with a release?" is answerable
  * without leaving the chart.
  *
- * The mark deliberately lives *outside* the plot. It began as a full-height
- * dotted rule, which located the release but crossed every measured value to do
- * it — nine releases in a 90-day window meant nine lines drawn through the data
- * to convey nine x positions. A tick in the top margin says the same thing while
- * leaving the measurement alone, which is the rule annotation has to follow here
- * (the same reason the baseline overlay paints under the data layers).
+ * The mark deliberately lives *outside* the plot. A full-height rule would
+ * locate the release just as well, but it crosses every measured value to do it
+ * — nine releases in a 90-day window means nine lines drawn through the data to
+ * convey nine x positions. A tick in the top margin says the same thing while
+ * leaving the measurement alone, which is the rule annotation follows here (the
+ * same reason the baseline overlay paints under the data layers).
  *
  * Markers whose release was actually benchmarked (`measured`) sit above that
  * run's point; the rest fall back to the tag's own date. Both are drawn
@@ -472,10 +472,9 @@ function ReleaseMarkers(props: {
   // one name.
   //
   // Crucially the *text* of a thinned label is not discarded — it folds into the
-  // label that survives, as "+n". Dropping it outright is what made v6.10.1
-  // vanish from the all-time view while its tick was still drawn: a mark with no
-  // name and no hint that a name existed. Marks stay one-per-release wherever
-  // they are separable; only the naming collapses.
+  // label that survives, as "+n", so a release is never left with a tick that
+  // carries no name and no hint that a name exists. Marks stay one-per-release
+  // wherever they are separable; only the naming collapses.
   const clusters = clusterTags(tags, xScale, 6)
   // 14px between labels: at -60° that is ~12px perpendicular against a 9px line
   // height. See labelledClusters for why the gap is measured where it is.

--- a/dev/metrics-studio/tools/trends/TrendChart.tsx
+++ b/dev/metrics-studio/tools/trends/TrendChart.tsx
@@ -11,9 +11,16 @@ import {
   formatValue,
   INP_MIN_INTERACTIONS,
   isSignedUnit,
+  clusterTags,
+  labelledClusters,
+  medianGapMs,
+  type TagCluster,
+  type ResolvedTag,
+  resolveTagPositions,
   type TrendLine,
   type TrendPoint,
   type TrendSeries,
+  type TrendTag,
 } from './data'
 import {baselineDetail, type DriftBaseline, type DriftResult} from './drift'
 import {ALL_LAYERS_VISIBLE, type LayerState} from './layers'
@@ -21,7 +28,29 @@ import {categoricalColor} from './palette'
 import {RunDetailPopover} from './RunDetailPopover'
 
 // Left gutter is computed per chart from its tick labels — see marginLeft
-const MARGIN = {top: 8, right: 8, bottom: 22}
+// top: 12 so the release markers' 6px ticks (drawn above the plot, at negative
+// y) clear the SVG's own edge with a little room rather than touching it — paid
+// unconditionally so the plot never resizes when the releases layer is toggled.
+// bottom: 22 for the axis line + its tick labels, plus 4 so the last row of
+// glyphs isn't shaved by the SVG's own edge.
+const MARGIN = {top: 12, right: 8, bottom: 26}
+
+/**
+ * Top gutter on a chart that can draw release labels.
+ *
+ * Deliberately a **fixed** amount, and reserved whenever the chart is capable of
+ * labelling releases — not only when it currently is. Sizing it to the labels
+ * actually drawn (or making it conditional on the `releases` layer) meant the
+ * plot resized when the layer was toggled and differed between charts in the
+ * same grid, so the same metric read at two different heights. A stable plot is
+ * worth more than the ~60px a short-label chart could reclaim: the eye compares
+ * these small multiples against each other.
+ *
+ * Sized for the longest label in practice — 'v10.10.10 +2 (latest)' is ~21
+ * glyphs of 9px text at ~5.4px/glyph, of which sin(60°) ≈ 87% becomes height at
+ * the label's tilt — plus the tick and breathing room.
+ */
+const TAG_LABEL_MARGIN_TOP = 112
 
 /**
  * The nearest earlier point on the selected point's own line that measured a
@@ -120,6 +149,17 @@ export const COLOR = {
    * neutral baseline's before-rule.
    */
   goodThreshold: 'var(--card-badge-caution-fg-color, #a35200)',
+  /**
+   * Release markers. The same neutral as the host-calibration context line —
+   * both are reference, not measurement, and a hue here would compete with the
+   * data series for meaning ("is the purple one a branch?"). They stay
+   * distinguishable by position and shape rather than color: calibration is a
+   * horizontal dotted trail *inside* the plot, a release is a short vertical
+   * tick *above* it, and the legend names both. Its own entry rather than
+   * reusing `context` because a future re-tone of one must not silently move
+   * the other.
+   */
+  release: 'var(--card-fg-color, #101112)',
 }
 
 /**
@@ -158,6 +198,27 @@ export function seriesHasCalibration(series: TrendSeries): boolean {
   if (series.xKind === 'minute') return false
   if (series.unit !== 'ms') return false
   return series.lines[0].points.filter((point) => point.calibrationMs !== undefined).length > 1
+}
+
+/**
+ * Whether this chart can carry release markers.
+ *
+ * Only the x-axis kind decides it: soak latest-run charts plot minutes *within*
+ * one run, so a calendar-dated release rule there would claim a relationship
+ * between a release and a minute of runtime, which is nonsense. Everything else
+ * qualifies — including branch comparisons, unlike the band and the baseline
+ * overlay: a release is global context, identical for every line, so it can't
+ * turn into per-branch mud.
+ *
+ * Exported so `ChartLegend` keys off the same predicate. Unlike
+ * `seriesHasBand` this is a *capability* test, not a "currently drawing" test:
+ * markers are domain-filtered per chart, so a chart whose plotted range holds
+ * no release still advertises the layer — the toggle applies grid-wide, and
+ * hiding it because one window is empty would make it unreachable.
+ */
+export function seriesHasReleases(series: TrendSeries, tags: TrendTag[]): boolean {
+  if (series.xKind === 'minute') return false
+  return tags.length > 0
 }
 
 /** Per-line color: the studio accent for a lone line, categorical when comparing. */
@@ -347,6 +408,162 @@ function BaselineOverlay(props: {
   )
 }
 
+/**
+ * A cluster's label: its name, "+n" when the mark stands for several releases,
+ * and "latest" when one of them is what npm currently serves.
+ *
+ * `latest` is marked in *text* rather than by drawing that tick differently. It
+ * is worth pointing out — it's the release most readers mean — but an
+ * unexplained heavier mark reads as a different kind of thing, and needs a
+ * legend entry to decode. A word next to a version number needs nothing: it
+ * also carries its own tense, so a reader takes it as a current fact about that
+ * version rather than something baked into the chart's history (dist-tags
+ * re-point on the next publish).
+ */
+function labelFor(cluster: TagCluster): string {
+  const isLatest = cluster.tags.some((entry) => entry.distTags?.includes('latest'))
+  const also = cluster.alsoCount > 0 ? ` +${cluster.alsoCount}` : ''
+  // Parenthesised, so it reads as an aside about the version rather than running
+  // together with it into one token ("v6.10.1 latest")
+  return `${cluster.tag.tag}${also}${isLatest ? ' (latest)' : ''}`
+}
+
+/**
+ * Release markers: a small tick above the plot per stable `v*` tag positioned in
+ * the plotted window, so "did this step land with a release?" is answerable
+ * without leaving the chart.
+ *
+ * The mark deliberately lives *outside* the plot. It began as a full-height
+ * dotted rule, which located the release but crossed every measured value to do
+ * it — nine releases in a 90-day window meant nine lines drawn through the data
+ * to convey nine x positions. A tick in the top margin says the same thing while
+ * leaving the measurement alone, which is the rule annotation has to follow here
+ * (the same reason the baseline overlay paints under the data layers).
+ *
+ * Markers whose release was actually benchmarked (`measured`) sit above that
+ * run's point; the rest fall back to the tag's own date. Both are drawn
+ * identically — see ResolvedTag for why the distinction lives in the wording
+ * rather than in the mark.
+ *
+ * The position claim stays weak for unanchored markers: "this release shipped
+ * here", never "this run measured this release".
+ *
+ * Labels are opt-in (`showLabels`) because at grid-card width (~330px) a 90-day
+ * window holds ~20 markers, i.e. one every ~15px: resting text there is
+ * guaranteed overlap. The maximized dialog has the room, and at card size the
+ * hover tooltip names the release instead.
+ *
+ * `aria-hidden` like the other annotation layers: the capture rect's label
+ * carries the count, and the tooltip names the individual release.
+ */
+function ReleaseMarkers(props: {
+  tags: ResolvedTag[]
+  xScale: (ms: number) => number
+  /** Resting text labels above the plot — only where there is room for them. */
+  showLabels?: boolean
+}) {
+  const {tags, xScale, showLabels} = props
+  if (tags.length === 0) return null
+  // Two gaps, because marks and text need different room. Marks merge below 6px,
+  // where two ticks stop reading as two; labels need 14px, since at -60° a
+  // 7-glyph tag leans ~19px sideways (~12px perpendicular to its neighbour,
+  // against a 9px line height). Marks merge first, then labels thin across what
+  // survives — so a cluster is one mark with one label, never two marks sharing
+  // one name.
+  //
+  // Crucially the *text* of a thinned label is not discarded — it folds into the
+  // label that survives, as "+n". Dropping it outright is what made v6.10.1
+  // vanish from the all-time view while its tick was still drawn: a mark with no
+  // name and no hint that a name existed. Marks stay one-per-release wherever
+  // they are separable; only the naming collapses.
+  const clusters = clusterTags(tags, xScale, 6)
+  // 14px between labels: at -60° that is ~12px perpendicular against a 9px line
+  // height. See labelledClusters for why the gap is measured where it is.
+  const labels = showLabels ? labelledClusters(clusters, 14) : new Map<number, TagCluster>()
+
+  return (
+    <g aria-hidden="true" pointerEvents="none">
+      {clusters.map((cluster, index) => {
+        const {tag, x} = cluster
+        // Every marker is drawn identically — the `latest` release is called out
+        // in its label's text instead (see labelFor), which needs no legend to
+        // decode and no second mark weight to notice.
+        return (
+          <g key={tag.tag}>
+            {/* A tick above the plot, not a rule through it.
+
+                A full-height dotted rule marked the same x, but it crossed
+                every measured value on the way — and with ~9 releases in a
+                90-day window that is nine lines drawn over the data to convey
+                nine positions. The tick sits in the top margin and touches the
+                plot's edge, so it locates the release without competing with
+                the series, the band, or the reference marks for the reader's
+                attention inside the plot.
+
+                It has to carry findability alone now, so it is solid and full
+                strength rather than the recessive dotting a rule needed: a mark
+                that only exists in 6px must actually read at a glance. */}
+            <line
+              x1={x}
+              x2={x}
+              y1={-6}
+              y2={1}
+              stroke={COLOR.release}
+              strokeWidth={1.5}
+              opacity={0.7}
+              strokeLinecap="round"
+            />
+            {labels.has(index) && (
+              // A shallow tilt, rotated about the point where the text meets its
+              // own tick.
+              //
+              // Three positions were tried. -45° leaned ~40px sideways, crossing
+              // the neighbouring tick and forcing most labels to be thinned
+              // away. Fully vertical (-90°) fixed the density but is genuinely
+              // hard to read. -60° keeps most of the width saving — a 7-glyph
+              // tag leans only ~19px — while staying legible at a glance.
+              //
+              // Rotating about `translate(x, -7)` with textAnchor="start" means
+              // the text's *start* is pinned a couple of px above the tick and
+              // the string grows up-and-right from there, so a label always sits
+              // against the mark it names instead of drifting away from it as
+              // the tag gets longer.
+              <text
+                transform={`translate(${x + 1}, -7) rotate(-60)`}
+                textAnchor="start"
+                fontSize={9}
+                fill={COLOR.axis}
+                opacity={0.9}
+              >
+                {/* "+n" rather than dropping the others silently: the reader can
+                    see more shipped here and hover for the names */}
+                {labelFor(labels.get(index)!)}
+              </text>
+            )}
+          </g>
+        )
+      })}
+    </g>
+  )
+}
+
+/**
+ * The release nearest a run, when it is near enough to be worth naming in that
+ * run's tooltip.
+ *
+ * "Near enough" is half the median gap between runs: the marker the crosshair is
+ * standing next to is the release that plausibly explains this run's value, and
+ * anything further away belongs to a different run. A fixed pixel or day
+ * tolerance would either go silent on sparse history or name an unrelated
+ * release on dense history.
+ */
+function releasesNearRun(tags: ResolvedTag[], runMs: number, toleranceMs: number): TrendTag[] {
+  return tags
+    .filter((entry) => Math.abs(entry.atMs - runMs) <= toleranceMs)
+    .sort((a, b) => Math.abs(a.atMs - runMs) - Math.abs(b.atMs - runMs))
+    .map((entry) => entry.tag)
+}
+
 export function TrendChart(props: {
   series: TrendSeries
   width: number
@@ -355,8 +572,23 @@ export function TrendChart(props: {
   drift?: DriftResult
   /** Which encoding layers to draw; defaults to all. */
   layers?: LayerState
+  /** Stable release tags, drawn as vertical markers. Empty = no markers. */
+  tags?: TrendTag[]
+  /**
+   * Draw resting labels on the release markers. Only true where there is room
+   * for them (the maximized dialog) — see ReleaseMarkers.
+   */
+  showTagLabels?: boolean
 }) {
-  const {series, width, height, drift, layers = ALL_LAYERS_VISIBLE} = props
+  const {
+    series,
+    width,
+    height,
+    drift,
+    layers = ALL_LAYERS_VISIBLE,
+    tags = [],
+    showTagLabels = false,
+  } = props
   const {lines, unit} = series
   const [hoverMs, setHoverMs] = useState<number | null>(null)
   // The selected point only — its anchor coords are derived from the current
@@ -368,7 +600,25 @@ export function TrendChart(props: {
   const allPoints = lines.flatMap((line) => line.points)
   if (width < 10 || allPoints.length === 0) return null
 
-  const innerHeight = height - MARGIN.top - MARGIN.bottom
+  const showReleases = layers.visible('releases') && seriesHasReleases(series, tags)
+  // Reserved by *capability*, not by what is currently drawn: keyed on the
+  // layer's visibility (or on the label lengths) the plot resized when releases
+  // were toggled, and charts in one grid disagreed on height depending on
+  // whether a release happened to fall in their window.
+  //
+  // The conditions here stay stable under the reader: `showTagLabels` is a
+  // property of the surface (only the maximized dialog sets it), and a
+  // minute-axis chart can *never* label a release — seriesHasReleases rejects
+  // `xKind: 'minute'` outright, since a calendar-dated release says nothing
+  // about a minute of one run's soak. Reserving for them anyway cost a
+  // maximized soak chart ~100px of its 460 to permanently empty space.
+  // `tags.length > 0` is the same reasoning against a tag-less dataset (or a
+  // failed tag query): no tag can ever be labelled, so the gutter would be
+  // permanently blank. It can reflow once, when the tag stream first emits
+  // after the dialog mounts — a one-time jump on one chart, not grid churn.
+  const canLabelReleases = showTagLabels && series.xKind !== 'minute' && tags.length > 0
+  const marginTop = canLabelReleases ? TAG_LABEL_MARGIN_TOP : MARGIN.top
+  const innerHeight = height - marginTop - MARGIN.bottom
 
   // Signed units (slopes) center on zero with a symmetric domain, so a
   // near-flat metric reads as a calm line through the middle rather than
@@ -418,6 +668,16 @@ export function TrendChart(props: {
   const xScale = scaleTime({domain: [new Date(minDate), new Date(maxDate)], range: [0, innerWidth]})
 
   const x = (point: TrendPoint) => xScale(point.date)
+  // Anchored to the runs that measured them where possible — a release run's
+  // point *is* the release, so the marker belongs on it rather than on the tag
+  // date (which is hours earlier). resolveTagPositions owns the whole pipeline
+  // (anchor, then filter to the domain, then sort by drawn position) precisely
+  // so those steps cannot be ordered wrongly here — see its docstring.
+  //
+  // Cheap by construction: the tags array is shared across every chart and tiny
+  // (~54 documents for all of v5+v6), so one O(n) pass per chart render costs
+  // nothing next to the plot itself.
+  const visibleTags = showReleases ? resolveTagPositions(tags, allPoints, minDate, maxDate) : []
   // The band only reads when there's one line — overlapping bands across branches
   // would be mud, so comparison mode shows lines only (see seriesHasBand for the
   // low-sample case)
@@ -496,13 +756,37 @@ export function TrendChart(props: {
           .filter((entry): entry is {branch: string; color: string; point: TrendPoint} =>
             Boolean(entry.point),
           )
+  // The release the crosshair is standing next to, named in the tooltip — this
+  // is how a marker gets identified at grid-card size, where resting labels
+  // don't fit. The floor keeps a very dense history (several runs an hour) from
+  // narrowing the tolerance to the point where no marker is ever nameable.
+  // A release run states its release outright — it measured that commit, so
+  // there is nothing to infer; it is named from the run itself, not from the
+  // tag documents, which can lag the run (the tag sync is a separate cron).
+  const measuredRelease = hovered.find((entry) => entry.point.releaseTag)?.point.releaseTag
+  // All of them, not just the nearest: releases ship in bursts (v6.10.0 and
+  // v6.10.1 6.8 hours apart), and their marks merge into one tick — so the
+  // tooltip is where the individual names have to remain reachable, including
+  // next to a measured release (which gets its own row above this list).
+  const hoveredReleases = (
+    snappedMs === null || visibleTags.length === 0
+      ? []
+      : releasesNearRun(
+          visibleTags,
+          snappedMs,
+          Math.max(medianGapMs(stepTimes) / 2, 60 * 60 * 1000),
+        )
+  ).filter((entry) => entry.tag !== measuredRelease)
+  const measuredIsLatest = visibleTags.some(
+    (entry) => entry.tag.tag === measuredRelease && entry.tag.distTags?.includes('latest'),
+  )
 
   return (
     <div style={{position: 'relative', width, height}}>
       {/* No role="img": the plot is interactive (see the focusable capture
           rect below), not a static image — claiming "img" would hide that */}
       <svg width={width} height={height}>
-        <Group left={marginLeft} top={MARGIN.top}>
+        <Group left={marginLeft} top={marginTop}>
           {/* Zero reference for signed slope charts — the "flat is good" line.
               Dashed like the other reference marks: solid, it reads as a flat
               data series the moment the median layer is toggled off. */}
@@ -546,6 +830,14 @@ export function TrendChart(props: {
               innerHeight={innerHeight}
             />
           )}
+          {/* Release markers sit with the other annotation, under the band,
+              line and dots: they explain the measurement and must never
+              obscure it. */}
+          <ReleaseMarkers
+            tags={visibleTags}
+            xScale={(ms) => xScale(new Date(ms))}
+            showLabels={canLabelReleases}
+          />
           {showBand && (
             <>
               <Area<TrendPoint>
@@ -701,6 +993,16 @@ export function TrendChart(props: {
               series.goodThreshold !== undefined
                 ? ` Good is ${formatValue(series.goodThreshold, unit)} or less (web.dev).`
                 : ''
+            }${
+              // The markers themselves are aria-hidden (decoration), so the count
+              // is what tells a screen reader user the annotation exists at all;
+              // the individual tag is named in the tooltip as the crosshair
+              // reaches it. Naming all ~20 here would bury the metric.
+              visibleTags.length === 1
+                ? ` 1 release marked, ${visibleTags[0].tag.tag}.`
+                : visibleTags.length > 1
+                  ? ` ${visibleTags.length} releases marked, ${visibleTags[0].tag.tag} to ${visibleTags.at(-1)!.tag.tag}.`
+                  : ''
             } Arrow keys inspect runs, Enter opens details.`}
             onPointerMove={handleMove}
             onPointerLeave={() => setHoverMs(null)}
@@ -843,6 +1145,56 @@ export function TrendChart(props: {
                     ))}
                 </Stack>
               )}
+              {/* The run's own release, when it measured one. "measured" is a
+                  stronger claim than "near", and only earned when the run
+                  built that exact commit. */}
+              {measuredRelease && (
+                <Flex
+                  align="center"
+                  gap={2}
+                  title="This run measured the release commit, so the value is that release."
+                >
+                  <Text size={0} muted>
+                    measured release
+                  </Text>
+                  <Text size={0} weight="semibold">
+                    {measuredRelease}
+                  </Text>
+                  {measuredIsLatest && (
+                    <Text size={0} muted>
+                      latest
+                    </Text>
+                  )}
+                </Flex>
+              )}
+              {/* The other release markers the crosshair is standing next to,
+                  named. This is how a marker is identified at grid-card size,
+                  where resting labels don't fit — and the wording stays honest
+                  about the join: these releases shipped near this run, they
+                  were not necessarily what this run measured. */}
+              {hoveredReleases.length > 0 && (
+                <Flex
+                  align="center"
+                  gap={2}
+                  title="Release tags near this run. Unmeasured releases are placed by tag date, so a release near a run does not mean that run measured it."
+                >
+                  <Text size={0} muted>
+                    {measuredRelease
+                      ? 'also near'
+                      : hoveredReleases.length > 1
+                        ? 'releases'
+                        : 'release'}
+                  </Text>
+                  <Text size={0} weight="semibold">
+                    {hoveredReleases.map((entry) => entry.tag).join(', ')}
+                  </Text>
+                  {hoveredReleases.some((entry) => entry.distTags?.includes('latest')) && (
+                    <Text size={0} muted>
+                      latest
+                    </Text>
+                  )}
+                </Flex>
+              )}
               {/* No baseline medians here: the legend names the baseline and
                   its window, the overlay draws the levels, and repeating the
                   same two labelled rows in every chart's tooltip was noise. */}
@@ -860,7 +1212,7 @@ export function TrendChart(props: {
             style={{
               position: 'absolute',
               left: marginLeft + x(selected),
-              top: MARGIN.top + yScale(selected.value),
+              top: marginTop + yScale(selected.value),
               width: 1,
               height: 1,
               pointerEvents: 'none',
@@ -871,6 +1223,12 @@ export function TrendChart(props: {
             series={series}
             point={selected}
             previousPoint={previousPointFor(lines, selected)}
+            // The *full* tag list, not `visibleTags`: the release a run comes
+            // after is often older than the plotted window (a 30-day view of a
+            // month with no release), and the popover states release context
+            // unconditionally. Independent of the `releases` layer toggle too —
+            // that hides marks on the plot, it doesn't make the fact untrue.
+            tags={tags}
             referenceElement={anchorEl}
             onClose={() => {
               setSelected(null)

--- a/dev/metrics-studio/tools/trends/TrendsTool.tsx
+++ b/dev/metrics-studio/tools/trends/TrendsTool.tsx
@@ -7,6 +7,7 @@ import {ClockIcon} from '@sanity/icons/Clock'
 import {ControlsIcon} from '@sanity/icons/Controls'
 import {DropIcon} from '@sanity/icons/Drop'
 import {EllipsisVerticalIcon} from '@sanity/icons/EllipsisVertical'
+import {ExpandIcon} from '@sanity/icons/Expand'
 import {HelpCircleIcon} from '@sanity/icons/HelpCircle'
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {LaunchIcon} from '@sanity/icons/Launch'
@@ -16,6 +17,7 @@ import {
   Button,
   Card,
   Container,
+  Dialog,
   Flex,
   Grid,
   PortalProvider,
@@ -49,14 +51,16 @@ import {
   calibrationSeries,
   filterByRange,
   formatValue,
+  TAGS_QUERY,
   TREND_QUERY,
   TREND_GROUPS,
   type TrendGroup,
   type TrendRun,
   type TrendSeries,
+  type TrendTag,
   vitalSections,
 } from './data'
-import {DEBUG_SOURCES, type DebugSource, generateDebugRuns} from './debugData'
+import {DEBUG_SOURCES, type DebugSource, generateDebugRuns, generateDebugTags} from './debugData'
 import {type DriftResult, worstBySeries} from './drift'
 import {DriftFeed} from './DriftFeed'
 import {type LayerState, useLayerState} from './layers'
@@ -342,9 +346,33 @@ function SeriesCard(props: {
   onAck?: (state: 'silenced' | 'snoozed' | 'fixed') => void
   onUnack?: () => void
   layers?: LayerState
+  /** Release tags for the chart's markers. */
+  tags?: TrendTag[]
+  /** Open this chart in the maximized dialog. Absent = not expandable. */
+  onExpand?: () => void
+  /**
+   * Rendered inside the maximize dialog. The card is then the superset view:
+   * no expand button (it's already expanded), the description reads as visible
+   * text instead of hiding behind ⓘ, and the release markers carry labels —
+   * all things there is room for at dialog width and not in a grid cell.
+   */
+  expanded?: boolean
 }) {
-  const {series, height, drift, silenced, baseline, focused, onFocus, onAck, onUnack, layers} =
-    props
+  const {
+    series,
+    height,
+    drift,
+    silenced,
+    baseline,
+    focused,
+    onFocus,
+    onAck,
+    onUnack,
+    layers,
+    tags,
+    onExpand,
+    expanded,
+  } = props
   // The overlay draws from any computed baseline; the badge and tint only from a
   // flagged one
   const overlay = baseline ?? drift ?? silenced
@@ -374,9 +402,14 @@ function SeriesCard(props: {
             percentage it contextualizes instead of floating top-right while
             the badge wraps under a long title. */}
         <Flex align="center" justify="space-between" gap={3}>
+          {/* flexBasis/flexGrow rather than `flex`: this is ui5's Box, which
+              (unlike @sanity/ui's) has no `flex` prop — same pair
+              RunDetailPopover's header uses. */}
           <Box flexBasis="0%" flexGrow={1} style={{minWidth: 0}}>
-            {/* Clicking the title deep-links to this chart (shareable focus) */}
-            {onFocus ? (
+            {/* In the dialog the title lives in the dialog header — repeating it
+                here would only push the plot down. Clicking the grid card's
+                title deep-links to that chart (shareable focus). */}
+            {expanded ? null : onFocus ? (
               <Box
                 as="button"
                 onClick={onFocus}
@@ -413,19 +446,42 @@ function SeriesCard(props: {
                 onUnack={onUnack ?? (() => {})}
               />
             )}
+            {onExpand && (
+              <Button
+                mode="bleed"
+                padding={2}
+                fontSize={1}
+                icon={ExpandIcon}
+                tone="default"
+                aria-label={`Expand ${series.title}`}
+                onClick={onExpand}
+              />
+            )}
             {/* Context hidden behind the info button so the grid stays
-                scannable — one click, not a paragraph per card */}
-            <InfoButton
-              text={series.description}
-              label={`About ${series.title}`}
-              sourceFile={series.sourceFile}
-              vitalDoc={webVitalDocUrl(series.title)}
-              // Explain the dotted context line where the chart is explained —
-              // "calibration of what?" shouldn't require the Calibration tab
-              calibrationNote={seriesHasCalibration(series) ? CALIBRATION_EXPLAINER : undefined}
-            />
+                scannable — one click, not a paragraph per card. In the dialog
+                it's redundant: the description is already visible text there. */}
+            {!expanded && (
+              <InfoButton
+                text={series.description}
+                label={`About ${series.title}`}
+                sourceFile={series.sourceFile}
+                vitalDoc={webVitalDocUrl(series.title)}
+                // Explain the dotted context line where the chart is explained —
+                // "calibration of what?" shouldn't require the Calibration tab
+                calibrationNote={seriesHasCalibration(series) ? CALIBRATION_EXPLAINER : undefined}
+              />
+            )}
           </Flex>
         </Flex>
+        {/* The dialog has room for the paragraph the grid cannot afford — the
+            whole point of maximizing is more context per chart, not just a
+            bigger plot. */}
+        {expanded && (
+          <Text size={1} muted>
+            {series.description}
+            {seriesHasCalibration(series) ? ` ${CALIBRATION_EXPLAINER}` : ''}
+          </Text>
+        )}
         {(badge || silenced || latest) && (
           // Value first, badge after — "64ms ↓ -22%" reads as a statement
           // qualified by its move, where badge-first read as two stats
@@ -462,10 +518,13 @@ function SeriesCard(props: {
               height={height}
               drift={overlay}
               layers={layers}
+              tags={tags}
+              // Resting marker labels need ~40px per marker; only the dialog has it
+              showTagLabels={expanded}
             />
           )}
         </ParentSize>
-        <ChartLegend series={series} drift={overlay} layers={layers} />
+        <ChartLegend series={series} drift={overlay} layers={layers} tags={tags} />
       </Stack>
     </Card>
   )
@@ -482,6 +541,9 @@ function ChartGrid(props: {
   focusedKey?: string | null
   onFocusMetric?: (seriesKey: string) => void
   layers?: LayerState
+  /** Release tags for the charts' markers. */
+  tags?: TrendTag[]
+  onExpand?: (seriesKey: string) => void
 }) {
   return (
     <Grid gridTemplateColumns={[1, 1, 2, 3]} gap={3}>
@@ -506,6 +568,8 @@ function ChartGrid(props: {
               entrySilenced && props.drift ? () => props.drift!.clear(entrySilenced) : undefined
             }
             layers={props.layers}
+            tags={props.tags}
+            onExpand={props.onExpand ? () => props.onExpand!(entry.key) : undefined}
           />
         )
       })}
@@ -522,6 +586,8 @@ function SoakPanel(props: {
   slopes: TrendSeries[]
   endValues: TrendSeries[]
   layers?: LayerState
+  tags?: TrendTag[]
+  onExpand?: (seriesKey: string) => void
   latest: {run: TrendRun; charts: TrendSeries[]} | null
 }) {
   const {slopes, endValues, latest} = props
@@ -570,10 +636,64 @@ function SoakPanel(props: {
           <Text size={1} muted>
             {active.hint}
           </Text>
-          <ChartGrid series={active.charts} layers={props.layers} />
+          <ChartGrid
+            series={active.charts}
+            layers={props.layers}
+            tags={props.tags}
+            onExpand={props.onExpand}
+          />
         </Stack>
       </TabPanel>
     </Stack>
+  )
+}
+
+/**
+ * One chart, maximized. The grid is 40+ small multiples — great for scanning,
+ * too cramped for reading: at ~330px a 90-day window puts a release marker every
+ * ~15px and the metric's own description has to hide behind an ⓘ. This is the
+ * same `SeriesCard`, not a second implementation of it, given room to draw
+ * labelled markers and show its description.
+ *
+ * State lives in `?max=<series key>` (see TrendsTool) so a maximized chart is
+ * shareable and reloadable like every other view state, and opening it pushes a
+ * history entry so Back closes it.
+ */
+function MaximizedChartDialog(props: {
+  series: TrendSeries
+  drift?: DriftResult
+  silenced?: DriftResult
+  baseline?: DriftResult
+  layers?: LayerState
+  tags?: TrendTag[]
+  onAck?: (state: 'silenced' | 'snoozed' | 'fixed') => void
+  onUnack?: () => void
+  onClose: () => void
+}) {
+  const {series, onClose, ...rest} = props
+  return (
+    // width={4} rather than "fill": on a very wide monitor a full-viewport plot
+    // stretches ~90 days across 2500px, which reads as a flat line no matter
+    // what the metric did. Dialog owns Escape and the focus trap.
+    <Dialog
+      id="chart-maximize"
+      header={series.title}
+      width={4}
+      onClose={onClose}
+      onClickOutside={onClose}
+    >
+      <Box padding={3}>
+        {/* No border/padding duplication: the card renders inside the dialog's
+            own content box.
+
+            560 rather than 460: the label gutter grew to ~112px once markers
+            carried rotated '(latest)' labels, and at 460 that left the plot
+            itself only ~320px — the labels had room but the data no longer did.
+            This keeps ~420px of plot, which is what the original 460 was chosen
+            to give, while still fitting the legend without scrolling. */}
+        <SeriesCard series={series} height={560} expanded {...rest} />
+      </Box>
+    </Dialog>
   )
 }
 
@@ -615,8 +735,27 @@ export function TrendsTool() {
   )
   const live = useObservable(live$, {runs: null, error: null})
 
+  // Release tags, for the chart markers. Its own stream, and its own error
+  // handling: markers are annotation, so a tag query that fails degrades to
+  // "no markers" rather than poisoning the runs stream into an error card.
+  // Realtime like everything else — a new release appears without a reload
+  // (the daily cron re-upserts tags, and dist-tags re-point between releases).
+  const liveTags$ = useMemo(
+    () =>
+      documentStore.listenQuery(TAGS_QUERY, {}, {tag: 'metrics.trends.tags'}).pipe(
+        map((result) => result as TrendTag[]),
+        catchError(() => of<TrendTag[]>([])),
+      ),
+    [documentStore],
+  )
+  const liveTags = useObservable(liveTags$, [])
+
   const debugRuns = useMemo(() => (source === 'live' ? null : generateDebugRuns(source)), [source])
   const runs = source === 'live' ? live.runs : debugRuns
+  // Debug sources get synthetic tags too, so the marker layer (including label
+  // collision) is testable offline like every other layer — see SPEC
+  const debugTags = useMemo(() => (source === 'live' ? [] : generateDebugTags(source)), [source])
+  const tags = source === 'live' ? liveTags : debugTags
   const error = source === 'live' ? live.error : null
   const loading = source === 'live' && live.runs === null && live.error === null
 
@@ -700,6 +839,23 @@ export function TrendsTool() {
     return map
   }, [series, calibration])
 
+  // Every chart the tool can show, by key — what `?max=` resolves against.
+  // The soak views and the environment tab build their series outside `series`,
+  // so a maximize link into one of those has to find them here.
+  const seriesByKey = useMemo(() => {
+    const map = new Map<string, TrendSeries>()
+    for (const entry of [
+      ...series,
+      ...environmentSeries,
+      ...soakSlopes,
+      ...soakEndValues,
+      ...(latestSoak?.charts ?? []),
+    ]) {
+      map.set(entry.key, entry)
+    }
+    return map
+  }, [series, environmentSeries, soakSlopes, soakEndValues, latestSoak])
+
   // Deep-linkable focused chart: the `chart` URL param names the series to
   // jump to (shareable). Jumping from a drift-feed row or a chart header writes
   // it (pushState, so Back returns) and flashes a focus ring; the URL param
@@ -760,6 +916,38 @@ export function TrendsTool() {
       if (timer !== undefined) window.clearTimeout(timer)
     }
   }, [focusedKey])
+
+  // Which chart is maximized, as a URL param — same vocabulary as `?chart=`, so
+  // a maximized chart is shareable and survives reload. Resolved by key at
+  // render: a stale link (or a chart filtered out by the current branch/range)
+  // resolves to nothing and simply shows no dialog.
+  const [maximizedParam, setMaximizedParam] = useUrlState('max', '')
+  const maximized = maximizedParam ? seriesByKey.get(maximizedParam) : undefined
+  const expandMetric = (seriesKey: string) => {
+    // 'push' so Back closes the dialog — the same precedent focusMetric sets,
+    // and the behaviour a Back press means once something modal is open
+    setMaximizedParam(seriesKey, 'push')
+  }
+  const closeMaximized = () => setMaximizedParam('')
+  // Return focus to the expand button that opened the dialog, rather than
+  // dropping the keyboard user at the top of the document.
+  //
+  // Keyed on the param clearing rather than done in the close handler, because
+  // the dialog also closes via Back (popstate updates the param without going
+  // through any handler) — an effect covers every route out. Deferred a frame
+  // so it lands after the dialog's own focus restoration.
+  const previousMaximized = useRef('')
+  useEffect(() => {
+    const justClosed = previousMaximized.current && !maximizedParam
+    const key = previousMaximized.current
+    previousMaximized.current = maximizedParam
+    if (!justClosed) return undefined
+    const raf = requestAnimationFrame(() => {
+      const card = document.getElementById(chartDomId(key))
+      card?.querySelector<HTMLButtonElement>('button[aria-label^="Expand "]')?.focus()
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [maximizedParam])
 
   const regressionsByGroup = useMemo(() => {
     const counts = new Map<TrendGroup, number>()
@@ -949,6 +1137,8 @@ export function TrendsTool() {
                         endValues={soakEndValues}
                         latest={latestSoak}
                         layers={layers}
+                        tags={tags}
+                        onExpand={expandMetric}
                       />
                     ) : activeTab.id === 'vitals' ? (
                       // One section per vital, so the overview reads by metric
@@ -978,6 +1168,8 @@ export function TrendsTool() {
                                 drift={drift}
                                 focusedKey={focusedKey}
                                 onFocusMetric={focusMetric}
+                                tags={tags}
+                                onExpand={expandMetric}
                               />
                             </Stack>
                           ),
@@ -997,6 +1189,8 @@ export function TrendsTool() {
                         drift={drift}
                         focusedKey={focusedKey}
                         onFocusMetric={focusMetric}
+                        tags={tags}
+                        onExpand={expandMetric}
                       />
                     )}
                   </Stack>
@@ -1006,6 +1200,29 @@ export function TrendsTool() {
           </Stack>
         </Container>
       </Card>
+      {/* The maximized chart. Rendered last, outside the scroll container: it's
+          a Dialog, and it gets the same per-series drift/baseline/ack props the
+          grid card gets, so maximizing is always a superset of the card and
+          never a downgrade. */}
+      {maximized && (
+        <MaximizedChartDialog
+          series={maximized}
+          drift={driftBySeries.get(maximized.key)}
+          silenced={silencedBySeries.get(maximized.key)}
+          baseline={baselineBySeries.get(maximized.key)}
+          layers={layers}
+          tags={tags}
+          onAck={(state) => {
+            const entry = driftBySeries.get(maximized.key)
+            if (entry) drift.ack(entry, state)
+          }}
+          onUnack={() => {
+            const entry = silencedBySeries.get(maximized.key)
+            if (entry) drift.clear(entry)
+          }}
+          onClose={closeMaximized}
+        />
+      )}
     </PortalProvider>
   )
 }

--- a/dev/metrics-studio/tools/trends/data.test.ts
+++ b/dev/metrics-studio/tools/trends/data.test.ts
@@ -25,12 +25,26 @@ function run(options: {
   calibrationMs?: number
   /** Per-scenario shard calibration, as mergeShards stamps on multi-shard CI runs. */
   shardCalibrationMs?: number
+  trigger?: TrendRun['trigger']
+  releaseTag?: string
 }): TrendRun {
-  const {id, sha, day, value, repeats = 1, calibrationMs = 8, shardCalibrationMs} = options
+  const {
+    id,
+    sha,
+    day,
+    value,
+    repeats = 1,
+    calibrationMs = 8,
+    shardCalibrationMs,
+    trigger,
+    releaseTag,
+  } = options
   return {
     _id: id,
     startedAt: new Date(START + day * DAY).toISOString(),
     mode: 'absolute',
+    ...(trigger ? {trigger} : {}),
+    ...(releaseTag ? {releaseTag} : {}),
     git: {sha, branch: 'main', committedAt: new Date(START + day * DAY).toISOString()},
     runner: {calibrationMs, runId: id, runAttempt: 1},
     bundle: null,
@@ -473,4 +487,22 @@ test('ms ticks share one unit across the axis', () => {
 test('other ticks keep the full formatValue rendering', () => {
   expect(formatTick(88, 'ms')).toBe('88ms')
   expect(formatTick(60_000, 'count')).toBe('60000')
+})
+
+// The release tag rides on the point so a marker can anchor to the run that
+// measured it, and the popover can say "released as" rather than bracketing.
+// Gated on the trigger, not just the tag's presence: a tag on a non-release run
+// would claim that run measured the release, which is the attribution error
+// release runs exist to remove.
+test('carries the release tag only for release runs', () => {
+  const [series] = buildSeries([
+    run({id: 'r1', sha: 'a1', day: 0, value: 30, trigger: 'release', releaseTag: 'v6.10.1'}),
+    run({id: 'r2', sha: 'a2', day: 1, value: 31, trigger: 'cron', releaseTag: 'v6.10.1'}),
+    run({id: 'r3', sha: 'a3', day: 2, value: 32}),
+  ])
+  expect(series.lines[0].points.map((point) => point.releaseTag)).toEqual([
+    'v6.10.1',
+    undefined,
+    undefined,
+  ])
 })

--- a/dev/metrics-studio/tools/trends/data.test.ts
+++ b/dev/metrics-studio/tools/trends/data.test.ts
@@ -27,6 +27,8 @@ function run(options: {
   shardCalibrationMs?: number
   trigger?: TrendRun['trigger']
   releaseTag?: string
+  /** Hour within `day`, to order same-commit runs (cron at 05:00, release later). */
+  hour?: number
 }): TrendRun {
   const {
     id,
@@ -38,10 +40,11 @@ function run(options: {
     shardCalibrationMs,
     trigger,
     releaseTag,
+    hour = 0,
   } = options
   return {
     _id: id,
-    startedAt: new Date(START + day * DAY).toISOString(),
+    startedAt: new Date(START + day * DAY + hour * 60 * 60 * 1000).toISOString(),
     mode: 'absolute',
     ...(trigger ? {trigger} : {}),
     ...(releaseTag ? {releaseTag} : {}),
@@ -505,4 +508,32 @@ test('carries the release tag only for release runs', () => {
     undefined,
     undefined,
   ])
+})
+
+// A cron run and a release run of the same commit merge into one point (the
+// cron measures main at 05:00; the release run measures the tag hours later).
+// The tag describes the commit, so the merged point keeps it regardless of
+// which run sorts last — otherwise the marker, tooltip and popover fall back to
+// weaker by-date claims for exactly the commits that can be attributed.
+test('the release tag survives a same-commit merge, whichever run sorts last', () => {
+  const release = {sha: 'a1', day: 0, value: 30, trigger: 'release' as const, releaseTag: 'v6.10.1'}
+  const cron = {sha: 'a1', day: 0, value: 32, trigger: 'cron' as const}
+
+  const releaseFirst = buildSeries([
+    run({id: 'rel', hour: 1, ...release}),
+    run({id: 'cron', hour: 9, ...cron}),
+  ])
+  const releaseLast = buildSeries([
+    run({id: 'cron', hour: 1, ...cron}),
+    run({id: 'rel', hour: 9, ...release}),
+  ])
+
+  for (const [name, series] of [
+    ['release first', releaseFirst],
+    ['release last', releaseLast],
+  ] as const) {
+    const points = series[0].lines[0].points
+    expect(points, name).toHaveLength(1)
+    expect(points[0].releaseTag, name).toBe('v6.10.1')
+  }
 })

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -820,9 +820,9 @@ export function clusterTags(
  * place its label will actually be drawn — which makes it a true label-to-label
  * distance: the next group's first mark is at least `minGapPx` to the right of
  * this label, and that group's own label only moves further right. Measuring
- * from the group's first mark instead is equivalent only while labels are
- * left-anchored; with right-anchored labels it let two land ~6px apart, which
- * overlaps at these font sizes.
+ * from the group's *first* mark would only bound the distance from a position
+ * no label occupies, letting two labels land a few px apart — close enough to
+ * overlap at these font sizes.
  *
  * A chain of sub-gap steps folds into a single label, matching the
  * chain-collapse `clusterTags` already applies to marks.
@@ -997,8 +997,15 @@ function mergeRunsPerCommit(points: TrendPoint[]): TrendPoint[] {
     // re-run's CPU model/browser would attribute a synthetic point to one
     // specific machine it does not describe.
     const hostKeys = new Set(group.map((point) => JSON.stringify(point.host ?? null)))
+    // The release tag describes the *commit*, not the individual run, so it
+    // survives the merge from any member rather than only from `last`. A release
+    // run regularly shares its commit with a cron run (the cron measures main at
+    // 05:00; the release run measures the tag hours later), and the merged point
+    // has to keep the tag for the marker, tooltip and popover to attribute it.
+    const releaseTag = group.find((point) => point.releaseTag)?.releaseTag
     merged.push({
       ...last,
+      ...(releaseTag ? {releaseTag} : {}),
       value: medianOf(group.map((point) => point.value)),
       p75: p75s.length > 0 ? medianOf(p75s) : undefined,
       p90: p90s.length > 0 ? medianOf(p90s) : undefined,

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -7,6 +7,13 @@ export interface TrendRun {
   _id: string
   startedAt: string
   mode: 'ab' | 'absolute'
+  /**
+   * Why this run happened. Absent on documents written before the field
+   * existed — those were all cron runs.
+   */
+  trigger?: 'cron' | 'release' | 'backfill' | 'dispatch' | 'pr' | null
+  /** Release runs only: the tag this run measured, e.g. `v6.10.1`. */
+  releaseTag?: string | null
   git: {
     sha: string
     branch: string
@@ -72,6 +79,8 @@ export const TREND_QUERY = `*[_type == "benchRun" && mode == "absolute"] | order
   _id,
   startedAt,
   mode,
+  trigger,
+  releaseTag,
   git{sha, branch, committedAt, prNumber, mergeBaseSha},
   runner{calibrationMs, runId, runAttempt, os, arch, cpus, memGb, nodeVersion, cpuModel, imageOs, imageVersion, browserVersion},
   bundle{experiment{initialJsBytes, totalJsBytes}},
@@ -135,6 +144,13 @@ export interface TrendPoint {
     browserVersion?: string
   }
   sha: string
+  /**
+   * Set when this run measured a tagged release commit (`trigger: 'release'`),
+   * naming the tag. This is what lets a release marker anchor on a real
+   * measured point instead of being placed by date, and what lets the run
+   * popover say "released as" instead of bracketing between two releases.
+   */
+  releaseTag?: string
   /** benchRun document id — opens the run in the studio. */
   runId: string
   /** Backlink metadata (GitHub PR / commit / CI run). */
@@ -530,6 +546,320 @@ export function filterByRange(runs: TrendRun[], days: number | null): TrendRun[]
 }
 
 /**
+ * A release tag as the charts need it: enough to place a mark on the time axis
+ * and name it. Projected from `gitTag` (see schemaTypes/gitTag.ts).
+ */
+export interface TrendTag {
+  /** Tag name, e.g. `v6.10.1`. */
+  tag: string
+  /** ISO datetime the tag was created — the marker's x position. */
+  taggedAt: string
+  /**
+   * Semver major. Release lines interleave in time (v5.31.2 shipped after
+   * v6.10.1), so the major is what tells two markers apart when they don't
+   * belong to the same line.
+   */
+  major: number
+  /**
+   * Dist-tags currently pointing at this version. `latest` is the release the
+   * ecosystem is actually installing, which is worth distinguishing from a
+   * maintenance-line tag that shipped the same week.
+   */
+  distTags?: string[] | null
+}
+
+/**
+ * Stable releases cut **from main**, in time order.
+ *
+ * Two filters, for two different reasons:
+ *
+ * - `!defined(prerelease)` — rc tags would roughly double marker density for no
+ *   added reading; nobody asks "did this regress at v6.11.0-rc.2?" of a trend
+ *   chart.
+ * - the `gitCommit` existence check — the charts only ever plot main (bench runs
+ *   are main-branch crons), so a release cut off main is a *false* annotation:
+ *   its commits are not in the line being measured. `gitCommit` documents are
+ *   main-only by construction, so "is this tag's commit on main?" is a by-value
+ *   sha join against them. This is what excludes maintenance releases like
+ *   v5.31.2, which shipped mid-window from a release branch.
+ *
+ * Note it is *not* a filter on `major`: the v5 tags up to the v6 cutover were
+ * cut from main and belong on a chart that reaches back that far. Being on main
+ * is the property that matters, and it is the one being tested.
+ *
+ * Cost note: the correlated subquery means `listenQuery` treats every
+ * `gitCommit` mutation as relevant, so the daily history sync causes a refetch
+ * burst. Fine here — the projection is ~54 tiny documents and this is an
+ * internal dashboard — but don't copy the pattern somewhere hot.
+ *
+ * The tag's own `commit` weak reference is deliberately not used for this: it
+ * dangles for off-main tags today, but a dangling weak ref means "not synced",
+ * which is not the same claim as "not on main" and would silently start
+ * including release-branch tags if sync coverage ever widened.
+ *
+ * Projection stays tiny (SPEC: never over-fetch).
+ */
+export const TAGS_QUERY = `*[
+  _type == "gitTag"
+  && !defined(prerelease)
+  && defined(*[_type == "gitCommit" && sha == ^.sha][0])
+] | order(taggedAt asc) {
+  tag,
+  taggedAt,
+  major,
+  "distTags": npm.distTags
+}`
+
+/** A release marker resolved to a position, and how certain that position is. */
+export interface ResolvedTag {
+  tag: TrendTag
+  /** Where to draw it, as a time on the chart's x-axis. */
+  atMs: number
+  /**
+   * True when a run in this chart actually measured this release's commit, so
+   * the marker sits on a real measured point rather than on the tag's date.
+   *
+   * Both kinds are drawn identically — the distinction is carried by the run
+   * popover's wording, not by the mark (a second visual language would need a
+   * legend entry to explain a difference that only matters once you are already
+   * asking about a specific run). What it changes is *where* the rule sits, and
+   * whether the tooltip can claim the run measured the release.
+   */
+  measured: boolean
+}
+
+/**
+ * The release markers a chart draws: anchored to the runs that measured them
+ * where those exist, placed by tag date otherwise, filtered to the chart's
+ * x-domain and ordered by drawn position.
+ *
+ * A release run (`trigger: 'release'`) measures the tagged commit itself, so its
+ * point *is* the release: the marker belongs exactly on it. Without one the only
+ * honest position is the tag's own date — what every marker did before release
+ * runs existed — so history keeps working and the two kinds mix on one chart.
+ *
+ * **Anchoring happens before domain filtering, deliberately.** The two positions
+ * genuinely differ: a tag is cut, then CI measures it hours later. Filtering on
+ * the tag date first would drop a release tagged just outside the window whose
+ * measuring run is inside it (a 23:00 tag measured the next morning is a real
+ * case) — and worse, hovering that run would then show no release at all, losing
+ * the strongest claim the feature can make for exactly the run that earned it.
+ * Resolving first makes the anchor position *the* position, for filtering and
+ * ordering alike.
+ *
+ * Sorted by `atMs` rather than by tag date for the same reason: re-anchoring can
+ * move a marker past a close neighbour, and both `clusterTags` (which merges
+ * adjacent marks scanning left to right, keeping each cluster's last release)
+ * and the chart's aria-label (which reports first and last as the range) require
+ * the array to agree with what is drawn.
+ *
+ * Domain bounds are inclusive: a release on the first or last plotted run is
+ * part of that window's story, and dropping it would lose the marker most likely
+ * to explain an edge step.
+ *
+ * Tolerates unsorted and unparseable `taggedAt` — this reads live documents, and
+ * one bad date must not take a chart down.
+ */
+export function resolveTagPositions(
+  tags: TrendTag[],
+  points: TrendPoint[],
+  minDateMs: number,
+  maxDateMs: number,
+): ResolvedTag[] {
+  // One pass over the points; charts hold at most a few hundred
+  const measuredByTag = new Map<string, number>()
+  for (const point of points) {
+    if (!point.releaseTag) continue
+    // Earliest measurement wins if a release somehow got measured twice (a
+    // re-run stores a second document — see documentIdForRun), so the marker
+    // position is stable rather than flipping between equally valid runs
+    const existing = measuredByTag.get(point.releaseTag)
+    const ms = point.date.getTime()
+    if (existing === undefined || ms < existing) measuredByTag.set(point.releaseTag, ms)
+  }
+  return tags
+    .map((tag) => {
+      const measuredAt = measuredByTag.get(tag.tag)
+      if (measuredAt !== undefined) return {tag, atMs: measuredAt, measured: true}
+      return {tag, atMs: new Date(tag.taggedAt).getTime(), measured: false}
+    })
+    .filter(
+      (entry) => Number.isFinite(entry.atMs) && entry.atMs >= minDateMs && entry.atMs <= maxDateMs,
+    )
+    .sort((a, b) => a.atMs - b.atMs)
+}
+
+/**
+ * The most recent release at or before `atMs`, and the next one after it.
+ *
+ * This is the release context of a run: `previous` is the newest release whose
+ * code the run's commit builds on, `next` is the release that shipped it. The
+ * run popover states both unconditionally — unlike the hover tooltip, which
+ * names whichever marker the crosshair is *near*, this is a claim that can
+ * always be made and is always the same for a given run.
+ *
+ * Deliberately still a **by-time** statement, like the markers themselves: it
+ * bounds a run between two releases in time, and does not assert that the run's
+ * commit is contained in `next`. Proving containment needs an ancestry walk over
+ * `gitCommit.parentSha`, which is not what this reads.
+ *
+ * Either side is undefined at the ends of history (a run before the first known
+ * release, or after the latest one — the common case for recent runs).
+ */
+export function releaseContextAt(
+  tags: TrendTag[],
+  atMs: number,
+): {previous?: TrendTag; next?: TrendTag} {
+  let previous: (TrendTag & {ms: number}) | undefined
+  let next: (TrendTag & {ms: number}) | undefined
+  for (const tag of tags) {
+    const ms = new Date(tag.taggedAt).getTime()
+    if (!Number.isFinite(ms)) continue
+    // `<=` so a run measured exactly at a tag counts as being in that release
+    if (ms <= atMs) {
+      if (!previous || ms > previous.ms) previous = {...tag, ms}
+    } else if (!next || ms < next.ms) {
+      next = {...tag, ms}
+    }
+  }
+  return {previous, next}
+}
+
+/**
+ * Median gap between consecutive run times, in ms — the natural "how far apart
+ * are these runs?" scale, used to decide whether a release marker is near
+ * enough to a run to name in that run's tooltip.
+ *
+ * Median rather than mean because run history is gappy by nature (weekend
+ * skips, CI outages, a backfill landing a dozen historical runs at once) and a
+ * single 3-week hole would triple a mean. Falls back to one day — the cron
+ * cadence — when there is no gap to measure.
+ */
+export function medianGapMs(times: number[]): number {
+  const DEFAULT = 24 * 60 * 60 * 1000
+  if (times.length < 2) return DEFAULT
+  const sorted = [...times].sort((a, b) => a - b)
+  const gaps = sorted.slice(1).map((time, index) => time - sorted[index])
+  gaps.sort((a, b) => a - b)
+  return gaps[Math.floor(gaps.length / 2)] || DEFAULT
+}
+
+/** A drawn release marker: one mark, which may stand for several releases. */
+export interface TagCluster {
+  /** The release the mark is positioned on and named after. */
+  tag: TrendTag
+  /** Where to draw it (px). */
+  x: number
+  /** How many further releases this mark stands for (0 when it is alone). */
+  alsoCount: number
+  /**
+   * Every release the mark stands for, newest last. Read when composing the
+   * label — a merged mark is "(latest)" if *any* of its releases carries that
+   * dist-tag, not only the one it is named after.
+   *
+   * Invariant: `alsoCount === tags.length - 1`.
+   */
+  tags: TrendTag[]
+}
+
+/**
+ * Group markers that are too close to draw separately into one mark each.
+ *
+ * Releases cluster hard: v6.10.0 and v6.10.1 shipped 6.8 hours apart, which is
+ * **4.6px** on a 90-day maximized chart and about 1px on a grid card. Drawing
+ * both produced one thick smudge with a single label lying across it — two marks
+ * conveying one position, badly.
+ *
+ * So a cluster collapses to a single mark, positioned and named after its
+ * **last** release (scanning left to right, that is the one in effect for the
+ * runs that follow) and carrying `alsoCount` for the rest, which the label
+ * renders as "v6.10.1 +1". Nothing is silently dropped: the count says more
+ * shipped here, and hovering names each one (the chart's tooltip lists every
+ * release within its snapping tolerance).
+ *
+ * This supersedes label-only thinning. Thinning text while still drawing every
+ * mark was defensible for faint full-height rules, but a solid tick has to be
+ * either drawn legibly or merged — there is no recessive version of a 6px mark.
+ *
+ * `minGapPx` is the smallest separation at which two marks read as two. Input
+ * must be sorted by `x` (resolveTagPositions guarantees it).
+ */
+export function clusterTags(
+  resolved: {tag: TrendTag; atMs: number}[],
+  xOf: (atMs: number) => number,
+  minGapPx: number,
+): TagCluster[] {
+  const clusters: TagCluster[] = []
+  for (const entry of resolved) {
+    const x = xOf(entry.atMs)
+    const open = clusters.at(-1)
+    // Compared against the cluster's own mark, so a run of releases each just
+    // under the gap collapses into one mark rather than chaining indefinitely
+    if (open && x - open.x < minGapPx) {
+      // The newest release takes the mark: it is the one in effect afterwards
+      open.tag = entry.tag
+      open.x = x
+      open.alsoCount += 1
+      open.tags.push(entry.tag)
+      continue
+    }
+    clusters.push({tag: entry.tag, x, alsoCount: 0, tags: [entry.tag]})
+  }
+  return clusters
+}
+
+/**
+ * Which marks carry a resting text label, and what each label speaks for.
+ *
+ * Marks merge at a few px (see `clusterTags`), but text needs much more room, so
+ * a label can cover several marks. A label is drawn at the **last** mark it
+ * speaks for and named after that mark's release, so its name and its position
+ * never disagree.
+ *
+ * The gap is therefore measured against the group's *current last* mark — the
+ * place its label will actually be drawn — which makes it a true label-to-label
+ * distance: the next group's first mark is at least `minGapPx` to the right of
+ * this label, and that group's own label only moves further right. Measuring
+ * from the group's first mark instead is equivalent only while labels are
+ * left-anchored; with right-anchored labels it let two land ~6px apart, which
+ * overlaps at these font sizes.
+ *
+ * A chain of sub-gap steps folds into a single label, matching the
+ * chain-collapse `clusterTags` already applies to marks.
+ *
+ * Returns a map from cluster index to the cluster that index's label describes.
+ */
+export function labelledClusters(
+  clusters: TagCluster[],
+  minGapPx: number,
+): Map<number, TagCluster> {
+  const labels = new Map<number, TagCluster>()
+  let group: {index: number; merged: TagCluster} | null = null
+  const flush = () => {
+    if (group) labels.set(group.index, group.merged)
+  }
+  for (const [index, cluster] of clusters.entries()) {
+    if (group && cluster.x - group.merged.x < minGapPx) {
+      // Too close to label separately: fold it into the open group, which moves
+      // to this cluster's mark and takes its newer name
+      group = {
+        index,
+        merged: {
+          ...cluster,
+          alsoCount: group.merged.alsoCount + cluster.tags.length,
+          tags: [...group.merged.tags, ...cluster.tags],
+        },
+      }
+      continue
+    }
+    flush()
+    group = {index, merged: cluster}
+  }
+  flush()
+  return labels
+}
+
+/**
  * One series per scenario·metric across all runs, plus the bundle size. Each
  * series holds one line per git branch present in the runs — a single branch
  * renders as one line, several overlay for comparison.
@@ -578,10 +908,17 @@ function shardMeta(
 /** Backlink + identity fields every TrendPoint carries, derived from a run. */
 function pointMeta(
   run: TrendRun,
-): Pick<TrendPoint, 'sha' | 'runId' | 'prNumber' | 'ciRunId' | 'ciRunAttempt' | 'host'> {
+): Pick<
+  TrendPoint,
+  'sha' | 'runId' | 'prNumber' | 'ciRunId' | 'ciRunAttempt' | 'host' | 'releaseTag'
+> {
   const host = hostOf(run)
   return {
     sha: run.git?.sha ?? 'unknown',
+    // Gated on the trigger, not just the tag's presence: a tag on a non-release
+    // run would claim that run measured the release, which is the attribution
+    // error release runs exist to remove (perf/bench keeps them paired too)
+    ...(run.trigger === 'release' && run.releaseTag ? {releaseTag: run.releaseTag} : {}),
     runId: run._id,
     prNumber: run.git?.prNumber,
     ciRunId: run.runner?.runId,
@@ -924,7 +1261,11 @@ export function latestSoakCharts(runs: TrendRun[]): {run: TrendRun; charts: Tren
         ...shardMeta(latest.run, latest.runner),
       }))
     return {
-      key: `soak:latest:${metric.key}`,
+      // `soak:run:` — NOT `soak:latest:`, which soakLatestValueSeries owns
+      // for the end-of-run history charts. The two sets cover the same
+      // metrics, and `?max=` resolves against a single key → series map, so
+      // a shared prefix would open the wrong chart from a maximize link.
+      key: `soak:run:${metric.key}`,
       title: metric.title,
       unit: metric.unit,
       description: metric.description,

--- a/dev/metrics-studio/tools/trends/debugData.ts
+++ b/dev/metrics-studio/tools/trends/debugData.ts
@@ -7,7 +7,7 @@
  * actually stores: both load conditions (boot-cold + open-doc-warm),
  * main-thread blocking, INP, soak, and the PR/CI backlink fields.
  */
-import {type TrendRun} from './data'
+import {type TrendRun, type TrendTag} from './data'
 
 /** mulberry32 — same tiny PRNG the bench fixtures use. */
 function mulberry32(seed: number): () => number {
@@ -25,6 +25,41 @@ export type DebugSource = (typeof DEBUG_SOURCES)[number]
 
 const DAYS = 90
 const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Synthetic release schedule: day offset within the window and the version cut
+ * that day. Shared by `generateDebugTags` (which turns these into `gitTag`-ish
+ * markers) and `generateDemo` (which adds a release *run* for most of them), so
+ * the debug data exercises both marker kinds — anchored to a measured run, and
+ * placed by tag date where no run measured it.
+ *
+ * Deliberately awkward: the cadence is uneven, the 54/56 pair collides at
+ * card width so label thinning gets hit, and day 70 is a major cutover.
+ */
+const RELEASE_SCHEDULE: {day: number; major: number; minor: number; patch: number}[] = [
+  {day: 3, major: 6, minor: 8, patch: 0},
+  {day: 14, major: 6, minor: 8, patch: 1},
+  {day: 21, major: 6, minor: 8, patch: 2},
+  {day: 30, major: 6, minor: 9, patch: 0},
+  {day: 41, major: 6, minor: 9, patch: 1},
+  {day: 54, major: 6, minor: 9, patch: 2},
+  {day: 56, major: 6, minor: 10, patch: 0},
+  {day: 70, major: 7, minor: 0, patch: 0},
+  {day: 83, major: 7, minor: 1, patch: 0},
+]
+
+const versionOf = (entry: (typeof RELEASE_SCHEDULE)[number]) =>
+  `v${entry.major}.${entry.minor}.${entry.patch}`
+
+/**
+ * The releases that got a benchmark run, keyed by day. The two oldest are left
+ * unmeasured on purpose: release runs started partway through the real history
+ * too, so a chart has to render both kinds side by side without looking
+ * inconsistent.
+ */
+const MEASURED_RELEASES = new Map(
+  RELEASE_SCHEDULE.slice(2).map((entry) => [entry.day, versionOf(entry)]),
+)
 
 function fakeSha(rng: () => number): string {
   return Array.from({length: 40}, () => '0123456789abcdef'[Math.floor(rng() * 16)]).join('')
@@ -61,10 +96,17 @@ function generateDemo(branch = 'main', shift = 0): TrendRun[] {
     const calibration = 11 + 2 * Math.sin(day / 9) + (rng() - 0.5)
     const hostFactor = calibration / 11
 
+    // Release runs exist on main only (releases are cut from main) and land a
+    // few hours after the tag, as a dispatched CI run does — so the anchored
+    // marker visibly sits on the run rather than on the tag's own timestamp
+    const releaseTag = branch === 'main' ? MEASURED_RELEASES.get(day) : undefined
+    const releaseOffsetMs = releaseTag ? 14 * 60 * 60 * 1000 : 0
+
     runs.push({
       _id: `debug-run-${branch}-${day}`,
-      startedAt: new Date(start + day * DAY_MS).toISOString(),
+      startedAt: new Date(start + day * DAY_MS + releaseOffsetMs).toISOString(),
       mode: 'absolute',
+      ...(releaseTag ? {trigger: 'release' as const, releaseTag} : {trigger: 'cron' as const}),
       // Every ~9th run is a labeled PR run (has a PR number) so the run-detail
       // popover's PR backlink is exercised; all runs carry a CI run id/attempt.
       git: {sha: fakeSha(rng), branch, ...(day % 9 === 0 ? {prNumber: 13000 + day} : {})},
@@ -170,6 +212,44 @@ function generateDemo(branch = 'main', shift = 0): TrendRun[] {
     })
   }
   return runs
+}
+
+/**
+ * Synthetic release tags spanning the same 90 days the demo runs cover, so the
+ * release markers are exercisable offline like every other layer.
+ *
+ * Deliberately awkward: the cadence is uneven and one pair lands two days apart
+ * so label collision handling actually gets hit rather than only appearing
+ * against live data.
+ *
+ * All main-line tags, like the live query returns — `TAGS_QUERY` excludes
+ * releases cut off main, so synthetic maintenance-branch tags here would model a
+ * case the charts never actually receive. The major still steps (6 → 7) so the
+ * cutover a long-range chart spans is represented.
+ */
+export function generateDebugTags(source: DebugSource): TrendTag[] {
+  if (source === 'empty') return []
+  const start = Date.now() - DAYS * DAY_MS
+  const tagAt = (day: number) =>
+    // Mid-morning, so a marker never coincides exactly with a run's timestamp
+    new Date(start + day * DAY_MS + 10 * 60 * 60 * 1000).toISOString()
+
+  // `single-run` plots one run, so its domain is a two-day pad around the last
+  // day of the window — the 90-day schedule below falls entirely outside it.
+  // One tag on that day instead, so the case exercises "marker on a lone run"
+  // rather than looking like markers are broken.
+  if (source === 'single-run') {
+    return [{tag: 'v6.11.0', taggedAt: tagAt(DAYS - 1), major: 6, distTags: ['latest']}]
+  }
+
+  // The newest tag is what npm serves as `latest` — its label says so
+  const latestDay = RELEASE_SCHEDULE.at(-1)?.day
+  return RELEASE_SCHEDULE.map((entry) => ({
+    tag: versionOf(entry),
+    taggedAt: tagAt(entry.day),
+    major: entry.major,
+    distTags: entry.day === latestDay ? ['latest'] : null,
+  }))
 }
 
 export function generateDebugRuns(source: DebugSource): TrendRun[] {

--- a/dev/metrics-studio/tools/trends/layers.ts
+++ b/dev/metrics-studio/tools/trends/layers.ts
@@ -6,7 +6,7 @@
  */
 import {useCallback, useMemo} from 'react'
 
-export const LAYERS = ['median', 'band', 'calibration', 'baseline'] as const
+export const LAYERS = ['median', 'band', 'calibration', 'baseline', 'releases'] as const
 export type Layer = (typeof LAYERS)[number]
 
 export interface LayerState {

--- a/dev/metrics-studio/tools/trends/tags.test.ts
+++ b/dev/metrics-studio/tools/trends/tags.test.ts
@@ -147,10 +147,10 @@ test('a point tagged with an unknown release adds no marker', () => {
   expect(names(resolved)).toEqual(['v6.1.0'])
 })
 
-// Regression: anchoring must happen BEFORE domain filtering. A release tagged
-// just outside the window whose measuring run is inside it still belongs on the
-// chart — filtering on the tag date first dropped it, and hovering that run then
-// showed no release at all, losing the strongest claim for the run that earned
+// Anchoring happens BEFORE domain filtering. A release tagged just outside the
+// window whose measuring run is inside it still belongs on the chart: filtering
+// on the tag date would drop it, and hovering that run would then show no
+// release at all — losing the strongest claim available for the run that earned
 // it. Release runs are dispatched hours after tagging, so this is a real case.
 test('a tag outside the domain is kept when its run is inside', () => {
   const taggedAt = '2026-02-09T23:00:00.000Z'
@@ -194,11 +194,12 @@ test('a shared label sits on the last mark it speaks for', () => {
   expect(labels.get(1)!.alsoCount).toBe(1)
 })
 
-// Regression: the gap must be measured against the group's *last* mark (where
-// its label is drawn), not its first. Measuring from the first put a group's
-// label at x=12 and the next group's at x=18 — 6px apart, ~5px perpendicular at
-// -60° against a 9px line height, so they overlapped. Reachable from a hotfix
-// burst: three releases inside ~2 days.
+// The gap is measured against the group's *last* mark, where its label is drawn,
+// not its first. Measuring from the first would bound the distance from a
+// position no label occupies: marks at 0/6/12 label at 12 while the next group
+// starts at 18, leaving 6px — ~5px perpendicular at -60° against a 9px line
+// height, so they overlap. Reachable from a hotfix burst of three releases
+// inside ~2 days.
 test('adjacent labels are never closer than the gap', () => {
   const clusters = clusterTags(at([0, 6, 12, 18]), identity, 6)
   const labels = labelledClusters(clusters, 14)
@@ -219,9 +220,9 @@ test('a chain of sub-gap steps folds into one label', () => {
   expect(only.alsoCount).toBe(only.tags.length - 1)
 })
 
-// Regression: re-anchoring can move a marker past a close neighbour, and both
-// clusterTags (which merges adjacent marks left-to-right) and the aria-label
-// range depend on the array agreeing with what is drawn
+// Anchoring can move a marker past a close neighbour, and both clusterTags
+// (which merges adjacent marks left-to-right) and the aria-label range depend on
+// the array agreeing with what is drawn
 test('sorts by drawn position, not by tag date', () => {
   const resolved = markers(
     [tag('v6.1.0', '2026-02-10T01:00:00.000Z'), tag('v6.2.0', '2026-02-10T12:00:00.000Z')],

--- a/dev/metrics-studio/tools/trends/tags.test.ts
+++ b/dev/metrics-studio/tools/trends/tags.test.ts
@@ -1,0 +1,344 @@
+import {expect, test} from 'vitest'
+
+import {
+  clusterTags,
+  labelledClusters,
+  medianGapMs,
+  releaseContextAt,
+  resolveTagPositions,
+  type TrendPoint,
+  type TrendTag,
+} from './data'
+
+const DAY = 24 * 60 * 60 * 1000
+
+function tag(name: string, taggedAt: string, major = 6): TrendTag {
+  return {tag: name, taggedAt, major}
+}
+
+const JAN = '2026-01-10T12:00:00.000Z'
+const FEB = '2026-02-10T12:00:00.000Z'
+const MAR = '2026-03-10T12:00:00.000Z'
+
+function point(dateIso: string, releaseTag?: string): TrendPoint {
+  return {
+    date: new Date(dateIso),
+    value: 100,
+    sha: 'a'.repeat(40),
+    runId: `run-${dateIso}`,
+    ...(releaseTag ? {releaseTag} : {}),
+  }
+}
+
+/** Markers for a wide-open domain, so a test only constrains what it means to. */
+const markers = (tags: TrendTag[], points: TrendPoint[] = []) =>
+  resolveTagPositions(tags, points, Date.parse(JAN) - DAY, Date.parse(MAR) + DAY)
+
+const names = (resolved: {tag: TrendTag}[]) => resolved.map((entry) => entry.tag.tag)
+
+test('no tags means no markers', () => {
+  expect(markers([])).toEqual([])
+})
+
+test('keeps only tags inside the domain', () => {
+  const tags = [tag('v6.0.0', JAN), tag('v6.1.0', FEB), tag('v6.2.0', MAR)]
+  const inside = resolveTagPositions(tags, [], Date.parse(FEB) - 1000, Date.parse(FEB) + 1000)
+  expect(names(inside)).toEqual(['v6.1.0'])
+})
+
+// A release cut on the first or last plotted run is part of that window's
+// story — it's the marker most likely to explain a step at the chart's edge
+test('the domain boundaries are inclusive', () => {
+  const tags = [tag('v6.0.0', JAN), tag('v6.2.0', MAR)]
+  const inside = resolveTagPositions(tags, [], Date.parse(JAN), Date.parse(MAR))
+  expect(names(inside)).toEqual(['v6.0.0', 'v6.2.0'])
+})
+
+test('output is time-ordered even when the input is not', () => {
+  const tags = [tag('v6.2.0', MAR), tag('v6.0.0', JAN), tag('v6.1.0', FEB)]
+  expect(names(markers(tags))).toEqual(['v6.0.0', 'v6.1.0', 'v6.2.0'])
+})
+
+// Live documents: one unparseable date must not take a whole chart down
+test('drops tags with an unparseable date', () => {
+  expect(names(markers([tag('v6.0.0', 'not-a-date'), tag('v6.1.0', FEB)]))).toEqual(['v6.1.0'])
+})
+
+test('carries the tag the markers render', () => {
+  const tags = [{...tag('v6.1.0', FEB, 6), distTags: ['latest']}]
+  expect(markers(tags)[0]).toEqual({
+    tag: {tag: 'v6.1.0', taggedAt: FEB, major: 6, distTags: ['latest']},
+    atMs: Date.parse(FEB),
+    measured: false,
+  })
+})
+
+// The cron cadence is the honest default when there is nothing to measure
+test('fewer than two runs falls back to a day', () => {
+  expect(medianGapMs([])).toBe(DAY)
+  expect(medianGapMs([1000])).toBe(DAY)
+})
+
+test('an even cadence is its own gap', () => {
+  expect(medianGapMs([0, DAY, 2 * DAY, 3 * DAY])).toBe(DAY)
+})
+
+// Gappy history is the norm (weekend skips, CI outages, backfills): one long
+// hole must not drag the scale the way a mean would
+test('a single long gap does not move the median', () => {
+  expect(medianGapMs([0, DAY, 2 * DAY, 30 * DAY])).toBe(DAY)
+})
+
+test('unsorted times give the same answer', () => {
+  expect(medianGapMs([2 * DAY, 0, 30 * DAY, DAY])).toBe(DAY)
+})
+
+// Repeated timestamps (shard runs of one commit) make zero-width gaps; a zero
+// tolerance would silence every marker, so it falls back instead
+test('identical times fall back rather than returning zero', () => {
+  expect(medianGapMs([1000, 1000, 1000])).toBe(DAY)
+})
+
+const RELEASES = [tag('v6.0.0', JAN), tag('v6.1.0', FEB), tag('v6.2.0', MAR)]
+
+// No release runs: every marker keeps the tag's own date, which is what the
+// whole 90 days of existing history looks like
+test('falls back to the tag date when nothing measured the release', () => {
+  const resolved = markers(RELEASES, [point(FEB)])
+  expect(resolved.map((entry) => [entry.tag.tag, entry.measured])).toEqual([
+    ['v6.0.0', false],
+    ['v6.1.0', false],
+    ['v6.2.0', false],
+  ])
+  expect(resolved[1].atMs).toBe(Date.parse(FEB))
+})
+
+// The point that measured a release is the release, so the marker moves onto
+// it — the run happens hours after the tag was cut
+test('anchors a marker on the run that measured it', () => {
+  const measuredAt = '2026-02-10T18:30:00.000Z'
+  const resolved = markers(RELEASES, [point(measuredAt, 'v6.1.0')])
+  const anchored = resolved.find((entry) => entry.tag.tag === 'v6.1.0')!
+  expect(anchored.measured).toBe(true)
+  expect(anchored.atMs).toBe(Date.parse(measuredAt))
+  // The others are untouched
+  expect(resolved.filter((entry) => entry.measured)).toHaveLength(1)
+})
+
+test('mixes anchored and date-placed markers on one chart', () => {
+  expect(markers(RELEASES, [point(MAR, 'v6.2.0')]).map((entry) => entry.measured)).toEqual([
+    false,
+    false,
+    true,
+  ])
+})
+
+// A re-run stores a second document for the same release (documentIdForRun keys
+// on runId), so the position must not flip between two equally valid runs
+test('a re-measured release keeps the earliest position', () => {
+  const first = '2026-02-10T18:00:00.000Z'
+  const second = '2026-02-11T09:00:00.000Z'
+  const resolved = markers(RELEASES, [point(second, 'v6.1.0'), point(first, 'v6.1.0')])
+  expect(resolved.find((entry) => entry.tag.tag === 'v6.1.0')!.atMs).toBe(Date.parse(first))
+})
+
+test('a point tagged with an unknown release adds no marker', () => {
+  const resolved = markers([tag('v6.1.0', FEB)], [point(FEB, 'v6.1.0'), point(MAR, 'v9.9.9')])
+  expect(names(resolved)).toEqual(['v6.1.0'])
+})
+
+// Regression: anchoring must happen BEFORE domain filtering. A release tagged
+// just outside the window whose measuring run is inside it still belongs on the
+// chart — filtering on the tag date first dropped it, and hovering that run then
+// showed no release at all, losing the strongest claim for the run that earned
+// it. Release runs are dispatched hours after tagging, so this is a real case.
+test('a tag outside the domain is kept when its run is inside', () => {
+  const taggedAt = '2026-02-09T23:00:00.000Z'
+  const measuredAt = '2026-02-10T13:00:00.000Z'
+  const resolved = resolveTagPositions(
+    [tag('v6.1.0', taggedAt)],
+    [point(measuredAt, 'v6.1.0')],
+    Date.parse('2026-02-10T00:00:00.000Z'),
+    Date.parse(MAR),
+  )
+  expect(resolved).toHaveLength(1)
+  expect(resolved[0].atMs).toBe(Date.parse(measuredAt))
+  expect(resolved[0].measured).toBe(true)
+})
+
+// The mirror case: a tag inside the window whose run landed past the end is
+// positioned on that run, so it drops out rather than drawing at the tag date
+// while claiming to be the run's position
+test('a tag inside the domain drops when its run is outside', () => {
+  const resolved = resolveTagPositions(
+    [tag('v6.1.0', FEB)],
+    [point(MAR, 'v6.1.0')],
+    Date.parse(JAN),
+    Date.parse('2026-02-20T00:00:00.000Z'),
+  )
+  expect(resolved).toEqual([])
+})
+
+test('labels every mark when they are far enough apart', () => {
+  const labels = labelledClusters(clusterTags(at([0, 40, 80]), identity, 6), 14)
+  expect([...labels.keys()]).toEqual([0, 1, 2])
+})
+
+// A label is drawn at the LAST mark it speaks for and named after that mark, so
+// its name and position agree
+test('a shared label sits on the last mark it speaks for', () => {
+  const clusters = clusterTags(at([0, 8]), identity, 6)
+  const labels = labelledClusters(clusters, 14)
+  expect([...labels.keys()]).toEqual([1])
+  expect(labels.get(1)!.tag.tag).toBe('v6.0.1')
+  expect(labels.get(1)!.alsoCount).toBe(1)
+})
+
+// Regression: the gap must be measured against the group's *last* mark (where
+// its label is drawn), not its first. Measuring from the first put a group's
+// label at x=12 and the next group's at x=18 — 6px apart, ~5px perpendicular at
+// -60° against a 9px line height, so they overlapped. Reachable from a hotfix
+// burst: three releases inside ~2 days.
+test('adjacent labels are never closer than the gap', () => {
+  const clusters = clusterTags(at([0, 6, 12, 18]), identity, 6)
+  const labels = labelledClusters(clusters, 14)
+  const xs = [...labels.keys()].map((index) => clusters[index].x)
+  for (const [i, x] of xs.slice(1).entries()) {
+    expect(x - xs[i]).toBeGreaterThanOrEqual(14)
+  }
+})
+
+// The chain folds into one label rather than re-opening the comparison at each
+// step — the same chain-collapse clusterTags applies to marks
+test('a chain of sub-gap steps folds into one label', () => {
+  const clusters = clusterTags(at([0, 12, 24, 36]), identity, 6)
+  const labels = labelledClusters(clusters, 14)
+  expect(labels.size).toBe(1)
+  const only = [...labels.values()][0]
+  expect(only.tag.tag).toBe('v6.0.3')
+  expect(only.alsoCount).toBe(only.tags.length - 1)
+})
+
+// Regression: re-anchoring can move a marker past a close neighbour, and both
+// clusterTags (which merges adjacent marks left-to-right) and the aria-label
+// range depend on the array agreeing with what is drawn
+test('sorts by drawn position, not by tag date', () => {
+  const resolved = markers(
+    [tag('v6.1.0', '2026-02-10T01:00:00.000Z'), tag('v6.2.0', '2026-02-10T12:00:00.000Z')],
+    // v6.1.0 measured 20h after its tag, leapfrogging v6.2.0
+    [point('2026-02-10T21:00:00.000Z', 'v6.1.0')],
+  )
+  expect(names(resolved)).toEqual(['v6.2.0', 'v6.1.0'])
+  const positions = resolved.map((entry) => entry.atMs)
+  expect(positions).toEqual([...positions].sort((a, b) => a - b))
+})
+
+test('no releases means no context', () => {
+  expect(releaseContextAt([], Date.parse(FEB))).toEqual({})
+})
+
+test('brackets a run between the surrounding releases', () => {
+  const at = Date.parse(FEB) + 5 * DAY
+  const {previous, next} = releaseContextAt(RELEASES, at)
+  expect([previous?.tag, next?.tag]).toEqual(['v6.1.0', 'v6.2.0'])
+})
+
+// The common case for recent runs: past the latest release, not yet shipped
+test('a run after every release has no next', () => {
+  const {previous, next} = releaseContextAt(RELEASES, Date.parse(MAR) + DAY)
+  expect([previous?.tag, next]).toEqual(['v6.2.0', undefined])
+})
+
+test('a run before every release has no previous', () => {
+  const {previous, next} = releaseContextAt(RELEASES, Date.parse(JAN) - DAY)
+  expect([previous, next?.tag]).toEqual([undefined, 'v6.0.0'])
+})
+
+// A run measured exactly at the tag is *in* that release, not before it
+test('a run exactly at a release counts as after it', () => {
+  const {previous, next} = releaseContextAt(RELEASES, Date.parse(FEB))
+  expect([previous?.tag, next?.tag]).toEqual(['v6.1.0', 'v6.2.0'])
+})
+
+test('picks the nearest release on each side regardless of input order', () => {
+  const shuffled = [RELEASES[2], RELEASES[0], RELEASES[1]]
+  const {previous, next} = releaseContextAt(shuffled, Date.parse(FEB) + DAY)
+  expect([previous?.tag, next?.tag]).toEqual(['v6.1.0', 'v6.2.0'])
+})
+
+test('ignores releases with an unparseable date', () => {
+  const tags = [tag('v6.9.9', 'nonsense'), ...RELEASES]
+  const {previous} = releaseContextAt(tags, Date.parse(MAR) + DAY)
+  expect(previous?.tag).toBe('v6.2.0')
+})
+
+/** Resolved entries at given px positions, for clustering tests. */
+const at = (positions: number[]) =>
+  positions.map((x, index) => ({tag: tag(`v6.0.${index}`, JAN), atMs: x}))
+
+/** Identity xOf, so test positions read as px directly. */
+const identity = (ms: number) => ms
+
+test('an empty plot draws no marks', () => {
+  expect(clusterTags([], identity, 5)).toEqual([])
+})
+
+test('well-separated markers each get their own mark', () => {
+  const clusters = clusterTags(at([0, 40, 80]), identity, 5)
+  expect(clusters.map((c) => [c.x, c.alsoCount])).toEqual([
+    [0, 0],
+    [40, 0],
+    [80, 0],
+  ])
+})
+
+// v6.10.0 and v6.10.1 shipped 6.8h apart — 4.6px on a 90-day chart. Two ticks
+// that close read as one thick smudge, so they merge into a single mark.
+test('near-coincident markers merge into one mark', () => {
+  const clusters = clusterTags(at([100, 104]), identity, 5)
+  expect(clusters).toHaveLength(1)
+  expect(clusters[0].alsoCount).toBe(1)
+})
+
+// The mark takes the cluster's last release: that's the one in effect for the
+// runs that follow it
+test('a merged mark is positioned and named after its last release', () => {
+  const clusters = clusterTags(at([100, 102, 104]), identity, 5)
+  expect(clusters).toHaveLength(1)
+  expect(clusters[0].x).toBe(104)
+  expect(clusters[0].tag.tag).toBe('v6.0.2')
+  expect(clusters[0].alsoCount).toBe(2)
+  // Nothing is lost — every release stays reachable for the label and tooltip
+  expect(clusters[0].tags.map((t) => t.tag)).toEqual(['v6.0.0', 'v6.0.1', 'v6.0.2'])
+})
+
+test('merges clusters but keeps distant marks apart', () => {
+  const clusters = clusterTags(at([0, 3, 100, 102, 200]), identity, 5)
+  expect(clusters.map((c) => [c.x, c.alsoCount])).toEqual([
+    [3, 1],
+    [102, 1],
+    [200, 0],
+  ])
+})
+
+// The label reads "(latest)" when *any* release in the cluster carries the
+// dist-tag, not only the one the mark is named after
+test('a merged cluster keeps every release for its label', () => {
+  const tags = [
+    {tag: {...tag('v6.9.9', JAN), distTags: ['latest']}, atMs: 100},
+    {tag: tag('v6.10.0', JAN), atMs: 103},
+  ]
+  const [cluster] = clusterTags(tags, identity, 5)
+  expect(cluster.tag.tag).toBe('v6.10.0')
+  expect(cluster.tags.some((t) => t.distTags?.includes('latest'))).toBe(true)
+  // The documented invariant
+  expect(cluster.alsoCount).toBe(cluster.tags.length - 1)
+})
+
+// Compared against the cluster's own mark, so a chain of sub-gap steps collapses
+// into one mark rather than each step re-opening the comparison
+test('a chain of sub-gap steps collapses into one mark', () => {
+  const clusters = clusterTags(at([0, 4, 8, 12]), identity, 5)
+  expect(clusters).toHaveLength(1)
+  expect(clusters[0].x).toBe(12)
+})

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -16,6 +16,9 @@ const ENV_KEYS = [
   'BENCH_MERGE_BASE',
   'BENCH_GIT_SHA',
   'BENCH_GIT_COMMITTED_AT',
+  'BENCH_TRIGGER',
+  'BENCH_RELEASE_TAG',
+  'GITHUB_EVENT_NAME',
   'ImageOS',
   'ImageVersion',
 ] as const
@@ -37,6 +40,17 @@ afterEach(() => {
 function metadata() {
   return collectRunMetadata({
     mode: 'ab',
+    calibrationMs: 10,
+    cpuThrottleRate: 4,
+    seed: 1,
+    startedAt: '2026-07-10T05:00:00.000Z',
+  })
+}
+
+/** The stored-to-metrics shape: only absolute-mode runs reach the dashboards. */
+function absoluteMetadata() {
+  return collectRunMetadata({
+    mode: 'absolute',
     calibrationMs: 10,
     cpuThrottleRate: 4,
     seed: 1,
@@ -125,6 +139,57 @@ describe('collectRunMetadata', () => {
     // poison the trend axis ordering/filtering built on this field
     process.env.BENCH_GIT_COMMITTED_AT = 'not-a-date'
     expect(metadata().git.committedAt).toBeUndefined()
+  })
+
+  it('records a release run and the tag it measured', () => {
+    process.env.BENCH_TRIGGER = 'release'
+    process.env.BENCH_RELEASE_TAG = 'v6.10.1'
+    expect(metadata()).toMatchObject({trigger: 'release', releaseTag: 'v6.10.1'})
+  })
+
+  // A tag on a non-release run would assert that the run measured that release,
+  // which is the false attribution the field exists to remove
+  it('keeps the release tag only on release runs', () => {
+    process.env.BENCH_TRIGGER = 'cron'
+    process.env.BENCH_RELEASE_TAG = 'v6.10.1'
+    expect(metadata().releaseTag).toBeUndefined()
+  })
+
+  it('infers cron for the daily schedule', () => {
+    process.env.GITHUB_EVENT_NAME = 'schedule'
+    expect(metadata().trigger).toBe('cron')
+  })
+
+  // The daily cron predates this field; documents it wrote have no trigger and
+  // consumers read them as cron, so the inference must agree with that
+  it('infers pr, backfill and dispatch from the run shape', () => {
+    process.env.GITHUB_REF = 'refs/pull/14234/merge'
+    expect(metadata().trigger).toBe('pr')
+    delete process.env.GITHUB_REF
+
+    // An absolute-mode dispatch measuring a historical commit is a backfill
+    process.env.BENCH_GIT_SHA = 'a'.repeat(40)
+    expect(absoluteMetadata().trigger).toBe('backfill')
+    delete process.env.BENCH_GIT_SHA
+
+    expect(metadata().trigger).toBe('dispatch')
+  })
+
+  // An A/B dispatch also sets BENCH_GIT_SHA (to ab_to), but it compares two
+  // commits rather than repairing a hole in the series — calling it a backfill
+  // would misdescribe it. Harmless today (consumers filter mode == 'absolute'),
+  // but the provenance should still be honest.
+  it('does not call an A/B dispatch a backfill', () => {
+    process.env.BENCH_GIT_SHA = 'a'.repeat(40)
+    expect(metadata().trigger).toBe('dispatch')
+  })
+
+  // A typo in a workflow edit must not invent a trigger kind that consumers
+  // then filter on — fall back to inference instead of storing the garbage
+  it('ignores an unrecognized declared trigger', () => {
+    process.env.BENCH_TRIGGER = 'relase'
+    process.env.GITHUB_EVENT_NAME = 'schedule'
+    expect(metadata().trigger).toBe('cron')
   })
 })
 

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -24,6 +24,51 @@ function git(args: string[]): string {
   }
 }
 
+const TRIGGERS = new Set(['cron', 'release', 'backfill', 'dispatch', 'pr'])
+
+/**
+ * Why this run happened, and (for release runs) which tag it measured.
+ *
+ * `BENCH_TRIGGER` is set by the workflow, but it is not trusted blindly: an
+ * unrecognized value falls back to inference rather than being stored, so a typo
+ * in a workflow edit cannot invent a trigger kind that consumers then filter on.
+ * Inference covers every path that does not set it — notably the daily schedule,
+ * which predates this field and must keep producing `cron`.
+ *
+ * `releaseTag` is only kept for `release` runs: a tag on a cron run would claim
+ * that run measured a release, which is exactly the false attribution this
+ * field exists to eliminate.
+ */
+function triggerFields(
+  prNumber: number,
+  mode: 'ab' | 'absolute',
+): {
+  trigger?: BenchRunDocument['trigger']
+  releaseTag?: string
+} {
+  const declared = process.env.BENCH_TRIGGER
+  const trigger: BenchRunDocument['trigger'] =
+    declared && TRIGGERS.has(declared)
+      ? (declared as BenchRunDocument['trigger'])
+      : !Number.isNaN(prNumber)
+        ? 'pr'
+        : process.env.GITHUB_EVENT_NAME === 'schedule'
+          ? 'cron'
+          : // A dispatch measuring a historical commit is a backfill — but only
+            // in absolute mode. An A/B dispatch also sets BENCH_GIT_SHA (to
+            // ab_to), and calling that a backfill would misdescribe it: it
+            // measures two commits against each other rather than repairing a
+            // hole in the series.
+            mode === 'absolute' && process.env.BENCH_GIT_SHA
+            ? 'backfill'
+            : 'dispatch'
+  const releaseTag = process.env.BENCH_RELEASE_TAG
+  return {
+    trigger,
+    ...(trigger === 'release' && releaseTag ? {releaseTag} : {}),
+  }
+}
+
 export function collectRunMetadata(options: {
   mode: 'ab' | 'absolute'
   calibrationMs: number
@@ -48,10 +93,12 @@ export function collectRunMetadata(options: {
   // repo, and a malformed workflow override must not poison the time axis
   // consumers sort and filter on
   const committedAt = Number.isNaN(Date.parse(committedAtRaw)) ? undefined : committedAtRaw
+
   return {
     _type: 'benchRun',
     schemaVersion: 1,
     mode: options.mode,
+    ...triggerFields(prNumber, options.mode),
     git: {
       // BENCH_GIT_SHA: the commit the measured dist was actually built from,
       // when that differs from the checkout — backfill runs build a

--- a/perf/bench/report/types.ts
+++ b/perf/bench/report/types.ts
@@ -11,6 +11,24 @@ export interface BenchRunDocument {
   _type: 'benchRun'
   schemaVersion: 1
   mode: 'ab' | 'absolute'
+  /**
+   * Why this run happened.
+   *
+   * `release` is the load-bearing one: those runs measure a tagged release
+   * commit, and are the only runs whose numbers can be attributed to a shipped
+   * version. Everything else measures whatever main happened to be — the daily
+   * `cron`, a `backfill` repairing history, a manual `dispatch`, or a `pr` run.
+   *
+   * Absent on documents stored before this field existed; consumers treat that
+   * as `cron`, which is what the schedule wrote for all of them.
+   */
+  trigger?: 'cron' | 'release' | 'backfill' | 'dispatch' | 'pr'
+  /**
+   * Release runs only: the tag whose commit this run measured, e.g. `v6.10.1`.
+   * Lets a chart anchor a release marker on this exact run instead of guessing
+   * by date, and lets the run popover name the release outright.
+   */
+  releaseTag?: string
   git: {
     sha: string
     branch: string


### PR DESCRIPTION
### Description

This PR runs benchmarks on each release commit, then marks releases on the charts.

Additionally, since the trend charts are getting more information dense now, charts can now be expanded:
<img width="424" height="80" alt="image" src="https://github.com/user-attachments/assets/478b0d80-2c3d-4777-9992-5a6fb6afd6bf" />
👇🏼 
<img width="1146" height="534" alt="image" src="https://github.com/user-attachments/assets/1f85452e-64de-4942-93dc-eeabf527a9d3" />

Preview build: https://vercel.com/api/toolbar/link/studio-metrics-git-metrics-release-markers.sanity.dev

### What to review

- `data.ts`: the pure helpers (anchoring, clustering) hold the geometry rules
- `TAGS_QUERY`: main-only, by `gitCommit` existence, not by major version
- `release-latest.yml`: the bench job must never fail or delay a release

Affects `perf/bench` and `dev/metrics-studio` only.

### Testing

38 new unit tests over the pure helpers.

### Notes for release

N/A – Internal tooling only

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes release CI dispatch and how benchmark documents attribute performance to shipped versions; failures are isolated from the release path, but incorrect pairing of tag/sha in workflows would store misleading metrics.
> 
> **Overview**
> **Release benchmarking** — After a normal release (`release-latest.yml`), CI dispatches `bench.yml` with `backfill_sha` + `release_tag` to measure the tagged commit (non-blocking; nothing waits on it). The bench workflow validates that `release_tag` pairs with `backfill_sha` and matches the tag’s commit, and stamps runs with `BENCH_TRIGGER=release` and `BENCH_RELEASE_TAG`.
> 
> **Stored provenance** — `benchRun` documents gain `trigger` and `releaseTag`; `collectRunMetadata` records them from env (with inference for cron/PR/backfill/dispatch) and only attaches `releaseTag` when `trigger` is `release`, so cron runs cannot falsely claim they measured a release.
> 
> **Trends UI** — Charts load main-line stable tags via `TAGS_QUERY`, draw a toggleable **releases** layer (ticks above the plot; labels in the maximized view), anchor markers on release-measured runs when present, and show release context in tooltips and the run popover. Charts can be opened at **`?max=<series key>`** in a dialog with labelled markers and visible descriptions. Debug data and many unit tests cover anchoring, clustering, and attribution edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7678b821e485bef209793aca0c05246de4158838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->