### PR TITLE
chore(metrics): add bisect + releases tool

### DIFF
--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -4,7 +4,7 @@ One place to answer repo-health questions without opening CI logs: **is
 studio performance drifting on main?** (Trends), **what did a specific run
 look like?** (run detail), **did anything change that needs a human?**
 (drift feed), **which commit broke it?** (Bisect), **what shipped when, and
-what regressed?** (Releases). Primary users: studio engineers checking the
+what regressed?** (Studio Releases). Primary users: studio engineers checking the
 effect of merged work; secondary: leads scanning health weekly.
 
 ## Data reality
@@ -160,10 +160,12 @@ effect of merged work; secondary: leads scanning health weekly.
    `?layers=-band` so a stripped-back view is shareable. Global rather than
    per-card because the grid is 40+ small multiples.
 
-5. **Release markers** — one dotted vertical rule per stable `v*` tag
-   (`gitTag`, rc tags excluded) inside the plotted window, so "did this step
-   land with a release?" is answerable without leaving the chart. The first
-   consumer of the git-history join surface.
+5. **Release markers** — one tick above the plot per stable `v*` tag
+   (`gitTag`, rc tags excluded) inside the plotted window — a tick rather than
+   a rule through the data, so ~20 annotations don't compete with the series
+   they annotate — making "did this step land with a release?" answerable
+   without leaving the chart. The first consumer of the git-history join
+   surface.
 
    **Main-branch releases only.** The charts only ever plot main (bench runs are
    main-branch crons), so a release cut off main is a _false_ annotation — its
@@ -220,12 +222,14 @@ effect of merged work; secondary: leads scanning health weekly.
 
    **Labels are size-dependent.** At grid-card width (~330px) a 90-day window
    holds ~20 markers, one every ~15px, so resting text is guaranteed overlap:
-   cards draw unlabelled rules (each with a tick at the top so it still reads as
-   an anchor) and the hover tooltip names the release nearest the crosshair,
-   within half the median run gap. The maximized view has the room and draws
-   rotated labels, thinned so that a cluster keeps its last tag — releases
-   cluster on release days, and the last of a cluster is the one in effect for
-   the runs that follow.
+   cards draw unlabelled ticks, and the hover tooltip names every release
+   within half the median run gap of the crosshair (floored at one hour) —
+   all of them, not just the nearest, since releases ship in bursts whose
+   marks merge into one tick. A run that measured a release names it from the
+   run itself, on its own "measured release" row. The maximized view has the
+   room and draws rotated labels, thinned so that a cluster keeps its last
+   tag (the others fold into a "+n") — releases cluster on release days, and
+   the last of a cluster is the one in effect for the runs that follow.
 
 6. **Maximize a single chart** — the grid is built for scanning; reading one
    chart closely needs room. An expand button on each card opens the same
@@ -237,7 +241,7 @@ effect of merged work; secondary: leads scanning health weekly.
    full-viewport — stretching 90 days across a 2500px monitor reads as a flat
    line no matter what the metric did.
 
-5. **Bisect** — guided binary search over mainline history: pick a good and a
+7. **Bisect** — guided binary search over mainline history: pick a good and a
    bad commit (or a release tag as shortcut), and the tool proposes which
    commit's test-studio preview build (`gitCommit.testStudioUrl`) to test
    next, halving the range per good/bad verdict until the first bad commit is
@@ -253,16 +257,23 @@ effect of merged work; secondary: leads scanning health weekly.
    endpoints, current bounds, every visited commit and the one under test,
    with the runs in between collapsed into gap rows labelled by what the
    bisect has already deduced (broken / untested / working), each linking to
-   the GitHub compare of the span.
+   the GitHub compare of the span. Sessions can be deleted from the session
+   view (hard delete behind a confirm — they're the only user-owned documents
+   here).
 
-6. **Releases** — every synced release tag, newest first: current dist-tags,
-   weekly downloads, publish time, and links out (GitHub release, sanity.io
-   changelog, npmx.dev). The changelog link is derived from the release's
-   base version — the previous release on the first-parent chain, the same
-   value release automation computes — so off-mainline releases (maintenance
-   lines) may lack it. Each release also shows the count of confirmed
-   regressions bisect sessions have attributed to it, blamed on the release
-   that FIRST shipped the offending commit.
+8. **Studio Releases** — every synced release tag, newest first: current
+   dist-tags, weekly downloads, publish time, links out (GitHub release,
+   sanity.io changelog, npmx.dev), and the version linking to the gitTag
+   document in the structure tool. The changelog link is derived from the
+   release's base version — the previous release on the first-parent chain,
+   the same value release automation computes — so off-mainline releases
+   (maintenance lines) may lack it. Each release also shows the count of
+   confirmed regressions bisect sessions have attributed to it, blamed on the
+   release that FIRST shipped the offending commit. Regressions found outside
+   a bisect (user reports) are added by hand via "Add regression", stored as
+   a born-converged releases-only bisectSession (base release → blamed
+   release, the commits between as suspects) so attribution and the bisect
+   drill-down work unchanged.
 
 ## Architecture
 

--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -40,14 +40,14 @@ secondary: leads scanning health weekly.
   v5.0.0.
 
   Commit documents are metadata only: sha, first-parent sha (the exact
-  mainline chain — `committedAt` ordering has tie/rebase hazards), author,
-  dates, subject, and a best-effort conventional-commit parse plus PR
-  number. Tag documents carry the dereferenced sha, a weak reference to
-  their commit, and parsed semver so interleaved release lines group by
-  major. Tags also carry npm data (`publishedAt`, `distTags`,
-  `weeklyDownloads`), collected on releases, the daily cron, and dispatches
-  — the cron is the floor because dist-tags re-point and download counts
-  roll without commits.
+  mainline chain link the Bisect tool walks — `committedAt` ordering has
+  tie/rebase hazards), author, dates, subject, and a best-effort
+  conventional-commit parse plus PR number. Tag documents carry the
+  dereferenced sha, a weak reference to their commit, and parsed semver so
+  interleaved release lines group by major. Tags also carry npm data
+  (`publishedAt`, `distTags`, `weeklyDownloads`), collected on releases, the
+  daily cron, and dispatches — the cron is the floor because dist-tags
+  re-point and download counts roll without commits.
 
   Sync (scripts/syncGitHistory.ts via sync-git-metrics.yml): every push to
   main re-upserts the last 50 commits — deterministic ids + createOrReplace
@@ -235,6 +235,24 @@ secondary: leads scanning health weekly.
    ack props, so maximizing is never a downgrade. Fixed width rather than
    full-viewport — stretching 90 days across a 2500px monitor reads as a flat
    line no matter what the metric did.
+
+5. **Bisect** — guided binary search over mainline history: pick a good and a
+   bad commit (or a release tag as shortcut), and the tool proposes which
+   commit's test-studio preview build (`gitCommit.testStudioUrl`) to test
+   next, halving the range per good/bad verdict until the first bad commit is
+   named. The chain is the exact first-parent walk (`gitCommit.parentSha`),
+   not a date sort. Each run is a `bisectSession` document (studio-written,
+   liveEdit, like `driftAck`): endpoints, an append-only marks log (last mark
+   per sha wins; undo removes the tail), and — denormalized at convergence
+   only, for the session list — the result. Commits without a testable build
+   (skipped builds, one-sync URL lag) are never proposed and end up as
+   explicit "suspects" in the verdict rather than silently blamed.
+   Conflicting marks (a good newer than a bad) surface as an error state that
+   undo resolves. A timeline "map" below the stepper shows where you are:
+   endpoints, current bounds, every visited commit and the one under test,
+   with the runs in between collapsed into gap rows labelled by what the
+   bisect has already deduced (broken / untested / working), each linking to
+   the GitHub compare of the span.
 
 ## Architecture
 

--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -1,10 +1,11 @@
 # Metrics-studio dashboard
 
-One place to answer three questions without opening CI logs: **is studio
-performance drifting on main?** (Trends), **what did a specific run look
-like?** (run detail), **did anything change that needs a human?** (drift
-feed). Primary users: studio engineers checking the effect of merged work;
-secondary: leads scanning health weekly.
+One place to answer repo-health questions without opening CI logs: **is
+studio performance drifting on main?** (Trends), **what did a specific run
+look like?** (run detail), **did anything change that needs a human?**
+(drift feed), **which commit broke it?** (Bisect), **what shipped when, and
+what regressed?** (Releases). Primary users: studio engineers checking the
+effect of merged work; secondary: leads scanning health weekly.
 
 ## Data reality
 
@@ -253,6 +254,15 @@ secondary: leads scanning health weekly.
    with the runs in between collapsed into gap rows labelled by what the
    bisect has already deduced (broken / untested / working), each linking to
    the GitHub compare of the span.
+
+6. **Releases** — every synced release tag, newest first: current dist-tags,
+   weekly downloads, publish time, and links out (GitHub release, sanity.io
+   changelog, npmx.dev). The changelog link is derived from the release's
+   base version — the previous release on the first-parent chain, the same
+   value release automation computes — so off-mainline releases (maintenance
+   lines) may lack it. Each release also shows the count of confirmed
+   regressions bisect sessions have attributed to it, blamed on the release
+   that FIRST shipped the offending commit.
 
 ## Architecture
 

--- a/dev/metrics-studio/sanity.config.ts
+++ b/dev/metrics-studio/sanity.config.ts
@@ -5,6 +5,7 @@ import {MetricsStudioIcon} from './MetricsStudioIcon'
 import {schemaTypes} from './schemaTypes'
 import {bisectTool} from './tools/bisect'
 import {comparisonsTool} from './tools/comparisons'
+import {releasesTool} from './tools/releases'
 import {trendsTool} from './tools/trends'
 
 export default defineConfig({
@@ -13,12 +14,15 @@ export default defineConfig({
   icon: MetricsStudioIcon,
   projectId: 'mhfozd0z',
   dataset: 'bench',
-  // Trends first (the dashboard and default view), then the investigation
-  // tools — comparisons last, it's the least visited
+  // Trends first (the dashboard and default view), raw document access
+  // second, then the investigation tools — comparisons last, it's the least
+  // visited
   tools: (prev) => {
     const structure = prev.filter((tool) => tool.name === 'structure')
-    const rest = prev.filter((tool) => tool.name !== 'structure')
-    return [trendsTool, bisectTool, ...structure, ...rest, comparisonsTool]
+    // Drop the built-in Content Releases tool: this dataset has no content
+    // releases, and our release-tags tool owns the "Releases" name
+    const rest = prev.filter((tool) => tool.name !== 'structure' && tool.name !== 'releases')
+    return [trendsTool, releasesTool, bisectTool, ...structure, ...rest, comparisonsTool]
   },
   plugins: [
     structureTool({

--- a/dev/metrics-studio/sanity.config.ts
+++ b/dev/metrics-studio/sanity.config.ts
@@ -14,16 +14,16 @@ export default defineConfig({
   icon: MetricsStudioIcon,
   projectId: 'mhfozd0z',
   dataset: 'bench',
-  // Trends first (the dashboard and default view), raw document access
-  // second, then the investigation tools — comparisons last, it's the least
-  // visited
+  // Trends first (the dashboard and default view), then the investigation
+  // tools (releases, bisect), then raw document access — comparisons last,
+  // it's the least visited
   tools: (prev) => {
     const structure = prev.filter((tool) => tool.name === 'structure')
-    // Drop the built-in Content Releases tool: this dataset has no content
-    // releases, and our release-tags tool owns the "Releases" name
-    const rest = prev.filter((tool) => tool.name !== 'structure' && tool.name !== 'releases')
+    const rest = prev.filter((tool) => tool.name !== 'structure')
     return [trendsTool, releasesTool, bisectTool, ...structure, ...rest, comparisonsTool]
   },
+  releases: {enabled: false},
+  scheduledDrafts: {enabled: false},
   plugins: [
     structureTool({
       structure: (S) =>

--- a/dev/metrics-studio/sanity.config.ts
+++ b/dev/metrics-studio/sanity.config.ts
@@ -3,6 +3,7 @@ import {structureTool} from 'sanity/structure'
 
 import {MetricsStudioIcon} from './MetricsStudioIcon'
 import {schemaTypes} from './schemaTypes'
+import {bisectTool} from './tools/bisect'
 import {comparisonsTool} from './tools/comparisons'
 import {trendsTool} from './tools/trends'
 
@@ -12,8 +13,13 @@ export default defineConfig({
   icon: MetricsStudioIcon,
   projectId: 'mhfozd0z',
   dataset: 'bench',
-  // Trends first: it's the dashboard and the studio's default view
-  tools: (prev) => [trendsTool, comparisonsTool, ...prev],
+  // Trends first (the dashboard and default view), then the investigation
+  // tools — comparisons last, it's the least visited
+  tools: (prev) => {
+    const structure = prev.filter((tool) => tool.name === 'structure')
+    const rest = prev.filter((tool) => tool.name !== 'structure')
+    return [trendsTool, bisectTool, ...structure, ...rest, comparisonsTool]
+  },
   plugins: [
     structureTool({
       structure: (S) =>
@@ -40,6 +46,13 @@ export default defineConfig({
                 S.documentTypeList('gitTag')
                   .title('Releases')
                   .defaultOrdering([{field: 'taggedAt', direction: 'desc'}]),
+              ),
+            S.listItem()
+              .title('Bisect sessions')
+              .child(
+                S.documentTypeList('bisectSession')
+                  .title('Bisect sessions')
+                  .defaultOrdering([{field: 'createdAt', direction: 'desc'}]),
               ),
           ]),
     }),

--- a/dev/metrics-studio/schemaTypes/bisectSession.ts
+++ b/dev/metrics-studio/schemaTypes/bisectSession.ts
@@ -1,0 +1,130 @@
+import {TargetIcon} from '@sanity/icons/Target'
+import {defineField, defineType} from 'sanity'
+
+/**
+ * One guided bisect run over mainline history: endpoints picked in the Bisect
+ * tool, a append-only log of good/bad/skip marks, and — once converged — the
+ * verdict. Unlike `gitCommit`/`gitTag` (machine written, read-only), these
+ * are written from the Bisect tool via the client, like `driftAck`.
+ *
+ * Everything the stepper shows is derived live from `marks` + the commit
+ * chain (tools/bisect/bisect.ts); `result` is denormalized at convergence
+ * only so the sessions list can show the verdict without loading the ~2k
+ * commit documents. Undoing a mark clears it again.
+ *
+ * Id: `bisectSession-<uuid>` — sessions are user-created, not idempotent.
+ */
+export const bisectSession = defineType({
+  name: 'bisectSession',
+  title: 'Bisect session',
+  type: 'document',
+  icon: TargetIcon,
+  // Written by the Bisect tool via client.create/patch — no draft workflow;
+  // the tool's realtime listenQuery expects immediate effect.
+  liveEdit: true,
+  fields: [
+    defineField({
+      name: 'title',
+      description: 'Set at creation, e.g. “v6.9.2 → 1a2b3c4”',
+      type: 'string',
+    }),
+    defineField({
+      name: 'good',
+      description: 'The known-good endpoint (older)',
+      type: 'object',
+      fields: [
+        defineField({name: 'sha', description: 'Full 40-char sha', type: 'string'}),
+        defineField({
+          name: 'label',
+          description: 'How it was picked — a tag name or short sha',
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'bad',
+      description: 'The known-bad endpoint (newer)',
+      type: 'object',
+      fields: [
+        defineField({name: 'sha', description: 'Full 40-char sha', type: 'string'}),
+        defineField({
+          name: 'label',
+          description: 'How it was picked — a tag name or short sha',
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'releasesOnly',
+      description: 'Only propose commits that are release tags — bisecting versions, not commits',
+      type: 'boolean',
+    }),
+    defineField({
+      name: 'marks',
+      description: 'Append-only verdict log — the last mark per sha wins; undo removes the tail',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            defineField({name: 'sha', type: 'string'}),
+            defineField({
+              name: 'verdict',
+              type: 'string',
+              options: {list: ['good', 'bad', 'skip']},
+            }),
+            defineField({name: 'markedAt', type: 'datetime'}),
+            defineField({name: 'markedBy', type: 'string'}),
+          ],
+          preview: {
+            select: {sha: 'sha', verdict: 'verdict'},
+            prepare: ({sha, verdict}) => ({title: `${verdict}: ${sha?.slice(0, 10)}`}),
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'result',
+      description: 'Written once at convergence — the sessions list reads this, nothing else does',
+      type: 'object',
+      fields: [
+        defineField({name: 'firstBadSha', type: 'string'}),
+        defineField({name: 'lastGoodSha', type: 'string'}),
+        defineField({
+          name: 'suspectShas',
+          description: 'Untestable/skipped commits between last good and first bad',
+          type: 'array',
+          of: [{type: 'string'}],
+        }),
+        defineField({
+          name: 'regression',
+          description: 'Human classification: the found commit is a confirmed regression',
+          type: 'boolean',
+        }),
+        defineField({
+          name: 'description',
+          description: 'What broke, in the bisector’s words',
+          type: 'text',
+          rows: 2,
+        }),
+        defineField({
+          name: 'linearIssue',
+          description: 'Linear ticket id, e.g. SAPP-1234',
+          type: 'string',
+        }),
+        defineField({name: 'concludedAt', type: 'datetime'}),
+      ],
+    }),
+    defineField({name: 'createdAt', type: 'datetime'}),
+    defineField({name: 'createdBy', type: 'string'}),
+  ],
+  preview: {
+    select: {title: 'title', firstBadSha: 'result.firstBadSha', markCount: 'marks'},
+    prepare: ({title, firstBadSha, markCount}) => ({
+      title,
+      subtitle: firstBadSha
+        ? `found ${firstBadSha.slice(0, 10)}`
+        : `${Array.isArray(markCount) ? markCount.length : 0} mark${Array.isArray(markCount) && markCount.length === 1 ? '' : 's'}`,
+    }),
+  },
+})

--- a/dev/metrics-studio/schemaTypes/index.ts
+++ b/dev/metrics-studio/schemaTypes/index.ts
@@ -1,6 +1,7 @@
 import {benchRunTypes} from './benchRun'
+import {bisectSession} from './bisectSession'
 import {driftAck} from './driftAck'
 import {gitCommit} from './gitCommit'
 import {gitTag} from './gitTag'
 
-export const schemaTypes = [...benchRunTypes, driftAck, gitCommit, gitTag]
+export const schemaTypes = [...benchRunTypes, bisectSession, driftAck, gitCommit, gitTag]

--- a/dev/metrics-studio/tools/bisect/AuthorAvatar.tsx
+++ b/dev/metrics-studio/tools/bisect/AuthorAvatar.tsx
@@ -1,0 +1,22 @@
+import {Avatar} from '@sanity/ui'
+
+import {useAuthorAvatarUrl} from './useGravatar'
+
+/** Commit author's avatar (synced GitHub avatarUrl, noreply parse, login, then gravatar), initials meanwhile. */
+export function AuthorAvatar(props: {
+  name?: string
+  email?: string
+  login?: string
+  avatarUrl?: string
+  size?: 0 | 1
+}) {
+  const {name, email, login, avatarUrl, size = 0} = props
+  const url = useAuthorAvatarUrl({avatarUrl, email, login})
+  const initials = (name ?? '?')
+    .split(/\s+/)
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+  return <Avatar src={url} initials={initials} size={size} title={name} />
+}

--- a/dev/metrics-studio/tools/bisect/BisectTool.tsx
+++ b/dev/metrics-studio/tools/bisect/BisectTool.tsx
@@ -1,0 +1,239 @@
+import {AddIcon} from '@sanity/icons/Add'
+import {Badge, Box, Button, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {useToast} from '@sanity/ui/toast'
+import {useMemo, useState} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, of} from 'rxjs'
+import {useClient, useCurrentUser, useDocumentStore} from 'sanity'
+
+import {useUrlState} from '../trends/useUrlState'
+import {
+  BISECT_COMMITS_QUERY,
+  BISECT_SESSIONS_QUERY,
+  BISECT_TAGS_QUERY,
+  type GitCommitSlice,
+  type SessionSummary,
+  type TagSlice,
+  toBisectCommit,
+} from './data'
+import {NewSessionDialog} from './NewSessionDialog'
+import {RelativeDate} from './RelativeDate'
+import {createSession, type NewSessionInput} from './sessions'
+import {SessionView} from './SessionView'
+import {pluralize} from './text'
+
+interface LiveState<T> {
+  data: T | null
+  error: string | null
+}
+
+/**
+ * Guided bisect over mainline history: pick a good and a bad commit, and the
+ * tool walks you through which preview build (`gitCommit.testStudioUrl`) to
+ * test next, halving the range on every good/bad verdict until the first bad
+ * commit is named. Each run is a `bisectSession` document — this overview
+ * lists them (verdict for concluded runs, progress for active ones) and the
+ * stepper lives behind `?session=<id>`.
+ */
+export function BisectTool() {
+  const documentStore = useDocumentStore()
+  const client = useClient({apiVersion: '2025-02-19'})
+  const currentUser = useCurrentUser()
+  const toast = useToast()
+  const [sessionId, setSessionId] = useUrlState('session', '')
+  const [creating, setCreating] = useState(false)
+
+  const commitsLive$ = useMemo(
+    () =>
+      documentStore.listenQuery(BISECT_COMMITS_QUERY, {}, {tag: 'metrics.bisect.commits'}).pipe(
+        map((result): LiveState<GitCommitSlice[]> => ({
+          data: result as GitCommitSlice[],
+          error: null,
+        })),
+        catchError((error: unknown) =>
+          of<LiveState<GitCommitSlice[]>>({
+            data: null,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        ),
+      ),
+    [documentStore],
+  )
+  const commitsLive = useObservable(commitsLive$, {data: null, error: null})
+
+  const sessionsLive$ = useMemo(
+    () =>
+      documentStore.listenQuery(BISECT_SESSIONS_QUERY, {}, {tag: 'metrics.bisect.sessions'}).pipe(
+        map((result): LiveState<SessionSummary[]> => ({
+          data: result as SessionSummary[],
+          error: null,
+        })),
+        catchError((error: unknown) =>
+          of<LiveState<SessionSummary[]>>({
+            data: null,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        ),
+      ),
+    [documentStore],
+  )
+  const sessionsLive = useObservable(sessionsLive$, {data: null, error: null})
+
+  const tagsLive$ = useMemo(
+    () =>
+      documentStore.listenQuery(BISECT_TAGS_QUERY, {}, {tag: 'metrics.bisect.tags'}).pipe(
+        map((result): LiveState<TagSlice[]> => ({data: result as TagSlice[], error: null})),
+        catchError((error: unknown) =>
+          of<LiveState<TagSlice[]>>({
+            data: null,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        ),
+      ),
+    [documentStore],
+  )
+  const tagsLive = useObservable(tagsLive$, {data: null, error: null})
+
+  const commitsBySha = useMemo(
+    () => new Map((commitsLive.data ?? []).map((slice) => [slice.sha, toBisectCommit(slice)])),
+    [commitsLive.data],
+  )
+
+  const userName = currentUser?.name ?? currentUser?.email ?? 'unknown'
+
+  // Async so the dialog can disable its submit until it settles
+  const handleCreate = async (input: NewSessionInput) => {
+    try {
+      const id = await createSession(client, input)
+      setCreating(false)
+      setSessionId(id, 'push')
+    } catch (err) {
+      toast.push({
+        status: 'error',
+        title: 'Could not create bisect session',
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  if (sessionId) {
+    return (
+      <SessionView
+        sessionId={sessionId}
+        commitsBySha={commitsBySha}
+        tags={tagsLive.data}
+        dataError={commitsLive.error ?? tagsLive.error}
+        client={client}
+        userName={userName}
+        onBack={() => setSessionId('', 'push')}
+        onOpenSession={(id) => setSessionId(id, 'push')}
+      />
+    )
+  }
+
+  const error = commitsLive.error ?? sessionsLive.error ?? tagsLive.error
+  const sessions = sessionsLive.data
+
+  return (
+    <Box padding={4} style={{overflowY: 'auto', height: '100%'}}>
+      <Container width={2}>
+        <Stack gap={4}>
+          <Flex align="center" gap={3}>
+            <Box flex={1}>
+              <Stack gap={3}>
+                <Text size={3} weight="semibold">
+                  Bisect
+                </Text>
+                <Text size={1} muted>
+                  Hunt down the commit that broke something: pick a known-good and a known-bad
+                  commit, then test the preview build the tool proposes at each step. Every run is
+                  stored as a session, so a bisect can be shared or picked up later.
+                </Text>
+              </Stack>
+            </Box>
+            <Button
+              icon={AddIcon}
+              text="Start bisect"
+              tone="primary"
+              disabled={!commitsLive.data}
+              onClick={() => setCreating(true)}
+            />
+          </Flex>
+
+          {error && (
+            <Card padding={4} radius={3} tone="critical">
+              <Text size={1}>Failed to load: {error}</Text>
+            </Card>
+          )}
+          {!error && sessions === null && (
+            <Text size={1} muted>
+              Loading…
+            </Text>
+          )}
+          {sessions?.length === 0 && (
+            <Card padding={4} radius={3} tone="transparent" border>
+              <Text size={1} muted>
+                No bisect sessions yet.
+              </Text>
+            </Card>
+          )}
+
+          {sessions?.map((session) => (
+            <SessionRow
+              key={session._id}
+              session={session}
+              onOpen={() => setSessionId(session._id, 'push')}
+            />
+          ))}
+        </Stack>
+      </Container>
+
+      {creating && (
+        <NewSessionDialog
+          commits={commitsLive.data ?? []}
+          tags={tagsLive.data ?? []}
+          commitsBySha={commitsBySha}
+          onClose={() => setCreating(false)}
+          onCreate={handleCreate}
+          createdBy={userName}
+        />
+      )}
+    </Box>
+  )
+}
+
+function SessionRow(props: {session: SessionSummary; onOpen: () => void}) {
+  const {session, onOpen} = props
+  const concluded = Boolean(session.result?.firstBadSha)
+
+  return (
+    <Card as="button" padding={4} radius={3} border onClick={onOpen} style={{textAlign: 'left'}}>
+      <Flex align="center" gap={3} wrap="wrap">
+        <Box flex={1}>
+          <Stack gap={2}>
+            <Text size={1} weight="medium">
+              {session.title ?? session._id}
+            </Text>
+            <Flex align="center" gap={2}>
+              {session.createdAt && <RelativeDate dateTime={session.createdAt} size={0} muted />}
+              <Text size={0} muted>
+                · {session.createdBy}
+              </Text>
+            </Flex>
+          </Stack>
+        </Box>
+        {concluded ? (
+          <Badge tone={session.result?.regression ? 'critical' : 'positive'} fontSize={0}>
+            {session.result?.regression ? 'regression' : 'found'}{' '}
+            {session.result?.firstBadSha?.slice(0, 10)}
+            {session.resultSubject ? ` — ${session.resultSubject}` : ''}
+          </Badge>
+        ) : (
+          <Badge tone="caution" fontSize={0}>
+            {pluralize(session.markCount ?? 0, 'mark')}
+          </Badge>
+        )}
+      </Flex>
+    </Card>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/CommitCard.tsx
+++ b/dev/metrics-studio/tools/bisect/CommitCard.tsx
@@ -1,0 +1,56 @@
+import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {type ReactNode} from 'react'
+
+import {commitUrl, prUrl} from '../trends/links'
+import {AuthorAvatar} from './AuthorAvatar'
+import {type BisectCommit} from './bisect'
+import {RelativeDate} from './RelativeDate'
+
+/** One commit, fully identified: subject, sha, PR, author, age — plus slots. */
+export function CommitCard(props: {
+  commit: BisectCommit
+  tone?: 'critical' | 'primary'
+  heading?: ReactNode
+  children?: ReactNode
+}) {
+  const {commit, tone, heading, children} = props
+  return (
+    <Card padding={4} radius={3} border tone={tone}>
+      <Stack gap={3}>
+        {heading}
+        <Text size={2} weight="medium">
+          <a href={commitUrl(commit.sha)} target="_blank" rel="noreferrer">
+            {commit.subject}
+          </a>
+        </Text>
+        <Flex align="center" gap={3} wrap="wrap">
+          <Text size={1}>
+            <a href={commitUrl(commit.sha)} target="_blank" rel="noreferrer">
+              <code>{commit.sha.slice(0, 10)}</code>
+            </a>
+          </Text>
+          {typeof commit.prNumber === 'number' && (
+            <Text size={1}>
+              <a href={prUrl(commit.prNumber)} target="_blank" rel="noreferrer">
+                #{commit.prNumber}
+              </a>
+            </Text>
+          )}
+          <AuthorAvatar
+            name={commit.authorName}
+            email={commit.authorEmail}
+            login={commit.authorLogin}
+            avatarUrl={commit.authorAvatarUrl}
+          />
+          {commit.authorName && (
+            <Text size={1} muted>
+              {commit.authorName} ·
+            </Text>
+          )}
+          <RelativeDate dateTime={commit.committedAt} muted />
+        </Flex>
+        {children}
+      </Stack>
+    </Card>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/IncludedIn.tsx
+++ b/dev/metrics-studio/tools/bisect/IncludedIn.tsx
@@ -1,0 +1,64 @@
+import {Text} from '@sanity/ui'
+import {type CSSProperties, useState} from 'react'
+
+import {releaseUrl} from '../trends/links'
+import {type TagSlice} from './data'
+
+// A real button (keyboard/AT-correct), styled as the surrounding link text
+const linkButtonStyle: CSSProperties = {
+  background: 'none',
+  border: 0,
+  padding: 0,
+  font: 'inherit',
+  color: 'inherit',
+  textDecoration: 'underline',
+  cursor: 'pointer',
+}
+
+/**
+ * "Included in v6.9.2 (stable), v6.10.0, … +12 more" — the releases whose
+ * ancestry contains a commit, truncated past a few with an inline expander.
+ */
+export function IncludedIn(props: {releases: TagSlice[]}) {
+  const {releases} = props
+  const [expanded, setExpanded] = useState(false)
+  const limit = 3
+  const visible = expanded ? releases : releases.slice(0, limit)
+  const hiddenCount = releases.length - visible.length
+  return (
+    <Text size={1} muted>
+      {releases.length === 0 ? (
+        'Not included in any release yet.'
+      ) : (
+        <>
+          Included in{' '}
+          {visible.map((release, index) => (
+            <span key={release.tag}>
+              {index > 0 && ', '}
+              <a href={releaseUrl(release.tag)} target="_blank" rel="noreferrer">
+                {release.tag}
+              </a>
+              {release.npm?.distTags?.length ? ` (${release.npm.distTags.join(', ')})` : ''}
+            </span>
+          ))}
+          {hiddenCount > 0 && (
+            <>
+              {' '}
+              <button type="button" style={linkButtonStyle} onClick={() => setExpanded(true)}>
+                +{hiddenCount} more
+              </button>
+            </>
+          )}
+          {expanded && releases.length > limit && (
+            <>
+              {' '}
+              <button type="button" style={linkButtonStyle} onClick={() => setExpanded(false)}>
+                show less
+              </button>
+            </>
+          )}
+        </>
+      )}
+    </Text>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/NewSessionDialog.tsx
+++ b/dev/metrics-studio/tools/bisect/NewSessionDialog.tsx
@@ -1,0 +1,298 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Dialog,
+  Flex,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from '@sanity/ui'
+import {useMemo, useState} from 'react'
+
+import {compareUrl} from '../trends/links'
+import {AuthorAvatar} from './AuthorAvatar'
+import {type BisectCommit, buildChain, chainErrorCopy} from './bisect'
+import {filterCommits, type GitCommitSlice, type TagSlice} from './data'
+import {RelativeDate} from './RelativeDate'
+import {type NewSessionInput} from './sessions'
+import {pluralize} from './text'
+
+interface Endpoint {
+  sha: string
+  label?: string
+}
+
+function shortLabel(endpoint: Endpoint): string {
+  return endpoint.label ?? endpoint.sha.slice(0, 7)
+}
+
+/**
+ * Endpoint picking for a new session: a release tag as a one-click shortcut,
+ * or a commit found by sha prefix / subject search. Creation is gated on a
+ * client-side chain pre-check so a doomed session (swapped endpoints,
+ * off-mainline pick) is blocked with an explanation instead of created.
+ */
+export function NewSessionDialog(props: {
+  commits: GitCommitSlice[]
+  tags: TagSlice[]
+  commitsBySha: Map<string, BisectCommit>
+  createdBy: string
+  onClose: () => void
+  /** Must settle (the tool toasts failures) — the submit stays disabled until it does. */
+  onCreate: (input: NewSessionInput) => Promise<unknown>
+}) {
+  const {commits, tags, commitsBySha, createdBy, onClose, onCreate} = props
+  const [good, setGood] = useState<Endpoint | null>(null)
+  const [bad, setBad] = useState<Endpoint | null>(null)
+  const [releasesOnly, setReleasesOnly] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const chainCheck = useMemo(() => {
+    if (!good || !bad) return null
+    return buildChain(commitsBySha, good.sha, bad.sha)
+  }, [commitsBySha, good, bad])
+
+  // A not-ancestor pair whose REVERSE chain works means the endpoints are
+  // simply swapped — say so precisely and offer the one-click fix
+  const isSwapped = useMemo(() => {
+    if (!good || !bad || chainCheck?.ok !== false || chainCheck.reason !== 'not-ancestor') {
+      return false
+    }
+    return buildChain(commitsBySha, bad.sha, good.sha).ok
+  }, [commitsBySha, good, bad, chainCheck])
+
+  const blocked = !good || !bad || !chainCheck?.ok
+
+  return (
+    <Dialog id="bisect-new-session" header="Start bisect" width={1} onClose={onClose}>
+      <Box padding={4}>
+        <Stack gap={5}>
+          <EndpointPicker
+            badge="Bad"
+            title="known broken"
+            tone="critical"
+            commits={commits}
+            tags={tags}
+            value={bad}
+            onChange={setBad}
+          />
+          <EndpointPicker
+            badge="Good"
+            title="last known working"
+            tone="positive"
+            commits={commits}
+            tags={tags}
+            value={good}
+            onChange={setGood}
+          />
+
+          {good && bad && isSwapped && (
+            <Card padding={3} radius={2} tone="caution">
+              <Flex align="center" gap={3}>
+                <Box flex={1}>
+                  <Text size={1}>
+                    Good ({shortLabel(good)}) is newer than bad ({shortLabel(bad)}) — the endpoints
+                    look swapped.
+                  </Text>
+                </Box>
+                <Button
+                  mode="ghost"
+                  fontSize={1}
+                  text="Swap endpoints"
+                  onClick={() => {
+                    setGood(bad)
+                    setBad(good)
+                  }}
+                />
+              </Flex>
+            </Card>
+          )}
+          {good && bad && chainCheck && !chainCheck.ok && !isSwapped && (
+            <Card padding={3} radius={2} tone="caution">
+              <Text size={1}>
+                {chainErrorCopy(chainCheck.reason, shortLabel(good), shortLabel(bad))}
+              </Text>
+            </Card>
+          )}
+          {good && bad && chainCheck?.ok && (
+            <Text size={1} muted>
+              {pluralize(chainCheck.chain.length - 2, 'commit')} between good and bad —{' '}
+              <a href={compareUrl(good.sha, bad.sha)} target="_blank" rel="noreferrer">
+                compare on GitHub
+              </a>
+            </Text>
+          )}
+
+          <Flex align="center" gap={2} as="label">
+            <Checkbox
+              checked={releasesOnly}
+              onChange={(event) => setReleasesOnly(event.currentTarget.checked)}
+            />
+            <Text size={1}>Bisect released versions only</Text>
+          </Flex>
+
+          <Flex gap={2} justify="flex-end">
+            <Button mode="ghost" text="Cancel" onClick={onClose} />
+            <Button
+              tone="primary"
+              text={submitting ? 'Starting…' : 'Start bisecting'}
+              disabled={blocked || submitting}
+              onClick={() => {
+                if (!good || !bad || submitting) return
+                setSubmitting(true)
+                // On success the tool unmounts this dialog; on failure the
+                // button re-arms next to the error toast
+                void onCreate({good, bad, releasesOnly, createdBy}).finally(() =>
+                  setSubmitting(false),
+                )
+              }}
+            />
+          </Flex>
+        </Stack>
+      </Box>
+    </Dialog>
+  )
+}
+
+function EndpointPicker(props: {
+  badge: string
+  title: string
+  tone: 'positive' | 'critical'
+  commits: GitCommitSlice[]
+  tags: TagSlice[]
+  value: Endpoint | null
+  onChange: (endpoint: Endpoint | null) => void
+}) {
+  const {badge, title, tone, commits, tags, value, onChange} = props
+  const [query, setQuery] = useState('')
+  const results = useMemo(() => filterCommits(commits, query, 8), [commits, query])
+  const selected = value ? commits.find((commit) => commit.sha === value.sha) : undefined
+
+  return (
+    <Stack gap={3}>
+      <Flex align="center" gap={2}>
+        <Badge tone={tone} fontSize={0}>
+          {badge}
+        </Badge>
+        <Text size={1} weight="medium">
+          {title}
+        </Text>
+      </Flex>
+
+      {value ? (
+        <Card padding={3} radius={2} tone={tone} border>
+          <Flex align="center" gap={3}>
+            <Box flex={1} style={{minWidth: 0}}>
+              <Stack gap={2}>
+                <Text size={1}>
+                  <code>{value.sha.slice(0, 10)}</code>
+                  {value.label && value.label !== value.sha.slice(0, 7) ? ` (${value.label})` : ''}
+                </Text>
+                {selected ? (
+                  <>
+                    <Text size={1} textOverflow="ellipsis">
+                      {selected.subject}
+                    </Text>
+                    <Flex align="center" gap={2}>
+                      <AuthorAvatar
+                        name={selected.authorName ?? undefined}
+                        email={selected.authorEmail ?? undefined}
+                        login={selected.authorLogin ?? undefined}
+                        avatarUrl={
+                          selected.authorAvatarUrl?.startsWith('https://')
+                            ? selected.authorAvatarUrl
+                            : undefined
+                        }
+                      />
+                      {selected.authorName && (
+                        <Text size={0} muted>
+                          {selected.authorName} ·
+                        </Text>
+                      )}
+                      <RelativeDate dateTime={selected.committedAt} size={0} muted />
+                    </Flex>
+                  </>
+                ) : (
+                  // A tag can point off-mainline (release-branch cut) — the
+                  // chain check below is what decides if it's usable
+                  <Text size={0} muted>
+                    not on the synced mainline
+                  </Text>
+                )}
+              </Stack>
+            </Box>
+            <Button mode="bleed" fontSize={1} text="Change" onClick={() => onChange(null)} />
+          </Flex>
+        </Card>
+      ) : (
+        <Stack gap={3}>
+          <Select
+            fontSize={1}
+            value=""
+            onChange={(event) => {
+              const tag = tags.find((candidate) => candidate.tag === event.currentTarget.value)
+              if (tag) onChange({sha: tag.sha, label: tag.tag})
+            }}
+          >
+            <option value="">Pick a release tag…</option>
+            {tags.map((tag) => (
+              <option key={tag._id} value={tag.tag}>
+                {tag.tag} ({tag.taggedAt.slice(0, 10)})
+              </option>
+            ))}
+          </Select>
+          <TextInput
+            fontSize={1}
+            placeholder="…or search commits by sha or subject"
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+          />
+          <Stack gap={1}>
+            {results.length === 0 && (
+              <Text size={1} muted>
+                No commits match “{query.trim()}”.
+              </Text>
+            )}
+            {results.map((commit) => (
+              <Card
+                key={commit._id}
+                as="button"
+                padding={2}
+                radius={2}
+                onClick={() => onChange({sha: commit.sha})}
+                style={{textAlign: 'left'}}
+              >
+                <Flex align="center" gap={2}>
+                  <Box style={{flexShrink: 0}}>
+                    <Badge fontSize={0}>{commit.sha.slice(0, 7)}</Badge>
+                  </Box>
+                  {/* flex + minWidth 0 so the ellipsis truncates the subject
+                      instead of letting it overlap its siblings */}
+                  <Box flex={1} style={{minWidth: 0}}>
+                    <Text size={1} textOverflow="ellipsis">
+                      {commit.subject}
+                    </Text>
+                  </Box>
+                  {!commit.testStudioUrl && (
+                    <Box style={{flexShrink: 0}}>
+                      <Text size={0} muted>
+                        no preview build
+                      </Text>
+                    </Box>
+                  )}
+                  <Box style={{flexShrink: 0}}>
+                    <RelativeDate dateTime={commit.committedAt} size={0} muted />
+                  </Box>
+                </Flex>
+              </Card>
+            ))}
+          </Stack>
+        </Stack>
+      )}
+    </Stack>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/RelativeDate.tsx
+++ b/dev/metrics-studio/tools/bisect/RelativeDate.tsx
@@ -1,0 +1,29 @@
+import {Box, Text} from '@sanity/ui'
+import {Tooltip} from '@sanity/ui/tooltip'
+import {useState} from 'react'
+
+import {relativeDate} from './dates'
+
+/**
+ * "3 days ago" with the absolute date+time in a tooltip. "Now" is sampled
+ * once per mount (lazy init — render-time Date.now() is impure under the
+ * React Compiler); these views are short-lived enough that a ticking clock
+ * isn't worth the re-renders.
+ */
+export function RelativeDate(props: {dateTime: string; size?: 0 | 1; muted?: boolean}) {
+  const {dateTime, size = 1, muted} = props
+  const [now] = useState(() => Date.now())
+  return (
+    <Tooltip
+      content={
+        <Box padding={2}>
+          <Text size={1}>{new Date(dateTime).toLocaleString()}</Text>
+        </Box>
+      }
+    >
+      <Text size={size} muted={muted}>
+        {relativeDate(dateTime, now)}
+      </Text>
+    </Tooltip>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/ResultCard.tsx
+++ b/dev/metrics-studio/tools/bisect/ResultCard.tsx
@@ -20,6 +20,8 @@ import {pluralize} from './text'
 export function ResultCard(props: {
   state: Extract<ReturnType<typeof deriveBisectState>, {kind: 'converged'}>
   releases: TagSlice[]
+  /** Releases-only session — the suspects are untested by design, not unbuildable */
+  releasesOnly?: boolean
   /** npm version if the first bad commit is itself a release */
   version?: string
   annotations: ResultAnnotations
@@ -28,7 +30,8 @@ export function ResultCard(props: {
   onContinue?: () => void
   onUndo?: () => void
 }) {
-  const {state, releases, version, annotations, onAnnotate, onContinue, onUndo} = props
+  const {state, releases, releasesOnly, version, annotations, onAnnotate, onContinue, onUndo} =
+    props
   return (
     <CommitCard
       commit={state.firstBad}
@@ -107,8 +110,15 @@ export function ResultCard(props: {
         <Card padding={3} radius={2} tone="caution">
           <Stack gap={3}>
             <Text size={1} weight="semibold">
-              {pluralize(state.suspects.length, 'commit')} between last good and first bad had no
-              testable preview build (skipped or never built) — any of these could be the culprit:
+              {/* Two different reasons the range stays untested: a releases-only
+                  session never proposes non-release commits (most have builds —
+                  the drill-down below tests them), while in a commit-granular
+                  session the only leftovers are genuinely untestable ones */}
+              {pluralize(state.suspects.length, 'commit')}{' '}
+              {releasesOnly
+                ? `shipped between these releases and ${state.suspects.length === 1 ? 'was' : 'were'} not individually tested`
+                : 'between last good and first bad had no testable preview build (skipped or never built)'}{' '}
+              — any of these could be the culprit:
             </Text>
             {state.suspects.map((suspect) => (
               <Text key={suspect.sha} size={1}>

--- a/dev/metrics-studio/tools/bisect/ResultCard.tsx
+++ b/dev/metrics-studio/tools/bisect/ResultCard.tsx
@@ -1,0 +1,135 @@
+import {LaunchIcon} from '@sanity/icons/Launch'
+import {UndoIcon} from '@sanity/icons/Undo'
+import {Badge, Box, Button, Card, Flex, Stack, Text, TextArea} from '@sanity/ui'
+
+import {commitUrl, compareUrl} from '../trends/links'
+import {type deriveBisectState} from './bisect'
+import {CommandChip, InstallChip} from './chips'
+import {CommitCard} from './CommitCard'
+import {type TagSlice} from './data'
+import {IncludedIn} from './IncludedIn'
+import {type ResultAnnotations} from './sessions'
+import {pluralize} from './text'
+
+/**
+ * The verdict, rendered in place in the timeline: the first bad commit with
+ * everything needed to act on it — reproduction (test studio, checkout,
+ * install), classification (regression toggle, description), the suspect
+ * range when the verdict is ambiguous, and the drill-down into it.
+ */
+export function ResultCard(props: {
+  state: Extract<ReturnType<typeof deriveBisectState>, {kind: 'converged'}>
+  releases: TagSlice[]
+  /** npm version if the first bad commit is itself a release */
+  version?: string
+  annotations: ResultAnnotations
+  onAnnotate: (patch: ResultAnnotations) => void
+  /** Start a commit-granular session over the suspect range (releases-only drill-down) */
+  onContinue?: () => void
+  onUndo?: () => void
+}) {
+  const {state, releases, version, annotations, onAnnotate, onContinue, onUndo} = props
+  return (
+    <CommitCard
+      commit={state.firstBad}
+      tone="critical"
+      heading={
+        <Flex align="center" gap={2}>
+          <Badge tone="critical" fontSize={0}>
+            first bad commit
+          </Badge>
+          <Box flex={1} />
+          {onUndo && (
+            <Button
+              mode="bleed"
+              fontSize={1}
+              icon={UndoIcon}
+              text="Undo previous mark"
+              onClick={onUndo}
+            />
+          )}
+        </Flex>
+      }
+    >
+      <IncludedIn releases={releases} />
+      <Flex align="center" gap={3} wrap="wrap">
+        {state.firstBad.testStudioUrl && (
+          <Button
+            as="a"
+            href={state.firstBad.testStudioUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open test studio (opens in a new tab)"
+            tone="primary"
+            icon={LaunchIcon}
+            text="Open test studio"
+          />
+        )}
+        {/* A clean verdict spans a single commit — a compare link adds nothing */}
+        {state.suspects.length > 0 && (
+          <Button
+            as="a"
+            href={compareUrl(state.lastGood.sha, state.firstBad.sha)}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Compare on GitHub (opens in a new tab)"
+            mode="ghost"
+            icon={LaunchIcon}
+            text={`Compare ${state.lastGood.sha.slice(0, 7)}…${state.firstBad.sha.slice(0, 7)}`}
+          />
+        )}
+        <CommandChip command={`git checkout ${state.firstBad.sha.slice(0, 10)}`} />
+        {version && <InstallChip version={version} />}
+      </Flex>
+      {/* stretch: the toggle matches the textarea's height */}
+      <Flex gap={2} align="stretch" wrap="wrap">
+        <Box flex={1} style={{minWidth: 220}}>
+          <TextArea
+            rows={2}
+            fontSize={1}
+            placeholder="Describe the issue…"
+            defaultValue={annotations.description ?? ''}
+            onBlur={(event) => {
+              const value = event.currentTarget.value.trim()
+              if (value !== (annotations.description ?? '')) onAnnotate({description: value})
+            }}
+          />
+        </Box>
+        <Button
+          mode={annotations.regression ? 'default' : 'ghost'}
+          tone="critical"
+          fontSize={1}
+          text={annotations.regression ? 'Unmark as regression' : 'Mark as regression'}
+          onClick={() => onAnnotate({regression: !annotations.regression})}
+        />
+      </Flex>
+      {state.suspects.length > 0 && (
+        <Card padding={3} radius={2} tone="caution">
+          <Stack gap={3}>
+            <Text size={1} weight="semibold">
+              {pluralize(state.suspects.length, 'commit')} between last good and first bad had no
+              testable preview build (skipped or never built) — any of these could be the culprit:
+            </Text>
+            {state.suspects.map((suspect) => (
+              <Text key={suspect.sha} size={1}>
+                <a href={commitUrl(suspect.sha)} target="_blank" rel="noreferrer">
+                  <code>{suspect.sha.slice(0, 10)}</code> {suspect.subject}
+                </a>
+              </Text>
+            ))}
+            {onContinue && (
+              <Flex>
+                <Button
+                  tone="primary"
+                  fontSize={1}
+                  text="Bisect these commits in a new session"
+                  onClick={onContinue}
+                />
+              </Flex>
+            )}
+          </Stack>
+        </Card>
+      )}
+    </CommitCard>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/SessionView.tsx
+++ b/dev/metrics-studio/tools/bisect/SessionView.tsx
@@ -21,7 +21,6 @@ import {
 import {BISECT_SESSION_QUERY, type SessionDocument, type TagSlice} from './data'
 import {
   appendMark,
-  clearResult,
   createSession,
   deleteSession,
   type ResultAnnotations,
@@ -160,21 +159,23 @@ export function SessionView(props: {
   // forever-active. A deliberate effect-driven write, guarded on the document
   // lacking a result so the realtime echo terminates it; a concurrent
   // duplicate is an idempotent set.
+  // Deliberately NO mirror-image auto-clear when the derived state is active
+  // while a result is stored. Marks are the source of truth and every mark
+  // patch already keeps `result` in sync atomically (appendMark sets or
+  // unsets it, undoMark unsets it), so a contradicting concurrent mark never
+  // leaves a stale verdict. The only other way the two can disagree is the
+  // dataset catching up — a suspect's `testStudioUrl` lands one sync late and
+  // becomes testable — and there the concluded verdict (with its annotations
+  // and regression pin) must stand until a human's mark says otherwise.
   const hasStoredResult = Boolean(session?.result?.firstBadSha)
   useEffect(() => {
     if (!session || !state) return
-    const fail = (title: string) => toastError(toast, title)
     if (state.kind === 'converged' && !hasStoredResult) {
       void setResult(client, sessionId, {
         firstBadSha: state.firstBad.sha,
         lastGoodSha: state.lastGood.sha,
         suspectShas: state.suspects.map((suspect) => suspect.sha),
-      }).catch(fail('Could not store the verdict'))
-    } else if (state.kind === 'active' && hasStoredResult) {
-      // Mirror image: a concurrent editor's contradicting mark can land a
-      // stale verdict on the document while the live-derived state has
-      // re-opened — clear it so the sessions list agrees with reality
-      void clearResult(client, sessionId).catch(fail('Could not clear the stale verdict'))
+      }).catch(toastError(toast, 'Could not store the verdict'))
     }
   }, [state, session, hasStoredResult, client, sessionId, toast])
 
@@ -346,6 +347,7 @@ export function SessionView(props: {
                   ? {
                       state,
                       releases,
+                      releasesOnly,
                       annotations: {
                         regression: session?.result?.regression ?? undefined,
                         description: session?.result?.description ?? undefined,

--- a/dev/metrics-studio/tools/bisect/SessionView.tsx
+++ b/dev/metrics-studio/tools/bisect/SessionView.tsx
@@ -1,0 +1,347 @@
+import {ArrowLeftIcon} from '@sanity/icons/ArrowLeft'
+import {Badge, Box, Button, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {useToast} from '@sanity/ui/toast'
+import {useEffect, useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, of} from 'rxjs'
+import {type SanityClient, useDocumentStore} from 'sanity'
+
+import {commitUrl, compareUrl} from '../trends/links'
+import {
+  type BisectCommit,
+  buildChain,
+  buildTimeline,
+  chainErrorCopy,
+  deriveBisectState,
+  type Mark,
+  releasesContaining,
+  type Verdict,
+} from './bisect'
+import {BISECT_SESSION_QUERY, type SessionDocument, type TagSlice} from './data'
+import {
+  appendMark,
+  clearResult,
+  createSession,
+  type ResultAnnotations,
+  setResult,
+  undoMark,
+  updateResult,
+} from './sessions'
+import {pluralize} from './text'
+import {Timeline} from './Timeline'
+
+interface LiveState {
+  session: SessionDocument | null | undefined
+  error: string | null
+}
+
+/**
+ * The stepper for one bisect session. All state is derived live from the
+ * session's marks and the commit chain — `result` on the document is only
+ * denormalized bookkeeping for the list view, written in the same patch as
+ * the converging mark (and cleared by undo).
+ */
+export function SessionView(props: {
+  sessionId: string
+  commitsBySha: Map<string, BisectCommit>
+  tags: TagSlice[]
+  client: SanityClient
+  userName: string
+  onBack: () => void
+  onOpenSession: (id: string) => void
+}) {
+  const {sessionId, commitsBySha, tags, client, userName, onBack, onOpenSession} = props
+  const documentStore = useDocumentStore()
+  const toast = useToast()
+
+  const live$ = useMemo(
+    () =>
+      documentStore
+        .listenQuery(BISECT_SESSION_QUERY, {id: sessionId}, {tag: 'metrics.bisect.session'})
+        .pipe(
+          map((result): LiveState => ({session: result as SessionDocument | null, error: null})),
+          catchError((error: unknown) =>
+            of<LiveState>({
+              session: undefined,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          ),
+        ),
+    [documentStore, sessionId],
+  )
+  const live = useObservable(live$, {session: undefined, error: null})
+  const session = live.session
+
+  const goodSha = session?.good?.sha
+  const badSha = session?.bad?.sha
+  const chainResult = useMemo(() => {
+    if (!goodSha || !badSha || commitsBySha.size === 0) return null
+    return buildChain(commitsBySha, goodSha, badSha)
+  }, [commitsBySha, goodSha, badSha])
+
+  const marks: (Mark & {_key: string})[] = useMemo(
+    () =>
+      (session?.marks ?? [])
+        .filter(
+          (mark) => mark.verdict === 'good' || mark.verdict === 'bad' || mark.verdict === 'skip',
+        )
+        .map((mark) => ({_key: mark._key, sha: mark.sha, verdict: mark.verdict as Verdict})),
+    [session?.marks],
+  )
+
+  // Release tag lookup: sha → npm version ("v6.10.1" → "6.10.1")
+  const versionBySha = useMemo(
+    () => new Map(tags.map((tag) => [tag.sha, tag.tag.replace(/^v/, '')])),
+    [tags],
+  )
+  const releasesOnly = Boolean(session?.releasesOnly)
+  const bisectOptions = useMemo(
+    () => (releasesOnly ? {candidateShas: new Set(versionBySha.keys())} : {}),
+    [releasesOnly, versionBySha],
+  )
+
+  const state = useMemo(
+    () => (chainResult?.ok ? deriveBisectState(chainResult.chain, marks, bisectOptions) : null),
+    [chainResult, marks, bisectOptions],
+  )
+
+  const timeline = useMemo(
+    () => (chainResult?.ok ? buildTimeline(chainResult.chain, marks, bisectOptions) : []),
+    [chainResult, marks, bisectOptions],
+  )
+
+  // Releases containing the commit in focus — the one under test while
+  // active, the culprit once converged
+  const focusSha =
+    state?.kind === 'converged'
+      ? state.firstBad.sha
+      : state?.kind === 'active'
+        ? state.next.sha
+        : undefined
+  const releases = useMemo(
+    () => (focusSha ? releasesContaining(commitsBySha, tags, focusSha) : []),
+    [focusSha, commitsBySha, tags],
+  )
+
+  const onError = (title: string) => (err: unknown) =>
+    toast.push({
+      status: 'error',
+      title,
+      description: err instanceof Error ? err.message : String(err),
+    })
+
+  // Sessions can be converged FROM BIRTH (adjacent endpoints, a drill-down
+  // over an untestable range) — no converging mark ever fires, so appendMark
+  // never persists the verdict and the sessions list would show them as
+  // forever-active. A deliberate effect-driven write, guarded on the document
+  // lacking a result so the realtime echo terminates it; a concurrent
+  // duplicate is an idempotent set.
+  const hasStoredResult = Boolean(session?.result?.firstBadSha)
+  useEffect(() => {
+    if (!session || !state) return
+    const fail = (title: string) => (err: unknown) =>
+      toast.push({
+        status: 'error',
+        title,
+        description: err instanceof Error ? err.message : String(err),
+      })
+    if (state.kind === 'converged' && !hasStoredResult) {
+      void setResult(client, sessionId, {
+        firstBadSha: state.firstBad.sha,
+        lastGoodSha: state.lastGood.sha,
+        suspectShas: state.suspects.map((suspect) => suspect.sha),
+      }).catch(fail('Could not store the verdict'))
+    } else if (state.kind === 'active' && hasStoredResult) {
+      // Mirror image: a concurrent editor's contradicting mark can land a
+      // stale verdict on the document while the live-derived state has
+      // re-opened — clear it so the sessions list agrees with reality
+      void clearResult(client, sessionId).catch(fail('Could not clear the stale verdict'))
+    }
+  }, [state, session, hasStoredResult, client, sessionId, toast])
+
+  const mark = (sha: string, verdict: Verdict) => {
+    if (!chainResult?.ok) return
+    // Detect convergence with the new mark included, so the denormalized
+    // result lands in the same patch as the mark that concluded the run —
+    // and a non-converging mark clears any (now possibly stale) result
+    const nextState = deriveBisectState(
+      chainResult.chain,
+      [...marks, {sha, verdict}],
+      bisectOptions,
+    )
+    const result =
+      nextState.kind === 'converged'
+        ? {
+            firstBadSha: nextState.firstBad.sha,
+            lastGoodSha: nextState.lastGood.sha,
+            suspectShas: nextState.suspects.map((suspect) => suspect.sha),
+          }
+        : undefined
+    appendMark(client, sessionId, {sha, verdict, markedBy: userName}, result).catch(
+      onError('Could not save mark'),
+    )
+  }
+
+  const undo = () => {
+    const last = marks.at(-1)
+    if (last) undoMark(client, sessionId, last._key).catch(onError('Could not undo mark'))
+  }
+
+  // Drill-down from a releases-only verdict: a fresh commit-granular session
+  // over exactly the suspect range
+  const continueBisect = () => {
+    if (state?.kind !== 'converged') return
+    const label = (sha: string) => {
+      const version = versionBySha.get(sha)
+      return version ? {sha, label: `v${version}`} : {sha}
+    }
+    createSession(client, {
+      good: label(state.lastGood.sha),
+      bad: label(state.firstBad.sha),
+      createdBy: userName,
+    })
+      .then(onOpenSession)
+      .catch(onError('Could not create session'))
+  }
+
+  return (
+    <Box padding={4} style={{overflowY: 'auto', height: '100%'}}>
+      <Container width={2}>
+        <Stack gap={4}>
+          <Flex align="center" gap={3}>
+            <Button mode="bleed" icon={ArrowLeftIcon} text="Sessions" onClick={onBack} />
+            <Box flex={1}>
+              <Text size={2} weight="semibold">
+                {session?.title ?? 'Bisect session'}
+              </Text>
+            </Box>
+          </Flex>
+
+          {live.error && (
+            <Card padding={4} radius={3} tone="critical">
+              <Text size={1}>Failed to load session: {live.error}</Text>
+            </Card>
+          )}
+          {!live.error && session === undefined && (
+            <Text size={1} muted>
+              Loading…
+            </Text>
+          )}
+          {session === null && (
+            <Card padding={4} radius={3} tone="caution">
+              <Text size={1}>This session no longer exists.</Text>
+            </Card>
+          )}
+
+          {session && chainResult && !chainResult.ok && (
+            <Card padding={4} radius={3} tone="caution">
+              <Text size={1}>
+                {chainErrorCopy(
+                  chainResult.reason,
+                  session.good?.label ?? session.good?.sha?.slice(0, 7) ?? 'unknown',
+                  session.bad?.label ?? session.bad?.sha?.slice(0, 7) ?? 'unknown',
+                )}{' '}
+                The session is kept as a record.
+              </Text>
+            </Card>
+          )}
+
+          {state?.kind === 'inconsistent' && (
+            <Card padding={4} radius={3} tone="caution">
+              <Text size={1}>
+                Conflicting marks: <code>{state.goodMarkSha.slice(0, 10)}</code> is marked good but
+                is newer than bad-marked <code>{state.badMarkSha.slice(0, 10)}</code>. Undo a mark
+                to resolve.
+              </Text>
+            </Card>
+          )}
+
+          {state?.kind === 'active' && <RangeStatus state={state} releasesOnly={releasesOnly} />}
+          {timeline.length > 0 && (
+            <Timeline
+              entries={timeline}
+              onMark={mark}
+              onUndo={marks.length > 0 ? undo : undefined}
+              stepsLeft={state?.kind === 'active' ? state.stepsLeft : undefined}
+              currentReleases={state?.kind === 'active' ? releases : []}
+              versionBySha={versionBySha}
+              converged={
+                state?.kind === 'converged'
+                  ? {
+                      state,
+                      releases,
+                      annotations: {
+                        regression: session?.result?.regression ?? undefined,
+                        description: session?.result?.description ?? undefined,
+                        linearIssue: session?.result?.linearIssue ?? undefined,
+                      },
+                      onAnnotate: (patch: ResultAnnotations) =>
+                        updateResult(client, sessionId, patch).catch(
+                          onError('Could not save annotation'),
+                        ),
+                      onContinue: releasesOnly ? continueBisect : undefined,
+                    }
+                  : undefined
+              }
+            />
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  )
+}
+
+/** Where the search stands — rendered as the timeline's preamble. */
+function RangeStatus(props: {
+  state: Extract<ReturnType<typeof deriveBisectState>, {kind: 'active'}>
+  releasesOnly?: boolean
+}) {
+  const {state, releasesOnly} = props
+  return (
+    <Stack gap={3}>
+      <Flex align="center" gap={2} wrap="wrap">
+        <Text size={1} muted>
+          The bad commit is between
+        </Text>
+        <Badge tone="positive" fontSize={0}>
+          <a href={commitUrl(state.goodBound.sha)} target="_blank" rel="noreferrer">
+            good {state.goodBound.sha.slice(0, 7)}
+          </a>
+        </Badge>
+        <Text size={1} muted>
+          and
+        </Text>
+        <Badge tone="critical" fontSize={0}>
+          <a href={commitUrl(state.badBound.sha)} target="_blank" rel="noreferrer">
+            bad {state.badBound.sha.slice(0, 7)}
+          </a>
+        </Badge>
+        <Text size={1} muted>
+          —{' '}
+          <a
+            href={compareUrl(state.goodBound.sha, state.badBound.sha)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {pluralize(state.unknownCount, 'commit')} in range
+          </a>
+          , about {pluralize(state.stepsLeft, 'commit')} left to test.
+        </Text>
+      </Flex>
+      {releasesOnly ? (
+        <Text size={1} muted>
+          Bisecting released versions only — {pluralize(state.testableCount, 'release')} left to
+          test in the range; the commits between releases are reported as suspects at the end.
+        </Text>
+      ) : (
+        state.unknownCount > state.testableCount && (
+          <Text size={1} muted>
+            {state.unknownCount - state.testableCount} of these have no preview build (or were
+            skipped) and can't be tested directly — if the range narrows down to them, they're
+            reported as suspects.
+          </Text>
+        )
+      )}
+    </Stack>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/SessionView.tsx
+++ b/dev/metrics-studio/tools/bisect/SessionView.tsx
@@ -313,11 +313,22 @@ export function SessionView(props: {
 
           {state?.kind === 'inconsistent' && (
             <Card padding={4} radius={3} tone="caution">
-              <Text size={1}>
-                Conflicting marks: <code>{state.goodMarkSha.slice(0, 10)}</code> is marked good but
-                is newer than bad-marked <code>{state.badMarkSha.slice(0, 10)}</code>. Undo a mark
-                to resolve.
-              </Text>
+              {/* The timeline (and its undo control) doesn't render for an
+                  inconsistent session, so the resolution the copy asks for has
+                  to be offered right here. Undo peels the newest mark; repeat
+                  until the conflicting one is gone. */}
+              <Flex align="center" gap={3}>
+                <Box flex={1}>
+                  <Text size={1}>
+                    Conflicting marks: <code>{state.goodMarkSha.slice(0, 10)}</code> is marked good
+                    but is newer than bad-marked <code>{state.badMarkSha.slice(0, 10)}</code>. Undo
+                    a mark to resolve.
+                  </Text>
+                </Box>
+                {marks.length > 0 && (
+                  <Button mode="ghost" fontSize={1} text="Undo last mark" onClick={undo} />
+                )}
+              </Flex>
             </Card>
           )}
 

--- a/dev/metrics-studio/tools/bisect/SessionView.tsx
+++ b/dev/metrics-studio/tools/bisect/SessionView.tsx
@@ -1,7 +1,8 @@
 import {ArrowLeftIcon} from '@sanity/icons/ArrowLeft'
-import {Badge, Box, Button, Card, Container, Flex, Stack, Text} from '@sanity/ui'
-import {useToast} from '@sanity/ui/toast'
-import {useEffect, useMemo} from 'react'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {Badge, Box, Button, Card, Container, Dialog, Flex, Stack, Text} from '@sanity/ui'
+import {type ToastContextValue, useToast} from '@sanity/ui/toast'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {catchError, map, of} from 'rxjs'
 import {type SanityClient, useDocumentStore} from 'sanity'
@@ -22,6 +23,7 @@ import {
   appendMark,
   clearResult,
   createSession,
+  deleteSession,
   type ResultAnnotations,
   setResult,
   undoMark,
@@ -35,6 +37,16 @@ interface LiveState {
   error: string | null
 }
 
+/** Error-toast curry, hoisted so the persist effect and the handlers share it. */
+function toastError(toast: ToastContextValue, title: string) {
+  return (err: unknown) =>
+    toast.push({
+      status: 'error',
+      title,
+      description: err instanceof Error ? err.message : String(err),
+    })
+}
+
 /**
  * The stepper for one bisect session. All state is derived live from the
  * session's marks and the commit chain — `result` on the document is only
@@ -44,15 +56,22 @@ interface LiveState {
 export function SessionView(props: {
   sessionId: string
   commitsBySha: Map<string, BisectCommit>
-  tags: TagSlice[]
+  /** `null` while the tags query is loading (or after it errored) — the
+   * distinction matters: releases-only sessions derive their candidate set
+   * from the tags, and an empty set would spuriously converge. */
+  tags: TagSlice[] | null
+  /** Commits/tags query failure, surfaced here since both feed this view. */
+  dataError?: string | null
   client: SanityClient
   userName: string
   onBack: () => void
   onOpenSession: (id: string) => void
 }) {
-  const {sessionId, commitsBySha, tags, client, userName, onBack, onOpenSession} = props
+  const {sessionId, commitsBySha, tags, dataError, client, userName, onBack, onOpenSession} = props
   const documentStore = useDocumentStore()
   const toast = useToast()
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   const live$ = useMemo(
     () =>
@@ -91,22 +110,32 @@ export function SessionView(props: {
 
   // Release tag lookup: sha → npm version ("v6.10.1" → "6.10.1")
   const versionBySha = useMemo(
-    () => new Map(tags.map((tag) => [tag.sha, tag.tag.replace(/^v/, '')])),
+    () => new Map((tags ?? []).map((tag) => [tag.sha, tag.tag.replace(/^v/, '')])),
     [tags],
   )
   const releasesOnly = Boolean(session?.releasesOnly)
+  // `null` = can't derive yet: a releases-only session must wait for the tags
+  // to load. An empty candidate set is NOT "unrestricted" to the engine — it
+  // is "nothing testable", which would derive a spurious `converged` and the
+  // persist effect below would write a false verdict onto the document.
   const bisectOptions = useMemo(
-    () => (releasesOnly ? {candidateShas: new Set(versionBySha.keys())} : {}),
-    [releasesOnly, versionBySha],
+    () => (releasesOnly ? (tags ? {candidateShas: new Set(versionBySha.keys())} : null) : {}),
+    [releasesOnly, tags, versionBySha],
   )
 
   const state = useMemo(
-    () => (chainResult?.ok ? deriveBisectState(chainResult.chain, marks, bisectOptions) : null),
+    () =>
+      chainResult?.ok && bisectOptions
+        ? deriveBisectState(chainResult.chain, marks, bisectOptions)
+        : null,
     [chainResult, marks, bisectOptions],
   )
 
   const timeline = useMemo(
-    () => (chainResult?.ok ? buildTimeline(chainResult.chain, marks, bisectOptions) : []),
+    () =>
+      chainResult?.ok && bisectOptions
+        ? buildTimeline(chainResult.chain, marks, bisectOptions)
+        : [],
     [chainResult, marks, bisectOptions],
   )
 
@@ -119,16 +148,11 @@ export function SessionView(props: {
         ? state.next.sha
         : undefined
   const releases = useMemo(
-    () => (focusSha ? releasesContaining(commitsBySha, tags, focusSha) : []),
+    () => (focusSha ? releasesContaining(commitsBySha, tags ?? [], focusSha) : []),
     [focusSha, commitsBySha, tags],
   )
 
-  const onError = (title: string) => (err: unknown) =>
-    toast.push({
-      status: 'error',
-      title,
-      description: err instanceof Error ? err.message : String(err),
-    })
+  const onError = (title: string) => toastError(toast, title)
 
   // Sessions can be converged FROM BIRTH (adjacent endpoints, a drill-down
   // over an untestable range) — no converging mark ever fires, so appendMark
@@ -139,12 +163,7 @@ export function SessionView(props: {
   const hasStoredResult = Boolean(session?.result?.firstBadSha)
   useEffect(() => {
     if (!session || !state) return
-    const fail = (title: string) => (err: unknown) =>
-      toast.push({
-        status: 'error',
-        title,
-        description: err instanceof Error ? err.message : String(err),
-      })
+    const fail = (title: string) => toastError(toast, title)
     if (state.kind === 'converged' && !hasStoredResult) {
       void setResult(client, sessionId, {
         firstBadSha: state.firstBad.sha,
@@ -160,7 +179,7 @@ export function SessionView(props: {
   }, [state, session, hasStoredResult, client, sessionId, toast])
 
   const mark = (sha: string, verdict: Verdict) => {
-    if (!chainResult?.ok) return
+    if (!chainResult?.ok || !bisectOptions) return
     // Detect convergence with the new mark included, so the denormalized
     // result lands in the same patch as the mark that concluded the run —
     // and a non-converging mark clears any (now possibly stale) result
@@ -187,10 +206,29 @@ export function SessionView(props: {
     if (last) undoMark(client, sessionId, last._key).catch(onError('Could not undo mark'))
   }
 
+  // On failure the confirm dialog stays open, so the toast lands next to a
+  // retryable Delete button
+  const removeSession = () => {
+    setDeleting(true)
+    deleteSession(client, sessionId)
+      .then(() => {
+        setConfirmingDelete(false)
+        onBack()
+      })
+      .catch((err: unknown) => {
+        setDeleting(false)
+        onError('Could not delete session')(err)
+      })
+  }
+
   // Drill-down from a releases-only verdict: a fresh commit-granular session
-  // over exactly the suspect range
+  // over exactly the suspect range. Ref-guarded rather than disabling the
+  // (deeply nested) button: a repeat click during the round-trip would
+  // otherwise create a duplicate session.
+  const continuePending = useRef(false)
   const continueBisect = () => {
-    if (state?.kind !== 'converged') return
+    if (state?.kind !== 'converged' || continuePending.current) return
+    continuePending.current = true
     const label = (sha: string) => {
       const version = versionBySha.get(sha)
       return version ? {sha, label: `v${version}`} : {sha}
@@ -202,6 +240,9 @@ export function SessionView(props: {
     })
       .then(onOpenSession)
       .catch(onError('Could not create session'))
+      .finally(() => {
+        continuePending.current = false
+      })
   }
 
   return (
@@ -215,8 +256,22 @@ export function SessionView(props: {
                 {session?.title ?? 'Bisect session'}
               </Text>
             </Box>
+            {session && (
+              <Button
+                mode="bleed"
+                tone="critical"
+                icon={TrashIcon}
+                text="Delete session"
+                onClick={() => setConfirmingDelete(true)}
+              />
+            )}
           </Flex>
 
+          {dataError && (
+            <Card padding={4} radius={3} tone="critical">
+              <Text size={1}>Failed to load: {dataError}</Text>
+            </Card>
+          )}
           {live.error && (
             <Card padding={4} radius={3} tone="critical">
               <Text size={1}>Failed to load session: {live.error}</Text>
@@ -231,6 +286,16 @@ export function SessionView(props: {
             <Card padding={4} radius={3} tone="caution">
               <Text size={1}>This session no longer exists.</Text>
             </Card>
+          )}
+          {session && !dataError && !chainResult && (
+            <Text size={1} muted>
+              Loading commit history…
+            </Text>
+          )}
+          {session && !dataError && chainResult?.ok && !bisectOptions && (
+            <Text size={1} muted>
+              Loading release tags…
+            </Text>
           )}
 
           {session && chainResult && !chainResult.ok && (
@@ -287,6 +352,33 @@ export function SessionView(props: {
           )}
         </Stack>
       </Container>
+
+      {confirmingDelete && (
+        <Dialog
+          id="bisect-delete-session"
+          header="Delete session"
+          width={0}
+          onClose={() => setConfirmingDelete(false)}
+        >
+          <Box padding={4}>
+            <Stack gap={4}>
+              <Text size={1}>
+                Delete “{session?.title ?? sessionId}”? The session, its marks log, and any verdict
+                (including a regression pinned on a release) are permanently removed.
+              </Text>
+              <Flex gap={2} justify="flex-end">
+                <Button mode="ghost" text="Cancel" onClick={() => setConfirmingDelete(false)} />
+                <Button
+                  tone="critical"
+                  text={deleting ? 'Deleting…' : 'Delete'}
+                  disabled={deleting}
+                  onClick={removeSession}
+                />
+              </Flex>
+            </Stack>
+          </Box>
+        </Dialog>
+      )}
     </Box>
   )
 }

--- a/dev/metrics-studio/tools/bisect/Timeline.tsx
+++ b/dev/metrics-studio/tools/bisect/Timeline.tsx
@@ -1,0 +1,230 @@
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {CloseIcon} from '@sanity/icons/Close'
+import {LaunchIcon} from '@sanity/icons/Launch'
+import {StackCompactIcon} from '@sanity/icons/StackCompact'
+import {UndoIcon} from '@sanity/icons/Undo'
+import {Badge, type BadgeTone, Box, Button, Card, Flex, Stack, Text} from '@sanity/ui'
+
+import {commitUrl, compareUrl} from '../trends/links'
+import {AuthorAvatar} from './AuthorAvatar'
+import {type deriveBisectState, type TimelineEntry, type TimelineRole, type Verdict} from './bisect'
+import {CommandChip, InstallChip} from './chips'
+import {CommitCard} from './CommitCard'
+import {type TagSlice} from './data'
+import {IncludedIn} from './IncludedIn'
+import {ResultCard} from './ResultCard'
+import {type ResultAnnotations} from './sessions'
+import {pluralize} from './text'
+
+const TIMELINE_ROLE: Record<TimelineRole, {tone: BadgeTone; label: string}> = {
+  current: {tone: 'primary', label: 'you are here'},
+  good: {tone: 'positive', label: 'good'},
+  bad: {tone: 'critical', label: 'bad'},
+  skip: {tone: 'default', label: 'skipped'},
+}
+
+const GAP_ZONE: Record<'bad' | 'unknown' | 'good', {tone: BadgeTone; label: string}> = {
+  bad: {tone: 'critical', label: 'bad'},
+  unknown: {tone: 'default', label: 'untested'},
+  good: {tone: 'positive', label: 'good'},
+}
+
+/**
+ * The session map, newest commit first: endpoints, bounds, visited commits,
+ * with collapsed runs in between (labelled by what the bisect already
+ * deduced about them, linking to the GitHub compare of the span). The commit
+ * under test renders in place as the full interactive card — "you are here"
+ * IS the next step — and the verdict renders in place the same way.
+ */
+export function Timeline(props: {
+  entries: TimelineEntry[]
+  onMark: (sha: string, verdict: Verdict) => void
+  onUndo?: () => void
+  /** From the active state — shown on the current step's badge. */
+  stepsLeft?: number
+  currentReleases?: TagSlice[]
+  versionBySha?: Map<string, string>
+  converged?: {
+    state: Extract<ReturnType<typeof deriveBisectState>, {kind: 'converged'}>
+    releases: TagSlice[]
+    annotations: ResultAnnotations
+    onAnnotate: (patch: ResultAnnotations) => void
+    onContinue?: () => void
+  }
+}) {
+  const {entries, onMark, onUndo, stepsLeft, currentReleases, versionBySha, converged} = props
+  return (
+    <Stack gap={2}>
+      <Text size={1} weight="semibold">
+        Bisect timeline
+      </Text>
+      <Stack gap={1}>
+        {entries.map((entry) =>
+          entry.kind === 'gap' ? (
+            <GapRow key={`gap-${entry.newestSha}`} entry={entry} />
+          ) : converged && entry.commit.sha === converged.state.firstBad.sha ? (
+            <ResultCard
+              key={entry.commit.sha}
+              state={converged.state}
+              releases={converged.releases}
+              version={versionBySha?.get(entry.commit.sha)}
+              annotations={converged.annotations}
+              onAnnotate={converged.onAnnotate}
+              onContinue={converged.onContinue}
+              onUndo={onUndo}
+            />
+          ) : entry.role === 'current' ? (
+            <CurrentStepCard
+              key={entry.commit.sha}
+              entry={entry}
+              stepsLeft={stepsLeft}
+              releases={currentReleases ?? []}
+              version={versionBySha?.get(entry.commit.sha)}
+              onMark={onMark}
+              onUndo={onUndo}
+            />
+          ) : (
+            <CommitRow key={entry.commit.sha} entry={entry} />
+          ),
+        )}
+      </Stack>
+    </Stack>
+  )
+}
+
+function GapRow(props: {entry: Extract<TimelineEntry, {kind: 'gap'}>}) {
+  const {entry} = props
+  return (
+    <Card padding={2} radius={2} tone="neutral">
+      <Flex align="center" gap={2}>
+        <Box style={{width: 96, flexShrink: 0}}>
+          <Badge tone={GAP_ZONE[entry.zone].tone} fontSize={0}>
+            {GAP_ZONE[entry.zone].label}
+          </Badge>
+        </Box>
+        <Text size={1} muted>
+          <StackCompactIcon />
+        </Text>
+        <Box flex={1} style={{minWidth: 0}}>
+          <Text size={1} muted>
+            <a href={compareUrl(entry.baseSha, entry.newestSha)} target="_blank" rel="noreferrer">
+              {pluralize(entry.count, 'commit')}
+            </a>
+          </Text>
+        </Box>
+      </Flex>
+    </Card>
+  )
+}
+
+function CurrentStepCard(props: {
+  entry: Extract<TimelineEntry, {kind: 'commit'}>
+  stepsLeft?: number
+  releases: TagSlice[]
+  version?: string
+  onMark: (sha: string, verdict: Verdict) => void
+  onUndo?: () => void
+}) {
+  const {entry, stepsLeft, releases, version, onMark, onUndo} = props
+  return (
+    <CommitCard
+      commit={entry.commit}
+      tone="primary"
+      heading={
+        <Flex align="center" gap={2}>
+          <Text size={1} weight="semibold">
+            Next commit to test
+            {stepsLeft === undefined ? '' : ` (${pluralize(stepsLeft, 'commit')} left)`}
+          </Text>
+          <Box flex={1} />
+          {onUndo && (
+            <Button
+              mode="bleed"
+              fontSize={1}
+              icon={UndoIcon}
+              text="Undo previous mark"
+              onClick={onUndo}
+            />
+          )}
+        </Flex>
+      }
+    >
+      <IncludedIn releases={releases} />
+      <Flex align="center" gap={3} wrap="wrap">
+        <Button
+          as="a"
+          href={entry.commit.testStudioUrl}
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Open test studio (opens in a new tab)"
+          tone="primary"
+          icon={LaunchIcon}
+          text="Open test studio"
+        />
+        <CommandChip command={`git checkout ${entry.commit.sha.slice(0, 10)}`} />
+        {version && <InstallChip version={version} />}
+        <Box flex={1} />
+        <Flex align="center" gap={2}>
+          <Text size={1} muted>
+            Mark as
+          </Text>
+          <Button
+            mode="ghost"
+            tone="positive"
+            fontSize={1}
+            icon={CheckmarkIcon}
+            text="Good"
+            onClick={() => onMark(entry.commit.sha, 'good')}
+          />
+          <Button
+            mode="ghost"
+            tone="critical"
+            fontSize={1}
+            icon={CloseIcon}
+            text="Bad"
+            onClick={() => onMark(entry.commit.sha, 'bad')}
+          />
+          <Button
+            mode="ghost"
+            fontSize={1}
+            text="Skip"
+            onClick={() => onMark(entry.commit.sha, 'skip')}
+          />
+        </Flex>
+      </Flex>
+    </CommitCard>
+  )
+}
+
+function CommitRow(props: {entry: Extract<TimelineEntry, {kind: 'commit'}>}) {
+  const {entry} = props
+  return (
+    <Card padding={2} radius={2}>
+      <Flex align="center" gap={2}>
+        <Box style={{width: 96, flexShrink: 0}}>
+          <Badge tone={TIMELINE_ROLE[entry.role].tone} fontSize={0}>
+            {TIMELINE_ROLE[entry.role].label}
+          </Badge>
+        </Box>
+        <AuthorAvatar
+          name={entry.commit.authorName}
+          email={entry.commit.authorEmail}
+          login={entry.commit.authorLogin}
+          avatarUrl={entry.commit.authorAvatarUrl}
+        />
+        <Text size={1}>
+          <a href={commitUrl(entry.commit.sha)} target="_blank" rel="noreferrer">
+            <code>{entry.commit.sha.slice(0, 7)}</code>
+          </a>
+        </Text>
+        <Box flex={1} style={{minWidth: 0}}>
+          <Text size={1} muted textOverflow="ellipsis">
+            <a href={commitUrl(entry.commit.sha)} target="_blank" rel="noreferrer">
+              {entry.commit.subject}
+            </a>
+          </Text>
+        </Box>
+      </Flex>
+    </Card>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/Timeline.tsx
+++ b/dev/metrics-studio/tools/bisect/Timeline.tsx
@@ -47,6 +47,8 @@ export function Timeline(props: {
   converged?: {
     state: Extract<ReturnType<typeof deriveBisectState>, {kind: 'converged'}>
     releases: TagSlice[]
+    /** Releases-only session — the suspects are untested by design, not unbuildable */
+    releasesOnly?: boolean
     annotations: ResultAnnotations
     onAnnotate: (patch: ResultAnnotations) => void
     onContinue?: () => void
@@ -67,6 +69,7 @@ export function Timeline(props: {
               key={entry.commit.sha}
               state={converged.state}
               releases={converged.releases}
+              releasesOnly={converged.releasesOnly}
               version={versionBySha?.get(entry.commit.sha)}
               annotations={converged.annotations}
               onAnnotate={converged.onAnnotate}

--- a/dev/metrics-studio/tools/bisect/bisect.test.ts
+++ b/dev/metrics-studio/tools/bisect/bisect.test.ts
@@ -1,0 +1,271 @@
+import {expect, test} from 'vitest'
+
+import {
+  type BisectCommit,
+  buildChain,
+  buildTimeline,
+  deriveBisectState,
+  type Mark,
+  releasesContaining,
+} from './bisect'
+
+/**
+ * chain(10) builds a linear history c0 (newest) … c9 (oldest): sha of c<i> is
+ * the 40-char repeat of the index's hex digit, parent is the next index.
+ */
+function sha(index: number): string {
+  return index.toString(16).repeat(40).slice(0, 40)
+}
+
+function chainOf(length: number, options: {urlless?: number[]} = {}): BisectCommit[] {
+  return Array.from({length}, (_, index) => ({
+    sha: sha(index),
+    parentSha: index + 1 < length ? sha(index + 1) : undefined,
+    subject: `commit ${index}`,
+    committedAt: `2026-08-${String(20 - index).padStart(2, '0')}T12:00:00Z`,
+    ...(options.urlless?.includes(index)
+      ? {}
+      : {testStudioUrl: `https://test-studio-${index}.sanity.dev`}),
+  }))
+}
+
+function bySha(commits: BisectCommit[]): Map<string, BisectCommit> {
+  return new Map(commits.map((commit) => [commit.sha, commit]))
+}
+
+// -- buildChain ---------------------------------------------------------------
+
+test('builds the chain bad-first, good-last, following first parents', () => {
+  const commits = chainOf(10)
+  const result = buildChain(bySha(commits), sha(7), sha(2))
+  expect(result.ok).toBe(true)
+  if (!result.ok) return
+  expect(result.chain.map((commit) => commit.sha)).toEqual([2, 3, 4, 5, 6, 7].map(sha))
+})
+
+test('rejects endpoints that are not synced', () => {
+  const commits = chainOf(5)
+  expect(buildChain(bySha(commits), sha(9), sha(1))).toEqual({ok: false, reason: 'good-not-synced'})
+  expect(buildChain(bySha(commits), sha(3), sha(9))).toEqual({ok: false, reason: 'bad-not-synced'})
+})
+
+test('rejects identical endpoints', () => {
+  const commits = chainOf(5)
+  expect(buildChain(bySha(commits), sha(2), sha(2))).toEqual({ok: false, reason: 'same-commit'})
+})
+
+test('swapped endpoints (good newer than bad) fail as not-ancestor', () => {
+  const commits = chainOf(10)
+  // good=c2 is NEWER than bad=c7 — the walk from c7 goes older, never hits c2
+  expect(buildChain(bySha(commits), sha(2), sha(7))).toEqual({ok: false, reason: 'not-ancestor'})
+})
+
+test('a gap in the synced set fails as not-ancestor', () => {
+  // c2 missing from the sync (like a window gap): walk from c0 dead-ends at
+  // c1 even though the good endpoint c4 is synced
+  const commits = chainOf(5)
+  const map = bySha(commits.filter((commit) => commit.sha !== sha(2)))
+  expect(buildChain(map, sha(4), sha(0))).toEqual({ok: false, reason: 'not-ancestor'})
+})
+
+test('a parent cycle terminates instead of hanging', () => {
+  const commits = chainOf(3)
+  commits[2].parentSha = sha(0) // c2 → c0 cycle
+  expect(buildChain(bySha(commits), sha(1), sha(0))).toEqual({ok: true, chain: commits.slice(0, 2)})
+  commits[1].parentSha = sha(0) // c0 → c1 → c0
+  expect(buildChain(bySha(commits), sha(2), sha(0))).toEqual({ok: false, reason: 'not-ancestor'})
+})
+
+// -- deriveBisectState --------------------------------------------------------
+
+const marks = (...entries: [number, Mark['verdict']][]): Mark[] =>
+  entries.map(([index, verdict]) => ({sha: sha(index), verdict}))
+
+test('a fresh session tests the midpoint', () => {
+  const chain = chainOf(11) // c0 bad … c10 good
+  const state = deriveBisectState(chain, [])
+  expect(state.kind).toBe('active')
+  if (state.kind !== 'active') return
+  expect(state.next.sha).toBe(sha(5))
+  expect(state.unknownCount).toBe(9)
+  expect(state.testableCount).toBe(9)
+  expect(state.stepsLeft).toBe(Math.ceil(Math.log2(10)))
+})
+
+test('marking narrows the region on the right side', () => {
+  const chain = chainOf(11)
+  const afterGood = deriveBisectState(chain, marks([5, 'good']))
+  if (afterGood.kind !== 'active') throw new Error(afterGood.kind)
+  // good at c5 → unknown is c1..c4, midpoint between 0 and 5
+  expect(afterGood.goodBound.sha).toBe(sha(5))
+  expect(afterGood.unknownCount).toBe(4)
+  // median of candidates c1..c4
+  expect(afterGood.next.sha).toBe(sha(2))
+
+  const afterBad = deriveBisectState(chain, marks([5, 'bad']))
+  if (afterBad.kind !== 'active') throw new Error(afterBad.kind)
+  expect(afterBad.badBound.sha).toBe(sha(5))
+  expect(afterBad.unknownCount).toBe(4)
+})
+
+test('skipped and build-less commits are never proposed', () => {
+  const chain = chainOf(5, {urlless: [2]}) // c2 has no preview build
+  const state = deriveBisectState(chain, marks([1, 'skip'], [3, 'skip']))
+  // unknown = c1..c3; c1+c3 skipped, c2 untestable → converged with 3 suspects
+  expect(state.kind).toBe('converged')
+  if (state.kind !== 'converged') return
+  expect(state.firstBad.sha).toBe(sha(0))
+  expect(state.lastGood.sha).toBe(sha(4))
+  expect(state.suspects.map((suspect) => suspect.sha)).toEqual([1, 2, 3].map(sha))
+})
+
+test('a later mark on the same sha overrides the earlier one', () => {
+  const chain = chainOf(7)
+  const state = deriveBisectState(chain, marks([3, 'bad'], [3, 'good']))
+  if (state.kind !== 'active') throw new Error(state.kind)
+  expect(state.goodBound.sha).toBe(sha(3))
+})
+
+test('adjacent bounds converge with no suspects — the clean verdict', () => {
+  const chain = chainOf(6)
+  const state = deriveBisectState(chain, marks([2, 'bad'], [3, 'good']))
+  expect(state).toMatchObject({kind: 'converged', suspects: []})
+  if (state.kind !== 'converged') return
+  expect(state.firstBad.sha).toBe(sha(2))
+  expect(state.lastGood.sha).toBe(sha(3))
+})
+
+test('a good mark newer than a bad mark is inconsistent, not ignored', () => {
+  const chain = chainOf(8)
+  const state = deriveBisectState(chain, marks([5, 'bad'], [2, 'good']))
+  expect(state.kind).toBe('inconsistent')
+})
+
+test('marks on shas outside the chain are ignored', () => {
+  const chain = chainOf(5)
+  const state = deriveBisectState(chain, [{sha: 'f'.repeat(40), verdict: 'bad'}])
+  if (state.kind !== 'active') throw new Error(state.kind)
+  expect(state.badBound.sha).toBe(sha(0))
+})
+
+test('candidateShas restricts what gets proposed, not the bounds', () => {
+  const chain = chainOf(11)
+  const releases = new Set([sha(3), sha(8)])
+  const state = deriveBisectState(chain, [], {candidateShas: releases})
+  if (state.kind !== 'active') throw new Error(state.kind)
+  // median of the two eligible candidates
+  expect(state.next.sha).toBe(sha(3))
+  expect(state.testableCount).toBe(2)
+  // marking the releases exhausts the candidates → converged with suspects
+  const done = deriveBisectState(chain, marks([3, 'bad'], [8, 'good']), {candidateShas: releases})
+  expect(done.kind).toBe('converged')
+  if (done.kind !== 'converged') return
+  expect(done.firstBad.sha).toBe(sha(3))
+  expect(done.lastGood.sha).toBe(sha(8))
+  expect(done.suspects.length).toBe(4) // c4..c7 — commits between the releases
+})
+
+test('a two-commit chain converges immediately', () => {
+  const chain = chainOf(2)
+  const state = deriveBisectState(chain, [])
+  expect(state).toMatchObject({kind: 'converged', suspects: []})
+})
+
+// -- releasesContaining -------------------------------------------------------
+
+test('finds the releases whose ancestry includes the commit, oldest first', () => {
+  const chain = chainOf(10)
+  const tags = [
+    {tag: 'v2.0.0', sha: sha(2), taggedAt: '2026-08-18T00:00:00Z'}, // newest release
+    {tag: 'v1.0.0', sha: sha(6), taggedAt: '2026-08-10T00:00:00Z'}, // older release
+    {tag: 'v0.9.0', sha: 'f'.repeat(40), taggedAt: '2026-08-01T00:00:00Z'}, // off-mainline
+  ]
+  const map = bySha(chain)
+  // c4 landed after v1.0.0 (c6) — only v2.0.0 contains it
+  expect(releasesContaining(map, tags, sha(4)).map((t) => t.tag)).toEqual(['v2.0.0'])
+  // c7 predates both releases — contained in both, oldest first
+  expect(releasesContaining(map, tags, sha(7)).map((t) => t.tag)).toEqual(['v1.0.0', 'v2.0.0'])
+  // c0 is newer than every tag — unreleased
+  expect(releasesContaining(map, tags, sha(0))).toEqual([])
+})
+
+test('a release contains its own commit — the manual-regression endpoint case', () => {
+  // reportRegression writes the blamed release's OWN sha as firstBadSha, so
+  // release attribution hinges on a tag containing the commit it points at
+  const chain = chainOf(10)
+  const tags = [
+    {tag: 'v2.0.0', sha: sha(2), taggedAt: '2026-08-18T00:00:00Z'},
+    {tag: 'v1.0.0', sha: sha(6), taggedAt: '2026-08-10T00:00:00Z'},
+  ]
+  const map = bySha(chain)
+  expect(releasesContaining(map, tags, sha(2)).map((t) => t.tag)).toEqual(['v2.0.0'])
+  expect(releasesContaining(map, tags, sha(6)).map((t) => t.tag)).toEqual(['v1.0.0', 'v2.0.0'])
+})
+
+// -- buildTimeline ------------------------------------------------------------
+
+function summarize(entries: ReturnType<typeof buildTimeline>): string[] {
+  return entries.map((entry) =>
+    entry.kind === 'gap'
+      ? `gap:${entry.count}:${entry.zone}`
+      : `${entry.role}:${entry.commit.sha[0]}`,
+  )
+}
+
+test('a fresh timeline shows endpoints, you-are-here, and collapsed gaps', () => {
+  const chain = chainOf(11) // c0 bad … c10 good, next = c5
+  expect(summarize(buildTimeline(chain, []))).toEqual([
+    'bad:0',
+    'gap:4:unknown',
+    'current:5',
+    'gap:4:unknown',
+    'good:a',
+  ])
+})
+
+test('visited commits stay visible and gaps take the zone the bisect deduced', () => {
+  const chain = chainOf(11)
+  // good at c5 moves the good bound; next becomes c2
+  expect(summarize(buildTimeline(chain, marks([5, 'good'])))).toEqual([
+    'bad:0',
+    'gap:1:unknown', // c1
+    'current:2',
+    'gap:2:unknown', // c3..c4
+    'good:5',
+    'gap:4:good', // c6..c9 — deduced working
+    'good:a',
+  ])
+})
+
+test('skipped commits are shown with their mark even inside the unknown region', () => {
+  const chain = chainOf(7) // next would be c3
+  const entries = buildTimeline(chain, marks([3, 'skip']))
+  const skipEntry = entries.find((entry) => entry.kind === 'commit' && entry.commit.sha === sha(3))
+  expect(skipEntry).toMatchObject({kind: 'commit', role: 'skip'})
+})
+
+test('a converged timeline has no you-are-here and keeps the bounds', () => {
+  const chain = chainOf(6)
+  const entries = buildTimeline(chain, marks([2, 'bad'], [3, 'good']))
+  expect(summarize(entries)).toEqual([
+    'bad:0',
+    'gap:1:bad',
+    'bad:2',
+    'good:3',
+    'gap:1:good',
+    'good:5',
+  ])
+})
+
+test('an inconsistent session has no timeline', () => {
+  const chain = chainOf(8)
+  expect(buildTimeline(chain, marks([5, 'bad'], [2, 'good']))).toEqual([])
+})
+
+test('gap compare spans use the commit past the gap as base', () => {
+  const chain = chainOf(11)
+  const [, gap] = buildTimeline(chain, [])
+  // three-dot compare excludes the base, so the base must be OUTSIDE the
+  // gap (c5) for all four gap commits (c1..c4) to appear in the diff
+  expect(gap).toMatchObject({kind: 'gap', count: 4, newestSha: sha(1), baseSha: sha(5)})
+})

--- a/dev/metrics-studio/tools/bisect/bisect.ts
+++ b/dev/metrics-studio/tools/bisect/bisect.ts
@@ -1,0 +1,314 @@
+/**
+ * The bisect engine — pure functions, no I/O, no React (the Bisect tool's
+ * components stay thin; this module carries the semantics and the tests).
+ *
+ * The chain is the exact first-parent walk from the bad endpoint back to the
+ * good one (`gitCommit.parentSha`), not a `committedAt` sort — committer
+ * dates have tie/rebase hazards; ancestry doesn't. `chain[0]` is the bad
+ * endpoint, `chain[chain.length - 1]` the good one, so "newer" always means
+ * "lower index".
+ *
+ * Marks are an append-only log; the LAST mark per sha wins, so undo is
+ * "remove the tail entry" and a re-mark simply overrides. The endpoints act
+ * as implicit marks. A commit can only be tested if a preview build exists
+ * (`testStudioUrl`) and it wasn't skipped — untestable commits inside the
+ * final range are reported as suspects rather than silently blamed.
+ */
+
+export interface BisectCommit {
+  sha: string
+  parentSha?: string
+  subject: string
+  authorName?: string
+  authorEmail?: string
+  authorLogin?: string
+  authorAvatarUrl?: string
+  committedAt: string
+  prNumber?: number
+  testStudioUrl?: string
+}
+
+export type Verdict = 'good' | 'bad' | 'skip'
+
+export interface Mark {
+  sha: string
+  verdict: Verdict
+}
+
+export type ChainResult =
+  | {ok: true; chain: BisectCommit[]}
+  | {ok: false; reason: 'bad-not-synced' | 'good-not-synced' | 'not-ancestor' | 'same-commit'}
+
+/**
+ * Human copy for a failed chain, naming the endpoints (a tag name or short
+ * sha) so the message points at the actual pair instead of abstract roles.
+ */
+export function chainErrorCopy(
+  reason: Extract<ChainResult, {ok: false}>['reason'],
+  goodLabel: string,
+  badLabel: string,
+): string {
+  switch (reason) {
+    case 'same-commit':
+      return `Good and bad are the same commit (${goodLabel}).`
+    case 'bad-not-synced':
+      return `The bad commit (${badLabel}) is not in the synced history.`
+    case 'good-not-synced':
+      return `The good commit (${goodLabel}) is not in the synced history.`
+    case 'not-ancestor':
+      return `Good (${goodLabel}) is not an ancestor of bad (${badLabel}) on the synced mainline.`
+    default:
+      return reason satisfies never
+  }
+}
+
+/**
+ * Walk `parentSha` from `badSha` collecting commits until `goodSha`
+ * (inclusive). A missing/unknown parent ends the walk as `not-ancestor` —
+ * that covers swapped endpoints, off-mainline picks, and walking off the
+ * v5.0.0 sync boundary. A visited guard makes a (theoretically impossible)
+ * parent cycle terminate too.
+ */
+export function buildChain(
+  commitsBySha: Map<string, BisectCommit>,
+  goodSha: string,
+  badSha: string,
+): ChainResult {
+  if (goodSha === badSha) return {ok: false, reason: 'same-commit'}
+  if (!commitsBySha.has(badSha)) return {ok: false, reason: 'bad-not-synced'}
+  if (!commitsBySha.has(goodSha)) return {ok: false, reason: 'good-not-synced'}
+
+  const chain: BisectCommit[] = []
+  const visited = new Set<string>()
+  let current: BisectCommit | undefined = commitsBySha.get(badSha)
+  while (current && !visited.has(current.sha)) {
+    visited.add(current.sha)
+    chain.push(current)
+    if (current.sha === goodSha) return {ok: true, chain}
+    current = current.parentSha ? commitsBySha.get(current.parentSha) : undefined
+  }
+  return {ok: false, reason: 'not-ancestor'}
+}
+
+export type BisectState =
+  | {
+      kind: 'active'
+      next: BisectCommit
+      badBound: BisectCommit
+      goodBound: BisectCommit
+      /** Commits strictly between the bounds (any could still be the culprit). */
+      unknownCount: number
+      /** How many of those are actually testable (preview build, not skipped). */
+      testableCount: number
+      stepsLeft: number
+    }
+  | {kind: 'converged'; firstBad: BisectCommit; lastGood: BisectCommit; suspects: BisectCommit[]}
+  | {kind: 'inconsistent'; goodMarkSha: string; badMarkSha: string}
+
+export interface BisectOptions {
+  /**
+   * Restrict the testable candidates to these shas (releases-only mode:
+   * the shas that release tags point at). Bounds and suspects stay
+   * commit-level — only what gets *proposed* narrows.
+   */
+  candidateShas?: Set<string>
+}
+
+/**
+ * Derive the whole stepper state from the chain and the marks log. Expects a
+ * chain from buildChain, which is ≥2 commits by construction (identical
+ * endpoints are rejected as `same-commit`). The endpoints are implicit marks
+ * (chain[0] bad, chain[last] good). Next to test
+ * is the testable commit nearest the midpoint of the unknown region — the
+ * closest we can get to halving when builds are missing or skipped.
+ * Converged when nothing testable remains between the bounds; everything
+ * still strictly between them is a suspect.
+ */
+export function deriveBisectState(
+  chain: BisectCommit[],
+  marks: Mark[],
+  options: BisectOptions = {},
+): BisectState {
+  const indexBySha = new Map(chain.map((commit, index) => [commit.sha, index]))
+
+  // Last mark per sha wins (marks is append-only; undo removes the tail)
+  const effective = new Map<string, Verdict>()
+  for (const mark of marks) {
+    if (indexBySha.has(mark.sha)) effective.set(mark.sha, mark.verdict)
+  }
+  effective.set(chain[0].sha, 'bad')
+  effective.set(chain[chain.length - 1].sha, 'good')
+
+  // Newer = lower index. The bad bound moves down (oldest bad), the good
+  // bound up (newest good); a good mark newer than a bad mark is a
+  // contradiction the user must resolve by undoing.
+  let badBoundIndex = 0
+  let goodBoundIndex = chain.length - 1
+  for (const [sha, verdict] of effective) {
+    const index = indexBySha.get(sha)!
+    if (verdict === 'bad' && index > badBoundIndex) badBoundIndex = index
+    if (verdict === 'good' && index < goodBoundIndex) goodBoundIndex = index
+  }
+  for (const [sha, verdict] of effective) {
+    const index = indexBySha.get(sha)!
+    if (verdict === 'good' && index < badBoundIndex) {
+      return {kind: 'inconsistent', goodMarkSha: sha, badMarkSha: chain[badBoundIndex].sha}
+    }
+    if (verdict === 'bad' && index > goodBoundIndex) {
+      return {kind: 'inconsistent', goodMarkSha: chain[goodBoundIndex].sha, badMarkSha: sha}
+    }
+  }
+
+  const unknown = chain.slice(badBoundIndex + 1, goodBoundIndex)
+  const candidates = unknown.filter(
+    (commit) =>
+      commit.testStudioUrl &&
+      effective.get(commit.sha) !== 'skip' &&
+      (!options.candidateShas || options.candidateShas.has(commit.sha)),
+  )
+
+  if (candidates.length === 0) {
+    return {
+      kind: 'converged',
+      firstBad: chain[badBoundIndex],
+      lastGood: chain[goodBoundIndex],
+      suspects: unknown,
+    }
+  }
+
+  // Median CANDIDATE, not the commit nearest the range midpoint: when
+  // testable commits are sparse (missing builds, releases-only), only the
+  // median halves the candidate set and keeps stepsLeft honest
+  const next = candidates[Math.floor((candidates.length - 1) / 2)]
+
+  return {
+    kind: 'active',
+    next,
+    badBound: chain[badBoundIndex],
+    goodBound: chain[goodBoundIndex],
+    unknownCount: unknown.length,
+    testableCount: candidates.length,
+    stepsLeft: Math.ceil(Math.log2(candidates.length + 1)),
+  }
+}
+
+export interface ReleaseTag {
+  tag: string
+  sha: string
+  taggedAt: string
+}
+
+/**
+ * Which releases contain a commit: walk each tag's first-parent ancestry over
+ * the synced set and keep the tags that reach the sha. Returned oldest-first,
+ * so `[0]` is the release that first shipped the commit; empty means the
+ * commit hasn't been released yet. Tags cut off-mainline (their sha is not in
+ * the synced set) can't be answered and are skipped.
+ */
+export function releasesContaining<T extends ReleaseTag>(
+  commitsBySha: Map<string, BisectCommit>,
+  tags: T[],
+  sha: string,
+): T[] {
+  const containing = tags.filter((candidate) => {
+    const visited = new Set<string>()
+    let current = commitsBySha.get(candidate.sha)
+    while (current && !visited.has(current.sha)) {
+      if (current.sha === sha) return true
+      visited.add(current.sha)
+      current = current.parentSha ? commitsBySha.get(current.parentSha) : undefined
+    }
+    return false
+  })
+  return containing.toSorted((a, b) => a.taggedAt.localeCompare(b.taggedAt))
+}
+
+export type TimelineRole = 'current' | 'good' | 'bad' | 'skip'
+
+export type TimelineEntry =
+  | {kind: 'commit'; commit: BisectCommit; role: TimelineRole}
+  | {
+      kind: 'gap'
+      count: number
+      /** Newest commit inside the gap (compare head). */
+      newestSha: string
+      /**
+       * Compare BASE: the included commit just past the gap's oldest end —
+       * GitHub's three-dot compare excludes the base, so using a gap-internal
+       * commit would drop it from the diff.
+       */
+      baseSha: string
+      /** What the bisect already knows about the collapsed commits. */
+      zone: 'bad' | 'unknown' | 'good'
+    }
+
+/**
+ * The "map" of a session: the chain (newest first) reduced to the commits
+ * worth seeing — endpoints, current bounds, every visited (marked) commit,
+ * and the one being tested ("you are here") — with the runs in between
+ * collapsed into gap entries. Gap zones fall out of the bisect invariant:
+ * everything newer than the bad bound is broken, everything older than the
+ * good bound works, the middle is untested. Empty for an inconsistent
+ * session (the conflict card is the view there).
+ */
+export function buildTimeline(
+  chain: BisectCommit[],
+  marks: Mark[],
+  options: BisectOptions = {},
+): TimelineEntry[] {
+  const state = deriveBisectState(chain, marks, options)
+  if (state.kind === 'inconsistent') return []
+  const indexBySha = new Map(chain.map((commit, index) => [commit.sha, index]))
+
+  const effective = new Map<string, Verdict>()
+  for (const mark of marks) {
+    if (indexBySha.has(mark.sha)) effective.set(mark.sha, mark.verdict)
+  }
+
+  const badBoundIndex = indexBySha.get(
+    state.kind === 'active' ? state.badBound.sha : state.firstBad.sha,
+  )!
+  const goodBoundIndex = indexBySha.get(
+    state.kind === 'active' ? state.goodBound.sha : state.lastGood.sha,
+  )!
+  const currentIndex = state.kind === 'active' ? indexBySha.get(state.next.sha)! : undefined
+
+  const include = new Set<number>([0, chain.length - 1, badBoundIndex, goodBoundIndex])
+  if (currentIndex !== undefined) include.add(currentIndex)
+  for (const sha of effective.keys()) include.add(indexBySha.get(sha)!)
+
+  const roleOf = (index: number): TimelineRole => {
+    if (index === currentIndex) return 'current'
+    const marked = effective.get(chain[index].sha)
+    if (marked) return marked
+    return index <= badBoundIndex ? 'bad' : index >= goodBoundIndex ? 'good' : 'skip'
+  }
+  const zoneOf = (index: number): 'bad' | 'unknown' | 'good' =>
+    index < badBoundIndex ? 'bad' : index > goodBoundIndex ? 'good' : 'unknown'
+
+  const entries: TimelineEntry[] = []
+  let gapStart: number | undefined
+  const flushGap = (end: number) => {
+    if (gapStart === undefined) return
+    entries.push({
+      kind: 'gap',
+      count: end - gapStart,
+      newestSha: chain[gapStart].sha,
+      // end is always a valid index: the chain's last entry (the good
+      // endpoint) is always included, so a gap can't run off the end
+      baseSha: chain[end].sha,
+      zone: zoneOf(gapStart),
+    })
+    gapStart = undefined
+  }
+  chain.forEach((commit, index) => {
+    if (include.has(index)) {
+      flushGap(index)
+      entries.push({kind: 'commit', commit, role: roleOf(index)})
+    } else if (gapStart === undefined) {
+      gapStart = index
+    }
+  })
+  flushGap(chain.length)
+  return entries
+}

--- a/dev/metrics-studio/tools/bisect/chips.tsx
+++ b/dev/metrics-studio/tools/bisect/chips.tsx
@@ -1,0 +1,141 @@
+import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
+import {CopyIcon} from '@sanity/icons/Copy'
+import {Button, Card, Flex, Text} from '@sanity/ui'
+import {Menu, MenuButton, MenuItem} from '@sanity/ui/menu'
+import {useToast} from '@sanity/ui/toast'
+import {useId, useState} from 'react'
+
+function useCopyToClipboard() {
+  const toast = useToast()
+  return (command: string) => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      toast.push({status: 'error', title: 'Clipboard is not available'})
+      return
+    }
+    void navigator.clipboard
+      .writeText(command)
+      .then(() => toast.push({status: 'success', title: 'Copied to clipboard'}))
+      .catch((err: unknown) =>
+        toast.push({
+          status: 'error',
+          title: 'Could not copy to clipboard',
+          description: err instanceof Error ? err.message : String(err),
+        }),
+      )
+  }
+}
+
+/**
+ * Compact command chip (e.g. `git checkout <sha>`) with a copy button —
+ * what you see is what gets copied.
+ */
+export function CommandChip(props: {command: string}) {
+  const {command} = props
+  const copy = useCopyToClipboard()
+  return (
+    <Card padding={1} paddingLeft={2} radius={2} tone="transparent" border>
+      <Flex align="center" gap={1}>
+        <Text size={1} muted>
+          <code>{command}</code>
+        </Text>
+        <Button
+          mode="bleed"
+          fontSize={0}
+          padding={2}
+          icon={CopyIcon}
+          aria-label="Copy command to clipboard"
+          onClick={() => copy(command)}
+        />
+      </Flex>
+    </Card>
+  )
+}
+
+function NpmLogo() {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" aria-hidden="true">
+      <path
+        fill="#CB3837"
+        d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z"
+      />
+    </svg>
+  )
+}
+
+function PnpmLogo() {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" aria-hidden="true">
+      <path
+        fill="#F69220"
+        d="M0 0v7.5h7.5V0zm8.25 0v7.5h7.5V0zM16.5 0v7.5H24V0zm0 8.25v7.5H24v-7.5zm-8.25 0v7.5h7.5v-7.5zm8.25 8.25V24H24v-7.5zm-8.25 0V24h7.5v-7.5zM0 16.5V24h7.5v-7.5z"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Install command chip: the command for the selected package manager, a
+ * compact logo dropdown to switch it (persisted per browser), and a copy
+ * button that copies exactly what is shown.
+ */
+export function InstallChip(props: {version: string}) {
+  const {version} = props
+  const copy = useCopyToClipboard()
+  const menuId = useId()
+  const [pm, setPm] = useState<'npm' | 'pnpm'>(() =>
+    typeof localStorage !== 'undefined' && localStorage.getItem('metricsBisectPm') === 'npm'
+      ? 'npm'
+      : 'pnpm',
+  )
+  const command = pm === 'pnpm' ? `pnpm add sanity@${version}` : `npm install sanity@${version}`
+  const select = (next: 'npm' | 'pnpm') => {
+    setPm(next)
+    if (typeof localStorage !== 'undefined') localStorage.setItem('metricsBisectPm', next)
+  }
+  return (
+    <Card padding={1} radius={2} tone="transparent" border>
+      <Flex align="center" gap={1}>
+        <MenuButton
+          id={menuId}
+          button={
+            <Button
+              mode="bleed"
+              fontSize={0}
+              padding={2}
+              icon={pm === 'pnpm' ? PnpmLogo : NpmLogo}
+              iconRight={ChevronDownIcon}
+              aria-label="Package manager"
+            />
+          }
+          menu={
+            <Menu>
+              <MenuItem
+                icon={PnpmLogo}
+                text="pnpm"
+                pressed={pm === 'pnpm'}
+                onClick={() => select('pnpm')}
+              />
+              <MenuItem
+                icon={NpmLogo}
+                text="npm"
+                pressed={pm === 'npm'}
+                onClick={() => select('npm')}
+              />
+            </Menu>
+          }
+        />
+        <Text size={1} muted>
+          <code>{command}</code>
+        </Text>
+        <Button
+          mode="bleed"
+          fontSize={0}
+          padding={2}
+          icon={CopyIcon}
+          aria-label="Copy install command to clipboard"
+          onClick={() => copy(command)}
+        />
+      </Flex>
+    </Card>
+  )
+}

--- a/dev/metrics-studio/tools/bisect/data.test.ts
+++ b/dev/metrics-studio/tools/bisect/data.test.ts
@@ -1,0 +1,41 @@
+import {expect, test} from 'vitest'
+
+import {filterCommits, type GitCommitSlice} from './data'
+
+function commit(sha: string, subject: string): GitCommitSlice {
+  return {
+    _id: `gitCommit-${sha}`,
+    sha,
+    parentSha: null,
+    committedAt: '2026-08-20T12:00:00Z',
+    subject,
+    prNumber: null,
+    authorName: null,
+    authorEmail: null,
+    authorLogin: null,
+    authorAvatarUrl: null,
+    testStudioUrl: null,
+  }
+}
+
+const COMMITS = [
+  commit('abc123' + '0'.repeat(34), 'feat(form): add array input'),
+  commit('def456' + '0'.repeat(34), 'fix(core): Nested Object rendering'),
+  commit('abcfff' + '0'.repeat(34), 'chore: bump deps'),
+]
+
+test('empty query returns the newest commits up to the limit', () => {
+  expect(filterCommits(COMMITS, '', 2)).toHaveLength(2)
+  expect(filterCommits(COMMITS, '  ')).toHaveLength(3)
+})
+
+test('matches sha prefixes case-insensitively', () => {
+  expect(filterCommits(COMMITS, 'ABC').map((c) => c.sha.slice(0, 6))).toEqual(['abc123', 'abcfff'])
+  expect(filterCommits(COMMITS, 'def4')).toHaveLength(1)
+})
+
+test('matches subject substrings case-insensitively', () => {
+  expect(filterCommits(COMMITS, 'nested object')).toHaveLength(1)
+  expect(filterCommits(COMMITS, 'array input')[0].sha.startsWith('abc123')).toBe(true)
+  expect(filterCommits(COMMITS, 'no such thing')).toHaveLength(0)
+})

--- a/dev/metrics-studio/tools/bisect/data.ts
+++ b/dev/metrics-studio/tools/bisect/data.ts
@@ -1,0 +1,135 @@
+/**
+ * The Bisect tool's slice of the dataset: every synced commit (tight
+ * projection — never anything heavy), the session list (summary only; the
+ * marks array is fetched per session), and the release tags used as endpoint
+ * shortcuts.
+ */
+import {type BisectCommit} from './bisect'
+
+export interface GitCommitSlice {
+  _id: string
+  sha: string
+  parentSha: string | null
+  committedAt: string
+  subject: string
+  prNumber: number | null
+  authorName: string | null
+  authorEmail: string | null
+  authorLogin: string | null
+  authorAvatarUrl: string | null
+  testStudioUrl: string | null
+}
+
+/**
+ * All ~2k synced commits — accepted for now (tight projection); scope by the
+ * endpoint dates if the dataset outgrows this. Newest first feeds the picker.
+ */
+export const BISECT_COMMITS_QUERY = `*[_type == "gitCommit"] | order(committedAt desc) {
+  _id, sha, parentSha, committedAt, subject, prNumber, authorName, authorEmail, authorLogin, authorAvatarUrl, testStudioUrl
+}`
+
+export interface SessionEndpoint {
+  sha: string
+  label?: string | null
+}
+
+export interface SessionSummary {
+  _id: string
+  title: string | null
+  good: SessionEndpoint | null
+  bad: SessionEndpoint | null
+  createdAt: string | null
+  createdBy: string | null
+  markCount: number | null
+  result: {
+    firstBadSha: string | null
+    regression: boolean | null
+    linearIssue: string | null
+  } | null
+  resultSubject: string | null
+}
+
+/** Summary only — `marks` is deliberately not projected here (SessionView fetches the full doc). */
+export const BISECT_SESSIONS_QUERY = `*[_type == "bisectSession"] | order(createdAt desc) {
+  _id, title, good{sha, label}, bad{sha, label}, createdAt, createdBy,
+  "markCount": count(marks),
+  result{firstBadSha, regression, linearIssue},
+  "resultSubject": *[_type == "gitCommit" && sha == ^.result.firstBadSha][0].subject
+}`
+
+export interface SessionDocument {
+  _id: string
+  title: string | null
+  good: SessionEndpoint | null
+  bad: SessionEndpoint | null
+  releasesOnly: boolean | null
+  marks: {_key: string; sha: string; verdict: string}[] | null
+  result: {
+    firstBadSha: string
+    regression: boolean | null
+    description: string | null
+    linearIssue: string | null
+  } | null
+  createdAt: string | null
+  createdBy: string | null
+}
+
+export const BISECT_SESSION_QUERY = `*[_id == $id][0] {
+  _id, title, good{sha, label}, bad{sha, label}, releasesOnly,
+  marks[]{_key, sha, verdict},
+  result{firstBadSha, regression, description, linearIssue},
+  createdAt, createdBy
+}`
+
+export interface TagSlice {
+  _id: string
+  tag: string
+  sha: string
+  taggedAt: string
+  npm: {
+    publishedAt: string | null
+    distTags: string[] | null
+    weeklyDownloads: number | null
+  } | null
+}
+
+export const BISECT_TAGS_QUERY = `*[_type == "gitTag"] | order(taggedAt desc) {
+  _id, tag, sha, taggedAt, npm{publishedAt, distTags, weeklyDownloads}
+}`
+
+/** GROQ nulls → the engine's optional fields (tools/bisect/bisect.ts). */
+export function toBisectCommit(slice: GitCommitSlice): BisectCommit {
+  return {
+    sha: slice.sha,
+    parentSha: slice.parentSha ?? undefined,
+    subject: slice.subject,
+    authorName: slice.authorName ?? undefined,
+    authorEmail: slice.authorEmail ?? undefined,
+    authorLogin: slice.authorLogin ?? undefined,
+    authorAvatarUrl: slice.authorAvatarUrl?.startsWith('https://')
+      ? slice.authorAvatarUrl
+      : undefined,
+    committedAt: slice.committedAt,
+    prNumber: slice.prNumber ?? undefined,
+    // The URL is rendered straight into hrefs — refuse anything but https
+    // so a poisoned document can't smuggle a javascript: link
+    testStudioUrl: slice.testStudioUrl?.startsWith('https://') ? slice.testStudioUrl : undefined,
+  }
+}
+
+/**
+ * Endpoint-picker search: sha prefix (case-insensitive) or subject substring.
+ */
+export function filterCommits(
+  commits: GitCommitSlice[],
+  query: string,
+  limit = 20,
+): GitCommitSlice[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return commits.slice(0, limit)
+  return commits
+    .filter(
+      (commit) => commit.sha.startsWith(needle) || commit.subject.toLowerCase().includes(needle),
+    )
+    .slice(0, limit)
+}

--- a/dev/metrics-studio/tools/bisect/dates.test.ts
+++ b/dev/metrics-studio/tools/bisect/dates.test.ts
@@ -1,0 +1,23 @@
+import {expect, test} from 'vitest'
+
+import {relativeDate} from './dates'
+
+const NOW = Date.parse('2026-08-20T12:00:00Z')
+
+test('buckets elapsed time into the largest sensible unit', () => {
+  expect(relativeDate('2026-08-20T11:59:30Z', NOW)).toBe('just now')
+  expect(relativeDate('2026-08-20T11:45:00Z', NOW)).toBe('15 minutes ago')
+  expect(relativeDate('2026-08-20T07:00:00Z', NOW)).toBe('5 hours ago')
+  expect(relativeDate('2026-08-19T12:00:00Z', NOW)).toBe('yesterday')
+  expect(relativeDate('2026-08-13T12:00:00Z', NOW)).toBe('7 days ago')
+  expect(relativeDate('2026-06-20T12:00:00Z', NOW)).toBe('2 months ago')
+  expect(relativeDate('2024-08-20T12:00:00Z', NOW)).toBe('2 years ago')
+})
+
+test('falls back to the raw string for unparseable input', () => {
+  expect(relativeDate('not-a-date', NOW)).toBe('not-a-date')
+})
+
+test('a future timestamp (clock skew) reads as "just now", not a negative age', () => {
+  expect(relativeDate('2026-08-20T12:30:00Z', NOW)).toBe('just now')
+})

--- a/dev/metrics-studio/tools/bisect/dates.ts
+++ b/dev/metrics-studio/tools/bisect/dates.ts
@@ -1,0 +1,23 @@
+/**
+ * Relative date formatting for the Bisect tool ("3 days ago"), pure so it's
+ * testable — the absolute timestamp stays available in a tooltip
+ * (RelativeDate.tsx).
+ */
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+const FORMATTER = new Intl.RelativeTimeFormat('en', {numeric: 'auto'})
+
+export function relativeDate(iso: string, nowMs: number): string {
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return iso
+  const elapsed = nowMs - then
+  if (elapsed < MINUTE) return 'just now'
+  if (elapsed < HOUR) return FORMATTER.format(-Math.round(elapsed / MINUTE), 'minute')
+  if (elapsed < DAY) return FORMATTER.format(-Math.round(elapsed / HOUR), 'hour')
+  if (elapsed < 30 * DAY) return FORMATTER.format(-Math.round(elapsed / DAY), 'day')
+  if (elapsed < 365 * DAY) return FORMATTER.format(-Math.round(elapsed / (30 * DAY)), 'month')
+  return FORMATTER.format(-Math.round(elapsed / (365 * DAY)), 'year')
+}

--- a/dev/metrics-studio/tools/bisect/index.ts
+++ b/dev/metrics-studio/tools/bisect/index.ts
@@ -1,0 +1,12 @@
+import {TargetIcon} from '@sanity/icons/Target'
+import {type Tool} from 'sanity'
+
+import {BisectTool} from './BisectTool'
+
+/** Guided bisect over mainline preview builds — see BisectTool. */
+export const bisectTool: Tool = {
+  name: 'bisect',
+  title: 'Bisect',
+  icon: TargetIcon,
+  component: BisectTool,
+}

--- a/dev/metrics-studio/tools/bisect/sessions.ts
+++ b/dev/metrics-studio/tools/bisect/sessions.ts
@@ -40,6 +40,58 @@ export async function createSession(client: SanityClient, input: NewSessionInput
   return created._id
 }
 
+export interface ManualRegressionInput {
+  /** The release BEFORE the blamed one (base on the first-parent chain). */
+  good: {sha: string; label?: string}
+  /** The release the regression is pinned on. */
+  bad: {sha: string; label?: string}
+  /** Commits strictly between the two releases — the possible culprits. */
+  suspectShas: string[]
+  description: string
+  linearIssue?: string
+  createdBy: string
+}
+
+/**
+ * A regression reported by hand from the Studio Releases tool — no bisect was
+ * run, only the introducing release is known. Stored as a bisectSession that
+ * is converged from birth: releases-only endpoints at the blamed release and
+ * its base, no marks, and the verdict written at creation. That keeps one
+ * source of truth for regression attribution, and opening the session offers
+ * the usual drill-down over the suspect commits.
+ */
+export async function reportRegression(
+  client: SanityClient,
+  input: ManualRegressionInput,
+): Promise<string> {
+  const created = await client.create({
+    _id: `bisectSession-${crypto.randomUUID()}`,
+    _type: 'bisectSession',
+    title: `${endpointLabel(input.good)} → ${endpointLabel(input.bad)}`,
+    good: input.good,
+    bad: input.bad,
+    releasesOnly: true,
+    marks: [],
+    result: {
+      firstBadSha: input.bad.sha,
+      lastGoodSha: input.good.sha,
+      suspectShas: input.suspectShas,
+      regression: true,
+      description: input.description,
+      ...(input.linearIssue ? {linearIssue: input.linearIssue} : {}),
+      concludedAt: new Date().toISOString(),
+    },
+    createdAt: new Date().toISOString(),
+    createdBy: input.createdBy,
+  })
+  return created._id
+}
+
+/** Sessions are the only user-owned documents here — plain hard delete. */
+export function deleteSession(client: SanityClient, sessionId: string): Promise<unknown> {
+  return client.delete(sessionId)
+}
+
 /**
  * Append a mark. Every append is authoritative about `result`: a converging
  * mark writes it in the same patch (so the list and the marks log can never

--- a/dev/metrics-studio/tools/bisect/sessions.ts
+++ b/dev/metrics-studio/tools/bisect/sessions.ts
@@ -1,0 +1,127 @@
+import {type SanityClient} from 'sanity'
+
+import {type Verdict} from './bisect'
+
+/**
+ * bisectSession writes (see schemaTypes/bisectSession.ts). All fire-and-forget
+ * from the UI — the realtime listenQuery echoes the change back, and failures
+ * surface via toast (same pattern as tools/trends/useDriftState.ts).
+ */
+
+export interface NewSessionInput {
+  good: {sha: string; label?: string}
+  bad: {sha: string; label?: string}
+  releasesOnly?: boolean
+  createdBy: string
+}
+
+export interface SessionResult {
+  firstBadSha: string
+  lastGoodSha: string
+  suspectShas: string[]
+}
+
+function endpointLabel(endpoint: {sha: string; label?: string}): string {
+  return endpoint.label ?? endpoint.sha.slice(0, 7)
+}
+
+export async function createSession(client: SanityClient, input: NewSessionInput): Promise<string> {
+  const created = await client.create({
+    _id: `bisectSession-${crypto.randomUUID()}`,
+    _type: 'bisectSession',
+    title: `${endpointLabel(input.good)} → ${endpointLabel(input.bad)}`,
+    good: input.good,
+    bad: input.bad,
+    ...(input.releasesOnly ? {releasesOnly: true} : {}),
+    marks: [],
+    createdAt: new Date().toISOString(),
+    createdBy: input.createdBy,
+  })
+  return created._id
+}
+
+/**
+ * Append a mark. Every append is authoritative about `result`: a converging
+ * mark writes it in the same patch (so the list and the marks log can never
+ * disagree), and a non-converging mark UNSETS it — otherwise a concurrent
+ * editor's contradicting mark could leave a stale verdict on the document
+ * while the live-derived state disagrees.
+ */
+export function appendMark(
+  client: SanityClient,
+  sessionId: string,
+  mark: {sha: string; verdict: Verdict; markedBy: string},
+  result: SessionResult | undefined,
+): Promise<unknown> {
+  const patch = client
+    .patch(sessionId)
+    .setIfMissing({marks: []})
+    .append('marks', [
+      {_key: crypto.randomUUID().slice(0, 8), ...mark, markedAt: new Date().toISOString()},
+    ])
+  return (
+    result
+      ? patch.set({result: {...result, concludedAt: new Date().toISOString()}})
+      : patch.unset(['result'])
+  ).commit()
+}
+
+/**
+ * Persist a verdict outside the mark flow — for sessions that are converged
+ * from birth (adjacent endpoints, drill-downs over an untestable range),
+ * where no converging mark ever fires.
+ */
+export function setResult(
+  client: SanityClient,
+  sessionId: string,
+  result: SessionResult,
+): Promise<unknown> {
+  return client
+    .patch(sessionId)
+    .set({result: {...result, concludedAt: new Date().toISOString()}})
+    .commit()
+}
+
+/** Clear a stale verdict (live-derived state no longer converged). */
+export function clearResult(client: SanityClient, sessionId: string): Promise<unknown> {
+  return client.patch(sessionId).unset(['result']).commit()
+}
+
+export interface ResultAnnotations {
+  regression?: boolean
+  description?: string
+  linearIssue?: string
+}
+
+/** Human annotations on a concluded run — cleared string fields are unset, not stored empty. */
+export function updateResult(
+  client: SanityClient,
+  sessionId: string,
+  patch: ResultAnnotations,
+): Promise<unknown> {
+  const sets: Record<string, boolean | string> = {}
+  const unsets: string[] = []
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === '' || value === undefined) unsets.push(`result.${key}`)
+    else sets[`result.${key}`] = value
+  }
+  let mutation = client.patch(sessionId)
+  if (Object.keys(sets).length > 0) mutation = mutation.set(sets)
+  if (unsets.length > 0) mutation = mutation.unset(unsets)
+  return mutation.commit()
+}
+
+/** Undo removes exactly one mark — and any result, since it may no longer hold. */
+export function undoMark(
+  client: SanityClient,
+  sessionId: string,
+  markKey: string,
+): Promise<unknown> {
+  // The key is interpolated into a patch path — ours are self-generated
+  // hex, but guard anyway so a malformed key can't smuggle path syntax
+  if (!/^[\w-]+$/.test(markKey)) throw new Error(`Invalid mark key: ${JSON.stringify(markKey)}`)
+  return client
+    .patch(sessionId)
+    .unset([`marks[_key=="${markKey}"]`, 'result'])
+    .commit()
+}

--- a/dev/metrics-studio/tools/bisect/sessions.ts
+++ b/dev/metrics-studio/tools/bisect/sessions.ts
@@ -144,11 +144,6 @@ export function setResult(
   return withResult(client.patch(sessionId), result).commit()
 }
 
-/** Clear a stale verdict (live-derived state no longer converged). */
-export function clearResult(client: SanityClient, sessionId: string): Promise<unknown> {
-  return client.patch(sessionId).unset(['result']).commit()
-}
-
 export interface ResultAnnotations {
   regression?: boolean
   description?: string

--- a/dev/metrics-studio/tools/bisect/sessions.ts
+++ b/dev/metrics-studio/tools/bisect/sessions.ts
@@ -1,3 +1,4 @@
+import {type Patch} from '@sanity/client'
 import {type SanityClient} from 'sanity'
 
 import {type Verdict} from './bisect'
@@ -111,11 +112,23 @@ export function appendMark(
     .append('marks', [
       {_key: crypto.randomUUID().slice(0, 8), ...mark, markedAt: new Date().toISOString()},
     ])
-  return (
-    result
-      ? patch.set({result: {...result, concludedAt: new Date().toISOString()}})
-      : patch.unset(['result'])
-  ).commit()
+  return (result ? withResult(patch, result) : patch.unset(['result'])).commit()
+}
+
+/**
+ * Set the verdict fields WITHOUT replacing the `result` object: annotations
+ * (regression, description, linearIssue) are human-owned, and a whole-object
+ * `set` racing a concurrent `updateResult` would silently destroy typed text.
+ * The machine writes only the fields it derives; a stale annotation on a
+ * re-derived verdict is visible and editable, a wiped one is just gone.
+ */
+function withResult(patch: Patch, result: SessionResult): Patch {
+  return patch.setIfMissing({result: {}}).set({
+    'result.firstBadSha': result.firstBadSha,
+    'result.lastGoodSha': result.lastGoodSha,
+    'result.suspectShas': result.suspectShas,
+    'result.concludedAt': new Date().toISOString(),
+  })
 }
 
 /**
@@ -128,10 +141,7 @@ export function setResult(
   sessionId: string,
   result: SessionResult,
 ): Promise<unknown> {
-  return client
-    .patch(sessionId)
-    .set({result: {...result, concludedAt: new Date().toISOString()}})
-    .commit()
+  return withResult(client.patch(sessionId), result).commit()
 }
 
 /** Clear a stale verdict (live-derived state no longer converged). */

--- a/dev/metrics-studio/tools/bisect/text.test.ts
+++ b/dev/metrics-studio/tools/bisect/text.test.ts
@@ -1,0 +1,10 @@
+import {expect, test} from 'vitest'
+
+import {pluralize} from './text'
+
+test('pluralizes counts', () => {
+  expect(pluralize(1, 'commit')).toBe('1 commit')
+  expect(pluralize(4, 'commit')).toBe('4 commits')
+  expect(pluralize(0, 'mark')).toBe('0 marks')
+  expect(pluralize(2, 'branch', 'branches')).toBe('2 branches')
+})

--- a/dev/metrics-studio/tools/bisect/text.ts
+++ b/dev/metrics-studio/tools/bisect/text.ts
@@ -1,0 +1,4 @@
+/** "1 commit", "4 commits" — reads better than "commit(s)" in UI copy. */
+export function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}

--- a/dev/metrics-studio/tools/bisect/useGravatar.test.ts
+++ b/dev/metrics-studio/tools/bisect/useGravatar.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'vitest'
+
+import {githubAvatarUrl} from './useGravatar'
+
+test('resolves modern GitHub noreply emails via the embedded user id', () => {
+  expect(githubAvatarUrl('265501495+squiggler-app[bot]@users.noreply.github.com', 66)).toBe(
+    'https://avatars.githubusercontent.com/u/265501495?s=66&v=4',
+  )
+})
+
+test('resolves old-style GitHub noreply emails via the login', () => {
+  expect(githubAvatarUrl('bjoerge@users.noreply.github.com', 66)).toBe(
+    'https://github.com/bjoerge.png?size=66',
+  )
+})
+
+test('returns undefined for regular emails (gravatar handles those)', () => {
+  expect(githubAvatarUrl('ada@example.com', 66)).toBeUndefined()
+  expect(githubAvatarUrl('someone@users.noreply.gitlab.com', 66)).toBeUndefined()
+})

--- a/dev/metrics-studio/tools/bisect/useGravatar.ts
+++ b/dev/metrics-studio/tools/bisect/useGravatar.ts
@@ -1,0 +1,78 @@
+import {useCallback, useEffect, useSyncExternalStore} from 'react'
+
+/**
+ * Gravatar URL for a commit author. Gravatar accepts SHA-256 email hashes, so
+ * Web Crypto covers it without an md5 dependency — but `crypto.subtle` is
+ * async, hence a module-level hash cache (one digest per distinct email per
+ * session). The cache is read through `useSyncExternalStore`: a plain render
+ * read of a mutable Map is impure, and the React Compiler may legitimately
+ * memoize it away so the value never updates once the digest lands.
+ * `d=identicon` gives bots and non-gravatar users a deterministic pattern
+ * instead of a broken image.
+ */
+
+/**
+ * GitHub noreply addresses (`12345+login@users.noreply.github.com`, or the
+ * old `login@users.noreply.github.com`) never have a gravatar — but they name
+ * the GitHub account, whose real avatar we can use directly (and
+ * synchronously). Most commits in this repo use these.
+ */
+const GITHUB_NOREPLY_RE = /^(?:(\d+)\+)?([^@+]+)@users\.noreply\.github\.com$/
+
+export function githubAvatarUrl(email: string, size: number): string | undefined {
+  const match = GITHUB_NOREPLY_RE.exec(email)
+  if (!match) return undefined
+  const [, id, login] = match
+  return id
+    ? `https://avatars.githubusercontent.com/u/${id}?s=${size}&v=4`
+    : `https://github.com/${encodeURIComponent(login)}.png?size=${size}`
+}
+
+const hashCache = new Map<string, string>()
+const listeners = new Set<() => void>()
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export function useAuthorAvatarUrl(
+  author: {avatarUrl?: string; email?: string; login?: string},
+  size = 66,
+): string | undefined {
+  const normalized = author.email?.trim().toLowerCase()
+  // Priority: GitHub's own avatarUrl (collected by the sync — the only
+  // correct source for bots, whose avatars live under /in/<app-id>), then a
+  // noreply-email parse, then the synced login, then gravatar.
+  const github =
+    author.avatarUrl ??
+    (normalized ? githubAvatarUrl(normalized, size) : undefined) ??
+    (author.login
+      ? `https://github.com/${encodeURIComponent(author.login)}.png?size=${size}`
+      : undefined)
+  const hash = useSyncExternalStore(
+    subscribe,
+    useCallback(() => (normalized ? hashCache.get(normalized) : undefined), [normalized]),
+  )
+
+  useEffect(() => {
+    // GitHub-resolvable emails never need the gravatar digest
+    if (!normalized || github || hashCache.has(normalized)) return undefined
+    let cancelled = false
+    void sha256Hex(normalized).then((digest) => {
+      hashCache.set(normalized, digest)
+      if (!cancelled) for (const listener of listeners) listener()
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [normalized, github])
+
+  if (github) return github
+  return hash ? `https://www.gravatar.com/avatar/${hash}?d=identicon&s=${size}` : undefined
+}

--- a/dev/metrics-studio/tools/releases/AddRegressionDialog.tsx
+++ b/dev/metrics-studio/tools/releases/AddRegressionDialog.tsx
@@ -1,0 +1,153 @@
+import {Box, Button, Card, Dialog, Flex, Select, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+import {useMemo, useState} from 'react'
+
+import {type BisectCommit, buildChain} from '../bisect/bisect'
+import {type TagSlice} from '../bisect/data'
+import {type ManualRegressionInput} from '../bisect/sessions'
+import {pluralize} from '../bisect/text'
+import {baseTagOf} from './releaseInfo'
+
+/**
+ * Report a regression by hand when the introducing release is already known
+ * (a user report, a support ticket) and no bisect was run. The record is a
+ * bisectSession converged from birth — see reportRegression in
+ * tools/bisect/sessions.ts — so creation needs the same ingredients a
+ * releases-only bisect would end with: the blamed release, its base release,
+ * and the commits between them as suspects. Releases whose base can't be
+ * resolved on the synced mainline (off-mainline cuts, the sync cutoff) can't
+ * be encoded that way and are called out instead of silently allowed.
+ */
+export function AddRegressionDialog(props: {
+  tags: TagSlice[]
+  commitsBySha: Map<string, BisectCommit>
+  createdBy: string
+  onClose: () => void
+  /** Must settle (the tool toasts failures) — the submit stays disabled until it does. */
+  onCreate: (input: ManualRegressionInput) => Promise<unknown>
+}) {
+  const {tags, commitsBySha, createdBy, onClose, onCreate} = props
+  const [selectedTagName, setSelectedTagName] = useState('')
+  const [description, setDescription] = useState('')
+  const [linearIssue, setLinearIssue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const tagBySha = useMemo(() => new Map(tags.map((tag) => [tag.sha, tag.tag])), [tags])
+  const selected = tags.find((tag) => tag.tag === selectedTagName)
+
+  // The blamed release's endpoints: base release → this release, with the
+  // commits strictly between as suspects (chain[0] is the bad endpoint,
+  // chain[last] the good one)
+  const encoded = useMemo(() => {
+    if (!selected) return null
+    const baseTagName = baseTagOf(commitsBySha, tagBySha, selected)
+    const baseTag = baseTagName ? tags.find((tag) => tag.tag === baseTagName) : undefined
+    if (!baseTag) return {ok: false as const}
+    const chain = buildChain(commitsBySha, baseTag.sha, selected.sha)
+    if (!chain.ok) return {ok: false as const}
+    return {
+      ok: true as const,
+      baseTag,
+      suspectShas: chain.chain.slice(1, -1).map((commit) => commit.sha),
+    }
+  }, [selected, commitsBySha, tagBySha, tags])
+
+  const blocked = !selected || !encoded?.ok || description.trim() === ''
+
+  return (
+    <Dialog id="releases-add-regression" header="Add regression" width={1} onClose={onClose}>
+      <Box padding={4}>
+        <Stack gap={4}>
+          <Text size={1} muted>
+            Pin a regression on the release that introduced it — for issues found outside a bisect
+            (user reports, support tickets). It is recorded as a concluded bisect session, so it
+            counts in the regression badge and can be drilled into later.
+          </Text>
+
+          <Stack gap={2}>
+            <Text size={1} weight="medium">
+              Introduced in
+            </Text>
+            <Select
+              fontSize={1}
+              value={selectedTagName}
+              onChange={(event) => setSelectedTagName(event.currentTarget.value)}
+            >
+              <option value="">Pick a release…</option>
+              {tags.map((tag) => (
+                <option key={tag._id} value={tag.tag}>
+                  {tag.tag} ({tag.taggedAt.slice(0, 10)})
+                </option>
+              ))}
+            </Select>
+          </Stack>
+
+          {selected && encoded && !encoded.ok && (
+            <Card padding={3} radius={2} tone="caution">
+              <Text size={1}>
+                {selected.tag} has no resolvable previous release on the synced mainline
+                (off-mainline cut, or before the sync cutoff) — its regressions can't be recorded
+                here.
+              </Text>
+            </Card>
+          )}
+          {selected && encoded?.ok && (
+            <Text size={1} muted>
+              Recorded as {encoded.baseTag.tag} → {selected.tag}
+              {encoded.suspectShas.length > 0
+                ? `, with the ${pluralize(encoded.suspectShas.length, 'commit')} between them as suspects.`
+                : '.'}
+            </Text>
+          )}
+
+          <Stack gap={2}>
+            <Text size={1} weight="medium">
+              What broke
+            </Text>
+            <TextArea
+              rows={2}
+              fontSize={1}
+              placeholder="Describe the regression…"
+              value={description}
+              onChange={(event) => setDescription(event.currentTarget.value)}
+            />
+          </Stack>
+
+          <Stack gap={2}>
+            <Text size={1} weight="medium">
+              Linear issue (optional)
+            </Text>
+            <TextInput
+              fontSize={1}
+              placeholder="e.g. SAPP-1234"
+              value={linearIssue}
+              onChange={(event) => setLinearIssue(event.currentTarget.value)}
+            />
+          </Stack>
+
+          <Flex gap={2} justify="flex-end">
+            <Button mode="ghost" text="Cancel" onClick={onClose} />
+            <Button
+              tone="critical"
+              text={submitting ? 'Adding…' : 'Add regression'}
+              disabled={blocked || submitting}
+              onClick={() => {
+                if (!selected || !encoded?.ok || submitting) return
+                setSubmitting(true)
+                // On success the tool unmounts this dialog; on failure the
+                // button re-arms next to the error toast
+                void onCreate({
+                  good: {sha: encoded.baseTag.sha, label: encoded.baseTag.tag},
+                  bad: {sha: selected.sha, label: selected.tag},
+                  suspectShas: encoded.suspectShas,
+                  description: description.trim(),
+                  linearIssue: linearIssue.trim() || undefined,
+                  createdBy,
+                }).finally(() => setSubmitting(false))
+              }}
+            />
+          </Flex>
+        </Stack>
+      </Box>
+    </Dialog>
+  )
+}

--- a/dev/metrics-studio/tools/releases/ReleasesTool.tsx
+++ b/dev/metrics-studio/tools/releases/ReleasesTool.tsx
@@ -1,9 +1,12 @@
+import {AddIcon} from '@sanity/icons/Add'
 import {LaunchIcon} from '@sanity/icons/Launch'
-import {Badge, Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
-import {useMemo} from 'react'
+import {Badge, Box, Button, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {useToast} from '@sanity/ui/toast'
+import {useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {catchError, map, of} from 'rxjs'
-import {useDocumentStore} from 'sanity'
+import {useClient, useCurrentUser, useDocumentStore} from 'sanity'
+import {useIntentLink} from 'sanity/router'
 
 import {
   BISECT_COMMITS_QUERY,
@@ -15,8 +18,10 @@ import {
   toBisectCommit,
 } from '../bisect/data'
 import {RelativeDate} from '../bisect/RelativeDate'
+import {type ManualRegressionInput, reportRegression} from '../bisect/sessions'
 import {pluralize} from '../bisect/text'
 import {releaseUrl} from '../trends/links'
+import {AddRegressionDialog} from './AddRegressionDialog'
 import {baseVersionOf, changelogUrl, npmxUrl, regressionCountByTag} from './releaseInfo'
 
 interface LiveState<T> {
@@ -31,10 +36,15 @@ interface LiveState<T> {
  * sessions have attributed to it (blamed on the INTRODUCING release). The
  * changelog link needs the release's base version — the previous release on
  * the first-parent chain — so off-mainline releases (maintenance lines) may
- * lack it.
+ * lack it. Regressions found outside a bisect are added by hand via
+ * AddRegressionDialog, stored as born-converged bisect sessions.
  */
 export function ReleasesTool() {
   const documentStore = useDocumentStore()
+  const client = useClient({apiVersion: '2025-02-19'})
+  const currentUser = useCurrentUser()
+  const toast = useToast()
+  const [addingRegression, setAddingRegression] = useState(false)
 
   const tagsLive = useObservable(
     useMemo(
@@ -118,19 +128,45 @@ export function ReleasesTool() {
 
   const error = tagsLive.error ?? commitsLive.error ?? sessionsLive.error
 
+  const userName = currentUser?.name ?? currentUser?.email ?? 'unknown'
+  // Async so the dialog can disable its submit until it settles
+  const handleAddRegression = async (input: ManualRegressionInput) => {
+    try {
+      await reportRegression(client, input)
+      setAddingRegression(false)
+    } catch (err) {
+      toast.push({
+        status: 'error',
+        title: 'Could not add the regression',
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
   return (
     <Box padding={4} style={{overflowY: 'auto', height: '100%'}}>
       <Container width={2}>
         <Stack gap={4}>
-          <Stack gap={3}>
-            <Text size={3} weight="semibold">
-              Releases
-            </Text>
-            <Text size={1} muted>
-              Every synced release tag with its npm state and the regressions bisect sessions have
-              pinned on it (blamed on the release that first shipped the offending commit).
-            </Text>
-          </Stack>
+          <Flex align="center" gap={3}>
+            <Box flex={1}>
+              <Stack gap={3}>
+                <Text size={3} weight="semibold">
+                  Studio Releases
+                </Text>
+                <Text size={1} muted>
+                  Every synced release tag with its npm state and the regressions bisect sessions
+                  have pinned on it (blamed on the release that first shipped the offending commit).
+                </Text>
+              </Stack>
+            </Box>
+            <Button
+              icon={AddIcon}
+              text="Add regression"
+              mode="ghost"
+              disabled={!tagsLive.data || !commitsLive.data}
+              onClick={() => setAddingRegression(true)}
+            />
+          </Flex>
 
           {error && (
             <Card padding={4} radius={3} tone="critical">
@@ -160,6 +196,16 @@ export function ReleasesTool() {
           ))}
         </Stack>
       </Container>
+
+      {addingRegression && (
+        <AddRegressionDialog
+          tags={tags}
+          commitsBySha={commitsBySha}
+          createdBy={userName}
+          onClose={() => setAddingRegression(false)}
+          onCreate={handleAddRegression}
+        />
+      )}
     </Box>
   )
 }
@@ -167,13 +213,18 @@ export function ReleasesTool() {
 function ReleaseRow(props: {tag: TagSlice; baseVersion: string | undefined; regressions: number}) {
   const {tag, baseVersion, regressions} = props
   const version = tag.tag.replace(/^v/, '')
+  // The version opens the gitTag document in the structure tool — the raw
+  // synced record behind the row
+  const documentLink = useIntentLink({intent: 'edit', params: {id: tag._id, type: 'gitTag'}})
 
   return (
     <Card padding={3} radius={2} border>
       <Flex align="center" gap={3} wrap="wrap">
         <Box style={{width: 110, flexShrink: 0}}>
           <Text size={2} weight="medium">
-            {tag.tag}
+            <a href={documentLink.href} onClick={documentLink.onClick}>
+              {tag.tag}
+            </a>
           </Text>
         </Box>
         {tag.npm?.distTags?.map((distTag) => (

--- a/dev/metrics-studio/tools/releases/ReleasesTool.tsx
+++ b/dev/metrics-studio/tools/releases/ReleasesTool.tsx
@@ -1,0 +1,218 @@
+import {LaunchIcon} from '@sanity/icons/Launch'
+import {Badge, Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, of} from 'rxjs'
+import {useDocumentStore} from 'sanity'
+
+import {
+  BISECT_COMMITS_QUERY,
+  BISECT_SESSIONS_QUERY,
+  BISECT_TAGS_QUERY,
+  type GitCommitSlice,
+  type SessionSummary,
+  type TagSlice,
+  toBisectCommit,
+} from '../bisect/data'
+import {RelativeDate} from '../bisect/RelativeDate'
+import {pluralize} from '../bisect/text'
+import {releaseUrl} from '../trends/links'
+import {baseVersionOf, changelogUrl, npmxUrl, regressionCountByTag} from './releaseInfo'
+
+interface LiveState<T> {
+  data: T | null
+  error: string | null
+}
+
+/**
+ * Every release, newest first: when it shipped (npm publish time when known),
+ * which dist-tags point at it, weekly downloads, links out (GitHub release,
+ * sanity.io changelog, npmx.dev), and how many confirmed regressions bisect
+ * sessions have attributed to it (blamed on the INTRODUCING release). The
+ * changelog link needs the release's base version — the previous release on
+ * the first-parent chain — so off-mainline releases (maintenance lines) may
+ * lack it.
+ */
+export function ReleasesTool() {
+  const documentStore = useDocumentStore()
+
+  const tagsLive = useObservable(
+    useMemo(
+      () =>
+        documentStore.listenQuery(BISECT_TAGS_QUERY, {}, {tag: 'metrics.releases.tags'}).pipe(
+          map((result): LiveState<TagSlice[]> => ({data: result as TagSlice[], error: null})),
+          catchError((error: unknown) =>
+            of<LiveState<TagSlice[]>>({
+              data: null,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          ),
+        ),
+      [documentStore],
+    ),
+    {data: null, error: null},
+  )
+
+  const commitsLive = useObservable(
+    useMemo(
+      () =>
+        documentStore.listenQuery(BISECT_COMMITS_QUERY, {}, {tag: 'metrics.releases.commits'}).pipe(
+          map((result): LiveState<GitCommitSlice[]> => ({
+            data: result as GitCommitSlice[],
+            error: null,
+          })),
+          catchError((error: unknown) =>
+            of<LiveState<GitCommitSlice[]>>({
+              data: null,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          ),
+        ),
+      [documentStore],
+    ),
+    {data: null, error: null},
+  )
+
+  const sessionsLive = useObservable(
+    useMemo(
+      () =>
+        documentStore
+          .listenQuery(BISECT_SESSIONS_QUERY, {}, {tag: 'metrics.releases.sessions'})
+          .pipe(
+            map((result): LiveState<SessionSummary[]> => ({
+              data: result as SessionSummary[],
+              error: null,
+            })),
+            catchError((error: unknown) =>
+              of<LiveState<SessionSummary[]>>({
+                data: null,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            ),
+          ),
+      [documentStore],
+    ),
+    {data: null, error: null},
+  )
+
+  const commitsBySha = useMemo(
+    () => new Map((commitsLive.data ?? []).map((slice) => [slice.sha, toBisectCommit(slice)])),
+    [commitsLive.data],
+  )
+  const tags = useMemo(() => tagsLive.data ?? [], [tagsLive.data])
+  const tagBySha = useMemo(() => new Map(tags.map((tag) => [tag.sha, tag.tag])), [tags])
+
+  // Per-release base version (an O(chain) ancestry walk) — precomputed once
+  // instead of per row per render across three live queries
+  const baseVersions = useMemo(
+    () => new Map(tags.map((tag) => [tag.tag, baseVersionOf(commitsBySha, tagBySha, tag)])),
+    [tags, commitsBySha, tagBySha],
+  )
+
+  const regressionCounts = useMemo(() => {
+    const firstBadShas = (sessionsLive.data ?? [])
+      .filter((session) => session.result?.regression && session.result.firstBadSha)
+      .map((session) => session.result!.firstBadSha!)
+    return regressionCountByTag(commitsBySha, tags, firstBadShas)
+  }, [sessionsLive.data, commitsBySha, tags])
+
+  const error = tagsLive.error ?? commitsLive.error ?? sessionsLive.error
+
+  return (
+    <Box padding={4} style={{overflowY: 'auto', height: '100%'}}>
+      <Container width={2}>
+        <Stack gap={4}>
+          <Stack gap={3}>
+            <Text size={3} weight="semibold">
+              Releases
+            </Text>
+            <Text size={1} muted>
+              Every synced release tag with its npm state and the regressions bisect sessions have
+              pinned on it (blamed on the release that first shipped the offending commit).
+            </Text>
+          </Stack>
+
+          {error && (
+            <Card padding={4} radius={3} tone="critical">
+              <Text size={1}>Failed to load: {error}</Text>
+            </Card>
+          )}
+          {!error && tagsLive.data === null && (
+            <Text size={1} muted>
+              Loading…
+            </Text>
+          )}
+          {tagsLive.data?.length === 0 && (
+            <Card padding={4} radius={3} tone="transparent" border>
+              <Text size={1} muted>
+                No releases synced yet — the sync-git-metrics workflow populates these.
+              </Text>
+            </Card>
+          )}
+
+          {tags.map((tag) => (
+            <ReleaseRow
+              key={tag._id}
+              tag={tag}
+              baseVersion={baseVersions.get(tag.tag)}
+              regressions={regressionCounts.get(tag.tag) ?? 0}
+            />
+          ))}
+        </Stack>
+      </Container>
+    </Box>
+  )
+}
+
+function ReleaseRow(props: {tag: TagSlice; baseVersion: string | undefined; regressions: number}) {
+  const {tag, baseVersion, regressions} = props
+  const version = tag.tag.replace(/^v/, '')
+
+  return (
+    <Card padding={3} radius={2} border>
+      <Flex align="center" gap={3} wrap="wrap">
+        <Box style={{width: 110, flexShrink: 0}}>
+          <Text size={2} weight="medium">
+            {tag.tag}
+          </Text>
+        </Box>
+        {tag.npm?.distTags?.map((distTag) => (
+          <Badge key={distTag} tone="primary" fontSize={0}>
+            {distTag}
+          </Badge>
+        ))}
+        {regressions > 0 && (
+          <Badge tone="critical" fontSize={0}>
+            {pluralize(regressions, 'regression')}
+          </Badge>
+        )}
+        <Box flex={1} />
+        {typeof tag.npm?.weeklyDownloads === 'number' && (
+          <Text size={0} muted>
+            {tag.npm.weeklyDownloads.toLocaleString('en-US')}/wk
+          </Text>
+        )}
+        <RelativeDate dateTime={tag.npm?.publishedAt ?? tag.taggedAt} size={0} muted />
+        <Flex gap={3}>
+          <Text size={1}>
+            <a href={releaseUrl(tag.tag)} target="_blank" rel="noreferrer">
+              GitHub
+            </a>
+          </Text>
+          {baseVersion && (
+            <Text size={1}>
+              <a href={changelogUrl(baseVersion)} target="_blank" rel="noreferrer">
+                Changelog
+              </a>
+            </Text>
+          )}
+          <Text size={1}>
+            <a href={npmxUrl(version)} target="_blank" rel="noreferrer">
+              npmx <LaunchIcon />
+            </a>
+          </Text>
+        </Flex>
+      </Flex>
+    </Card>
+  )
+}

--- a/dev/metrics-studio/tools/releases/index.ts
+++ b/dev/metrics-studio/tools/releases/index.ts
@@ -1,0 +1,12 @@
+import {PackageIcon} from '@sanity/icons/Package'
+import {type Tool} from 'sanity'
+
+import {ReleasesTool} from './ReleasesTool'
+
+/** Release tags with npm state, links out, and attributed regressions — see ReleasesTool. */
+export const releasesTool: Tool = {
+  name: 'releases',
+  title: 'Releases',
+  icon: PackageIcon,
+  component: ReleasesTool,
+}

--- a/dev/metrics-studio/tools/releases/index.ts
+++ b/dev/metrics-studio/tools/releases/index.ts
@@ -6,7 +6,7 @@ import {ReleasesTool} from './ReleasesTool'
 /** Release tags with npm state, links out, and attributed regressions — see ReleasesTool. */
 export const releasesTool: Tool = {
   name: 'releases',
-  title: 'Releases',
+  title: 'Studio Releases',
   icon: PackageIcon,
   component: ReleasesTool,
 }

--- a/dev/metrics-studio/tools/releases/releaseInfo.test.ts
+++ b/dev/metrics-studio/tools/releases/releaseInfo.test.ts
@@ -1,0 +1,54 @@
+import {expect, test} from 'vitest'
+
+import {type BisectCommit} from '../bisect/bisect'
+import {baseVersionOf, changelogUrl, npmxUrl, regressionCountByTag} from './releaseInfo'
+
+function sha(index: number): string {
+  return index.toString(16).repeat(40).slice(0, 40)
+}
+
+function chainOf(length: number): BisectCommit[] {
+  return Array.from({length}, (_, index) => ({
+    sha: sha(index),
+    parentSha: index + 1 < length ? sha(index + 1) : undefined,
+    subject: `commit ${index}`,
+    committedAt: `2026-08-${String(20 - index).padStart(2, '0')}T12:00:00Z`,
+  }))
+}
+
+const bySha = (commits: BisectCommit[]) => new Map(commits.map((c) => [c.sha, c]))
+
+test('changelogUrl encodes the base version the way release automation does', () => {
+  // Verified live: sanity.io/changelog/studio-Ni4xMC4w is v6.10.1's changelog
+  expect(changelogUrl('6.10.0')).toBe('https://www.sanity.io/changelog/studio-Ni4xMC4w')
+})
+
+test('npmxUrl points at the canonical version page', () => {
+  expect(npmxUrl('6.10.1')).toBe('https://npmx.dev/package/sanity/v/6.10.1')
+})
+
+test('baseVersionOf walks first parents to the previous release', () => {
+  const commits = chainOf(10)
+  const tagBySha = new Map([
+    [sha(1), 'v2.1.0'],
+    [sha(5), 'v2.0.0'],
+  ])
+  expect(baseVersionOf(bySha(commits), tagBySha, {sha: sha(1)})).toBe('2.0.0')
+  // oldest tag walks off the cutoff without finding a predecessor
+  expect(baseVersionOf(bySha(commits), tagBySha, {sha: sha(5)})).toBeUndefined()
+  // off-mainline tag can't even start the walk
+  expect(baseVersionOf(bySha(commits), tagBySha, {sha: 'f'.repeat(40)})).toBeUndefined()
+})
+
+test('regressionCountByTag blames the introducing release', () => {
+  const commits = chainOf(10)
+  const tags = [
+    {tag: 'v2.1.0', sha: sha(1), taggedAt: '2026-08-19T00:00:00Z'},
+    {tag: 'v2.0.0', sha: sha(5), taggedAt: '2026-08-15T00:00:00Z'},
+  ]
+  // c3 first shipped in v2.1.0, c7 in v2.0.0, c0 is unreleased
+  const counts = regressionCountByTag(bySha(commits), tags, [sha(3), sha(7), sha(3), sha(0)])
+  expect(counts.get('v2.1.0')).toBe(2)
+  expect(counts.get('v2.0.0')).toBe(1)
+  expect(counts.size).toBe(2)
+})

--- a/dev/metrics-studio/tools/releases/releaseInfo.test.ts
+++ b/dev/metrics-studio/tools/releases/releaseInfo.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from 'vitest'
 
 import {type BisectCommit} from '../bisect/bisect'
-import {baseVersionOf, changelogUrl, npmxUrl, regressionCountByTag} from './releaseInfo'
+import {baseTagOf, baseVersionOf, changelogUrl, npmxUrl, regressionCountByTag} from './releaseInfo'
 
 function sha(index: number): string {
   return index.toString(16).repeat(40).slice(0, 40)
@@ -34,6 +34,9 @@ test('baseVersionOf walks first parents to the previous release', () => {
     [sha(5), 'v2.0.0'],
   ])
   expect(baseVersionOf(bySha(commits), tagBySha, {sha: sha(1)})).toBe('2.0.0')
+  // baseTagOf is the same walk but keeps the tag name (AddRegressionDialog
+  // uses it to find the base TagSlice by name)
+  expect(baseTagOf(bySha(commits), tagBySha, {sha: sha(1)})).toBe('v2.0.0')
   // oldest tag walks off the cutoff without finding a predecessor
   expect(baseVersionOf(bySha(commits), tagBySha, {sha: sha(5)})).toBeUndefined()
   // off-mainline tag can't even start the walk

--- a/dev/metrics-studio/tools/releases/releaseInfo.ts
+++ b/dev/metrics-studio/tools/releases/releaseInfo.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure helpers for the Releases tool: external URLs per release and the
+ * regression attribution (which release first shipped each confirmed
+ * regression, per the bisect sessions).
+ */
+import {type BisectCommit, type ReleaseTag, releasesContaining} from '../bisect/bisect'
+
+/**
+ * The sanity.io changelog URL for a release. The changelog document id is
+ * derived from the release's BASE version — the previous release on the
+ * first-parent chain, exactly what release automation computes with
+ * `git describe` (see packages/@repo/release-notes/src/utils/ids.ts, which
+ * base64url-encodes it into `studio-<...>`).
+ */
+export function changelogUrl(baseVersion: string): string {
+  const encoded = btoa(baseVersion).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return `https://www.sanity.io/changelog/studio-${encoded}`
+}
+
+export function npmxUrl(version: string): string {
+  return `https://npmx.dev/package/sanity/v/${encodeURIComponent(version)}`
+}
+
+/**
+ * The previous release on the first-parent chain — the release automation's
+ * "base version" for a tag. Undefined when the walk leaves the synced set
+ * (off-mainline tags) or hits the sync cutoff before another tag.
+ */
+export function baseVersionOf(
+  commitsBySha: Map<string, BisectCommit>,
+  tagBySha: Map<string, string>,
+  tag: {sha: string},
+): string | undefined {
+  const visited = new Set<string>()
+  let current = commitsBySha.get(tag.sha)
+  current = current?.parentSha ? commitsBySha.get(current.parentSha) : undefined
+  while (current && !visited.has(current.sha)) {
+    const found = tagBySha.get(current.sha)
+    if (found) return found.replace(/^v/, '')
+    visited.add(current.sha)
+    current = current.parentSha ? commitsBySha.get(current.parentSha) : undefined
+  }
+  return undefined
+}
+
+/**
+ * Count confirmed regressions per INTRODUCING release: for each first-bad
+ * sha from a regression-flagged bisect session, the oldest release whose
+ * ancestry contains it gets the blame. Shas no release contains (unreleased
+ * regressions) are not counted here.
+ */
+export function regressionCountByTag<T extends ReleaseTag>(
+  commitsBySha: Map<string, BisectCommit>,
+  tags: T[],
+  firstBadShas: string[],
+): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const sha of firstBadShas) {
+    const introducing = releasesContaining(commitsBySha, tags, sha)[0]
+    if (!introducing) continue
+    counts.set(introducing.tag, (counts.get(introducing.tag) ?? 0) + 1)
+  }
+  return counts
+}

--- a/dev/metrics-studio/tools/releases/releaseInfo.ts
+++ b/dev/metrics-studio/tools/releases/releaseInfo.ts
@@ -25,6 +25,15 @@ export function npmxUrl(version: string): string {
  * The previous release on the first-parent chain — the tag NAME (e.g.
  * "v6.10.0"). Undefined when the walk leaves the synced set (off-mainline
  * tags) or hits the sync cutoff before another tag.
+ *
+ * Prerelease tags are deliberately NOT skipped. This mirrors release
+ * automation's base-version computation (`git describe --first-parent
+ * --match "v*"` in @repo/release-notes bump.ts, which matches rc tags too),
+ * and the changelog URL derived from this value must reproduce the id that
+ * automation generated — filtering here would break the link whenever an rc
+ * ever lands on mainline. It also matches the blame model: releases are
+ * blamed for the commits they FIRST shipped, and an rc that shipped them
+ * first is the correct base for the span that follows it.
  */
 export function baseTagOf(
   commitsBySha: Map<string, BisectCommit>,

--- a/dev/metrics-studio/tools/releases/releaseInfo.ts
+++ b/dev/metrics-studio/tools/releases/releaseInfo.ts
@@ -22,11 +22,11 @@ export function npmxUrl(version: string): string {
 }
 
 /**
- * The previous release on the first-parent chain — the release automation's
- * "base version" for a tag. Undefined when the walk leaves the synced set
- * (off-mainline tags) or hits the sync cutoff before another tag.
+ * The previous release on the first-parent chain — the tag NAME (e.g.
+ * "v6.10.0"). Undefined when the walk leaves the synced set (off-mainline
+ * tags) or hits the sync cutoff before another tag.
  */
-export function baseVersionOf(
+export function baseTagOf(
   commitsBySha: Map<string, BisectCommit>,
   tagBySha: Map<string, string>,
   tag: {sha: string},
@@ -36,11 +36,24 @@ export function baseVersionOf(
   current = current?.parentSha ? commitsBySha.get(current.parentSha) : undefined
   while (current && !visited.has(current.sha)) {
     const found = tagBySha.get(current.sha)
-    if (found) return found.replace(/^v/, '')
+    if (found) return found
     visited.add(current.sha)
     current = current.parentSha ? commitsBySha.get(current.parentSha) : undefined
   }
   return undefined
+}
+
+/**
+ * The previous release as a bare VERSION ("6.10.0") — the release
+ * automation's "base version" for a tag, which the changelog URL is derived
+ * from.
+ */
+export function baseVersionOf(
+  commitsBySha: Map<string, BisectCommit>,
+  tagBySha: Map<string, string>,
+  tag: {sha: string},
+): string | undefined {
+  return baseTagOf(commitsBySha, tagBySha, tag)?.replace(/^v/, '')
 }
 
 /**

--- a/dev/metrics-studio/tools/trends/links.ts
+++ b/dev/metrics-studio/tools/trends/links.ts
@@ -25,6 +25,10 @@ export function ciRunUrl(runId: string, attempt?: number): string {
   return attempt && attempt > 1 ? `${base}/attempts/${attempt}` : base
 }
 
+export function releaseUrl(tag: string): string {
+  return `https://github.com/${REPO}/releases/tag/${encodeURIComponent(tag)}`
+}
+
 /**
  * GitHub compare view listing every commit between two runs' commits — the
  * question a suspicious step in a chart raises is "what landed between these


### PR DESCRIPTION
### Description

When a trend chart shows a step, naming the commit still means hand-running a binary search over test-studio preview builds. This adds a Bisect tool that guides that search over the synced mainline history: proposing the next `gitCommit.testStudioUrl` to test, halving per good/bad verdict.

Also adds a Studio Releases tool listing every release with dist-tags, downloads, changelog link, and the regressions bisect sessions have pinned on it. Sessions are stored as liveEdit `bisectSession` documents so a bisect can be shared, resumed, or recorded by hand for regressions found outside a bisect.

### What to review

`tools/bisect/bisect.ts` carries the search semantics (pure functions, tested). Everything else is dev-only studio UI under `dev/metrics-studio`.

### Testing

Unit tests cover the bisect engine, data layer, and release-info derivations (`pnpm vitest run --project=metrics-studio`); the UI was exercised manually against live data.

### Notes for release

N/A – Internal only

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to internal `dev/metrics-studio` tooling and user-owned bench dataset documents, with bisect logic covered by unit tests and https-only preview URL handling.
> 
> **Overview**
> Adds two investigation tools to **Metrics Studio** so engineers can move from “something broke on main” to a named commit or release without hand-running git bisect against preview deploys.
> 
> The **Bisect** tool walks the synced first-parent chain between good/bad endpoints (commits or release tags), proposes the next `gitCommit.testStudioUrl` to test, and persists progress in liveEdit **`bisectSession`** documents (marks log, optional releases-only mode, converged verdict with suspects for untestable commits). The UI includes session list/detail (`?session=`), timeline with gap compares, undo/conflict handling, and regression annotations.
> 
> The **Studio Releases** tool lists synced **`gitTag`** rows with npm dist-tags, downloads, changelog/npmx/GitHub links, and counts of confirmed regressions attributed to the release that first shipped the bad commit. **Add regression** creates a born-converged `bisectSession` when the introducing release is already known.
> 
> Studio wiring registers both tools (Trends → Releases → Bisect → structure), adds structure access for bisect sessions, registers the schema, and documents Bisect/Releases (plus release-marker behavior) in **`SPEC.md`**. Shared **`releaseUrl`** is added in trends links for release deep links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6653e0822695ff5b78f12f254c64cd059758b36f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->