### PR TITLE
fix(release-notes): strip pull request refs from renovate changelog entries

### DIFF
--- a/packages/@repo/release-notes/src/utils/__test__/__fixtures__/renovate-cli-update.md
+++ b/packages/@repo/release-notes/src/utils/__test__/__fixtures__/renovate-cli-update.md
@@ -11,15 +11,15 @@
 
 ##### Bug Fixes
 
-- use non-deprecated `--project-id` flag for dataset import during init ([#661](https://redirect.github.com/sanity-io/cli/issues/661)) ([0b660b9](https://redirect.github.com/sanity-io/cli/commit/0b660b9))
+- use non-deprecated `--project-id` flag for dataset import during init ([#&#8203;661](https://redirect.github.com/sanity-io/cli/issues/661)) ([0b660b9](https://redirect.github.com/sanity-io/cli/commit/0b660b9))
 
 ### [`v6.1.2`](https://redirect.github.com/sanity-io/cli/blob/HEAD/packages/@sanity/cli/CHANGELOG.md#612-2026-03-13)
 
 ##### Bug Fixes
 
-- bump react+react-dom to latest on new installs ([#658](https://redirect.github.com/sanity-io/cli/issues/658)) ([87b733f](https://redirect.github.com/sanity-io/cli/commit/87b733f))
-- resolve react-dom/server and @sanity/ui from studio workDir ([#657](https://redirect.github.com/sanity-io/cli/issues/657)) ([ce07d42](https://redirect.github.com/sanity-io/cli/commit/ce07d42))
-- **deps:** update oclif-tooling ([#651](https://github.com/sanity-io/cli/issues/651)) ([f807f1d](https://github.com/sanity-io/cli/commit/f807f1dc351e4657debf86c00c5537b014391feb))
+- bump react+react-dom to latest on new installs ([#&#8203;658](https://redirect.github.com/sanity-io/cli/issues/658)) ([87b733f](https://redirect.github.com/sanity-io/cli/commit/87b733f))
+- resolve react-dom/server and @sanity/ui from studio workDir ([#&#8203;657](https://redirect.github.com/sanity-io/cli/issues/657)) ([ce07d42](https://redirect.github.com/sanity-io/cli/commit/ce07d42))
+- **deps:** update oclif-tooling ([#&#8203;651](https://github.com/sanity-io/cli/issues/651)) ([f807f1d](https://github.com/sanity-io/cli/commit/f807f1dc351e4657debf86c00c5537b014391feb))
 
 ##### Dependencies
 
@@ -33,11 +33,11 @@
 
 ##### Bug Fixes
 
-- lazy-load icon resolver to avoid pulling in @sanity/ui at import time ([#636](https://redirect.github.com/sanity-io/cli/issues/636)) ([e2a6c6d](https://redirect.github.com/sanity-io/cli/commit/e2a6c6d))
+- lazy-load icon resolver to avoid pulling in @sanity/ui at import time ([#&#8203;636](https://redirect.github.com/sanity-io/cli/issues/636)) ([e2a6c6d](https://redirect.github.com/sanity-io/cli/commit/e2a6c6d))
 
 ##### Features
 
-- add new `--template` flag for `sanity init` ([#640](https://redirect.github.com/sanity-io/cli/issues/640)) ([a1b2c3d](https://redirect.github.com/sanity-io/cli/commit/a1b2c3d))
+- add new `--template` flag for `sanity init` ([#&#8203;640](https://redirect.github.com/sanity-io/cli/issues/640)) ([a1b2c3d](https://redirect.github.com/sanity-io/cli/commit/a1b2c3d))
 
 </details>
 

--- a/packages/@repo/release-notes/src/utils/__test__/parseRenovateReleaseNotes.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/parseRenovateReleaseNotes.test.ts
@@ -5,7 +5,13 @@ import {
   parseRenovateReleaseNotes,
   RENOVATE_RELEASE_NOTES_PACKAGES,
 } from '../parseRenovateReleaseNotes'
+import {type NormalizedMarkdownBlock} from '../portabletext-markdown/markdownToPortableText'
+import {type PortableTextBlock} from '../portabletext-markdown/types'
 import {readFixture} from './helpers'
+
+function markDefsOf(blocks: NormalizedMarkdownBlock[]): PortableTextBlock['markDefs'] {
+  return blocks.flatMap((block) => (block._type === 'block' ? block.markDefs : []))
+}
 
 describe('parseRenovateReleaseNotes', () => {
   it('parses @sanity/cli Renovate body and returns portable text with bug fix and feature content', async () => {
@@ -31,9 +37,9 @@ describe('parseRenovateReleaseNotes', () => {
     // Should NOT contain deps-scoped items even when under Bug Fixes
     expect(markdown).not.toContain('update oclif-tooling')
 
-    // Should preserve PR/issue refs as links (without outer parens)
-    expect(markdown).toMatch(/\[#\d+]\(/)
-    expect(markdown).not.toMatch(/\(\[#\d+]\(/)
+    // Should NOT contain PR/issue refs
+    expect(markdown).not.toMatch(/\[#/)
+    expect(markDefsOf(blocks)).toEqual([])
 
     // Should NOT contain commit hashes
     expect(markdown).not.toMatch(/\(\[[0-9a-f]{7}]\(/)
@@ -89,11 +95,8 @@ describe('parseRenovateReleaseNotes', () => {
     const blocks = parseRenovateReleaseNotes(body)
     const markdown = portableTextToMarkdown(blocks)
 
-    expect(markdown).toContain('a visible fix')
-    // PR ref link should be preserved
-    expect(markdown).toContain('[#1](https://example.com)')
-    // Commit hash should be stripped
-    expect(markdown).not.toContain('abc1234')
+    expect(markdown).toBe('- a visible fix')
+    expect(markDefsOf(blocks)).toEqual([])
     expect(markdown).not.toContain('dep bumped')
     expect(markdown).not.toContain('reformatted code')
     expect(markdown).not.toContain('updated config')
@@ -122,7 +125,7 @@ describe('parseRenovateReleaseNotes', () => {
     expect(markdown).not.toContain('deps')
   })
 
-  it('strips commit hashes but preserves PR refs as links', () => {
+  it('strips commit hashes and PR refs', () => {
     const body = `### Release Notes
 
 <details>
@@ -139,13 +142,29 @@ describe('parseRenovateReleaseNotes', () => {
     const blocks = parseRenovateReleaseNotes(body)
     const markdown = portableTextToMarkdown(blocks)
 
-    expect(markdown).toContain('fix something important')
-    // PR ref should be preserved as a link
-    expect(markdown).toContain('[#123](https://example.com/issues/123)')
-    // Commit hash should be stripped
-    expect(markdown).not.toContain('deadbeef')
-    // Outer parens around PR ref should be removed
-    expect(markdown).not.toContain('([#123]')
+    expect(markdown).toBe('- fix something important')
+    expect(markDefsOf(blocks)).toEqual([])
+  })
+
+  it('strips PR refs containing a zero-width space entity', () => {
+    const body = `### Release Notes
+
+<details>
+<summary>sanity-io/cli (@&#8203;sanity/cli)</summary>
+
+### [\`v8.3.0\`](https://example.com)
+
+##### Features
+
+- include source of auth token in \`sanity debug\` ([#&#8203;1690](https://redirect.github.com/sanity-io/cli/pull/1690)) ([e64da59](https://redirect.github.com/sanity-io/cli/commit/e64da59))
+
+</details>`
+
+    const blocks = parseRenovateReleaseNotes(body)
+    const markdown = portableTextToMarkdown(blocks)
+
+    expect(markdown).toBe('- include source of auth token in `sanity debug`')
+    expect(markDefsOf(blocks)).toEqual([])
   })
 
   it('returns empty for non-Renovate PR bodies', () => {

--- a/packages/@repo/release-notes/src/utils/parseRenovateReleaseNotes.ts
+++ b/packages/@repo/release-notes/src/utils/parseRenovateReleaseNotes.ts
@@ -125,11 +125,16 @@ function filterVisibleSections(markdown: string): string {
   return output.join('\n')
 }
 
+// Renovate writes PR refs as `[#&#8203;661]`, inserting a zero-width space to stop GitHub
+// auto-linking them, so the pattern tolerates both the entity and a literal U+200B.
+const PR_REF_PATTERN = String.raw`\[#(?:&#8203;|\u200B)?\d+]\([^)]*\)`
+const PARENTHESISED_PR_REF = new RegExp(String.raw`\s*\(${PR_REF_PATTERN}\)`, 'gm')
+const BARE_PR_REF = new RegExp(String.raw`\s*${PR_REF_PATTERN}`, 'gm')
+
 /**
- * Strip trailing commit hashes like `([0b660b9](url))` from list items,
- * unwrap PR/issue refs from outer parentheses so the link is preserved
- * (e.g. `([#661](url))` → `[#661](url)`),
- * and remove dependency-scoped items (e.g. `- **deps:** ...`) that aren't meaningful for release notes.
+ * Strip trailing commit hashes like `([0b660b9](url))`, PR/issue refs like `([#661](url))`,
+ * and dependency-scoped items (e.g. `- **deps:** ...`) from list items. The refs resolve
+ * through Renovate's redirector to another repo's pull requests, so they are noise here.
  */
 function cleanChangelogItems(markdown: string): string {
   return (
@@ -138,7 +143,8 @@ function cleanChangelogItems(markdown: string): string {
       .replace(/^\s*-\s+\*\*deps:\*\*.*$/gm, '')
       // Strip trailing commit hash links like ([0b660b9](url))
       .replace(/\s*\(\[[0-9a-f]+]\([^)]*\)\)/gm, '')
-      // Unwrap PR/issue refs: ([#123](url)) → [#123](url) so the link is preserved
-      .replace(/\(\[#(\d+)]\(([^)]*)\)\)/gm, '[#$1]($2)')
+      // Parenthesised refs first, so removing a ref never leaves a stray paren behind
+      .replace(PARENTHESISED_PR_REF, '')
+      .replace(BARE_PR_REF, '')
   )
 }


### PR DESCRIPTION
### Description

The release note generator scrapes upstream changelogs out of Renovate PR bodies for `@sanity/cli`, and preserved any PR ref it found as a link. Renovate writes those refs as `([#&#8203;1690](url))`, where a zero-width space stops GitHub auto-linking them, so the unwrap pattern matching `[#123]` never fired. Each scraped entry then landed in the changelog document as an annotated zero-width space between two orphaned parens, deleted by hand every release.

This PR strips PR and issue refs out of scraped Renovate items entirely, parens included, and updates the test fixture to the form Renovate actually emits.

### What to review

- `cleanChangelogItems` removes the parenthesised form before the bare form, so dropping a ref never leaves a stray paren behind.
- The refs resolve through `redirect.github.com` to `sanity-io/cli` pull requests, so nothing in Studio release notes should link to them.
- `renovate-cli-update.md` carried a hand-written `[#661]` while its `<summary>` used the real `@&#8203;sanity/cli` form. That divergence is why the dead pattern went unnoticed, so the fixture now matches real output.
- Scope is the bot path only. `extractReleaseNotesFromPrBody` and the Pending changes table in `bin/release-notes.ts` are untouched.

### Testing

Ran the new pattern against the real body of #14292 and confirmed both entries come out with no link annotations and no stray parens. The rewritten fixture test fails against the old pattern, so it is a genuine regression test rather than one that passes either way. 84 tests pass in `@repo/release-notes`.

### Notes for release

N/A

---
