### PR TITLE
chore(core): events store unit tests

### DIFF
--- a/packages/sanity/src/core/store/events/__fixtures__/collect.fixture.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/collect.fixture.ts
@@ -1,0 +1,14 @@
+import {type Observable, type Subscription} from 'rxjs'
+
+/**
+ * Subscribes to `observable` and collects every emission into `values`. Combine with
+ * `vi.waitFor` to await async emissions, and remember to unsubscribe.
+ */
+export function collectEmissions<T>(observable: Observable<T>): {
+  values: T[]
+  subscription: Subscription
+} {
+  const values: T[] = []
+  const subscription = observable.subscribe((value) => values.push(value))
+  return {values, subscription}
+}

--- a/packages/sanity/src/core/store/events/__fixtures__/events.fixture.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/events.fixture.ts
@@ -4,7 +4,6 @@ import {
   type DeleteDocumentGroupEvent,
   type DeleteDocumentVersionEvent,
   type EditDocumentVersionEvent,
-  type HistoryClearedEvent,
   type PublishDocumentVersionEvent,
   type ScheduleDocumentVersionEvent,
   type UnpublishDocumentEvent,
@@ -24,7 +23,7 @@ export function minutesAfterBase(minutes: number, time: string = BASE_TIME): str
 
 export const DOCUMENT_ID = 'doc-1'
 export const DRAFT_ID = `drafts.${DOCUMENT_ID}`
-export const RELEASE_ID = 'rSomeRelease'
+const RELEASE_ID = 'rSomeRelease'
 export const VERSION_ID = `versions.${RELEASE_ID}.${DOCUMENT_ID}`
 
 export function createDocumentVersionEvent(
@@ -194,20 +193,6 @@ export function editDocumentVersionEvent(
         revisionId,
       },
     ],
-    ...overrides,
-  }
-}
-
-export function historyClearedEvent(
-  overrides: Partial<HistoryClearedEvent> = {},
-): HistoryClearedEvent {
-  return {
-    type: 'historyCleared',
-    id: 'history-cleared',
-    timestamp: BASE_TIME,
-    author: 'author-1',
-    documentVariantType: 'draft',
-    documentId: DOCUMENT_ID,
     ...overrides,
   }
 }

--- a/packages/sanity/src/core/store/events/__fixtures__/events.fixture.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/events.fixture.ts
@@ -1,0 +1,213 @@
+import {
+  type CreateDocumentVersionEvent,
+  type CreateLiveDocumentEvent,
+  type DeleteDocumentGroupEvent,
+  type DeleteDocumentVersionEvent,
+  type EditDocumentVersionEvent,
+  type HistoryClearedEvent,
+  type PublishDocumentVersionEvent,
+  type ScheduleDocumentVersionEvent,
+  type UnpublishDocumentEvent,
+  type UnscheduleDocumentVersionEvent,
+  type UpdateLiveDocumentEvent,
+} from '../types'
+
+/**
+ * Deterministic base timestamp shared by all fixtures. Use {@link minutesAfterBase} to derive
+ * timestamps relative to it (useful for merge-window tests, which use a 5 minute window).
+ */
+export const BASE_TIME = '2024-01-01T00:00:00.000Z'
+
+export function minutesAfterBase(minutes: number, time: string = BASE_TIME): string {
+  return new Date(Date.parse(time) + minutes * 60_000).toISOString()
+}
+
+export const DOCUMENT_ID = 'doc-1'
+export const DRAFT_ID = `drafts.${DOCUMENT_ID}`
+export const RELEASE_ID = 'rSomeRelease'
+export const VERSION_ID = `versions.${RELEASE_ID}.${DOCUMENT_ID}`
+
+export function createDocumentVersionEvent(
+  overrides: Partial<CreateDocumentVersionEvent> = {},
+): CreateDocumentVersionEvent {
+  return {
+    type: 'createDocumentVersion',
+    id: 'tx-create',
+    timestamp: BASE_TIME,
+    author: 'author-1',
+    documentVariantType: 'draft',
+    documentId: DOCUMENT_ID,
+    versionId: DRAFT_ID,
+    versionRevisionId: 'tx-create',
+    ...overrides,
+  }
+}
+
+export function deleteDocumentVersionEvent(
+  overrides: Partial<DeleteDocumentVersionEvent> = {},
+): DeleteDocumentVersionEvent {
+  return {
+    type: 'deleteDocumentVersion',
+    id: 'tx-delete-version',
+    timestamp: minutesAfterBase(10),
+    author: 'author-1',
+    documentVariantType: 'draft',
+    documentId: DOCUMENT_ID,
+    versionId: DRAFT_ID,
+    versionRevisionId: 'tx-delete-version',
+    ...overrides,
+  }
+}
+
+export function publishDocumentVersionEvent(
+  overrides: Partial<PublishDocumentVersionEvent> = {},
+): PublishDocumentVersionEvent {
+  return {
+    type: 'publishDocumentVersion',
+    id: 'tx-publish',
+    timestamp: minutesAfterBase(20),
+    author: 'author-1',
+    documentVariantType: 'published',
+    documentId: DOCUMENT_ID,
+    revisionId: 'tx-publish',
+    versionId: DRAFT_ID,
+    versionRevisionId: 'tx-before-publish',
+    publishCause: 'document.publish',
+    ...overrides,
+  }
+}
+
+export function unpublishDocumentEvent(
+  overrides: Partial<UnpublishDocumentEvent> = {},
+): UnpublishDocumentEvent {
+  return {
+    type: 'unpublishDocument',
+    id: 'tx-unpublish',
+    timestamp: minutesAfterBase(30),
+    author: 'author-1',
+    documentVariantType: 'published',
+    documentId: DOCUMENT_ID,
+    versionId: DRAFT_ID,
+    versionRevisionId: 'tx-unpublish',
+    ...overrides,
+  }
+}
+
+export function scheduleDocumentVersionEvent(
+  overrides: Partial<ScheduleDocumentVersionEvent> = {},
+): ScheduleDocumentVersionEvent {
+  return {
+    type: 'scheduleDocumentVersion',
+    id: 'tx-schedule',
+    timestamp: minutesAfterBase(40),
+    author: 'author-1',
+    documentVariantType: 'version',
+    documentId: DOCUMENT_ID,
+    releaseId: RELEASE_ID,
+    versionId: VERSION_ID,
+    versionRevisionId: 'tx-schedule',
+    state: 'pending',
+    publishAt: minutesAfterBase(60),
+    ...overrides,
+  }
+}
+
+export function unscheduleDocumentVersionEvent(
+  overrides: Partial<UnscheduleDocumentVersionEvent> = {},
+): UnscheduleDocumentVersionEvent {
+  return {
+    type: 'unscheduleDocumentVersion',
+    id: 'tx-unschedule',
+    timestamp: minutesAfterBase(50),
+    author: 'author-1',
+    documentVariantType: 'version',
+    documentId: DOCUMENT_ID,
+    releaseId: RELEASE_ID,
+    versionId: VERSION_ID,
+    versionRevisionId: 'tx-unschedule',
+    ...overrides,
+  }
+}
+
+export function deleteDocumentGroupEvent(
+  overrides: Partial<DeleteDocumentGroupEvent> = {},
+): DeleteDocumentGroupEvent {
+  return {
+    type: 'deleteDocumentGroup',
+    id: 'tx-delete-group',
+    timestamp: minutesAfterBase(60),
+    author: 'author-1',
+    documentVariantType: 'published',
+    documentId: DOCUMENT_ID,
+    ...overrides,
+  }
+}
+
+export function createLiveDocumentEvent(
+  overrides: Partial<CreateLiveDocumentEvent> = {},
+): CreateLiveDocumentEvent {
+  return {
+    type: 'createLiveDocument',
+    id: 'tx-create-live',
+    timestamp: BASE_TIME,
+    author: 'author-1',
+    documentVariantType: 'published',
+    documentId: DOCUMENT_ID,
+    revisionId: 'tx-create-live',
+    ...overrides,
+  }
+}
+
+export function updateLiveDocumentEvent(
+  overrides: Partial<UpdateLiveDocumentEvent> = {},
+): UpdateLiveDocumentEvent {
+  return {
+    type: 'updateLiveDocument',
+    id: 'tx-update-live',
+    timestamp: minutesAfterBase(10),
+    author: 'author-1',
+    documentVariantType: 'published',
+    documentId: DOCUMENT_ID,
+    revisionId: 'tx-update-live',
+    ...overrides,
+  }
+}
+
+export function editDocumentVersionEvent(
+  overrides: Partial<EditDocumentVersionEvent> = {},
+): EditDocumentVersionEvent {
+  const revisionId = overrides.revisionId ?? 'tx-edit'
+  return {
+    type: 'editDocumentVersion',
+    id: revisionId,
+    timestamp: minutesAfterBase(5),
+    author: 'author-1',
+    documentVariantType: 'draft',
+    documentId: DOCUMENT_ID,
+    contributors: ['author-1'],
+    revisionId,
+    transactions: [
+      {
+        type: 'editTransaction',
+        author: 'author-1',
+        timestamp: minutesAfterBase(5),
+        revisionId,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+export function historyClearedEvent(
+  overrides: Partial<HistoryClearedEvent> = {},
+): HistoryClearedEvent {
+  return {
+    type: 'historyCleared',
+    id: 'history-cleared',
+    timestamp: BASE_TIME,
+    author: 'author-1',
+    documentVariantType: 'draft',
+    documentId: DOCUMENT_ID,
+    ...overrides,
+  }
+}

--- a/packages/sanity/src/core/store/events/__fixtures__/fixtures.test.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/fixtures.test.ts
@@ -3,11 +3,11 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import {getTransactionsLogs} from '../../translog/getTransactionsLogs'
 import {getEffectState} from '../getEditEvents'
+import {DRAFT_ID} from './events.fixture'
 import {createMockClient, createTranslogFetchStub} from './mockClient'
 import {
   createTransaction,
   deleteTransaction,
-  DRAFT_ID,
   editTransaction,
   effectPair,
 } from './transactions.fixture'

--- a/packages/sanity/src/core/store/events/__fixtures__/fixtures.test.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/fixtures.test.ts
@@ -1,0 +1,96 @@
+import {applyPatch} from 'mendoza'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {getTransactionsLogs} from '../../translog/getTransactionsLogs'
+import {getEffectState} from '../getEditEvents'
+import {createMockClient, createTranslogFetchStub} from './mockClient'
+import {
+  createTransaction,
+  deleteTransaction,
+  DRAFT_ID,
+  editTransaction,
+  effectPair,
+} from './transactions.fixture'
+
+describe('transactions.fixture', () => {
+  it('produces effect pairs that getEffectState classifies as expected', () => {
+    expect(getEffectState(editTransaction().effects[DRAFT_ID])).toBe('modified')
+    expect(getEffectState(createTransaction().effects[DRAFT_ID])).toBe('created')
+    expect(getEffectState(deleteTransaction().effects[DRAFT_ID])).toBe('deleted')
+    expect(getEffectState(undefined)).toBe('noop')
+  })
+
+  it('produces mendoza patches that replay with applyPatch', () => {
+    const before = {_id: DRAFT_ID, name: 'before'}
+    const after = {_id: DRAFT_ID, name: 'after'}
+    const {apply, revert} = effectPair({before, after})
+
+    expect(applyPatch(before, apply)).toEqual(after)
+    expect(applyPatch(after, revert)).toEqual(before)
+  })
+})
+
+describe('createMockClient', () => {
+  it('records requests and routes responses through respond', async () => {
+    const {client, requests} = createMockClient({
+      respond: (request) => ({echo: request.url}),
+    })
+
+    const response = await new Promise((resolve) => {
+      client.observable.request({url: '/data/test', tag: 'test-tag'}).subscribe(resolve)
+    })
+
+    expect(response).toEqual({echo: '/data/test'})
+    expect(requests).toEqual([{url: '/data/test', tag: 'test-tag'}])
+  })
+
+  it('emits an error when respond throws', async () => {
+    const {client} = createMockClient({
+      respond: () => {
+        throw new Error('boom')
+      },
+    })
+
+    const error = await new Promise((resolve) => {
+      client.observable.request({url: '/data/test'}).subscribe({error: resolve})
+    })
+
+    expect(error).toEqual(new Error('boom'))
+  })
+})
+
+describe('createTranslogFetchStub', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('serves NDJSON entries through getTransactionsLogs', async () => {
+    const entries = [
+      editTransaction({id: 'tx-1'}),
+      editTransaction({id: 'tx-2', timestamp: '2024-01-01T00:01:00.000Z'}),
+    ]
+    const stub = createTranslogFetchStub(() => entries)
+    vi.stubGlobal('fetch', stub.fetch)
+
+    const {client} = createMockClient()
+    const transactions = await getTransactionsLogs(client, DRAFT_ID, {
+      tag: 'sanity.studio.test',
+      effectFormat: 'mendoza',
+    })
+
+    expect(transactions).toEqual(entries)
+    expect(stub.calls).toHaveLength(1)
+    expect(stub.calls[0]).toContain(`/transactions/${DRAFT_ID}?`)
+    expect(stub.calls[0]).toContain('effectFormat=mendoza')
+  })
+
+  it('surfaces translog error entries as thrown errors', async () => {
+    const stub = createTranslogFetchStub(() => ({
+      error: {description: 'something failed', type: 'someError'},
+    }))
+    vi.stubGlobal('fetch', stub.fetch)
+
+    const {client} = createMockClient()
+    await expect(getTransactionsLogs(client, DRAFT_ID, {})).rejects.toThrow('something failed')
+  })
+})

--- a/packages/sanity/src/core/store/events/__fixtures__/mockClient.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/mockClient.ts
@@ -1,0 +1,81 @@
+import {type SanityClient} from '@sanity/client'
+import {isObservable, type Observable, of, throwError} from 'rxjs'
+
+export interface RecordedRequest {
+  url: string
+  tag?: string
+}
+
+export interface MockClientOptions {
+  dataset?: string
+  projectId?: string
+  token?: string
+  /**
+   * Routes `client.observable.request` calls. Return the response body (emitted through `of`),
+   * or an Observable for custom timing, or throw to simulate a request error.
+   */
+  respond?: (request: RecordedRequest) => unknown
+}
+
+export interface MockClient {
+  client: SanityClient
+  /** Every `observable.request` call, in order. Useful to assert URLs, tags and request counts. */
+  requests: RecordedRequest[]
+}
+
+/**
+ * Minimal `SanityClient` stub covering the surface the events store uses:
+ * `config()`, `getUrl()` and `observable.request()`. Translog calls go through the global
+ * `fetch` instead — stub that with {@link createTranslogFetchStub}.
+ */
+export function createMockClient(options: MockClientOptions = {}): MockClient {
+  const {
+    dataset = 'test-dataset',
+    projectId = 'test-project',
+    token = 'mock-token',
+    respond,
+  } = options
+  const requests: RecordedRequest[] = []
+
+  const client = {
+    config: () => ({dataset, projectId, token}),
+    getUrl: (uri: string) => `https://${projectId}.api.sanity.test/v1${uri}`,
+    observable: {
+      request: (request: RecordedRequest): Observable<unknown> => {
+        requests.push(request)
+        if (!respond) {
+          return throwError(() => new Error(`Unexpected request: ${request.url}`))
+        }
+        let response: unknown
+        try {
+          response = respond(request)
+        } catch (error) {
+          return throwError(() => error)
+        }
+        return isObservable(response) ? response : of(response)
+      },
+    },
+  }
+
+  return {client: client as unknown as SanityClient, requests}
+}
+
+/**
+ * Builds a `fetch` replacement that serves NDJSON translog responses, for code paths going
+ * through `getJsonStream`/`getTransactionsLogs`. Register it with
+ * `vi.stubGlobal('fetch', stub.fetch)` and route per-URL through `respond`.
+ */
+export function createTranslogFetchStub(
+  respond: (url: string) => unknown[] | {error: {description?: string; type: string}},
+): {fetch: typeof fetch; calls: string[]} {
+  const calls: string[] = []
+  const fetchStub = (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    calls.push(url)
+    const result = respond(url)
+    const entries = Array.isArray(result) ? result : [result]
+    const body = entries.map((entry) => JSON.stringify(entry)).join('\n')
+    return Promise.resolve(new Response(body, {headers: {'content-type': 'application/x-ndjson'}}))
+  }
+  return {fetch: fetchStub as typeof fetch, calls}
+}

--- a/packages/sanity/src/core/store/events/__fixtures__/transactions.fixture.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/transactions.fixture.ts
@@ -1,0 +1,137 @@
+import {
+  type SanityDocument,
+  type TransactionLogEventWithEffects,
+  type TransactionLogEventWithMutations,
+} from '@sanity/types'
+
+import {type DocumentRemoteMutationEvent} from '../../document/buffered-doc/types'
+import {type WithVersion} from '../../document/document-pair/checkoutPair'
+import {BASE_TIME, DOCUMENT_ID, DRAFT_ID} from './events.fixture'
+
+export type TranslogEntry = TransactionLogEventWithEffects & TransactionLogEventWithMutations
+
+/**
+ * Builds a mendoza effect pair using literal-value patches (`[0, value]` replaces the whole
+ * document with `value`; `[0, null]` is the delete patch the store recognises).
+ *
+ * These are valid mendoza patches, so they can be replayed by `calculateDiff`/`getEditEvents`
+ * consumers, with the caveat that a literal replacement attributes the entire document to the
+ * transaction (fine for pipeline tests; use recorded patches for fine-grained diff assertions).
+ */
+export function effectPair({
+  before,
+  after,
+}: {
+  before: Partial<SanityDocument> | null
+  after: Partial<SanityDocument> | null
+}): {apply: unknown[]; revert: unknown[]} {
+  return {
+    apply: [0, after],
+    revert: [0, before],
+  }
+}
+
+interface TransactionOptions {
+  id?: string
+  author?: string
+  timestamp?: string
+  /** The document id the effects apply to. Defaults to the draft id. */
+  documentId?: string
+  before?: Partial<SanityDocument> | null
+  after?: Partial<SanityDocument> | null
+}
+
+/**
+ * A transaction whose effect on `documentId` is a "modified" edit (neither apply nor revert is
+ * a delete patch).
+ */
+export function editTransaction(options: TransactionOptions = {}): TranslogEntry {
+  const {
+    id = 'tx-edit',
+    author = 'author-1',
+    timestamp = BASE_TIME,
+    documentId = DRAFT_ID,
+    before = {_id: documentId, name: 'before'},
+    after = {_id: documentId, name: 'after'},
+  } = options
+  return {
+    id,
+    timestamp,
+    author,
+    documentIDs: [documentId],
+    effects: {[documentId]: effectPair({before, after})},
+    mutations: [],
+  }
+}
+
+/**
+ * A transaction that creates `documentId` (revert patch is the delete patch `[0, null]`).
+ */
+export function createTransaction(options: TransactionOptions = {}): TranslogEntry {
+  const {
+    id = 'tx-create',
+    author = 'author-1',
+    timestamp = BASE_TIME,
+    documentId = DRAFT_ID,
+    after = {_id: documentId, name: 'created'},
+  } = options
+  return {
+    id,
+    timestamp,
+    author,
+    documentIDs: [documentId],
+    effects: {[documentId]: effectPair({before: null, after})},
+    mutations: [],
+  }
+}
+
+/**
+ * A transaction that deletes `documentId` (apply patch is the delete patch `[0, null]`).
+ */
+export function deleteTransaction(options: TransactionOptions = {}): TranslogEntry {
+  const {
+    id = 'tx-delete',
+    author = 'author-1',
+    timestamp = BASE_TIME,
+    documentId = DRAFT_ID,
+    before = {_id: documentId, name: 'before-delete'},
+  } = options
+  return {
+    id,
+    timestamp,
+    author,
+    documentIDs: [documentId],
+    effects: {[documentId]: effectPair({before, after: null})},
+    mutations: [],
+  }
+}
+
+/**
+ * A remote mutation event as emitted by the checkoutPair listeners, tagged with the document
+ * variant it belongs to (what `getRemoteTransactionsSubscription` consumes).
+ */
+export function remoteMutationEvent(
+  overrides: Partial<WithVersion<DocumentRemoteMutationEvent>> = {},
+): WithVersion<DocumentRemoteMutationEvent> {
+  return {
+    type: 'remoteMutation',
+    version: 'draft',
+    transactionId: 'tx-remote',
+    author: 'author-2',
+    timestamp: new Date(BASE_TIME),
+    head: {
+      _id: DRAFT_ID,
+      _type: 'testDocument',
+      _createdAt: BASE_TIME,
+      _updatedAt: BASE_TIME,
+      _rev: 'tx-remote',
+    },
+    effects: effectPair({
+      before: {_id: DRAFT_ID, name: 'before'},
+      after: {_id: DRAFT_ID, name: 'after'},
+    }),
+    ...overrides,
+  }
+}
+
+export {DOCUMENT_ID, DRAFT_ID}

--- a/packages/sanity/src/core/store/events/__fixtures__/transactions.fixture.ts
+++ b/packages/sanity/src/core/store/events/__fixtures__/transactions.fixture.ts
@@ -6,7 +6,7 @@ import {
 
 import {type DocumentRemoteMutationEvent} from '../../document/buffered-doc/types'
 import {type WithVersion} from '../../document/document-pair/checkoutPair'
-import {BASE_TIME, DOCUMENT_ID, DRAFT_ID} from './events.fixture'
+import {BASE_TIME, DRAFT_ID} from './events.fixture'
 
 export type TranslogEntry = TransactionLogEventWithEffects & TransactionLogEventWithMutations
 
@@ -133,5 +133,3 @@ export function remoteMutationEvent(
     ...overrides,
   }
 }
-
-export {DOCUMENT_ID, DRAFT_ID}

--- a/packages/sanity/src/core/store/events/calculateDiff.test.ts
+++ b/packages/sanity/src/core/store/events/calculateDiff.test.ts
@@ -1,5 +1,7 @@
 import {describe, expect, it} from 'vitest'
 
+import {publishDocumentVersionEvent} from './__fixtures__/events.fixture'
+import {DRAFT_ID, editTransaction} from './__fixtures__/transactions.fixture'
 import {calculateDiff} from './calculateDiff'
 import {type DocumentGroupEvent} from './types'
 
@@ -386,5 +388,67 @@ describe('calculateDiff', () => {
         "type": "object",
       }
     `)
+  })
+
+  it('attaches the matching non-edit event to the annotation', () => {
+    const initialDoc = {
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+      _id: DRAFT_ID,
+      _rev: 'rev-0',
+      _type: 'author',
+      name: 'foo',
+    }
+    const before = {
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+      _id: DRAFT_ID,
+      _type: 'author',
+      name: 'foo',
+    }
+    const after = {...before, _updatedAt: '2024-01-01T00:05:00Z', name: 'bar'}
+    const publishEvent = publishDocumentVersionEvent({revisionId: 'tx-with-event'})
+    const transactions = [editTransaction({id: 'tx-with-event', before, after})]
+
+    const diff = calculateDiff({
+      initialDoc,
+      documentId: DRAFT_ID,
+      transactions,
+      events: [publishEvent],
+    })
+
+    expect(diff.isChanged).toBe(true)
+    const nameField = diff.fields.name
+    expect(nameField).toMatchObject({
+      action: 'changed',
+      fromValue: 'foo',
+      toValue: 'bar',
+      annotation: {
+        author: 'author-1',
+        event: publishEvent,
+      },
+    })
+  })
+
+  it('skips transactions that have no effect for the documentId', () => {
+    const initialDoc = {
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+      _id: DRAFT_ID,
+      _rev: 'rev-0',
+      _type: 'author',
+      name: 'foo',
+    }
+    // The transaction only carries effects for another document id.
+    const transactions = [editTransaction({id: 'tx-other', documentId: 'drafts.other-doc'})]
+
+    const diff = calculateDiff({
+      initialDoc,
+      documentId: DRAFT_ID,
+      transactions,
+      events: [],
+    })
+
+    expect(diff.isChanged).toBe(false)
   })
 })

--- a/packages/sanity/src/core/store/events/calculateDiff.test.ts
+++ b/packages/sanity/src/core/store/events/calculateDiff.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 
-import {publishDocumentVersionEvent} from './__fixtures__/events.fixture'
-import {DRAFT_ID, editTransaction} from './__fixtures__/transactions.fixture'
+import {publishDocumentVersionEvent, DRAFT_ID} from './__fixtures__/events.fixture'
+import {editTransaction} from './__fixtures__/transactions.fixture'
 import {calculateDiff} from './calculateDiff'
 import {type DocumentGroupEvent} from './types'
 

--- a/packages/sanity/src/core/store/events/calculateDiff.ts
+++ b/packages/sanity/src/core/store/events/calculateDiff.ts
@@ -10,6 +10,25 @@ function omitRev(document: SanityDocument): Omit<SanityDocument, '_rev'> {
   return doc
 }
 
+/**
+ * Computes the annotated diff between `initialDoc` and the document that results from replaying
+ * `transactions` (mendoza apply patches) on top of it.
+ *
+ * Each replayed transaction records `{transactionIndex, event}` metadata — `event` being the
+ * non-edit `DocumentGroupEvent` whose `revisionId` matches the transaction id, when one exists —
+ * so every changed value in the resulting `ObjectDiff` carries an `Annotation` with the
+ * author/timestamp of the transaction that changed it (and the related event, e.g. a publish).
+ *
+ * Annotation semantics:
+ * - "from" side: the annotation points at the transaction *after* the one recorded in the value's
+ *   end metadata (where the old value disappeared); when a value existed before the range, the
+ *   first transaction in the range is used as fallback.
+ * - "to" side: the annotation points at the transaction recorded in the value's start metadata
+ *   (where the new value appeared); values untouched within the range get no annotation.
+ *
+ * Transactions with no effect for `documentId` are skipped. `_rev` is stripped before diffing so
+ * revision churn alone never shows up as a change.
+ */
 export function calculateDiff({
   initialDoc,
   documentId,

--- a/packages/sanity/src/core/store/events/createEventsObservable.test.ts
+++ b/packages/sanity/src/core/store/events/createEventsObservable.test.ts
@@ -1,0 +1,133 @@
+import {BehaviorSubject, of} from 'rxjs'
+import {describe, expect, it} from 'vitest'
+
+import {activeASAPRelease} from '../../releases/__fixtures__/release.fixture'
+import {type ReleasesReducerState} from '../../releases/store/reducer'
+import {collectEmissions} from './__fixtures__/collect.fixture'
+import {
+  createDocumentVersionEvent,
+  DOCUMENT_ID,
+  DRAFT_ID,
+  editDocumentVersionEvent,
+  minutesAfterBase,
+  publishDocumentVersionEvent,
+  updateLiveDocumentEvent,
+  VERSION_ID,
+} from './__fixtures__/events.fixture'
+import {createEventsObservable} from './createEventsObservable'
+import {type EventsObservableValue} from './getInitialFetchEvents'
+import {type DocumentGroupEvent} from './types'
+
+const releasesState = (
+  releases: Map<string, typeof activeASAPRelease> = new Map(),
+): ReleasesReducerState => ({releases, state: 'loaded'})
+
+function eventsValue(events: DocumentGroupEvent[]): EventsObservableValue {
+  return {events, nextCursor: '', loading: false, error: null}
+}
+
+function setup({
+  documentId,
+  events,
+  releases = releasesState(),
+}: {
+  documentId: string
+  events: DocumentGroupEvent[]
+  releases?: ReleasesReducerState
+}) {
+  const releases$ = new BehaviorSubject(releases)
+  const events$ = new BehaviorSubject(eventsValue(events))
+  const observable = createEventsObservable({
+    documentId,
+    releases$: releases$ as never,
+    events$,
+    remoteEdits$: of([]),
+    expandedEvents$: of([]),
+  })
+  return {observable, releases$, events$}
+}
+
+describe('createEventsObservable', () => {
+  it('draft: links edits/creates to their publish event and stamps the variant', () => {
+    const create = createDocumentVersionEvent({timestamp: minutesAfterBase(0)})
+    const edit = editDocumentVersionEvent({
+      revisionId: 'edit-rev',
+      id: 'edit-rev',
+      timestamp: minutesAfterBase(1),
+    })
+    const publish = publishDocumentVersionEvent({
+      versionRevisionId: 'edit-rev',
+      timestamp: minutesAfterBase(2),
+    })
+
+    const {observable} = setup({documentId: DRAFT_ID, events: [publish, edit, create]})
+    const {values, subscription} = collectEmissions(observable)
+    subscription.unsubscribe()
+
+    const [result] = values
+    expect(result.events.map((event) => event.type)).toEqual([
+      'publishDocumentVersion',
+      'editDocumentVersion',
+      'createDocumentVersion',
+    ])
+    // addParentToEvents: the publish now points at the draft id and owns the creation event.
+    expect(result.events[0]).toMatchObject({
+      documentId: publish.versionId,
+      creationEvent: expect.objectContaining({type: 'createDocumentVersion'}),
+    })
+    expect(result.events[1]).toMatchObject({parentId: publish.id})
+    expect(result.events.every((event) => event.documentVariantType === 'draft')).toBe(true)
+  })
+
+  it('published: attaches release metadata to release publishes and stamps the variant', () => {
+    const publish = publishDocumentVersionEvent({
+      versionId: `versions.${activeASAPRelease.name}.${DOCUMENT_ID}`,
+    })
+    const releases = releasesState(new Map([[activeASAPRelease._id, activeASAPRelease]]))
+
+    const {observable} = setup({documentId: DOCUMENT_ID, events: [publish], releases})
+    const {values, subscription} = collectEmissions(observable)
+    subscription.unsubscribe()
+
+    expect(values[0].events[0]).toMatchObject({
+      release: activeASAPRelease,
+      documentVariantType: 'published',
+    })
+  })
+
+  it('version: re-points publish events at the version id and stamps the variant', () => {
+    const publish = publishDocumentVersionEvent({versionId: VERSION_ID})
+
+    const {observable} = setup({documentId: VERSION_ID, events: [publish]})
+    const {values, subscription} = collectEmissions(observable)
+    subscription.unsubscribe()
+
+    expect(values[0].events[0]).toMatchObject({
+      documentId: VERSION_ID,
+      documentVariantType: 'version',
+    })
+  })
+
+  it('squashes same-author live edit events within the merge window', () => {
+    const newest = updateLiveDocumentEvent({id: 'live-2', timestamp: minutesAfterBase(4)})
+    const oldest = updateLiveDocumentEvent({id: 'live-1', timestamp: minutesAfterBase(0)})
+
+    const {observable} = setup({documentId: DOCUMENT_ID, events: [newest, oldest]})
+    const {values, subscription} = collectEmissions(observable)
+    subscription.unsubscribe()
+
+    expect(values[0].events.map((event) => event.id)).toEqual(['live-2'])
+  })
+
+  it('recomputes the whole list whenever the releases store emits (known perf quirk)', () => {
+    const publish = publishDocumentVersionEvent()
+
+    const {observable, releases$} = setup({documentId: DOCUMENT_ID, events: [publish]})
+    const {values, subscription} = collectEmissions(observable)
+    expect(values).toHaveLength(1)
+
+    releases$.next(releasesState())
+    expect(values).toHaveLength(2)
+    subscription.unsubscribe()
+  })
+})

--- a/packages/sanity/src/core/store/events/createEventsObservable.ts
+++ b/packages/sanity/src/core/store/events/createEventsObservable.ts
@@ -31,6 +31,21 @@ const addDocumentVariantTypeToEvents = (
   return events.map((event) => ({...event, documentVariantType}))
 }
 
+/**
+ * Combines the four event sources (fetched events, live remote edits, user-expanded edit events,
+ * releases state) into the final event list the UI consumes.
+ *
+ * Per emission:
+ * 1. Merge and sort all events newest-first ({@link sortEvents}).
+ * 2. Apply the variant-specific transform:
+ *    - published: attach release metadata to publish events ({@link updatePublishedEvents})
+ *    - draft: link edits/creates to their publish events ({@link addParentToEvents})
+ *    - version: re-point publish events at the version id ({@link updateVersionEvents})
+ * 3. Stamp every event with the `documentVariantType` of the viewed document.
+ * 4. Squash same-author live-edit events within the merge window
+ *    ({@link squashLiveEditEvents}; temporary until the API squashes them).
+ *
+ */
 export function createEventsObservable({
   releases$,
   events$,

--- a/packages/sanity/src/core/store/events/createEventsStore.ts
+++ b/packages/sanity/src/core/store/events/createEventsStore.ts
@@ -18,10 +18,20 @@ interface EventsStoreOptions {
 }
 
 /**
- * Creates an event store for a document.
- * If you want to use this in a React component, consider using `useEventsStore` instead.
+ * Creates the (non-React) events store for a document variant, wiring together:
+ * - `getInitialFetchEvents`: fetching/paginating events + synthesizing edit events,
+ * - `getExpandEvents`: on-demand expansion of publish/delete events,
+ * - `getRemoteTransactionsSubscription`: real-time remote mutations (append or trigger refetch),
+ * - `createEventsObservable`: merge, sort and per-variant post-processing.
  *
- * Consider subscribing the remoteEventsListener to get updates on remote transactions.
+ * Returns:
+ * - `eventsObservable$`: the final `{events, nextCursor, loading, error}` stream for the UI.
+ * - `getDocumentChanges(revision$, since$)`: annotated diff stream between two revisions.
+ * - `handleExpandEvent`, `loadMoreEvents`, `reloadEvents`: imperative actions.
+ * - `remoteTransactionsListener`: call to activate the remote listener; returns the subscription
+ *   (the caller owns unsubscription — `useEventsStore` ties it to the component lifecycle).
+ *
+ * If you want to use this in a React component, use `useEventsStore` instead.
  */
 export function createEventsStore({
   client,

--- a/packages/sanity/src/core/store/events/diffValue.test.ts
+++ b/packages/sanity/src/core/store/events/diffValue.test.ts
@@ -1,0 +1,213 @@
+import {type StringInput} from '@sanity/diff'
+import {incremental} from 'mendoza'
+import {describe, expect, it} from 'vitest'
+
+import {type Annotation, type ObjectDiff} from '../../field/types'
+import {minutesAfterBase, publishDocumentVersionEvent} from './__fixtures__/events.fixture'
+import {DRAFT_ID, editTransaction} from './__fixtures__/transactions.fixture'
+import {type AnnotationExtractor, diffValue, type EventMeta, wrapValue} from './diffValue'
+
+describe('diffValue', () => {
+  const doc0 = {_id: DRAFT_ID, _type: 'author', name: 'v0', role: 'developer'}
+  const doc1 = {_id: DRAFT_ID, _type: 'author', name: 'v1', role: 'developer'}
+  const doc2 = {_id: DRAFT_ID, _type: 'author', name: 'v2'}
+
+  const tx0 = editTransaction({id: 'tx-0', author: 'author-a', timestamp: minutesAfterBase(0)})
+  const tx1 = editTransaction({id: 'tx-1', author: 'author-b', timestamp: minutesAfterBase(1)})
+  const transactions = [tx0, tx1]
+
+  const initial = incremental.wrap<EventMeta>(doc0, null)
+  const afterTx0 = incremental.applyPatch(initial, [0, doc1], {transactionIndex: 0})
+  const afterTx1 = incremental.applyPatch(afterTx0, [0, doc2], {transactionIndex: 1})
+
+  it('annotates changed values with the transaction that introduced them (to side)', () => {
+    const diff = diffValue({
+      transactions,
+      fromValue: initial,
+      fromRaw: doc0,
+      toValue: afterTx1,
+      toRaw: doc2,
+    }) as ObjectDiff
+
+    expect(diff.isChanged).toBe(true)
+    expect(diff.fields.name).toMatchObject({
+      action: 'changed',
+      fromValue: 'v0',
+      toValue: 'v2',
+      annotation: {author: 'author-b', timestamp: tx1.timestamp},
+    })
+  })
+
+  it('annotates removals: null meta falls back to the first transaction in the range', () => {
+    // The from side is the initially wrapped document (null metas), so the removal of `role`
+    // is attributed to transactions[0] even though tx1 removed it.
+    const diff = diffValue({
+      transactions,
+      fromValue: initial,
+      fromRaw: doc0,
+      toValue: afterTx1,
+      toRaw: doc2,
+    }) as ObjectDiff
+
+    expect(diff.fields.role).toMatchObject({
+      action: 'removed',
+      annotation: {author: 'author-a', timestamp: tx0.timestamp},
+    })
+  })
+
+  it('annotates removals with the transaction *after* the recorded meta (where the value disappeared)', () => {
+    // Diffing from the state after tx0: `role` carries endMeta {transactionIndex: 0}, so the
+    // removal is attributed to transactions[0 + 1] = tx1.
+    const diff = diffValue({
+      transactions,
+      fromValue: afterTx0,
+      fromRaw: doc1,
+      toValue: afterTx1,
+      toRaw: doc2,
+    }) as ObjectDiff
+
+    expect(diff.fields.role).toMatchObject({
+      action: 'removed',
+      annotation: {author: 'author-b', timestamp: tx1.timestamp},
+    })
+  })
+
+  it('propagates the event recorded in the transaction meta into annotations', () => {
+    const publishEvent = publishDocumentVersionEvent({revisionId: 'tx-1'})
+    const withEvent = incremental.applyPatch(afterTx0, [0, doc2], {
+      transactionIndex: 1,
+      event: publishEvent,
+    })
+
+    const diff = diffValue({
+      transactions,
+      fromValue: afterTx0,
+      fromRaw: doc1,
+      toValue: withEvent,
+      toRaw: doc2,
+    }) as ObjectDiff
+
+    expect(diff.fields.name).toMatchObject({
+      action: 'changed',
+      annotation: {author: 'author-b', event: publishEvent},
+    })
+  })
+
+  it('produces an unchanged diff when nothing happened', () => {
+    const diff = diffValue({
+      transactions: [],
+      fromValue: initial,
+      fromRaw: doc0,
+      toValue: initial,
+      toRaw: doc0,
+    }) as ObjectDiff
+
+    expect(diff.action).toBe('unchanged')
+    expect(diff.isChanged).toBe(false)
+  })
+})
+
+const stringPart = (value: string, meta: Annotation) => ({
+  value,
+  utf8size: value.length,
+  uses: [],
+  startMeta: meta,
+  endMeta: meta,
+})
+
+describe('wrapValue', () => {
+  const annotationA: Annotation = {author: 'author-a', timestamp: minutesAfterBase(0)}
+  const annotationB: Annotation = {author: 'author-b', timestamp: minutesAfterBase(1)}
+
+  // Metas *are* annotations in these tests, so the extractor is the identity.
+  const extractor: AnnotationExtractor<Annotation> = {
+    fromValue: (value) => value.endMeta,
+    fromMeta: (meta) => meta,
+  }
+
+  it('wraps values without content through @sanity/diff wrap, keeping the annotation', () => {
+    const input = wrapValue({data: 42, startMeta: annotationA, endMeta: annotationA}, 42, extractor)
+
+    expect(input.type).toBe('number')
+    expect(input.value).toBe(42)
+    expect(input.annotation).toEqual(annotationA)
+  })
+
+  it('object content: exposes keys, wraps fields lazily with caching, undefined for missing keys', () => {
+    const titleValue = {data: 'hello', startMeta: annotationB, endMeta: annotationB}
+    const input = wrapValue(
+      {
+        startMeta: annotationA,
+        endMeta: annotationA,
+        content: {type: 'object', fields: {title: titleValue}},
+      },
+      {title: 'hello'},
+      extractor,
+    )
+
+    if (input.type !== 'object') throw new Error('expected object input')
+    expect(input.keys).toEqual(['title'])
+    const title = input.get('title')
+    expect(title).toMatchObject({type: 'string', value: 'hello', annotation: annotationB})
+    expect(input.get('title')).toBe(title)
+    expect(input.get('missing')).toBeUndefined()
+  })
+
+  it('array content: wraps elements lazily, exposes per-index metas, throws out of bounds', () => {
+    const elements = [
+      {data: 'first', startMeta: annotationA, endMeta: annotationA},
+      {data: 'second', startMeta: annotationB, endMeta: annotationB},
+    ]
+    const input = wrapValue(
+      {
+        startMeta: annotationA,
+        endMeta: annotationA,
+        content: {type: 'array', elements, metas: [annotationA, annotationB]},
+      },
+      ['first', 'second'],
+      extractor,
+    )
+
+    if (input.type !== 'array') throw new Error('expected array input')
+    expect(input.length).toBe(2)
+    const first = input.at(0)
+    expect(first).toMatchObject({type: 'string', value: 'first', annotation: annotationA})
+    expect(input.at(0)).toBe(first)
+    expect(input.annotationAt(1)).toEqual(annotationB)
+    expect(() => input.at(2)).toThrow('out of bounds')
+  })
+
+  describe('string content sliceAnnotation', () => {
+    const input = wrapValue(
+      {
+        startMeta: annotationA,
+        endMeta: annotationA,
+        content: {
+          type: 'string',
+          parts: [
+            stringPart('Hello ', annotationA),
+            stringPart('wor', annotationA),
+            stringPart('ld', annotationB),
+          ],
+        },
+      },
+      'Hello world',
+      extractor,
+    ) as StringInput<Annotation>
+
+    it('merges adjacent segments with the same annotation', () => {
+      expect(input.sliceAnnotation(0, 11)).toEqual([
+        {text: 'Hello wor', annotation: annotationA},
+        {text: 'ld', annotation: annotationB},
+      ])
+    })
+
+    it('slices across part boundaries', () => {
+      expect(input.sliceAnnotation(6, 9)).toEqual([{text: 'wor', annotation: annotationA}])
+      expect(input.sliceAnnotation(8, 11)).toEqual([
+        {text: 'r', annotation: annotationA},
+        {text: 'ld', annotation: annotationB},
+      ])
+    })
+  })
+})

--- a/packages/sanity/src/core/store/events/diffValue.test.ts
+++ b/packages/sanity/src/core/store/events/diffValue.test.ts
@@ -3,8 +3,12 @@ import {incremental} from 'mendoza'
 import {describe, expect, it} from 'vitest'
 
 import {type Annotation, type ObjectDiff} from '../../field/types'
-import {minutesAfterBase, publishDocumentVersionEvent} from './__fixtures__/events.fixture'
-import {DRAFT_ID, editTransaction} from './__fixtures__/transactions.fixture'
+import {
+  DRAFT_ID,
+  minutesAfterBase,
+  publishDocumentVersionEvent,
+} from './__fixtures__/events.fixture'
+import {editTransaction} from './__fixtures__/transactions.fixture'
 import {type AnnotationExtractor, diffValue, type EventMeta, wrapValue} from './diffValue'
 
 describe('diffValue', () => {

--- a/packages/sanity/src/core/store/events/getDocumentAtRevision.test.ts
+++ b/packages/sanity/src/core/store/events/getDocumentAtRevision.test.ts
@@ -1,0 +1,140 @@
+import {type SanityDocument} from '@sanity/types'
+import {firstValueFrom, toArray} from 'rxjs'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {createMockClient} from './__fixtures__/mockClient'
+import {getDocumentAtRevision} from './getDocumentAtRevision'
+import {HISTORY_CLEARED_EVENT_ID} from './getInitialFetchEvents'
+
+// The module keeps a cache keyed by `${documentId}@<revision|time>` that survives between tests,
+// so every test uses its own document id.
+
+const document = (id: string, rev = 'rev-1'): SanityDocument => ({
+  _id: id,
+  _type: 'author',
+  _rev: rev,
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+})
+
+describe('getDocumentAtRevision', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('emits loading first, then the fetched document', async () => {
+    const doc = document('doc-loading')
+    const {client, requests} = createMockClient({respond: () => ({documents: [doc]})})
+
+    const emissions = await firstValueFrom(
+      getDocumentAtRevision({client, documentId: 'doc-loading', revisionId: 'rev-1'}).pipe(
+        toArray(),
+      ),
+    )
+
+    expect(emissions).toEqual([
+      {document: null, loading: true, revisionId: 'rev-1'},
+      {document: doc, loading: false, revisionId: 'rev-1'},
+    ])
+    expect(requests).toEqual([
+      {
+        url: '/data/history/test-dataset/documents/doc-loading?revision=rev-1',
+        tag: 'get-document-revision',
+      },
+    ])
+  })
+
+  it('fetches by time when no revisionId is given', async () => {
+    const doc = document('doc-time')
+    const {client, requests} = createMockClient({respond: () => ({documents: [doc]})})
+
+    const emissions = await firstValueFrom(
+      getDocumentAtRevision({
+        client,
+        documentId: 'doc-time',
+        time: '2024-01-01T00:00:00Z',
+      }).pipe(toArray()),
+    )
+
+    expect(requests[0].url).toBe(
+      `/data/history/test-dataset/documents/doc-time?time=${encodeURIComponent('2024-01-01T00:00:00Z')}`,
+    )
+    // When fetching by time the revisionId is only known after the fetch.
+    expect(emissions.at(-1)).toEqual({document: doc, loading: false, revisionId: doc._rev})
+  })
+
+  it('shares one request between subscribers via the module cache', async () => {
+    const doc = document('doc-shared')
+    const {client, requests} = createMockClient({respond: () => ({documents: [doc]})})
+
+    const first = await firstValueFrom(
+      getDocumentAtRevision({client, documentId: 'doc-shared', revisionId: 'rev-1'}).pipe(
+        toArray(),
+      ),
+    )
+    const second = await firstValueFrom(
+      getDocumentAtRevision({client, documentId: 'doc-shared', revisionId: 'rev-1'}).pipe(
+        toArray(),
+      ),
+    )
+
+    expect(requests).toHaveLength(1)
+    expect(first.at(-1)).toEqual({document: doc, loading: false, revisionId: 'rev-1'})
+    // Late subscribers replay only the settled value.
+    expect(second).toEqual([{document: doc, loading: false, revisionId: 'rev-1'}])
+  })
+
+  it('short-circuits the synthetic history-cleared revision without a request', async () => {
+    const {client, requests} = createMockClient()
+
+    const emissions = await firstValueFrom(
+      getDocumentAtRevision({
+        client,
+        documentId: 'doc-cleared',
+        revisionId: HISTORY_CLEARED_EVENT_ID,
+      }).pipe(toArray()),
+    )
+
+    expect(emissions).toEqual([
+      {document: null, loading: false, revisionId: HISTORY_CLEARED_EVENT_ID},
+    ])
+    expect(requests).toHaveLength(0)
+  })
+
+  it('emits an undefined document when the revision no longer exists (history retention)', async () => {
+    const {client} = createMockClient({respond: () => ({documents: []})})
+
+    const emissions = await firstValueFrom(
+      getDocumentAtRevision({client, documentId: 'doc-missing', revisionId: 'rev-gone'}).pipe(
+        toArray(),
+      ),
+    )
+
+    expect(emissions.at(-1)).toEqual({document: undefined, loading: false, revisionId: undefined})
+  })
+
+  it('logs and emits null on errors — and caches the failure forever (known quirk)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const {client, requests} = createMockClient({
+      respond: () => {
+        throw new Error('request failed')
+      },
+    })
+
+    const emissions = await firstValueFrom(
+      getDocumentAtRevision({client, documentId: 'doc-error', revisionId: 'rev-1'}).pipe(toArray()),
+    )
+    expect(emissions.at(-1)).toEqual({document: null, loading: false, revisionId: 'rev-1'})
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error fetching document at revision',
+      expect.any(Error),
+    )
+
+    // A new subscriber gets the cached error result; no retry happens.
+    const retry = await firstValueFrom(
+      getDocumentAtRevision({client, documentId: 'doc-error', revisionId: 'rev-1'}).pipe(toArray()),
+    )
+    expect(retry).toEqual([{document: null, loading: false, revisionId: 'rev-1'}])
+    expect(requests).toHaveLength(1)
+  })
+})

--- a/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
+++ b/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
@@ -33,6 +33,22 @@ type Context = {client: SanityClient; documentId: string} & (
     }
 )
 
+/**
+ * Fetches a document snapshot from the history API, either at a specific `revisionId` or at a
+ * point in `time`. Emits `{loading: true}` first, then the result.
+ *
+ * Main cases covered:
+ * - `revisionId === HISTORY_CLEARED_EVENT_ID` short-circuits to `{document: null, loading: false}`
+ *   without a request (that id is synthetic and has no revision behind it).
+ * - The revision may be missing (history retention): the API returns no documents and `document`
+ *   is `undefined`; callers like `getDocumentChanges` translate that into
+ *   `MissingSinceDocumentError`.
+ * - Errors are logged and emitted as `{document: null, loading: false}` — never thrown.
+ *
+ * Results are cached module-level per `documentId@<revisionId|time>` observable
+ * (`shareReplay(1)`), so concurrent and repeated subscribers share one request.
+ * Known quirks:  error results are cached forever, and the cache never evicts (tracked as known issues).
+ */
 export function getDocumentAtRevision<InputContext extends Context>({
   client,
   documentId,

--- a/packages/sanity/src/core/store/events/getDocumentChanges.test.ts
+++ b/packages/sanity/src/core/store/events/getDocumentChanges.test.ts
@@ -1,0 +1,215 @@
+import {type SanityDocument} from '@sanity/types'
+import {BehaviorSubject, of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {collectEmissions} from './__fixtures__/collect.fixture'
+import {createDocumentVersionEvent, DRAFT_ID, minutesAfterBase} from './__fixtures__/events.fixture'
+import {createMockClient} from './__fixtures__/mockClient'
+import {createTransaction, editTransaction} from './__fixtures__/transactions.fixture'
+import {getDocumentChanges, MissingSinceDocumentError} from './getDocumentChanges'
+import {getDocumentTransactions} from './getDocumentTransactions'
+import {HISTORY_CLEARED_EVENT_ID} from './getInitialFetchEvents'
+import {type EventsStoreRevision} from './types'
+
+vi.mock('./getDocumentTransactions', () => ({
+  getDocumentTransactions: vi.fn(),
+}))
+
+const mockGetDocumentTransactions = vi.mocked(getDocumentTransactions)
+
+const sinceDoc: SanityDocument = {
+  _id: DRAFT_ID,
+  _type: 'author',
+  _rev: 'rev-since',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  name: 'foo',
+}
+const toDoc: SanityDocument = {...sinceDoc, _rev: 'rev-to', name: 'bar'}
+
+const noEvents = of({events: [], nextCursor: '', loading: false, error: null})
+const revision = (revisionId: string, document: SanityDocument | null): EventsStoreRevision => ({
+  revisionId,
+  loading: false,
+  document,
+})
+
+describe('getDocumentChanges', () => {
+  beforeEach(() => {
+    mockGetDocumentTransactions.mockReset()
+    mockGetDocumentTransactions.mockResolvedValue([])
+  })
+
+  it('emits an annotation-less preview diff, then the annotated diff from the translog', async () => {
+    const {client} = createMockClient()
+    const {_rev: sinceRev, ...sinceContent} = sinceDoc
+    const {_rev: toRev, ...toContent} = toDoc
+    mockGetDocumentTransactions.mockResolvedValue([
+      editTransaction({id: 'tx-1', author: 'author-1', before: sinceContent, after: toContent}),
+    ])
+
+    const changes$ = getDocumentChanges({
+      client,
+      documentId: DRAFT_ID,
+      eventsObservable$: noEvents,
+      to$: of(revision('rev-to', toDoc)),
+      since$: of(revision('rev-since', sinceDoc)),
+      remoteTransactions$: new BehaviorSubject([]),
+    })
+    const {values, subscription} = collectEmissions(changes$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    // Preview: computed synchronously from the two documents, no annotations.
+    expect(values[0].loading).toBe(true)
+    expect(values[0].diff).toMatchObject({
+      action: 'changed',
+      fields: {name: {action: 'changed', annotation: null}},
+    })
+
+    // Final: transactions fetched for the since→to range, annotations attached.
+    expect(mockGetDocumentTransactions).toHaveBeenCalledWith({
+      documentId: DRAFT_ID,
+      client,
+      toTransaction: 'rev-to',
+      fromTransaction: 'rev-since',
+    })
+    expect(values.at(-1)).toMatchObject({
+      error: null,
+      diff: {fields: {name: {action: 'changed', annotation: {author: 'author-1'}}}},
+    })
+  })
+
+  it('synthesizes an empty since document when the selected revision is a creation event', async () => {
+    const {client} = createMockClient()
+    const createEvent = createDocumentVersionEvent({id: 'rev-to'})
+    const {_rev, ...toContent} = toDoc
+    // from === to returns the creation transaction itself, replaying the full creation.
+    mockGetDocumentTransactions.mockResolvedValue([
+      createTransaction({id: 'rev-to', after: toContent}),
+    ])
+
+    const changes$ = getDocumentChanges({
+      client,
+      documentId: DRAFT_ID,
+      eventsObservable$: of({events: [createEvent], nextCursor: '', loading: false, error: null}),
+      to$: of(revision('rev-to', toDoc)),
+      since$: of(null),
+      remoteTransactions$: new BehaviorSubject([]),
+    })
+    const {values, subscription} = collectEmissions(changes$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    expect(mockGetDocumentTransactions).toHaveBeenCalledWith(
+      expect.objectContaining({fromTransaction: 'rev-to', toTransaction: 'rev-to'}),
+    )
+    expect(values.at(-1)).toMatchObject({
+      error: null,
+      diff: {fields: {name: {action: 'added', toValue: 'bar'}}},
+    })
+  })
+
+  it('emits MissingSinceDocumentError when the since revision cannot be fetched', async () => {
+    const {client} = createMockClient()
+
+    const changes$ = getDocumentChanges({
+      client,
+      documentId: DRAFT_ID,
+      eventsObservable$: noEvents,
+      to$: of(revision('rev-to', toDoc)),
+      since$: of(revision('rev-gone', null)),
+      remoteTransactions$: new BehaviorSubject([]),
+    })
+    const {values, subscription} = collectEmissions(changes$)
+    await vi.waitFor(() => expect(values).toHaveLength(1))
+    subscription.unsubscribe()
+
+    const result = values[0]
+    expect(result.diff).toBeNull()
+    expect(result.error).toBeInstanceOf(MissingSinceDocumentError)
+    expect((result.error as MissingSinceDocumentError).revisionId).toBe('rev-gone')
+    expect(mockGetDocumentTransactions).not.toHaveBeenCalled()
+  })
+
+  it('emits no error while the since revision is still loading', async () => {
+    const {client} = createMockClient()
+
+    const changes$ = getDocumentChanges({
+      client,
+      documentId: DRAFT_ID,
+      eventsObservable$: noEvents,
+      to$: of(revision('rev-to', toDoc)),
+      since$: of({revisionId: 'rev-since', loading: true, document: null}),
+      remoteTransactions$: new BehaviorSubject([]),
+    })
+    const {values, subscription} = collectEmissions(changes$)
+    await vi.waitFor(() => expect(values).toHaveLength(1))
+    subscription.unsubscribe()
+
+    expect(values[0]).toEqual({loading: false, diff: null, error: null})
+  })
+
+  it('skips transaction fetching for the synthetic history-cleared since revision', async () => {
+    const {client} = createMockClient()
+    const clearedSince = {...sinceDoc, _rev: HISTORY_CLEARED_EVENT_ID}
+
+    const changes$ = getDocumentChanges({
+      client,
+      documentId: DRAFT_ID,
+      eventsObservable$: noEvents,
+      to$: of(revision('rev-to', toDoc)),
+      since$: of(revision(HISTORY_CLEARED_EVENT_ID, clearedSince)),
+      remoteTransactions$: new BehaviorSubject([]),
+    })
+    const {values, subscription} = collectEmissions(changes$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    expect(mockGetDocumentTransactions).not.toHaveBeenCalled()
+    expect(values.at(-1)?.error).toBeNull()
+  })
+
+  it('viewing latest: reuses fetched transactions and appends remote ones without refetching', async () => {
+    const {client} = createMockClient()
+    const {_rev: sinceRev, ...sinceContent} = sinceDoc
+    const intermediate = {...sinceContent, name: 'bar'}
+    mockGetDocumentTransactions.mockResolvedValue([
+      editTransaction({id: 'tx-1', author: 'author-1', before: sinceContent, after: intermediate}),
+    ])
+    const remoteTransactions$ = new BehaviorSubject([
+      // Present from the start; deduplication and concat behavior kick in on the next emission.
+    ] as ReturnType<typeof editTransaction>[])
+
+    const changes$ = getDocumentChanges({
+      client,
+      documentId: DRAFT_ID,
+      eventsObservable$: noEvents,
+      // No revision selected: the user is viewing the latest version.
+      to$: of(null),
+      since$: of(revision('rev-since', sinceDoc)),
+      remoteTransactions$,
+    })
+    const {values, subscription} = collectEmissions(changes$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    expect(mockGetDocumentTransactions).toHaveBeenCalledTimes(1)
+
+    // A remote edit arrives: the diff recomputes from cached + remote transactions, no refetch.
+    remoteTransactions$.next([
+      editTransaction({
+        id: 'tx-remote',
+        author: 'author-remote',
+        timestamp: minutesAfterBase(1),
+        before: intermediate,
+        after: {...intermediate, name: 'baz'},
+      }),
+    ])
+    await vi.waitFor(() =>
+      expect(values.at(-1)?.diff).toMatchObject({
+        fields: {name: {action: 'changed', toValue: 'baz', annotation: {author: 'author-remote'}}},
+      }),
+    )
+    expect(mockGetDocumentTransactions).toHaveBeenCalledTimes(1)
+    subscription.unsubscribe()
+  })
+})

--- a/packages/sanity/src/core/store/events/getDocumentChanges.ts
+++ b/packages/sanity/src/core/store/events/getDocumentChanges.ts
@@ -38,6 +38,12 @@ function removeDuplicatedTransactions(transactions: TransactionLogEventWithEffec
   })
 }
 
+/**
+ * Raised (as an emitted `error` value, not thrown) by {@link getDocumentChanges} when the "since"
+ * document can't be fetched from the history API — typically because history retention expired the
+ * revision even though the events API still lists an event for it. The UI shows a dedicated
+ * message for this error (see `ChangesError`).
+ */
 export class MissingSinceDocumentError extends Error {
   revisionId: string
 
@@ -48,6 +54,29 @@ export class MissingSinceDocumentError extends Error {
   }
 }
 
+/**
+ * Emits the annotated diff `{loading, diff, error}` between the "since" and "to" revisions,
+ * recomputing when either revision, the event list, or the remote transactions change.
+ *
+ * Since-document resolution:
+ * - Uses `since$`'s document when present.
+ * - Otherwise, when "to" points at a `createDocumentVersion` event, synthesizes an empty since
+ *   document (`_id`/`_type`/`_rev` only) so the diff shows everything as added.
+ * - Otherwise emits `MissingSinceDocumentError` when a since revision was requested but its
+ *   document couldn't be fetched (history retention); `null` error while still loading.
+ *
+ * Transaction fetching (for attribution):
+ * - A synthetic `historyCleared` since-revision yields no transactions.
+ * - When viewing the latest version (no `to._rev`) and the since revision is unchanged, previously
+ *   fetched transactions are reused and concatenated with live `remoteTransactions$` (deduped by
+ *   id) instead of refetching.
+ * - When both since and to are unchanged, transactions are fully reused.
+ * - Otherwise transactions are fetched from the translog for the since→to range.
+ *
+ * Emits a fast, annotation-less preview diff (`startWith`) while transactions load. Errors from
+ * the pipeline are logged and emitted as `{diff: null, error}`.
+ *
+ */
 export function getDocumentChanges({
   eventsObservable$,
   documentId,

--- a/packages/sanity/src/core/store/events/getDocumentTransactions.test.ts
+++ b/packages/sanity/src/core/store/events/getDocumentTransactions.test.ts
@@ -1,0 +1,178 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getTransactionsLogs} from '../translog/getTransactionsLogs'
+import {createMockClient} from './__fixtures__/mockClient'
+import {editTransaction, type TranslogEntry} from './__fixtures__/transactions.fixture'
+import {getDocumentTransactions} from './getDocumentTransactions'
+
+vi.mock('../translog/getTransactionsLogs', () => ({
+  getTransactionsLogs: vi.fn(),
+}))
+
+const mockGetTransactionsLogs = vi.mocked(getTransactionsLogs)
+
+// The module keeps a cache keyed by `${documentId}-${toTransaction}-${fromTransaction}` that
+// survives between tests, so every test uses its own document id.
+
+describe('getDocumentTransactions', () => {
+  beforeEach(() => {
+    mockGetTransactionsLogs.mockReset()
+  })
+
+  it('fetches the range and filters out the fromTransaction entry', async () => {
+    const {client} = createMockClient()
+    mockGetTransactionsLogs.mockResolvedValueOnce([
+      editTransaction({id: 'from-tx'}),
+      editTransaction({id: 'tx-1'}),
+      editTransaction({id: 'to-tx'}),
+    ])
+
+    const result = await getDocumentTransactions({
+      documentId: 'doc-filter',
+      client,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['tx-1', 'to-tx'])
+    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(client, 'doc-filter', {
+      tag: 'sanity.studio.documents.history',
+      effectFormat: 'mendoza',
+      excludeContent: true,
+      includeIdentifiedDocumentsOnly: true,
+      limit: 50,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+  })
+
+  it('does not filter the entry when fromTransaction equals toTransaction', async () => {
+    const {client} = createMockClient()
+    mockGetTransactionsLogs.mockResolvedValueOnce([editTransaction({id: 'same-tx'})])
+
+    const result = await getDocumentTransactions({
+      documentId: 'doc-same',
+      client,
+      fromTransaction: 'same-tx',
+      toTransaction: 'same-tx',
+    })
+
+    expect(result.map((tx) => tx.id)).toEqual(['same-tx'])
+  })
+
+  it('paginates past the 50-entry limit, continuing from the last received id', async () => {
+    const {client} = createMockClient()
+    // First page: the `from` entry plus 49 more — a full page after filtering, so pagination kicks in.
+    const firstPage: TranslogEntry[] = [
+      editTransaction({id: 'from-tx'}),
+      ...Array.from({length: 49}, (_, i) => editTransaction({id: `tx-${i + 1}`})),
+    ]
+    const secondPage: TranslogEntry[] = [
+      editTransaction({id: 'tx-49'}),
+      editTransaction({id: 'tx-50'}),
+      editTransaction({id: 'to-tx'}),
+    ]
+    mockGetTransactionsLogs.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage)
+
+    const result = await getDocumentTransactions({
+      documentId: 'doc-paginate',
+      client,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(2)
+    expect(mockGetTransactionsLogs.mock.calls[1][2]).toMatchObject({
+      fromTransaction: 'tx-49',
+      toTransaction: 'to-tx',
+    })
+    expect(result).toHaveLength(49 + 2)
+    expect(result.at(-1)?.id).toBe('to-tx')
+  })
+
+  it('stops paginating when the toTransaction is already in the page', async () => {
+    const {client} = createMockClient()
+    const fullPage: TranslogEntry[] = [
+      editTransaction({id: 'from-tx'}),
+      ...Array.from({length: 48}, (_, i) => editTransaction({id: `tx-${i + 1}`})),
+      editTransaction({id: 'to-tx'}),
+    ]
+    mockGetTransactionsLogs.mockResolvedValueOnce(fullPage)
+
+    const result = await getDocumentTransactions({
+      documentId: 'doc-stop',
+      client,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(1)
+    expect(result).toHaveLength(49)
+  })
+
+  it('serves closed ranges from the cache on repeated calls', async () => {
+    const {client} = createMockClient()
+    mockGetTransactionsLogs.mockResolvedValueOnce([editTransaction({id: 'tx-1'})])
+
+    const first = await getDocumentTransactions({
+      documentId: 'doc-cache',
+      client,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+    const second = await getDocumentTransactions({
+      documentId: 'doc-cache',
+      client,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(1)
+    expect(second).toBe(first)
+  })
+
+  it('never reads the cache for open ranges — they are written but refetched (known quirk)', async () => {
+    const {client} = createMockClient()
+    mockGetTransactionsLogs
+      .mockResolvedValueOnce([editTransaction({id: 'tx-1'})])
+      .mockResolvedValueOnce([editTransaction({id: 'tx-1'}), editTransaction({id: 'tx-2'})])
+
+    await getDocumentTransactions({
+      documentId: 'doc-open',
+      client,
+      fromTransaction: 'from-tx',
+      toTransaction: undefined,
+    })
+    const second = await getDocumentTransactions({
+      documentId: 'doc-open',
+      client,
+      fromTransaction: 'from-tx',
+      toTransaction: undefined,
+    })
+
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(2)
+    expect(second.map((tx) => tx.id)).toEqual(['tx-1', 'tx-2'])
+  })
+
+  it('cache key ignores project/dataset: a different client gets the cached result (known quirk)', async () => {
+    const {client: clientA} = createMockClient({projectId: 'project-a', dataset: 'dataset-a'})
+    const {client: clientB} = createMockClient({projectId: 'project-b', dataset: 'dataset-b'})
+    mockGetTransactionsLogs.mockResolvedValueOnce([editTransaction({id: 'tx-a'})])
+
+    const first = await getDocumentTransactions({
+      documentId: 'doc-workspace',
+      client: clientA,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+    const second = await getDocumentTransactions({
+      documentId: 'doc-workspace',
+      client: clientB,
+      fromTransaction: 'from-tx',
+      toTransaction: 'to-tx',
+    })
+
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(1)
+    expect(second).toBe(first)
+  })
+})

--- a/packages/sanity/src/core/store/events/getDocumentTransactions.ts
+++ b/packages/sanity/src/core/store/events/getDocumentTransactions.ts
@@ -16,6 +16,23 @@ const documentTransactionsCache: Record<
 // Transactions could be cached, given they are not gonna change EVER.
 // Transactions are in an order, so if we have [rev4, rev3, rev2] and we already got [rev4, rev3] we can just get the diff between rev3 and rev2 and increment it.
 
+/**
+ * Fetches the translog transactions for `documentId` between two revisions, transparently
+ * paginating past the 50-entries-per-request API limit.
+ *
+ * Behavior:
+ * - When `fromTransaction !== toTransaction`, the API includes the `fromTransaction` entry itself
+ *   in the response; it is filtered out so the returned range is exclusive of `from`.
+ * - When a full page is returned (accounting for the filtered `from` entry), the next page is
+ *   fetched recursively starting from the last received id — unless `toTransaction` was already
+ *   reached. With no `toTransaction`, pagination continues to the present (an empty
+ *   `fromTransaction` therefore walks the entire translog — tracked as a known issue).
+ * - Results are cached module-level per `documentId-toTransaction-fromTransaction`; the cache is
+ *   only *read* for closed ranges (`toTransaction` defined — those are immutable), but writes
+ *   happen for open ranges too.
+ *
+ * Known quirk: the cache never evicts (tracked as known issues).
+ */
 export async function getDocumentTransactions({
   documentId,
   client,

--- a/packages/sanity/src/core/store/events/getEditEvents.test.ts
+++ b/packages/sanity/src/core/store/events/getEditEvents.test.ts
@@ -1,6 +1,8 @@
 import {describe, expect, it} from 'vitest'
 
-import {getEditEvents} from './getEditEvents'
+import {minutesAfterBase} from './__fixtures__/events.fixture'
+import {DRAFT_ID, editTransaction} from './__fixtures__/transactions.fixture'
+import {getEditEvents, getEffectState} from './getEditEvents'
 import {type EditDocumentVersionEvent, type UpdateLiveDocumentEvent} from './types'
 
 describe('getEditEvents()', () => {
@@ -291,6 +293,64 @@ describe('getEditEvents()', () => {
         true,
       )
       expect(events).toEqual([expectedEvent])
+    })
+  })
+
+  describe('merge window characterization', () => {
+    it('anchors the window to the group head, not the previous transaction', () => {
+      // Three edits 4 minutes apart: each is within 5 minutes of the previous one, but the third
+      // is 8 minutes from the group head — so it starts a new event (known quirk: a continuous
+      // editing session splits every 5 minutes).
+      const transactions = [
+        editTransaction({id: 'tx-0', timestamp: minutesAfterBase(0)}),
+        editTransaction({id: 'tx-4', timestamp: minutesAfterBase(4)}),
+        editTransaction({id: 'tx-8', timestamp: minutesAfterBase(8)}),
+      ]
+
+      const events = getEditEvents(transactions, DRAFT_ID, false)
+      expect(events).toHaveLength(2)
+      expect(events[0].id).toBe('tx-8')
+      expect(
+        (events[0] as EditDocumentVersionEvent).transactions.map((tx) => tx.revisionId),
+      ).toEqual(['tx-8', 'tx-4'])
+      expect(events[1].id).toBe('tx-0')
+    })
+
+    it('accumulates distinct authors as contributors when merging', () => {
+      const transactions = [
+        editTransaction({id: 'tx-1', timestamp: minutesAfterBase(0), author: 'author-1'}),
+        editTransaction({id: 'tx-2', timestamp: minutesAfterBase(1), author: 'author-2'}),
+      ]
+
+      const [event] = getEditEvents(transactions, DRAFT_ID, false) as EditDocumentVersionEvent[]
+      expect(event.author).toBe('author-2')
+      expect(event.contributors).toEqual(['author-2', 'author-1'])
+      expect(event.transactions.map((tx) => tx.revisionId)).toEqual(['tx-2', 'tx-1'])
+    })
+
+    it('liveEdit drops merged in-window transactions entirely, including other authors', () => {
+      // Live edit checks for the events received from the events api, not the transactions.
+      const transactions = [
+        editTransaction({id: 'tx-1', timestamp: minutesAfterBase(0), author: 'author-1'}),
+        editTransaction({id: 'tx-2', timestamp: minutesAfterBase(1), author: 'author-2'}),
+      ]
+
+      const events = getEditEvents(transactions, DRAFT_ID, true)
+      // Only the newest transaction survives; author-1's edit leaves no trace.
+      expect(events).toEqual([
+        expect.objectContaining({type: 'updateLiveDocument', id: 'tx-2', author: 'author-2'}),
+      ])
+    })
+  })
+
+  describe('getEffectState()', () => {
+    it('classifies effects by their apply/revert delete patches', () => {
+      expect(getEffectState(undefined)).toBe('noop')
+      expect(getEffectState({apply: [0, null], revert: [11, 3]})).toBe('deleted')
+      expect(getEffectState({apply: [11, 3], revert: [0, null]})).toBe('created')
+      expect(getEffectState({apply: [11, 3], revert: [11, 4]})).toBe('modified')
+      // A transaction that both creates and deletes reports 'deleted' (apply wins).
+      expect(getEffectState({apply: [0, null], revert: [0, null]})).toBe('deleted')
     })
   })
 })

--- a/packages/sanity/src/core/store/events/getEditEvents.test.ts
+++ b/packages/sanity/src/core/store/events/getEditEvents.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 
-import {minutesAfterBase} from './__fixtures__/events.fixture'
-import {DRAFT_ID, editTransaction} from './__fixtures__/transactions.fixture'
+import {DRAFT_ID, minutesAfterBase} from './__fixtures__/events.fixture'
+import {editTransaction} from './__fixtures__/transactions.fixture'
 import {getEditEvents, getEffectState} from './getEditEvents'
 import {type EditDocumentVersionEvent, type UpdateLiveDocumentEvent} from './types'
 

--- a/packages/sanity/src/core/store/events/getEditEvents.ts
+++ b/packages/sanity/src/core/store/events/getEditEvents.ts
@@ -13,6 +13,16 @@ import {
 } from './types'
 import {isWithinMergeWindow} from './utils'
 
+/**
+ * Classifies a mendoza effect pair by what it did to the document:
+ * - `'deleted'`: the apply patch deletes the document (`[0, null]`).
+ * - `'created'`: the revert patch deletes the document, i.e. applying it forward created it.
+ * - `'modified'`: an effect exists but neither creates nor deletes.
+ * - `'noop'`: no effect for this document in the transaction.
+ *
+ * Used to filter edit transactions (only `'modified'` become edit events) and to decide whether a
+ * remote mutation requires refetching the event list (created/deleted look like lifecycle events).
+ */
 export function getEffectState(
   effect?: MendozaEffectPair,
 ): 'noop' | 'deleted' | 'modified' | 'created' {
@@ -66,6 +76,26 @@ export function getEditEvents(
   documentId: string,
   liveEdit: boolean,
 ): (EditDocumentVersionEvent | UpdateLiveDocumentEvent)[]
+/**
+ * Builds synthetic edit events from translog transactions — the events API does not expose edits,
+ * so the studio derives them client-side (both for the initial fetch and for real-time remote
+ * mutations).
+ *
+ * Behavior:
+ * - Only transactions whose effect on `documentId` is `'modified'` are considered
+ *   (see {@link getEffectState}); creations and deletions are lifecycle events, not edits.
+ * - Transactions are sorted newest-first, then grouped: a transaction within the merge window
+ *   (5 min) of the *current group's newest* transaction is merged into that group; otherwise it
+ *   starts a new event. Note the window is anchored to the group head, not the previous
+ *   transaction, so a continuous editing session splits every 5 minutes.
+ * - `liveEdit: false` produces `editDocumentVersionEvent`s: merged transactions are appended to
+ *   `transactions` and distinct authors accumulate in `contributors`. The event id/revisionId is
+ *   the *newest* transaction id of the group.
+ * - `liveEdit: true` produces `updateLiveDocument` events — one per group. Known quirk: merged
+ *   (in-window) transactions are dropped entirely, including those by *other authors*, losing
+ *   their attribution (tracked as a known issue; contrast with `squashLiveEditEvents`, which only
+ *   squashes same-author events).
+ */
 export function getEditEvents(
   transactions: TransactionLogEventWithEffects[],
   documentId: string,

--- a/packages/sanity/src/core/store/events/getExpandEvents.test.ts
+++ b/packages/sanity/src/core/store/events/getExpandEvents.test.ts
@@ -1,0 +1,102 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {collectEmissions} from './__fixtures__/collect.fixture'
+import {
+  createDocumentVersionEvent,
+  DRAFT_ID,
+  minutesAfterBase,
+  publishDocumentVersionEvent,
+} from './__fixtures__/events.fixture'
+import {createMockClient} from './__fixtures__/mockClient'
+import {editTransaction} from './__fixtures__/transactions.fixture'
+import {getDocumentTransactions} from './getDocumentTransactions'
+import {getExpandEvents} from './getExpandEvents'
+
+vi.mock('./getDocumentTransactions', () => ({
+  getDocumentTransactions: vi.fn(),
+}))
+
+const mockGetDocumentTransactions = vi.mocked(getDocumentTransactions)
+
+describe('getExpandEvents', () => {
+  beforeEach(() => {
+    mockGetDocumentTransactions.mockReset()
+  })
+
+  it('expands a publish event into parentId-stamped edit events', async () => {
+    const {client} = createMockClient()
+    const creationEvent = createDocumentVersionEvent({versionRevisionId: 'creation-rev'})
+    const publish = publishDocumentVersionEvent({
+      versionRevisionId: 'published-version-rev',
+      creationEvent,
+    })
+    mockGetDocumentTransactions.mockResolvedValue([
+      editTransaction({id: 'tx-edit-1', timestamp: minutesAfterBase(1)}),
+    ])
+
+    const {handleExpandEvent, expandedEvents$} = getExpandEvents({client, documentId: DRAFT_ID})
+    const {values, subscription} = collectEmissions(expandedEvents$)
+
+    await handleExpandEvent(publish)
+
+    expect(mockGetDocumentTransactions).toHaveBeenCalledWith({
+      client,
+      documentId: DRAFT_ID,
+      fromTransaction: 'creation-rev',
+      toTransaction: 'published-version-rev',
+    })
+    expect(values.at(-1)).toEqual([
+      expect.objectContaining({
+        type: 'editDocumentVersion',
+        id: 'tx-edit-1',
+        parentId: publish.id,
+      }),
+    ])
+    subscription.unsubscribe()
+  })
+
+  it('expanding the same event twice is a no-op', async () => {
+    const {client} = createMockClient()
+    const publish = publishDocumentVersionEvent({
+      versionRevisionId: 'published-version-rev',
+      creationEvent: createDocumentVersionEvent(),
+    })
+    mockGetDocumentTransactions.mockResolvedValue([editTransaction({id: 'tx-edit-1'})])
+
+    const {handleExpandEvent} = getExpandEvents({client, documentId: DRAFT_ID})
+    await handleExpandEvent(publish)
+    await handleExpandEvent(publish)
+
+    expect(mockGetDocumentTransactions).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs and ignores events that cannot be expanded', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const {client} = createMockClient()
+    // No creationEvent attached: not expandable.
+    const publish = publishDocumentVersionEvent()
+
+    const {handleExpandEvent, expandedEvents$} = getExpandEvents({client, documentId: DRAFT_ID})
+    const {values, subscription} = collectEmissions(expandedEvents$)
+
+    await handleExpandEvent(publish)
+
+    expect(mockGetDocumentTransactions).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith("This event can't be expanded", publish)
+    expect(values.at(-1)).toEqual([])
+    consoleError.mockRestore()
+    subscription.unsubscribe()
+  })
+
+  it('propagates transaction fetch failures as a rejected promise (known quirk: callers do not catch)', async () => {
+    const {client} = createMockClient()
+    const publish = publishDocumentVersionEvent({
+      versionRevisionId: 'published-version-rev',
+      creationEvent: createDocumentVersionEvent(),
+    })
+    mockGetDocumentTransactions.mockRejectedValue(new Error('translog unavailable'))
+
+    const {handleExpandEvent} = getExpandEvents({client, documentId: DRAFT_ID})
+    await expect(handleExpandEvent(publish)).rejects.toThrow('translog unavailable')
+  })
+})

--- a/packages/sanity/src/core/store/events/getExpandEvents.ts
+++ b/packages/sanity/src/core/store/events/getExpandEvents.ts
@@ -10,6 +10,24 @@ import {
   isPublishDocumentVersionEvent,
 } from './types'
 
+/**
+ * Provides the "expand event" capability of the events store: turning a publish or delete event
+ * into the list of edit events that led up to it.
+ *
+ * `handleExpandEvent(event)`:
+ * - Only `publishDocumentVersion` / `deleteDocumentVersion` events that carry both a
+ *   `versionRevisionId` and a `creationEvent` can be expanded (the creation event is attached by
+ *   `addParentToEvents` for drafts); anything else logs an error and is ignored.
+ * - Fetches the transactions between the creation revision and the published/deleted revision,
+ *   maps them to edit events (`getEditEvents`) and stamps each with `parentId: event.id` so the UI
+ *   can nest them under the expanded event.
+ * - Expanding the same event twice is a no-op (results are kept in a map keyed by event id).
+ * - Known quirk: the returned promise is not error-handled by callers and `getDocumentTransactions`
+ *   failures surface as unhandled rejections (tracked as a known issue).
+ *
+ * `expandedEvents$` emits the flattened list of all expanded edit events, consumed by
+ * `createEventsObservable` to merge them into the main list.
+ */
 export function getExpandEvents({documentId, client}: {client: SanityClient; documentId: string}) {
   const expandedEventsMap$ = new BehaviorSubject<Map<string, EditDocumentVersionEvent[]>>(new Map())
   const expandedEvents$ = expandedEventsMap$.pipe(

--- a/packages/sanity/src/core/store/events/getInitialFetchEvents.test.ts
+++ b/packages/sanity/src/core/store/events/getInitialFetchEvents.test.ts
@@ -1,0 +1,220 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {collectEmissions} from './__fixtures__/collect.fixture'
+import {
+  createDocumentVersionEvent,
+  DOCUMENT_ID,
+  DRAFT_ID,
+  minutesAfterBase,
+  publishDocumentVersionEvent,
+  VERSION_ID,
+} from './__fixtures__/events.fixture'
+import {createMockClient, type RecordedRequest} from './__fixtures__/mockClient'
+import {editTransaction} from './__fixtures__/transactions.fixture'
+import {getDocumentTransactions} from './getDocumentTransactions'
+import {getInitialFetchEvents, HISTORY_CLEARED_EVENT_ID} from './getInitialFetchEvents'
+import {type DocumentGroupEvent} from './types'
+
+vi.mock('./getDocumentTransactions', () => ({
+  getDocumentTransactions: vi.fn(),
+}))
+
+const mockGetDocumentTransactions = vi.mocked(getDocumentTransactions)
+
+function eventsResponse(documentId: string, events: DocumentGroupEvent[], nextCursor = '') {
+  return (request: RecordedRequest) => {
+    if (!request.url.includes('/events/documents/')) {
+      throw new Error(`Unexpected request: ${request.url}`)
+    }
+    return {events: {[documentId]: events}, nextCursor}
+  }
+}
+
+describe('getInitialFetchEvents', () => {
+  beforeEach(() => {
+    mockGetDocumentTransactions.mockReset()
+    mockGetDocumentTransactions.mockResolvedValue([])
+  })
+
+  it('draft: fetches events, assigns ids, and synthesizes edit events from the baseline revision', async () => {
+    const apiCreate = createDocumentVersionEvent()
+    const {client, requests} = createMockClient({respond: eventsResponse(DRAFT_ID, [apiCreate])})
+    mockGetDocumentTransactions.mockResolvedValue([
+      editTransaction({id: 'tx-edit-1', timestamp: minutesAfterBase(1)}),
+    ])
+
+    const {events$} = getInitialFetchEvents({client, documentId: DRAFT_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    expect(requests[0].url).toContain(`/events/documents/${DRAFT_ID}?limit=100`)
+    // Transactions are fetched from the newest revision-bearing event to the present.
+    expect(mockGetDocumentTransactions).toHaveBeenCalledWith({
+      client,
+      documentId: DRAFT_ID,
+      fromTransaction: apiCreate.versionRevisionId,
+      toTransaction: undefined,
+    })
+
+    const result = values.at(-1)!
+    expect(result.events.map((event) => event.type)).toEqual([
+      'editDocumentVersion',
+      'createDocumentVersion',
+    ])
+    // Ids are (re)assigned client-side per variant.
+    expect(result.events[1].id).toBe(apiCreate.versionRevisionId)
+    expect(result.error).toBeNull()
+  })
+
+  it('version: uses the creation event as the baseline for edit synthesis', async () => {
+    const apiCreate = createDocumentVersionEvent({
+      versionId: VERSION_ID,
+      versionRevisionId: 'version-create-rev',
+      documentVariantType: 'version',
+    })
+    const apiPublish = publishDocumentVersionEvent({versionId: VERSION_ID})
+    const {client} = createMockClient({
+      respond: eventsResponse(VERSION_ID, [apiPublish, apiCreate]),
+    })
+
+    const {events$} = getInitialFetchEvents({client, documentId: VERSION_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    expect(mockGetDocumentTransactions).toHaveBeenCalledWith(
+      expect.objectContaining({fromTransaction: 'version-create-rev'}),
+    )
+  })
+
+  it('published: does not fetch edit transactions', async () => {
+    const apiPublish = publishDocumentVersionEvent()
+    const {client} = createMockClient({respond: eventsResponse(DOCUMENT_ID, [apiPublish])})
+
+    const {events$} = getInitialFetchEvents({client, documentId: DOCUMENT_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    expect(mockGetDocumentTransactions).not.toHaveBeenCalled()
+    expect(values.at(-1)?.events.map((event) => event.type)).toEqual(['publishDocumentVersion'])
+  })
+
+  it('falls back to fromTransaction "" when the batch has no baseline (known quirk: walks the whole translog)', async () => {
+    const {client} = createMockClient({respond: eventsResponse(DRAFT_ID, [])})
+
+    const {events$} = getInitialFetchEvents({client, documentId: DRAFT_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    expect(mockGetDocumentTransactions).toHaveBeenCalledWith(
+      expect.objectContaining({fromTransaction: ''}),
+    )
+  })
+
+  it('prepends a synthetic historyCleared event when the API has no events but edits exist', async () => {
+    const {client} = createMockClient({respond: eventsResponse(DRAFT_ID, [])})
+    const edit = editTransaction({id: 'tx-edit-1', timestamp: minutesAfterBase(10)})
+    mockGetDocumentTransactions.mockResolvedValue([edit])
+
+    const {events$} = getInitialFetchEvents({client, documentId: DRAFT_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    const result = values.at(-1)!
+    expect(result.events.map((event) => event.type)).toEqual([
+      'historyCleared',
+      'editDocumentVersion',
+    ])
+    expect(result.events[0].id).toBe(HISTORY_CLEARED_EVENT_ID)
+    // Timestamped 1ms before the oldest edit event.
+    expect(Date.parse(result.events[0].timestamp)).toBe(Date.parse(edit.timestamp) - 1)
+  })
+
+  it('loadMore fetches the next page with the cursor, and is a no-op without one', async () => {
+    const firstBatch = publishDocumentVersionEvent({id: 'publish-1'})
+    const secondBatch = publishDocumentVersionEvent({
+      id: 'publish-2',
+      revisionId: 'publish-2',
+      timestamp: minutesAfterBase(-10),
+    })
+    let call = 0
+    const {client, requests} = createMockClient({
+      respond: () => {
+        call += 1
+        return call === 1
+          ? {events: {[DOCUMENT_ID]: [firstBatch]}, nextCursor: 'cursor-1'}
+          : {events: {[DOCUMENT_ID]: [secondBatch]}, nextCursor: ''}
+      },
+    })
+
+    const {events$, loadMore} = getInitialFetchEvents({client, documentId: DOCUMENT_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.nextCursor).toBe('cursor-1'))
+
+    loadMore()
+    await vi.waitFor(() => expect(values.at(-1)?.events).toHaveLength(2))
+    expect(requests[1].url).toContain('nextCursor=cursor-1')
+
+    // No cursor left: loadMore must not trigger another request.
+    loadMore()
+    expect(requests).toHaveLength(2)
+    subscription.unsubscribe()
+  })
+
+  it('reload fetches with limit 10 and keeps the previous cursor', async () => {
+    let call = 0
+    const {client, requests} = createMockClient({
+      respond: () => {
+        call += 1
+        return {
+          events: {[DOCUMENT_ID]: [publishDocumentVersionEvent()]},
+          nextCursor: call === 1 ? 'cursor-1' : 'reload-cursor',
+        }
+      },
+    })
+
+    const {events$, reloadEvents} = getInitialFetchEvents({client, documentId: DOCUMENT_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.nextCursor).toBe('cursor-1'))
+
+    reloadEvents()
+    await vi.waitFor(() => expect(requests).toHaveLength(2))
+    expect(requests[1].url).toContain('limit=10')
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    // The reload response cursor is discarded; the previous cursor is kept.
+    expect(values.at(-1)?.nextCursor).toBe('cursor-1')
+    subscription.unsubscribe()
+  })
+
+  it('emits the error and keeps previously accumulated events when a fetch fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let call = 0
+    const {client} = createMockClient({
+      respond: () => {
+        call += 1
+        if (call === 1) {
+          return {events: {[DOCUMENT_ID]: [publishDocumentVersionEvent()]}, nextCursor: 'cursor-1'}
+        }
+        throw new Error('events fetch failed')
+      },
+    })
+
+    const {events$, loadMore} = getInitialFetchEvents({client, documentId: DOCUMENT_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.nextCursor).toBe('cursor-1'))
+
+    loadMore()
+    await vi.waitFor(() => expect(values.at(-1)?.error).toBeInstanceOf(Error))
+    const result = values.at(-1)!
+    expect(result.events).toHaveLength(1)
+    // Known quirk: a failed non-reload fetch resets the cursor, disabling further pagination.
+    expect(result.nextCursor).toBe('')
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+    subscription.unsubscribe()
+  })
+})

--- a/packages/sanity/src/core/store/events/getInitialFetchEvents.ts
+++ b/packages/sanity/src/core/store/events/getInitialFetchEvents.ts
@@ -33,6 +33,31 @@ interface InitialFetchEventsOptions {
   client: SanityClient
   documentId: string
 }
+
+/**
+ * Creates the events-fetching pipeline for a document: an `events$` observable plus `loadMore` /
+ * `reloadEvents` triggers, all driven by a single refetch subject.
+ *
+ * Fetching:
+ * - Events come from `/data/history/<dataset>/events/documents/<id>` with `limit` 100 for
+ *   initial/loadMore fetches and 10 for reloads; each event gets a client-side id via `addEventId`.
+ * - For draft/version variants (not published, not loadMore), edit events are synthesized for the
+ *   fetched batch: the "baseline" event is the creation event (version) or the newest
+ *   revision-bearing non-delete event (draft), and transactions from that revision to the present
+ *   are fetched and mapped through `getEditEvents`. Known quirk: when the batch has no baseline
+ *   (e.g. reload's 10-event window misses it, or history was cleared), transactions are fetched
+ *   with `fromTransaction: ''` — the entire translog (tracked as a known issue).
+ * - A synthetic `historyCleared` event (id `history-cleared`, timestamped 1ms before the oldest
+ *   edit event) is prepended when the API returns no events but edit transactions exist.
+ *
+ * Accumulation (`scan`):
+ * - New batches merge into the previous list via `removeDupes` (existing events are kept).
+ * - Reloads keep the previous `nextCursor`; initial/loadMore fetches take the response cursor.
+ * - Errors are logged, emitted on `error`, and keep previously accumulated events (but reset the
+ *   emitted cursor for non-reload origins, which disables further pagination — known issue).
+ *
+ * `loadMore` is a no-op unless a cursor exists and differs from the last cursor requested.
+ */
 export function getInitialFetchEvents({client, documentId}: InitialFetchEventsOptions) {
   const documentVariantType = getDocumentVariantType(documentId)
   const refetchEventsTrigger$ = new BehaviorSubject<{

--- a/packages/sanity/src/core/store/events/getRemoteTransactionsSubscription.test.ts
+++ b/packages/sanity/src/core/store/events/getRemoteTransactionsSubscription.test.ts
@@ -1,0 +1,128 @@
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {type DocumentRemoteMutationEvent} from '../document/buffered-doc/types'
+import {type WithVersion} from '../document/document-pair/checkoutPair'
+import {remoteSnapshots} from '../document/document-pair/remoteSnapshots'
+import {collectEmissions} from './__fixtures__/collect.fixture'
+import {DOCUMENT_ID, DRAFT_ID, minutesAfterBase, VERSION_ID} from './__fixtures__/events.fixture'
+import {createMockClient} from './__fixtures__/mockClient'
+import {effectPair, remoteMutationEvent} from './__fixtures__/transactions.fixture'
+import {getRemoteTransactionsSubscription} from './getRemoteTransactionsSubscription'
+
+vi.mock('../document/document-pair/remoteSnapshots', () => ({
+  remoteSnapshots: vi.fn(),
+}))
+
+const mockRemoteSnapshots = vi.mocked(remoteSnapshots)
+
+describe('getRemoteTransactionsSubscription', () => {
+  let snapshots$: Subject<WithVersion<DocumentRemoteMutationEvent>>
+  let onRefetch: Mock<() => void>
+
+  beforeEach(() => {
+    snapshots$ = new Subject()
+    mockRemoteSnapshots.mockReset()
+    mockRemoteSnapshots.mockReturnValue(snapshots$ as never)
+    onRefetch = vi.fn<() => void>()
+  })
+
+  function setup(documentId: string, isLiveEdit = false) {
+    const {client} = createMockClient()
+    const result = getRemoteTransactionsSubscription({
+      client,
+      documentId,
+      documentType: 'author',
+      isLiveEdit,
+      onRefetch,
+    })
+    const subscription = result.subscribe()
+    return {...result, subscription}
+  }
+
+  it('appends modified mutations and emits synthesized edit events', () => {
+    const {remoteTransactions$, remoteEdits$, subscription} = setup(DRAFT_ID)
+    const {values: edits, subscription: editsSubscription} = collectEmissions(remoteEdits$)
+
+    snapshots$.next(remoteMutationEvent({transactionId: 'tx-remote-1'}))
+    expect(remoteTransactions$.value.map((tx) => tx.id)).toEqual(['tx-remote-1'])
+    expect(edits.at(-1)).toEqual([
+      expect.objectContaining({type: 'editDocumentVersion', id: 'tx-remote-1'}),
+    ])
+    expect(onRefetch).not.toHaveBeenCalled()
+
+    // Known quirk: transactions accumulate without bound during an editing session.
+    snapshots$.next(
+      remoteMutationEvent({
+        transactionId: 'tx-remote-2',
+        timestamp: new Date(minutesAfterBase(1)),
+      }),
+    )
+    expect(remoteTransactions$.value.map((tx) => tx.id)).toEqual(['tx-remote-1', 'tx-remote-2'])
+
+    editsSubscription.unsubscribe()
+    subscription.unsubscribe()
+  })
+
+  it('ignores mutations for a different variant than the one being viewed', () => {
+    const {remoteTransactions$, subscription} = setup(DRAFT_ID)
+
+    snapshots$.next(remoteMutationEvent({version: 'published'}))
+    expect(remoteTransactions$.value).toEqual([])
+    expect(onRefetch).not.toHaveBeenCalled()
+
+    subscription.unsubscribe()
+  })
+
+  it('refetches on published-document mutations when not live edit', () => {
+    const {remoteTransactions$, subscription} = setup(DOCUMENT_ID)
+
+    snapshots$.next(remoteMutationEvent({version: 'published'}))
+    expect(onRefetch).toHaveBeenCalledTimes(1)
+    expect(remoteTransactions$.value).toEqual([])
+
+    subscription.unsubscribe()
+  })
+
+  it('live edit: published-document modifications accumulate instead of refetching', () => {
+    const {remoteTransactions$, subscription} = setup(DOCUMENT_ID, true)
+
+    snapshots$.next(remoteMutationEvent({version: 'published', transactionId: 'tx-live'}))
+    expect(onRefetch).not.toHaveBeenCalled()
+    expect(remoteTransactions$.value.map((tx) => tx.id)).toEqual(['tx-live'])
+
+    subscription.unsubscribe()
+  })
+
+  it('refetches and clears accumulated transactions on created/deleted effects', () => {
+    const {remoteTransactions$, subscription} = setup(DRAFT_ID)
+
+    snapshots$.next(remoteMutationEvent({transactionId: 'tx-edit'}))
+    expect(remoteTransactions$.value).toHaveLength(1)
+
+    snapshots$.next(
+      remoteMutationEvent({
+        transactionId: 'tx-delete',
+        effects: effectPair({before: {_id: DRAFT_ID}, after: null}),
+      }),
+    )
+    expect(onRefetch).toHaveBeenCalledTimes(1)
+    expect(remoteTransactions$.value).toEqual([])
+
+    subscription.unsubscribe()
+  })
+
+  it('listens to the whole document pair, including the version id when applicable', () => {
+    setup(VERSION_ID).subscription.unsubscribe()
+
+    expect(mockRemoteSnapshots).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        draftId: DRAFT_ID,
+        publishedId: DOCUMENT_ID,
+        versionId: VERSION_ID,
+      },
+      'author',
+    )
+  })
+})

--- a/packages/sanity/src/core/store/events/getRemoteTransactionsSubscription.ts
+++ b/packages/sanity/src/core/store/events/getRemoteTransactionsSubscription.ts
@@ -18,6 +18,27 @@ interface GetRemoteTransactionsSubscriptionOptions {
   onRefetch: () => void
 }
 
+/**
+ * Sets up the real-time side of the events store: listens to remote mutations on the document
+ * pair (draft + published + version when applicable) and routes each mutation into one of three
+ * outcomes, depending on the variant being viewed:
+ *
+ * - Mutation for a *different* variant than the one being viewed → ignored.
+ * - Mutation on the published document (non-liveEdit) → `onRefetch()` (publishes/unpublishes are
+ *   lifecycle events the API must provide).
+ * - Effect state `'created'` or `'deleted'` → `onRefetch()` and the accumulated transactions are
+ *   cleared (the event list changed shape; local edit synthesis is stale).
+ * - Effect state `'modified'` → the mutation is converted via `remoteMutationToTransaction` and
+ *   appended to `remoteTransactions$`; `remoteEdits$` maps the accumulated transactions through
+ *   `getEditEvents` so they render as (live) edit events without refetching.
+ *
+ * Returns `remoteTransactions$` (consumed by `getDocumentChanges` for diffing while viewing the
+ * latest version), `remoteEdits$` (merged into the events list), and `subscribe` which activates
+ * the listener and returns the rxjs subscription.
+ *
+ * Known quirk: `remoteTransactions$` only resets on created/deleted effects, so it accumulates
+ * without bound during long editing sessions (tracked as a known issue).
+ */
 export function getRemoteTransactionsSubscription({
   client,
   isLiveEdit,

--- a/packages/sanity/src/core/store/events/useEventsStore.ts
+++ b/packages/sanity/src/core/store/events/useEventsStore.ts
@@ -34,6 +34,36 @@ const INITIAL_VALUE: EventsObservableValue = {
 }
 
 /**
+ * React entry point of the events store: creates a `createEventsStore` instance for the document
+ * (recreated when client/document/releases/liveEdit change), subscribes the remote-transactions
+ * listener for the component lifetime, and resolves the `rev`/`since` selection against the
+ * loaded events.
+ *
+ * `rev` resolution (→ `revisionId`):
+ * - `@lastPublished`: id of the newest publish event, `null` when none.
+ * - `@lastEdited`: `revisionId` of the newest edit event; falls through to the raw value if none.
+ * - `@release:<releaseId>`: id of the publish event for that release. While unresolved it keeps
+ *   calling `loadMoreEvents()` (side effect inside `useMemo` — known issue) and falls through to
+ *   the raw `@release:` string.
+ * - `undefined`: latest state; except when the newest event is a publish (its id is used) or a
+ *   delete-version (the newest edit event's `revisionId` is used — the delete's
+ *   `versionRevisionId` is unreliable).
+ *
+ * `since` resolution (→ `sinceId`), only meaningful with a revision to compare against:
+ * - explicit revision id: used as-is.
+ * - `@lastPublished` or `undefined`: the first publish event *older* than the current revision;
+ *   falls back to the creation event; then to the event right after the revision (or `events[1]`
+ *   when no revision is selected).
+ *
+ * `findRangeForRevision(nextRev)` / `findRangeForSince(nextSince)` compute the `[since, rev]` pair
+ * to write to the URL when the user picks a new revision/since in the timeline, clearing whichever
+ * side would make the range inverted (since must be older than rev).
+ *
+ * Also exposes per-revision document fetching (`getDocumentAtRevision`, plus resolved `revision` /
+ * `sinceRevision` snapshots), `getChangesList` (diff between the resolved revisions),
+ * `expandEvent`, `loadMoreEvents` and `lastNonDeletedRevId` (newest event that isn't a delete —
+ * used to restore deleted documents).
+ *
  * @internal
  */
 export function useEventsStore({

--- a/packages/sanity/src/core/store/events/utils.test.ts
+++ b/packages/sanity/src/core/store/events/utils.test.ts
@@ -1,11 +1,39 @@
 import {describe, expect, it} from 'vitest'
 
+import {activeASAPRelease} from '../../releases/__fixtures__/release.fixture'
+import {type ReleasesReducerState} from '../../releases/store/reducer'
+import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {
+  BASE_TIME,
+  createDocumentVersionEvent,
+  createLiveDocumentEvent,
+  deleteDocumentGroupEvent,
+  deleteDocumentVersionEvent,
+  editDocumentVersionEvent,
+  minutesAfterBase,
+  publishDocumentVersionEvent,
+  scheduleDocumentVersionEvent,
+  unpublishDocumentEvent,
+  unscheduleDocumentVersionEvent,
+  updateLiveDocumentEvent,
+} from './__fixtures__/events.fixture'
+import {remoteMutationEvent} from './__fixtures__/transactions.fixture'
 import {
   type DocumentGroupEvent,
   type EditDocumentVersionEvent,
   type UpdateLiveDocumentEvent,
 } from './types'
-import {addParentToEvents, sortEvents} from './utils'
+import {
+  addEventId,
+  addParentToEvents,
+  isWithinMergeWindow,
+  remoteMutationToTransaction,
+  removeDupes,
+  sortEvents,
+  squashLiveEditEvents,
+  updatePublishedEvents,
+  updateVersionEvents,
+} from './utils'
 
 describe('addParentToEvents', () => {
   it('should add the correct parentId to the events', () => {})
@@ -392,5 +420,248 @@ describe('addParentToEvents', () => {
         parentId: '577b6fa4-ceba-40bd-babd-9ffbcfff682d',
       },
     ])
+  })
+})
+
+describe('sortEvents (paired publish/edit)', () => {
+  it('sorts a publish before its paired edit even when the edit timestamp is newer', () => {
+    const edit = editDocumentVersionEvent({
+      revisionId: 'edit-rev',
+      id: 'edit-rev',
+      timestamp: minutesAfterBase(1),
+    })
+    const publish = publishDocumentVersionEvent({
+      versionRevisionId: 'edit-rev',
+      timestamp: BASE_TIME,
+    })
+
+    const result = sortEvents({remoteEdits: [edit], events: [publish], expandedEvents: []})
+    expect(result.map((event) => event.type)).toEqual([
+      'publishDocumentVersion',
+      'editDocumentVersion',
+    ])
+  })
+})
+
+describe('removeDupes', () => {
+  it('appends events with unseen ids in encounter order', () => {
+    const create = createDocumentVersionEvent({id: 'a'})
+    const edit = editDocumentVersionEvent({id: 'b'})
+    const publish = publishDocumentVersionEvent({id: 'c'})
+
+    expect(removeDupes([create, edit], [publish])).toEqual([create, edit, publish])
+    expect(removeDupes([create], [create])).toEqual([create])
+  })
+
+  it('replaces an existing edit event with a non-edit event sharing the same id', () => {
+    // A publish event and the last edit before that publish share the same id.
+    const edit = editDocumentVersionEvent({id: 'shared', revisionId: 'shared'})
+    const publish = publishDocumentVersionEvent({id: 'shared'})
+
+    const result = removeDupes([edit], [publish])
+    // Known quirk: because the types also differ, the publish is stored under both the plain id
+    // key and the synthetic `${id}-${type}` key, so it appears twice in the output.
+    expect(result).toEqual([publish, publish])
+  })
+
+  it('keeps both events when two non-edit events share an id but differ in type', () => {
+    const create = createDocumentVersionEvent({id: 'shared'})
+    const publish = publishDocumentVersionEvent({id: 'shared'})
+
+    expect(removeDupes([create], [publish])).toEqual([create, publish])
+  })
+
+  it('keeps only the first event when two events share id and type', () => {
+    const first = createDocumentVersionEvent({id: 'shared', author: 'author-1'})
+    const second = createDocumentVersionEvent({id: 'shared', author: 'author-2'})
+
+    expect(removeDupes([first], [second])).toEqual([first])
+  })
+
+  it('collides all empty-string ids onto one key (known quirk)', () => {
+    // addEventId produces empty ids e.g. for unpublish events on non-published variants.
+    const first = unpublishDocumentEvent({id: '', timestamp: BASE_TIME})
+    const second = unpublishDocumentEvent({id: '', timestamp: minutesAfterBase(1)})
+
+    expect(removeDupes([], [first, second])).toEqual([first])
+  })
+})
+
+describe('addEventId', () => {
+  it('createDocumentVersion: published uses revisionId, falling back to a synthetic id', () => {
+    const withRevision = createDocumentVersionEvent({revisionId: 'pub-rev'})
+    expect(addEventId(withRevision, 'published').id).toBe('pub-rev')
+
+    const withoutRevision = createDocumentVersionEvent({timestamp: BASE_TIME})
+    expect(addEventId(withoutRevision, 'published').id).toBe(`publishCreation--${BASE_TIME}`)
+
+    expect(addEventId(createDocumentVersionEvent(), 'draft').id).toBe(
+      createDocumentVersionEvent().versionRevisionId,
+    )
+  })
+
+  it('deleteDocumentVersion: published gets a synthetic deleteAt id, versions use versionRevisionId', () => {
+    const event = deleteDocumentVersionEvent({timestamp: BASE_TIME})
+    expect(addEventId(event, 'published').id).toBe(`deleteAt-${BASE_TIME}`)
+    expect(addEventId(event, 'draft').id).toBe(event.versionRevisionId)
+  })
+
+  it('publishDocumentVersion: published uses revisionId, versions prefer versionRevisionId', () => {
+    const event = publishDocumentVersionEvent({
+      revisionId: 'published-rev',
+      versionRevisionId: 'version-rev',
+    })
+    expect(addEventId(event, 'published').id).toBe('published-rev')
+    expect(addEventId(event, 'draft').id).toBe('version-rev')
+
+    // Release publishes have no versionRevisionId: falls back to revisionId.
+    const releasePublish = publishDocumentVersionEvent({
+      revisionId: 'published-rev',
+      versionRevisionId: undefined,
+      publishCause: 'release.publish',
+    })
+    expect(addEventId(releasePublish, 'version').id).toBe('published-rev')
+  })
+
+  it('unpublishDocument: synthetic id on published, empty string otherwise (known quirk)', () => {
+    const event = unpublishDocumentEvent({timestamp: BASE_TIME})
+    expect(addEventId(event, 'published').id).toBe(`unpublishAt-${BASE_TIME}`)
+    expect(addEventId(event, 'draft').id).toBe('')
+  })
+
+  it('schedule/unschedule: versionRevisionId on versions, empty string on published (known quirk)', () => {
+    const schedule = scheduleDocumentVersionEvent()
+    expect(addEventId(schedule, 'version').id).toBe(schedule.versionRevisionId)
+    expect(addEventId(schedule, 'published').id).toBe('')
+
+    const unschedule = unscheduleDocumentVersionEvent()
+    expect(addEventId(unschedule, 'version').id).toBe(unschedule.versionRevisionId)
+    expect(addEventId(unschedule, 'published').id).toBe('')
+  })
+
+  it('deleteDocumentGroup gets a synthetic deleted-<timestamp> id on every variant', () => {
+    const event = deleteDocumentGroupEvent({timestamp: BASE_TIME})
+    expect(addEventId(event, 'published').id).toBe(`deleted-${BASE_TIME}`)
+    expect(addEventId(event, 'draft').id).toBe(`deleted-${BASE_TIME}`)
+  })
+
+  it('live and edit events use their revisionId', () => {
+    const createLive = createLiveDocumentEvent({revisionId: 'live-rev'})
+    expect(addEventId(createLive, 'published').id).toBe('live-rev')
+
+    const updateLive = updateLiveDocumentEvent({revisionId: 'live-rev-2'})
+    expect(addEventId(updateLive, 'published').id).toBe('live-rev-2')
+
+    const edit = editDocumentVersionEvent({revisionId: 'edit-rev'})
+    expect(addEventId(edit, 'draft').id).toBe('edit-rev')
+  })
+})
+
+describe('isWithinMergeWindow', () => {
+  it('is true below 5 minutes, false at exactly 5 minutes, regardless of argument order', () => {
+    expect(isWithinMergeWindow(BASE_TIME, minutesAfterBase(4))).toBe(true)
+    expect(isWithinMergeWindow(minutesAfterBase(4), BASE_TIME)).toBe(true)
+    expect(isWithinMergeWindow(BASE_TIME, minutesAfterBase(5))).toBe(false)
+    expect(isWithinMergeWindow(BASE_TIME, minutesAfterBase(6))).toBe(false)
+  })
+})
+
+describe('squashLiveEditEvents', () => {
+  it('squashes adjacent same-author live edits within the merge window, keeping the first in list order', () => {
+    const newest = updateLiveDocumentEvent({id: 'live-2', timestamp: minutesAfterBase(4)})
+    const oldest = updateLiveDocumentEvent({id: 'live-1', timestamp: BASE_TIME})
+
+    expect(squashLiveEditEvents([newest, oldest])).toEqual([newest])
+  })
+
+  it('does not squash live edits by different authors', () => {
+    const a = updateLiveDocumentEvent({id: 'live-2', timestamp: minutesAfterBase(4)})
+    const b = updateLiveDocumentEvent({id: 'live-1', timestamp: BASE_TIME, author: 'author-2'})
+
+    expect(squashLiveEditEvents([a, b])).toEqual([a, b])
+  })
+
+  it('does not squash live edits outside the merge window', () => {
+    const a = updateLiveDocumentEvent({id: 'live-2', timestamp: minutesAfterBase(10)})
+    const b = updateLiveDocumentEvent({id: 'live-1', timestamp: BASE_TIME})
+
+    expect(squashLiveEditEvents([a, b])).toEqual([a, b])
+  })
+
+  it('breaks the run when another event type sits between live edits', () => {
+    const a = updateLiveDocumentEvent({id: 'live-2', timestamp: minutesAfterBase(2)})
+    const between = deleteDocumentGroupEvent({timestamp: minutesAfterBase(1)})
+    const b = updateLiveDocumentEvent({id: 'live-1', timestamp: BASE_TIME})
+
+    expect(squashLiveEditEvents([a, between, b])).toEqual([a, between, b])
+  })
+})
+
+describe('remoteMutationToTransaction', () => {
+  it('maps a remote mutation into the translog transaction shape', () => {
+    const mutation = remoteMutationEvent()
+    const transaction = remoteMutationToTransaction(mutation)
+
+    expect(transaction).toEqual({
+      id: mutation.transactionId,
+      author: mutation.author,
+      timestamp: mutation.timestamp.toISOString(),
+      documentIDs: [],
+      effects: {
+        [mutation.head._id]: {
+          apply: mutation.effects.apply,
+          revert: mutation.effects.revert,
+        },
+      },
+    })
+  })
+})
+
+describe('updateVersionEvents', () => {
+  it('rewrites documentId to versionId on publish events only', () => {
+    const publish = publishDocumentVersionEvent({versionId: 'versions.rX.doc-1'})
+    const edit = editDocumentVersionEvent()
+
+    const result = updateVersionEvents([publish, edit])
+    expect(result[0]).toEqual({...publish, documentId: 'versions.rX.doc-1'})
+    expect(result[1]).toBe(edit)
+  })
+})
+
+const releasesState = (releases: Map<string, typeof activeASAPRelease>): ReleasesReducerState => ({
+  releases,
+  state: 'loaded',
+})
+
+describe('updatePublishedEvents', () => {
+  it('attaches the release document when it exists in the releases store', () => {
+    const publish = publishDocumentVersionEvent({
+      versionId: `versions.${activeASAPRelease.name}.doc-1`,
+    })
+    const state = releasesState(new Map([[activeASAPRelease._id, activeASAPRelease]]))
+
+    const [result] = updatePublishedEvents([publish], state)
+    expect(result).toEqual({...publish, release: activeASAPRelease})
+  })
+
+  it('attaches a stub {_id} when the release is not in the store (e.g. deleted release)', () => {
+    const publish = publishDocumentVersionEvent({versionId: 'versions.rGone.doc-1'})
+    const state = releasesState(new Map())
+
+    const [result] = updatePublishedEvents([publish], state)
+    expect(result).toEqual({
+      ...publish,
+      release: {_id: getReleaseDocumentIdFromReleaseId('rGone')},
+    })
+  })
+
+  it('leaves draft publishes and other event types untouched', () => {
+    const draftPublish = publishDocumentVersionEvent({versionId: 'drafts.doc-1'})
+    const edit = editDocumentVersionEvent()
+    const state = releasesState(new Map())
+
+    const result = updatePublishedEvents([draftPublish, edit], state)
+    expect(result[0]).toBe(draftPublish)
+    expect(result[1]).toBe(edit)
   })
 })

--- a/packages/sanity/src/core/store/events/utils.ts
+++ b/packages/sanity/src/core/store/events/utils.ts
@@ -37,6 +37,8 @@ import {
  *   only the first one survives unless their types differ.
  * - The synthetic `${id}-${type}` key only disambiguates one extra event per id; a third event
  *   with the same id and same type as the second overwrites it.
+ * - The edit-replacement and different-type branches both run: an edit + non-edit pair sharing an
+ *   id stores the non-edit event under *both* keys, so it appears twice in the output.
  */
 export function removeDupes(
   events: DocumentGroupEvent[],

--- a/packages/sanity/src/core/store/events/utils.ts
+++ b/packages/sanity/src/core/store/events/utils.ts
@@ -21,6 +21,23 @@ import {
   type UpdateLiveDocumentEvent,
 } from './types'
 
+/**
+ * Merges two event lists (existing first, then incoming) into one, removing duplicates by event id.
+ *
+ * Main cases covered:
+ * - Events with unseen ids are appended in encounter order.
+ * - If an existing *edit* event shares its id with an incoming *non-edit* event, the non-edit event
+ *   replaces it — a publish event and the last edit before that publish share the same id.
+ * - If two events share an id but have *different* types, both are kept: the second one is stored
+ *   under a synthetic `${id}-${type}` map key (can happen when a document is created and published
+ *   with the same revision id, e.g. in e2e tests).
+ *
+ * Known quirks (current behavior, relied upon by tests):
+ * - Events with an empty-string id (see {@link addEventId}) all collide on the same map key, so
+ *   only the first one survives unless their types differ.
+ * - The synthetic `${id}-${type}` key only disambiguates one extra event per id; a third event
+ *   with the same id and same type as the second overwrites it.
+ */
 export function removeDupes(
   events: DocumentGroupEvent[],
   newEvents: DocumentGroupEvent[],
@@ -45,6 +62,25 @@ export function removeDupes(
   return Array.from(noDupes.values())
 }
 
+/**
+ * Assigns a client-side `id` to an API event. The id doubles as the *revision selector* used in
+ * URLs and by `getDocumentAtRevision`, so it must point at a revision that exists for the variant
+ * the user is looking at:
+ *
+ * - `createDocumentVersion`: published → `revisionId` (or a synthetic `publishCreation--<ts>` when
+ *   missing); draft/version → `versionRevisionId`.
+ * - `deleteDocumentVersion`: published → synthetic `deleteAt-<ts>`; draft/version → `versionRevisionId`.
+ * - `publishDocumentVersion`: published → `revisionId`; draft/version → `versionRevisionId`
+ *   (falls back to `revisionId` when the publish wasn't triggered by a Publish action).
+ * - `unpublishDocument`: published → synthetic `unpublishAt-<ts>`; **empty string otherwise**.
+ * - `scheduleDocumentVersion` / `unscheduleDocumentVersion`: draft/version → `versionRevisionId`;
+ *   **empty string on published**.
+ * - `deleteDocumentGroup`: synthetic `deleted-<ts>` for all variants.
+ * - `createLiveDocument` / `updateLiveDocument` / `editDocumentVersion`: `revisionId`.
+ *
+ * Known quirk: the empty-string ids collide in {@link removeDupes} (only the first such event
+ * survives) and cannot be selected as a revision in the UI.
+ */
 export function addEventId(
   event: Omit<DocumentGroupEvent, 'id'>,
   documentVariantType: DocumentVariantType,
@@ -84,6 +120,25 @@ export function addEventId(
   return {...event, id} as DocumentGroupEvent
 }
 
+/**
+ * Draft-variant post-processing: links publish/delete events to the edit and create events that
+ * produced them, so the UI can render those as an expandable group under the publish event.
+ *
+ * For every `publishDocumentVersion` / `deleteDocumentVersion` event (scanning newest → oldest):
+ * - Rewrites its `documentId` to the `versionId` (the draft id).
+ * - Walks the *older* events: every `editDocumentVersion` on the way gets `parentId` set to the
+ *   publish/delete event id; the first `createDocumentVersion` found is attached as
+ *   `creationEvent` (and gets `parentId` too), then the walk stops.
+ *
+ * For `editDocumentVersion` events whose id equals their own `parentId` (the last edit before a
+ * publish shares the publish event's id), the id is re-pointed at the second transaction's
+ * revision so the edit remains individually selectable.
+ *
+ * Notes on current behavior:
+ * - Operates on a `JSON.parse(JSON.stringify(...))` deep clone (runs on every pipeline emission
+ *   for drafts — known perf cost, tracked as a known issue).
+ * - Assumes `events` is sorted newest-first (as produced by {@link sortEvents}).
+ */
 export function addParentToEvents(events: DocumentGroupEvent[]): DocumentGroupEvent[] {
   const eventsWithParent = JSON.parse(JSON.stringify(events)) as DocumentGroupEvent[]
   eventsWithParent.forEach((event, index) => {
@@ -115,10 +170,21 @@ export function addParentToEvents(events: DocumentGroupEvent[]): DocumentGroupEv
 
 const MERGE_WINDOW = 5 * 60 * 1000 // 5 minutes
 
+/**
+ * True when two ISO timestamps are less than 5 minutes apart (absolute difference).
+ * Used to decide whether consecutive edit transactions belong to the same logical edit event.
+ */
 export function isWithinMergeWindow(a: string, b: string): boolean {
   return Math.abs(Date.parse(a) - Date.parse(b)) < MERGE_WINDOW
 }
 
+/**
+ * Collapses consecutive `updateLiveDocument` events into one when they are within the merge
+ * window **and** by the same author — the later (newer) event in the list survives.
+ *
+ * Only adjacent events are considered: a different event type or author in between breaks the run.
+ * Temporary client-side squashing until the API squashes live edit events itself.
+ */
 export function squashLiveEditEvents(events: DocumentGroupEvent[]): DocumentGroupEvent[] {
   return events.reduce((acc: DocumentGroupEvent[], event) => {
     if (isUpdateLiveDocumentEvent(event)) {
@@ -138,6 +204,12 @@ export function squashLiveEditEvents(events: DocumentGroupEvent[]): DocumentGrou
   }, [])
 }
 
+/**
+ * Converts a remote mutation (received through the document-pair listener) into the translog
+ * transaction shape, so real-time edits can flow through the same pipeline as fetched
+ * transactions ({@link getEditEvents}, diff calculation). `documentIDs` is intentionally left
+ * empty; the effects map is keyed by the mutated document's id.
+ */
 export function remoteMutationToTransaction(
   event: DocumentRemoteMutationEvent,
 ): TransactionLogEventWithEffects {
@@ -156,7 +228,9 @@ export function remoteMutationToTransaction(
 }
 
 /**
- * Updates the version publish document id.
+ * Version-variant post-processing: rewrites `documentId` to the `versionId` on
+ * `publishDocumentVersion` events, so the UI attributes the publish to the version document the
+ * user is viewing instead of the published id. All other events pass through untouched.
  */
 export function updateVersionEvents(events: DocumentGroupEvent[]) {
   return events.map((event) => {
@@ -171,7 +245,11 @@ export function updateVersionEvents(events: DocumentGroupEvent[]) {
 }
 
 /**
- * Adds the release information to the publish event.
+ * Published-variant post-processing: attaches release metadata to `publishDocumentVersion` events
+ * whose `versionId` belongs to a release. When the release document is in the releases store it is
+ * attached as `release`; otherwise a stub `{_id: <releaseDocumentId>}` is attached so the UI can
+ * still show that a (e.g. deleted/archived) release caused the publish. Draft publishes and all
+ * other events pass through untouched.
  */
 export function updatePublishedEvents(
   events: DocumentGroupEvent[],
@@ -194,6 +272,20 @@ export function updatePublishedEvents(
   })
 }
 
+/**
+ * Merges remote edits, API events and expanded edit events into one list sorted newest-first.
+ *
+ * Sorting rules:
+ * - Primary: timestamp descending.
+ * - Special case: a `publishDocumentVersion` event always sorts *before* the `editDocumentVersion`
+ *   event it published (`publish.versionRevisionId === edit.revisionId`), regardless of their
+ *   timestamps — the publish's API timestamp has seconds granularity and can tie with or trail the
+ *   edit's transaction timestamp.
+ *
+ * Known quirk: the special case makes the comparator non-transitive (publish < paired edit while
+ * both compare by timestamp against everything else), so ordering around such pairs can depend on
+ * input order — tracked as a known issue.
+ */
 export function sortEvents({
   remoteEdits,
   events,


### PR DESCRIPTION
### Description
It adds unit tests to the events store.
This store was not battle tested, now this adds the necessary tests and covers the already know use cases allowing us to add new use cases, like supporting variants or small refactors, within a safe scenario.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tests and documentation only; no production behavior changes in the diff.
> 
> **Overview**
> Adds **automated coverage** for the document events store and shared **test fixtures** so timeline/history behavior can be changed safely.
> 
> New helpers under `__fixtures__` include deterministic event/transaction builders, a minimal `SanityClient` mock, an NDJSON `fetch` stub for translog calls, and `collectEmissions` for RxJS assertions. New and expanded Vitest suites exercise the full pipeline: initial fetch/pagination/reload, observable merging per draft/published/version, expand-on-publish, remote mutations, revision snapshots, translog range fetch + pagination/cache behavior, annotated diffs (`calculateDiff` / `diffValue` / `getDocumentChanges`), and utilities (`sortEvents`, `removeDupes`, `addEventId`, live-edit squashing, etc.). Many tests explicitly record **known quirks** (cache never evicting, empty event ids colliding, merge-window anchoring).
> 
> Production code changes are **JSDoc only** on the main store modules—no runtime logic edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d12b4b9294843ed7a9575848a6b24bb1d09785. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->