### PR TITLE
chore(bench): measure the release commit directly

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -86,10 +86,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-          # Backfill and A/B builds add a worktree at a historical commit,
-          # which a depth-1 clone doesn't have (the inputs are empty on
-          # non-dispatch events)
-          fetch-depth: ${{ (inputs.backfill_sha != '' || inputs.ab_to != '') && '0' || '1' }}
+          # Backfill and A/B builds add a worktree at a historical commit, which
+          # a depth-1 clone doesn't have. A release run also needs history: the
+          # validation step resolves the tag to check the measured commit is the
+          # tagged one, and tags are not fetched at depth 1. (All inputs are
+          # empty on non-dispatch events, so the cron stays shallow.)
+          fetch-depth: ${{ (inputs.backfill_sha != '' || inputs.ab_to != '' || inputs.release_tag != '') && '0' || '1' }}
 
       - uses: ./.github/actions/detect-code-changes
         id: changes
@@ -142,28 +144,38 @@ jobs:
               exit 1
             fi
           fi
-          # A release run measures the tag's dereferenced sha via the backfill
-          # path. Without a sha the run would measure HEAD and be stored as the
-          # release's measurement — the exact false attribution release runs
-          # exist to prevent — so this is an error, not a warning.
-          if [ -n "$RELEASE_TAG" ] && [ -z "$BACKFILL_SHA" ]; then
-            echo "::error::release_tag requires backfill_sha (the tag's dereferenced commit)"
-            exit 1
-          fi
-          # ...and the sha must actually BE that commit. The pair is also set
-          # by hand (the recovery runbook in release-latest.yml), and a stale
-          # copy-paste would store numbers measured on some other commit as
-          # the release's measurement. The checkout above is fetch-depth 0
-          # whenever backfill_sha is set, so the tag is resolvable here.
+          # What a release run must guarantee: the measured commit IS the
+          # tagged one. There are two honest ways to get there.
+          #
+          # 1. No backfill_sha — the run measures HEAD, which is correct exactly
+          #    when HEAD is the tag's commit. That is the case during a release:
+          #    the tag is cut on the `chore(release): publish` commit at the tip
+          #    of main, so the ordinary HEAD build already measures the release.
+          #    Cheaper and more faithful than replaying it, since the historical
+          #    replay path exists to reconstruct trees that no longer match HEAD.
+          # 2. With backfill_sha — for a release whose commit is no longer HEAD
+          #    (measuring past releases), where the replay path is required.
+          #
+          # Either way the sha actually measured has to be the tag's, so both
+          # branches are checked rather than trusted. A stale copy-paste of the
+          # recovery command in release-latest.yml is the realistic mistake.
           if [ -n "$RELEASE_TAG" ]; then
             TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}" 2>/dev/null || true)"
             if [ -z "$TAG_SHA" ]; then
               echo "::error::release_tag $RELEASE_TAG does not exist"
               exit 1
             fi
-            if [ "$TAG_SHA" != "$BACKFILL_SHA" ]; then
-              echo "::error::backfill_sha $BACKFILL_SHA is not the commit $RELEASE_TAG points at ($TAG_SHA)"
-              exit 1
+            if [ -n "$BACKFILL_SHA" ]; then
+              if [ "$TAG_SHA" != "$BACKFILL_SHA" ]; then
+                echo "::error::backfill_sha $BACKFILL_SHA is not the commit $RELEASE_TAG points at ($TAG_SHA)"
+                exit 1
+              fi
+            else
+              HEAD_SHA="$(git rev-parse HEAD)"
+              if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+                echo "::error::$RELEASE_TAG points at $TAG_SHA but HEAD is $HEAD_SHA — pass backfill_sha=$TAG_SHA to measure that commit instead of HEAD"
+                exit 1
+              fi
             fi
           fi
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -144,21 +144,22 @@ jobs:
               exit 1
             fi
           fi
-          # What a release run must guarantee: the measured commit IS the
-          # tagged one. There are two honest ways to get there.
+          # What a release run must guarantee: the measured commit IS the tagged
+          # one. There are two ways to get there.
           #
-          # 1. No backfill_sha — the run measures HEAD, which is correct exactly
-          #    when HEAD is the tag's commit. That is the case during a release:
-          #    the tag is cut on the `chore(release): publish` commit at the tip
-          #    of main, so the ordinary HEAD build already measures the release.
-          #    Cheaper and more faithful than replaying it, since the historical
-          #    replay path exists to reconstruct trees that no longer match HEAD.
-          # 2. With backfill_sha — for a release whose commit is no longer HEAD
-          #    (measuring past releases), where the replay path is required.
+          # 1. No backfill_sha — the run measures the checkout, which is correct
+          #    when the workflow was dispatched at the tag itself (`--ref <tag>`,
+          #    what release-latest.yml does). An ordinary build of the right tree
+          #    is cheaper and more faithful than replaying it.
+          # 2. With backfill_sha — for a release whose commit is not the
+          #    checkout, i.e. measuring past releases from a main dispatch, where
+          #    the replay path is required.
           #
           # Either way the sha actually measured has to be the tag's, so both
-          # branches are checked rather than trusted. A stale copy-paste of the
-          # recovery command in release-latest.yml is the realistic mistake.
+          # branches are checked rather than trusted. Dispatching `--ref main`
+          # without a backfill_sha is the realistic mistake: main has almost
+          # always moved past the release by then, so it would silently measure
+          # someone else's commit as the release.
           if [ -n "$RELEASE_TAG" ]; then
             TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}" 2>/dev/null || true)"
             if [ -z "$TAG_SHA" ]; then
@@ -173,7 +174,7 @@ jobs:
             else
               HEAD_SHA="$(git rev-parse HEAD)"
               if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
-                echo "::error::$RELEASE_TAG points at $TAG_SHA but HEAD is $HEAD_SHA — pass backfill_sha=$TAG_SHA to measure that commit instead of HEAD"
+                echo "::error::$RELEASE_TAG points at $TAG_SHA but this run checked out $HEAD_SHA. Dispatch at the tag (--ref $RELEASE_TAG), or pass backfill_sha=$TAG_SHA to replay that commit from a main dispatch."
                 exit 1
               fi
             fi

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -199,16 +199,20 @@ jobs:
     # with the default GITHUB_TOKEN, whose events never start workflows (the
     # same reason sync-git-metrics is called rather than listening for tags).
     #
-    # Dispatches an ordinary HEAD run. The tag is cut on the
-    # `chore(release): publish` commit at the tip of main, so by the time this
-    # runs the release commit already IS main's HEAD and bench's normal build
-    # measures exactly the right tree. `release_tag` only labels the stored
-    # document; bench.yml verifies HEAD is that tag's commit before measuring.
+    # Dispatches an ordinary build of the release tag — `--ref` is the tag, so
+    # the checkout inside bench.yml lands exactly on the released commit and its
+    # normal build measures the right tree. `release_tag` labels the stored
+    # document, and bench.yml verifies the measured commit is the tag's.
+    #
+    # `--ref` is the tag rather than `main` on purpose: main moves every few
+    # minutes, and this job runs minutes after the release commit lands (behind
+    # build-and-validate and git-operations), so `main` is frequently no longer
+    # the release. The tag is immutable and cannot race.
     #
     # Deliberately no `backfill_sha`: that selects bench's historical replay
     # path, which rebuilds a commit in its own worktree from that commit's
-    # lockfile. It is for trees that no longer match HEAD, and does not work
-    # pointed at HEAD itself.
+    # lockfile. It is for trees that no longer match the checkout, which is not
+    # the case here.
     #
     # Non-blocking by construction: nothing depends on this job, so a failed
     # benchmark can never fail or delay a release.
@@ -216,9 +220,10 @@ jobs:
     # Requires git-operations to have actually run (not 'skipped', which
     # npm-publish tolerates), so a publish-only rerun does not re-measure a
     # release that was already measured. The flip side: if the original run's
-    # dispatch failed, a rerun will not retry it. To measure it by hand *after*
-    # main has moved on, the commit is no longer HEAD, so that case does need the
-    # replay path: `gh workflow run bench.yml -f run_suite=true
+    # dispatch failed, a rerun will not retry it. Measuring it by hand later
+    # needs the replay path, dispatched from main (a tag older than this
+    # workflow has no release_tag input of its own):
+    # `gh workflow run bench.yml --ref main -f run_suite=true
     # -f backfill_sha=<tag's commit> -f release_tag=<tag>`.
     needs: [build-and-validate, git-operations]
     if: >
@@ -236,7 +241,7 @@ jobs:
         run: |
           gh workflow run bench.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref main \
+            --ref "v$VERSION" \
             -f run_suite=true \
             -f release_tag="v$VERSION"
 

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -199,17 +199,27 @@ jobs:
     # with the default GITHUB_TOKEN, whose events never start workflows (the
     # same reason sync-git-metrics is called rather than listening for tags).
     #
-    # Runs through bench.yml's backfill path, which builds and measures a given
-    # commit with HEAD's harness — the release sha is just another commit to
-    # measure. Non-blocking by construction: nothing depends on this job, so a
-    # failed benchmark can never fail or delay a release.
+    # Dispatches an ordinary HEAD run. The tag is cut on the
+    # `chore(release): publish` commit at the tip of main, so by the time this
+    # runs the release commit already IS main's HEAD and bench's normal build
+    # measures exactly the right tree. `release_tag` only labels the stored
+    # document; bench.yml verifies HEAD is that tag's commit before measuring.
+    #
+    # Deliberately no `backfill_sha`: that selects bench's historical replay
+    # path, which rebuilds a commit in its own worktree from that commit's
+    # lockfile. It is for trees that no longer match HEAD, and does not work
+    # pointed at HEAD itself.
+    #
+    # Non-blocking by construction: nothing depends on this job, so a failed
+    # benchmark can never fail or delay a release.
     #
     # Requires git-operations to have actually run (not 'skipped', which
     # npm-publish tolerates), so a publish-only rerun does not re-measure a
     # release that was already measured. The flip side: if the original run's
-    # dispatch failed, a rerun will not retry it — measure it by hand with
-    # `gh workflow run bench.yml -f run_suite=true -f backfill_sha=<sha>
-    # -f release_tag=<tag>`, which is exactly what this job does.
+    # dispatch failed, a rerun will not retry it. To measure it by hand *after*
+    # main has moved on, the commit is no longer HEAD, so that case does need the
+    # replay path: `gh workflow run bench.yml -f run_suite=true
+    # -f backfill_sha=<tag's commit> -f release_tag=<tag>`.
     needs: [build-and-validate, git-operations]
     if: >
       always() && needs.build-and-validate.result == 'success' &&
@@ -219,35 +229,15 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          # The tag was pushed by git-operations; fetch it to dereference
-          fetch-depth: 0
-          ref: v${{ needs.build-and-validate.outputs.version }}
-
-      - name: Resolve the tag's commit
-        id: resolve
-        env:
-          VERSION: ${{ needs.build-and-validate.outputs.version }}
-        run: |
-          # The dereferenced commit, so an annotated tag yields the commit and
-          # not the tag object
-          sha=$(git rev-parse "v$VERSION^{commit}")
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "Measuring v$VERSION at $sha"
-
       - name: Dispatch the bench suite for this release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.build-and-validate.outputs.version }}
-          SHA: ${{ steps.resolve.outputs.sha }}
         run: |
           gh workflow run bench.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f run_suite=true \
-            -f backfill_sha="$SHA" \
             -f release_tag="v$VERSION"
 
   publish-releases:

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -147,6 +147,25 @@ describe('collectRunMetadata', () => {
     expect(metadata()).toMatchObject({trigger: 'release', releaseTag: 'v6.10.1'})
   })
 
+  // A release run is dispatched at its tag, so GITHUB_REF_NAME is the tag name.
+  // The measured commit is a main commit, and the dashboards group runs into
+  // per-branch lines defaulting to main — filing it under the tag would drop the
+  // run out of the series it belongs to.
+  it('files a release run on main, not on its tag ref', () => {
+    process.env.BENCH_TRIGGER = 'release'
+    process.env.BENCH_RELEASE_TAG = 'v6.10.1'
+    process.env.GITHUB_REF_NAME = 'v6.10.1'
+    expect(metadata().git.branch).toBe('main')
+  })
+
+  // ...but nothing else is rewritten: a PR or cron run keeps the ref it ran on
+  it('leaves the branch alone for non-release runs', () => {
+    process.env.GITHUB_REF_NAME = 'some-branch'
+    expect(metadata().git.branch).toBe('some-branch')
+    process.env.GITHUB_HEAD_REF = 'pr-branch'
+    expect(metadata().git.branch).toBe('pr-branch')
+  })
+
   // A tag on a non-release run would assert that the run measured that release,
   // which is the false attribution the field exists to remove
   it('keeps the release tag only on release runs', () => {

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -93,12 +93,13 @@ export function collectRunMetadata(options: {
   // repo, and a malformed workflow override must not poison the time axis
   // consumers sort and filter on
   const committedAt = Number.isNaN(Date.parse(committedAtRaw)) ? undefined : committedAtRaw
+  const triggerInfo = triggerFields(prNumber, options.mode)
 
   return {
     _type: 'benchRun',
     schemaVersion: 1,
     mode: options.mode,
-    ...triggerFields(prNumber, options.mode),
+    ...triggerInfo,
     git: {
       // BENCH_GIT_SHA: the commit the measured dist was actually built from,
       // when that differs from the checkout — backfill runs build a
@@ -106,10 +107,18 @@ export function collectRunMetadata(options: {
       // cli/commands/prepareBackfill.ts) and must be stored under that
       // commit, not the workflow's HEAD
       sha: process.env.BENCH_GIT_SHA || process.env.GITHUB_SHA || git(['rev-parse', 'HEAD']),
+      // A release run is dispatched at its tag, so GITHUB_REF_NAME is the tag
+      // name ('v6.11.0'). The commit it measures is a main commit, and the
+      // dashboards group runs into per-branch lines and default to main — a run
+      // filed under a tag name would sit outside the main series it belongs to.
+      // The ref names how the run was dispatched; the branch names where the
+      // measured commit lives, which for a release is always main.
+      //
       // GITHUB_HEAD_REF is empty (not unset) outside pull_request events, and
       // schedule runs are detached checkouts where rev-parse answers "HEAD" —
       // prefer GITHUB_REF_NAME there
       branch:
+        (triggerInfo.trigger === 'release' ? 'main' : '') ||
         process.env.GITHUB_HEAD_REF ||
         process.env.GITHUB_REF_NAME ||
         git(['rev-parse', '--abbrev-ref', 'HEAD']),


### PR DESCRIPTION
### Description

Follow-up to #14312. The `bench-release` job passed the tag's sha as `backfill_sha`, which sends the run down the historical replay path: a separate worktree built from that commit's own lockfile with HEAD's harness overlaid.

That machinery is for trees that no longer match HEAD. Pointed at HEAD itself its dependency remapping conflicts with the already-correct install, and the build fails. Every release would have triggered a failing bench run, and it was never needed: the tag is cut on the `chore(release): publish` commit in main, so the release commit already is `HEAD` when the job runs.

### What to review


### Testing

Not verified end to end: needs a real release or a manual dispatch.

### Notes for release

N/A – Internal tooling only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes release measurement and CI validation paths for shipped-version benchmarks; wrong dispatch refs could still be caught by tag-vs-HEAD checks, but metrics attribution depends on this wiring.
> 
> **Overview**
> Release benchmarks no longer use **`backfill_sha`**, which forced the historical replay worktree path and could break builds when the replayed commit is already the checkout. **`release-latest.yml`** now dispatches **`bench.yml`** with **`--ref v$VERSION`** and only **`release_tag`**, so the workflow checks out the immutable tag and runs a normal **`build:bench`** on that tree.
> 
> **`bench.yml`** treats **`release_tag`** as valid without **`backfill_sha`**: it still resolves the tag and fails if the measured commit is wrong—either **`backfill_sha`** must match the tag, or **`HEAD`** must match when replay is omitted. **`fetch-depth: 0`** also applies when **`release_tag`** is set so tags resolve during validation.
> 
> Stored run metadata in **`collect.ts`** sets **`git.branch`** to **`main`** for release-triggered runs (even when **`GITHUB_REF_NAME`** is the tag), so release points stay on the main time series in dashboards. Tests cover that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05ec0db9592d0d6f0c629157dc77acfe22a73ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->