### PR TITLE
chore(renovate): keep @portabletext/* majors in the group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -115,11 +115,12 @@
       "schedule": ["every weekday"]
     },
     {
-      "description": "Upgrade @portabletext/* packages together",
+      "description": "Upgrade @portabletext/* packages together, majors included: the editor monorepo versions its packages independently but releases them in lockstep (plugins peer-depend on the editor), so a new major line must land as one PR instead of one per major number",
       "matchPackageNames": ["@portabletext/*"],
       "dependencyDashboardApproval": false,
       "schedule": ["every weekday"],
-      "groupName": "portabletext"
+      "groupName": "portabletext",
+      "separateMajorMinor": false
     },
     {
       "description": "Group TypeScript related deps in a single PR, as they often have to update together",


### PR DESCRIPTION
### Description

https://github.com/sanity-io/sanity/pull/14311 shows that bumping a PTE plugin to the next major before bumping PTE itself will produce a peer dep warning.

In all honesty, it's better to just bump all PTE-related deps together when a new major line has been cut.

This PR sets `separateMajorMinor: false` on the `portabletext` group, so majors stay in the group.

### What to review

One property and an updated description on the existing rule. The group matches `@portabletext/*` by name, so the renderer packages (`@portabletext/react`, `@portabletext/to-html`) ride the same PR, as they already do for non-major bumps.

### Testing

n/a

### Notes for release

n/a

---
