### PR TITLE
chore: migrate flex in core/releases

### DIFF
--- a/packages/sanity/src/core/releases/components/ScheduleDatePicker.tsx
+++ b/packages/sanity/src/core/releases/components/ScheduleDatePicker.tsx
@@ -1,9 +1,9 @@
 import {EarthGlobeIcon} from '@sanity/icons/EarthGlobe'
-import {Flex} from '@sanity/ui'
 import {format} from 'date-fns/format'
 import {isValid} from 'date-fns/isValid'
 import {parse} from 'date-fns/parse'
 import {useCallback, useMemo} from 'react'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../ui-components/button/Button'
 import {MONTH_PICKER_VARIANT} from '../../components/inputs/DateInputs/calendar/Calendar'
@@ -48,7 +48,7 @@ export const ScheduleDatePicker = ({value, onChange, timeZoneScope}: ScheduleDat
   const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(t), [t])
 
   return (
-    <Flex flex={1} justify="space-between">
+    <Flex flexBasis="0%" flexGrow={1} justifyContent="space-between">
       <DateTimeInput
         selectTime
         monthPickerVariant={MONTH_PICKER_VARIANT.carousel}

--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -1,9 +1,9 @@
 import {type EditableReleaseDocument} from '@sanity/client'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Flex} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {type FormEvent, useCallback, useState} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
@@ -139,7 +139,7 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
           <Box paddingBottom={4}>
             <ReleaseForm onChange={handleOnChange} value={release} />
           </Box>
-          <Flex justify="flex-end" paddingTop={5}>
+          <Flex justifyContent="flex-end" paddingTop={5}>
             <Button
               size="large"
               disabled={isSubmitting || invalid}

--- a/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
@@ -1,7 +1,8 @@
 import {type EditableReleaseDocument, type ReleaseDocument} from '@sanity/client'
-import {Card, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+import {Card, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {type ChangeEvent, useCallback, useId, useRef, useState} from 'react'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
@@ -109,7 +110,7 @@ export function EditReleaseDialog({
             />
           </Stack>
         </Stack>
-        <Flex justify="flex-end" paddingTop={5}>
+        <Flex justifyContent="flex-end" paddingTop={5}>
           <Button
             data-testid="save-release-details-button"
             loading={isSaving}

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -4,7 +4,6 @@ import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {
   // oxlint-disable-next-line no-restricted-imports -- fine-grained control needed
   Button,
-  Flex,
   Stack,
   TabPanel,
   Text,
@@ -24,6 +23,7 @@ import {
   useId,
   useState,
 } from 'react'
+import {Flex} from 'ui5'
 
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -127,7 +127,7 @@ export function ReleaseForm(props: {
   return (
     <Stack gap={5}>
       <Stack gap={4}>
-        <Flex gap={2} align="center">
+        <Flex gap={2} alignItems="center">
           <Text as="label" htmlFor={menuButtonId}>
             {t('release.dialog.tooltip.title')}
           </Text>
@@ -155,7 +155,7 @@ export function ReleaseForm(props: {
             ref={setMenuButton}
             button={
               <Button mode="ghost">
-                <Flex justify="space-between" align="center">
+                <Flex justifyContent="space-between" alignItems="center">
                   <ReleaseTypeOption
                     text={t(`release.type.${releaseType}`)}
                     releaseType={releaseType}
@@ -212,7 +212,7 @@ const ReleaseTypeOption: ComponentType<{
   text: string
   releaseType: ReleaseType
 }> = ({releaseType, text}) => (
-  <Flex gap={3} align="center">
+  <Flex gap={3} alignItems="center">
     <ReleaseAvatar padding={1} releaseType={releaseType} />
     <Text>{text}</Text>
   </Flex>

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToDraftsMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToDraftsMenuItem.tsx
@@ -1,6 +1,6 @@
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {memo} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {useSchema} from '../../../../hooks/useSchema'
@@ -51,7 +51,7 @@ export const CopyToDraftsMenuItem = memo(function CopyToDraftsMenuItem(
       onClick={() => void onClick({shouldConfirmDraftDiscard: true})}
       data-testid="copy-to-drafts-menu-item"
       renderMenuItem={() => (
-        <Flex gap={3} align="center">
+        <Flex gap={3} alignItems="center">
           <Box flexBasis="auto" flexGrow={0} flexShrink={0} paddingX={2}>
             <ReleaseAvatar padding={0} release={LATEST} />
           </Box>

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
@@ -1,7 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {LockIcon} from '@sanity/icons/Lock'
-import {Flex, Stack, Text} from '@sanity/ui'
+import {Stack, Text} from '@sanity/ui'
 import {memo} from 'react'
+import {Flex} from 'ui5'
 
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useFormatRelativeLocalePublishDate} from '../../../hooks/useFormatRelativeLocalePublishDate'
@@ -18,7 +19,7 @@ export const VersionContextMenuItem = memo(function VersionContextMenuItem(props
   const isScheduled = isReleaseScheduledOrScheduling(release)
 
   return (
-    <Flex gap={3} justify="center" align="center">
+    <Flex gap={3} justifyContent="center" alignItems="center">
       <ReleaseAvatar padding={2} release={release} />
       <Stack flex={1} gap={2}>
         <ReleaseTitle

--- a/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
@@ -1,9 +1,9 @@
 import {type EditableReleaseDocument} from '@sanity/client'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Flex, Text} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {useState} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {Dialog} from '../../../../../ui-components/dialog/Dialog'
@@ -139,7 +139,7 @@ export function CopyToNewReleaseDialog(props: {
         marginBottom={2}
         style={{borderBottom: '1px solid var(--card-border-color)'}}
       >
-        <Flex align="center" padding={4} paddingTop={1} justify="space-between">
+        <Flex alignItems="center" padding={4} paddingTop={1} justifyContent="space-between">
           {schemaType ? (
             <Preview value={{_id: versionId}} schemaType={schemaType} />
           ) : (
@@ -147,7 +147,7 @@ export function CopyToNewReleaseDialog(props: {
           )}
 
           <Flex
-            align="center"
+            alignItems="center"
             gap={2}
             padding={1}
             paddingRight={2}
@@ -175,7 +175,7 @@ export function CopyToNewReleaseDialog(props: {
         )}
         <ReleaseForm onChange={handleOnChange} value={release} />
 
-        <Flex gap={3} justify="flex-end" paddingTop={3} align="center">
+        <Flex gap={3} justifyContent="flex-end" paddingTop={3} alignItems="center">
           <Button
             disabled={isSubmitting}
             text={t('common.dialog.cancel-button.text')}

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleasePreviewCard.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleasePreviewCard.tsx
@@ -1,5 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {ReleaseAvatar} from '../../../components/ReleaseAvatar'

--- a/packages/sanity/src/core/releases/tool/components/ReleaseTime.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseTime.tsx
@@ -1,6 +1,6 @@
 import {LockIcon} from '@sanity/icons/Lock'
-import {Flex, Text} from '@sanity/ui'
-import {Box} from 'ui5'
+import {Text} from '@sanity/ui'
+import {Box, Flex} from 'ui5'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useReleaseTime} from '../../hooks/useReleaseTime'
@@ -37,7 +37,7 @@ export const ReleaseTime: React.FC<{release: TableRelease}> = ({release}) => {
   const isInArchivedView = ARCHIVED_RELEASE_STATES.includes(release.state)
 
   return (
-    <Flex gap={1} align="center" wrap="wrap">
+    <Flex gap={1} alignItems="center" flexWrap="wrap">
       {isScheduledOrScheduling && (
         <Box paddingY={1}>
           <Text size={1} muted>

--- a/packages/sanity/src/core/releases/tool/components/StatusItem.tsx
+++ b/packages/sanity/src/core/releases/tool/components/StatusItem.tsx
@@ -1,6 +1,6 @@
-import {Card, Flex, Text} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 import {type ReactNode} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 export function StatusItem(props: {avatar?: ReactNode; text: ReactNode; testId?: string}) {
   const {avatar, text, testId} = props

--- a/packages/sanity/src/core/releases/tool/components/Table/DocumentTable.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/DocumentTable.tsx
@@ -1,7 +1,7 @@
 import {SearchIcon} from '@sanity/icons/Search'
-import {Badge, Card, Checkbox, Container, Flex, TextInput, useMediaIndex} from '@sanity/ui'
+import {Badge, Card, Checkbox, Container, TextInput, useMediaIndex} from '@sanity/ui'
 import {type CSSProperties, type ReactNode, useCallback, useMemo, useState} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {Table} from './Table'
@@ -190,7 +190,7 @@ export function DocumentTable<Row extends object>({
       // Select-all lives in the column-header row (above the row checkboxes it governs), not the
       // command lane. Doubles as clear.
       header: ({headerProps}) => (
-        <Flex {...headerProps} align="center" justify="center" paddingY={3} sizing="border">
+        <Flex {...headerProps} alignItems="center" justifyContent="center" paddingY={3}>
           <Checkbox
             aria-label={labels.selectAll}
             checked={allSelected}
@@ -201,7 +201,7 @@ export function DocumentTable<Row extends object>({
         </Flex>
       ),
       cell: ({cellProps, datum}) => (
-        <Flex {...cellProps} align="center" justify="center" paddingX={2} sizing="border">
+        <Flex {...cellProps} alignItems="center" justifyContent="center" paddingX={2}>
           {!datum.isLoading && (selection?.isRowSelectable?.(datum) ?? true) && (
             <Checkbox
               aria-label={labels.selectRow}
@@ -234,7 +234,7 @@ export function DocumentTable<Row extends object>({
   const showBulkToolbar = Boolean(selection) && selectedVisibleCount > 0
 
   return (
-    <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
+    <Flex flexDirection="column" flexBasis="0%" flexGrow={1} height="100%" overflow="hidden">
       {/* Command lane (zone 1). Fixed height so the browse↔bulk swap never shifts the rows. Idle:
           filter tabs lead from the left (aligned with the columns), search is right-aligned. On
           selection: selected count + Clear on the left, caller's bulk actions on the right.
@@ -243,7 +243,7 @@ export function DocumentTable<Row extends object>({
         <Card flex="none" borderBottom paddingY={2}>
           <Container flex="none" width={3}>
             <Box paddingX={2}>
-              <Flex align="center" gap={3} style={{minHeight: commandLaneMinHeight}}>
+              <Flex alignItems="center" gap={3} style={{minHeight: commandLaneMinHeight}}>
                 {showBulkToolbar && selection ? (
                   <>
                     <Badge data-testid="document-table-selected-count" fontSize={1} tone="primary">

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -1,9 +1,9 @@
-import {Card, type CardProps, Flex, rem, Text, useTheme} from '@sanity/ui'
+import {Card, type CardProps, rem, Text, useTheme} from '@sanity/ui'
 import {useVirtualizer, type VirtualItem} from '@tanstack/react-virtual'
 import {isValid} from 'date-fns/isValid'
 import get from 'lodash-es/get.js'
 import {type CSSProperties, type ElementType, Fragment, useMemo} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {TooltipDelayGroupProvider} from '../../../../../ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider'
 import {TableEmptyState} from './TableEmptyState'
@@ -120,14 +120,31 @@ const TableInner = <TableData, AdditionalRowTableData>({
       // here and size the header (border-box) to 50px to match — under-reserving clips the ⋯.
       width: 50,
       header: ({headerProps: {id}}) => (
-        <Flex as="th" id={id} paddingY={3} paddingX={3} sizing="border" style={{width: '50px'}}>
+        <Flex
+          as="th"
+          id={id}
+          paddingY={3}
+          paddingX={3}
+          style={{
+            width: '50px',
+          }}
+        >
           <Text muted size={1} weight="medium">
             &nbsp;
           </Text>
         </Flex>
       ),
       cell: ({datum, cellProps: {id}}) => (
-        <Flex as="td" id={id} align="center" flex="none" padding={3} style={{width: '25px'}}>
+        <Flex
+          as="td"
+          id={id}
+          alignItems="center"
+          flexBasis="auto"
+          flexGrow={0}
+          flexShrink={0}
+          padding={3}
+          style={{width: '25px'}}
+        >
           {(!datum.isLoading && rowActions?.({datum})) || <Box style={{width: '25px'}} />}
         </Flex>
       ),

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -116,8 +116,8 @@ const TableInner = <TableData, AdditionalRowTableData>({
       // Header and body rows are independent flexboxes: this trailing gutter must be the SAME width
       // in both, otherwise the flex:1 "Document" column absorbs the difference in the body only and
       // every column to its right (Last edited, Edited by) drifts out of alignment with its header.
-      // The body cell below is content-box (width:25px + padding:3 => ~50px actual), so reserve 50
-      // here and size the header (border-box) to 50px to match — under-reserving clips the ⋯.
+      // Both cells use border-box from the ui5 global reset, so reserve 50px in each — under-reserving
+      // clips the ⋯.
       width: 50,
       header: ({headerProps: {id}}) => (
         <Flex
@@ -143,7 +143,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
           flexGrow={0}
           flexShrink={0}
           padding={3}
-          style={{width: '25px'}}
+          style={{width: '50px'}}
         >
           {(!datum.isLoading && rowActions?.({datum})) || <Box style={{width: '25px'}} />}
         </Flex>

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -116,8 +116,8 @@ const TableInner = <TableData, AdditionalRowTableData>({
       // Header and body rows are independent flexboxes: this trailing gutter must be the SAME width
       // in both, otherwise the flex:1 "Document" column absorbs the difference in the body only and
       // every column to its right (Last edited, Edited by) drifts out of alignment with its header.
-      // Both cells use border-box from the ui5 global reset, so reserve 50px in each — under-reserving
-      // clips the ⋯.
+      // The body cell below is content-box (width:25px + padding:3 => ~50px actual), so reserve 50
+      // here and size the header (border-box) to 50px to match — under-reserving clips the ⋯.
       width: 50,
       header: ({headerProps: {id}}) => (
         <Flex
@@ -143,7 +143,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
           flexGrow={0}
           flexShrink={0}
           padding={3}
-          style={{width: '50px'}}
+          style={{width: '25px'}}
         >
           {(!datum.isLoading && rowActions?.({datum})) || <Box style={{width: '25px'}} />}
         </Flex>

--- a/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
@@ -73,7 +73,7 @@ const TableHeaderSearch = ({
   const {setSearchTerm, searchTerm} = useTableContext()
 
   return (
-    <Stack {...headerProps} flex={1} paddingY={2} paddingRight={3}>
+    <Stack {...headerProps} flex={1} paddingY={2} paddingRight={3} sizing="border">
       <TextInput
         border={false}
         fontSize={1}

--- a/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
@@ -1,10 +1,10 @@
 import {ArrowUpIcon} from '@sanity/icons/ArrowUp'
 import {SearchIcon} from '@sanity/icons/Search'
-import {Card, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {Card, Stack, Text, TextInput} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {type CSSProperties, useMemo} from 'react'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button, type ButtonProps} from '../../../../../ui-components/button/Button'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'

--- a/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
@@ -73,7 +73,7 @@ const TableHeaderSearch = ({
   const {setSearchTerm, searchTerm} = useTableContext()
 
   return (
-    <Stack {...headerProps} flex={1} paddingY={2} paddingRight={3} sizing="border">
+    <Stack {...headerProps} flex={1} paddingY={2} paddingRight={3}>
       <TextInput
         border={false}
         fontSize={1}

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
@@ -1,6 +1,7 @@
-import {Flex, Text, ThemeProvider} from '@sanity/ui'
+import {Text, ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
 import {useState} from 'react'
+import {Flex} from 'ui5'
 
 import {Table} from '../Table'
 import {Headers} from '../TableHeader'
@@ -21,12 +22,12 @@ const columns: Column<Datum>[] = [
     id: 'title',
     width: null,
     header: (props) => (
-      <Flex {...props.headerProps} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} paddingY={3}>
         <Headers.BasicHeader text="Title" />
       </Flex>
     ),
     cell: ({cellProps, datum}) => (
-      <Flex align="center" paddingX={2} {...cellProps}>
+      <Flex alignItems="center" paddingX={2} {...cellProps}>
         <Text size={1}>{datum.title}</Text>
       </Flex>
     ),

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -2,9 +2,10 @@ import {type ReleaseDocument} from '@sanity/client'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {PublishIcon} from '@sanity/icons/Publish'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Checkbox, Flex, Stack, Text} from '@sanity/ui'
+import {Checkbox, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {Dialog} from '../../../../../ui-components/dialog/Dialog'
@@ -209,7 +210,7 @@ export const ReleasePublishAllButton = ({
           </Text>
           {showUpdateDraftsOption && (
             <Stack gap={3}>
-              <Flex align="center" gap={3} as="label">
+              <Flex alignItems="center" gap={3} as="label">
                 <Checkbox
                   checked={shouldUpdateDrafts}
                   onChange={(event: ChangeEvent<HTMLInputElement>) =>
@@ -269,7 +270,7 @@ export const ReleasePublishAllButton = ({
     // TODO: this is a duplicate of logic in ReleaseScheduleButton
     return (
       <Text muted size={1}>
-        <Flex align="center" gap={3} padding={1}>
+        <Flex alignItems="center" gap={3} padding={1}>
           <ToneIcon icon={ErrorOutlineIcon} tone={isValidatingDocuments ? 'default' : 'critical'} />
           {tooltipText()}
         </Flex>

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
@@ -1,11 +1,11 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {RestoreIcon} from '@sanity/icons/Restore'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Checkbox, Flex, Text} from '@sanity/ui'
+import {Card, Checkbox, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {useCallback, useEffect, useRef, useState} from 'react'
 import {useRouter} from 'sanity/router'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../../../ui-components/button/Button'
 import {Dialog} from '../../../../../../ui-components/dialog/Dialog'
@@ -209,7 +209,7 @@ const ConfirmReleaseDialog = ({
           />
         }
       </Text>
-      <Flex align="center" paddingTop={4}>
+      <Flex alignItems="center" paddingTop={4}>
         <Checkbox
           onChange={() => setStageNewRevertRelease((current) => !current)}
           id="immediate-revert-release"

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -2,7 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 import {ClockIcon} from '@sanity/icons/Clock'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {format} from 'date-fns/format'
 import {isBefore} from 'date-fns/isBefore'
@@ -11,6 +11,7 @@ import {parse} from 'date-fns/parse'
 import {startOfMinute} from 'date-fns/startOfMinute'
 import isEqual from 'lodash-es/isEqual.js'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {Dialog} from '../../../../../ui-components/dialog/Dialog'
@@ -245,7 +246,7 @@ export const ReleaseScheduleButton = ({
             </Card>
           )}
           <Stack gap={3}>
-            <Flex align="center" justify="space-between" gap={2}>
+            <Flex alignItems="center" justifyContent="space-between" gap={2}>
               <label>
                 <Text size={1} weight="semibold">
                   {tCore('release.schedule-dialog.select-publish-date-label')}
@@ -360,7 +361,7 @@ export const ReleaseScheduleButton = ({
   const scheduleTooltipContent = useMemo(() => {
     return (
       <Text muted size={1}>
-        <Flex align="center" gap={3} padding={1}>
+        <Flex alignItems="center" gap={3} padding={1}>
           <ToneIcon icon={ErrorOutlineIcon} tone={isValidatingDocuments ? 'default' : 'critical'} />
           {tooltipText}
         </Flex>

--- a/packages/sanity/src/core/releases/tool/detail/ArchivedReleaseBanner.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ArchivedReleaseBanner.tsx
@@ -1,9 +1,10 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {addDays} from 'date-fns/addDays'
 import {format} from 'date-fns/format'
 import {useMemo} from 'react'
+import {Flex} from 'ui5'
 
 import {useProjectSubscriptions} from '../../../hooks/useProjectSubscriptions'
 import {useTimeZone} from '../../../hooks/useTimeZone'

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActivityListItem.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActivityListItem.tsx
@@ -1,7 +1,8 @@
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {memo, type ReactNode, useMemo} from 'react'
 import {styled} from 'styled-components'
+import {Flex} from 'ui5'
 
 import {UserAvatar} from '../../../components/userAvatar/UserAvatar'
 import {useDateTimeFormat} from '../../../hooks/useDateTimeFormat'
@@ -134,10 +135,10 @@ export const ReleaseActivityListItem = memo(
         animate={{opacity: 1}}
         transition={{type: 'spring', bounce: 0, duration: 0.4}}
       >
-        <Flex align="center" gap={2}>
+        <Flex alignItems="center" gap={2}>
           <UserAvatar user={event.author} />
           <Stack flex={1}>
-            <Flex gap={2} align="center">
+            <Flex gap={2} alignItems="center">
               <StatusText muted size={1}>
                 <Translate
                   t={t}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardActivityPanel.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardActivityPanel.tsx
@@ -1,11 +1,11 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {CloseIcon} from '@sanity/icons/Close'
-import {Card, Flex, Layer, Text, useLayer} from '@sanity/ui'
+import {Card, Layer, Text, useLayer} from '@sanity/ui'
 import {AnimatePresence, motion} from 'motion/react'
 import {useEffect} from 'react'
 import TrapFocus from 'react-focus-lock'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
@@ -63,8 +63,8 @@ export function ReleaseDashboardActivityPanel({
   const {t: tCore} = useTranslation()
 
   const content = (
-    <MotionFlex flex="none" height="fill" direction="column">
-      <Flex align="center" gap={2} justify="space-between" padding={4}>
+    <MotionFlex flexBasis="auto" flexGrow={0} flexShrink={0} height="100%" flexDirection="column">
+      <Flex alignItems="center" gap={2} justifyContent="space-between" padding={4}>
         <Text size={1} weight="medium">
           {t('activity.panel.title')}
         </Text>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -7,9 +7,9 @@ import {PinIcon} from '@sanity/icons/Pin'
 import {PinFilledIcon} from '@sanity/icons/PinFilled'
 import {UserIcon} from '@sanity/icons/User'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Card, Container, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {Card, Container, Skeleton, Stack, Text} from '@sanity/ui'
 import {useCallback, useEffect, useRef, useState} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
@@ -78,7 +78,7 @@ function ReleaseDashboardDetailsProduction({
   return (
     <Container width={3}>
       <Stack padding={3} paddingY={[3, 3, 4, 5]}>
-        <Flex gap={1} align="center">
+        <Flex gap={1} alignItems="center">
           {isReleaseOpen && (
             <Button
               icon={isSelected ? PinFilledIcon : PinIcon}
@@ -271,7 +271,7 @@ export function ReleaseDashboardDetails({
             on the right. Wraps to a single column on narrow widths (metadata stacks under the
             description). The pin control was removed (it's a global-perspective mode that belongs in
             the perspective bar, matching the Variants pin removal). */}
-        <Flex align="flex-start" gap={4} wrap="wrap">
+        <Flex alignItems="flex-start" gap={4} flexWrap="wrap">
           <Box flexBasis="0%" flexGrow={1} minWidth={RELEASE_IDENTITY_MIN_WIDTH}>
             <ReleaseDetailsEditor release={release} />
           </Box>

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
@@ -1,5 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Card, Flex} from '@sanity/ui'
+import {Card} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
 import {type ReleaseEvent} from './events/types'
@@ -19,11 +20,17 @@ export function ReleaseDashboardFooter(props: {
       <Card borderTop marginX={2} style={{opacity: 0.6}} />
 
       <Flex padding={3}>
-        <Flex flex={1} gap={1}>
+        <Flex flexBasis="0%" flexGrow={1} gap={1}>
           <ReleaseStatusItems events={events} release={release} />
         </Flex>
 
-        <Flex flex="none" gap={1} data-testid="release-dashboard-footer-actions">
+        <Flex
+          flexBasis="auto"
+          flexGrow={0}
+          flexShrink={0}
+          gap={1}
+          data-testid="release-dashboard-footer-actions"
+        >
           <ReleaseActionButton release={release} documents={documents} />
           <ReleaseMenuButton
             release={release}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
@@ -5,12 +5,11 @@ import {
   // oxlint-disable-next-line no-restricted-imports
   Button, // Custom button with a different textWeight, consider adding textWeight to the shared
   Container,
-  Flex,
   Text,
 } from '@sanity/ui'
 import {type Dispatch, type SetStateAction, useCallback} from 'react'
 import {useRouter} from 'sanity/router'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {DetailBackButton} from '../../../components/detailLayout'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -53,8 +52,8 @@ export function ReleaseDashboardHeader(props: {
 
   const headerContent = (
     <Box padding={3}>
-      <Flex align="flex-start">
-        <Flex flex={1} align="center" style={{minWidth: 0}}>
+      <Flex alignItems="flex-start">
+        <Flex flexBasis="0%" flexGrow={1} alignItems="center">
           {variantsEnabled ? (
             // A single back affordance — the release title already headlines the pane below, so
             // the breadcrumb's repeat of it is dropped. Mirrors the Variants detail's back arrow.
@@ -65,7 +64,7 @@ export function ReleaseDashboardHeader(props: {
             />
           ) : (
             <>
-              <Flex flex="none">
+              <Flex flexBasis="auto" flexGrow={0} flexShrink={0}>
                 <Button
                   mode="bleed"
                   onClick={handleNavigateToReleasesList}
@@ -80,7 +79,7 @@ export function ReleaseDashboardHeader(props: {
                   <ChevronRightIcon />
                 </Text>
               </Box>
-              <Box padding={2} style={{minWidth: 0, maxWidth: '300px'}}>
+              <Box padding={2} style={{maxWidth: '300px'}}>
                 <Text
                   size={1}
                   weight="semibold"
@@ -101,7 +100,7 @@ export function ReleaseDashboardHeader(props: {
           // sit alongside it here rather than in the table's command lane: the header always renders,
           // so they stay reachable even when the table is loading, errored, or an empty
           // cardinality-one release (where the command lane is not mounted).
-          <Flex flex="none" gap={2} align="center">
+          <Flex flexBasis="auto" flexGrow={0} flexShrink={0} gap={2} alignItems="center">
             <CopyReleaseActions release={release} />
             <Button
               data-testid="activity-button"
@@ -116,7 +115,7 @@ export function ReleaseDashboardHeader(props: {
             <ReleaseActionRail release={release} documents={documents} />
           </Flex>
         ) : (
-          <Flex flex="none" gap={2}>
+          <Flex flexBasis="auto" flexGrow={0} flexShrink={0} gap={2}>
             <CopyReleaseActions release={release} />
             <Button
               icon={RestoreIcon}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -1,9 +1,9 @@
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {useEffect, useMemo, useState} from 'react'
 import {useRouter} from 'sanity/router'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -109,9 +109,10 @@ export function ReleaseDetail() {
       // right-anchored drawer covers the top action rail (Run release + menu) too — not just the
       // content below it.
       <Flex
-        direction="column"
-        flex={1}
-        height="fill"
+        flexDirection="column"
+        flexBasis="0%"
+        flexGrow={1}
+        height="100%"
         overflow="hidden"
         style={{position: 'relative'}}
       >
@@ -124,8 +125,8 @@ export function ReleaseDetail() {
           />
         </Card>
 
-        <Flex flex={1}>
-          <Flex direction="column" flex={1} height="fill">
+        <Flex flexBasis="0%" flexGrow={1}>
+          <Flex flexDirection="column" flexBasis="0%" flexGrow={1} height="100%">
             <Card flex={1} overflow="auto">
               <ReleaseDashboardDetails
                 release={releaseInDetail}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseStatusItems.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseStatusItems.tsx
@@ -1,6 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Flex} from '@sanity/ui'
 import {useMemo} from 'react'
+import {Flex} from 'ui5'
 
 import {RelativeTime} from '../../../components/RelativeTime'
 import {AvatarSkeleton, UserAvatar} from '../../../components/userAvatar/UserAvatar'
@@ -43,7 +43,7 @@ export function ReleaseStatusItems({
 
   if (!footerEvents.length) {
     return (
-      <Flex flex={1} gap={1}>
+      <Flex flexBasis="0%" flexGrow={1} gap={1}>
         <StatusItem
           avatar={<AvatarSkeleton $size={0} />}
           text={
@@ -57,7 +57,7 @@ export function ReleaseStatusItems({
     )
   }
   return (
-    <Flex flex={1} gap={1}>
+    <Flex flexBasis="0%" flexGrow={1} gap={1}>
       {footerEvents.map((event) => (
         <StatusItem
           key={event.id}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -1,9 +1,10 @@
 import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
 import {AddIcon} from '@sanity/icons/Add'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Container, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {type CSSProperties, useCallback, useEffect, useMemo, useState} from 'react'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {type DocumentActionsVersionType} from '../../../config/types'
@@ -220,9 +221,9 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   if (isCardinalityOne && hasNoDocuments) {
     return (
       <Flex
-        direction="column"
-        align="center"
-        justify="center"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
         padding={5}
         style={FULL_HEIGHT_STYLE}
         data-testid="cardinality-one-empty-state"
@@ -281,7 +282,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     (isLoading || tableData.length > 0)
 
   return (
-    <Flex direction="column" style={FULL_HEIGHT_STYLE}>
+    <Flex flexDirection="column" style={FULL_HEIGHT_STYLE}>
       {variantsEnabled ? (
         <DocumentTable<DocumentInReleaseDetail>
           alwaysShowCommandLane

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
@@ -1,12 +1,13 @@
 import {type ReleaseType} from '@sanity/client'
 import {PublishIcon} from '@sanity/icons/Publish'
-import {Card, Flex, Spinner, Stack, TabList, Text, useClickOutsideEvent} from '@sanity/ui'
+import {Card, Spinner, Stack, TabList, Text, useClickOutsideEvent} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {isBefore} from 'date-fns/isBefore'
 import {startOfMinute} from 'date-fns/startOfMinute'
 import isEqual from 'lodash-es/isEqual.js'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {styled} from 'styled-components'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Popover} from '../../../../ui-components/popover/Popover'
@@ -207,7 +208,7 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
 
   const productionLabelContent = useMemo(
     () => (
-      <Flex flex={1} gap={2} align={'center'}>
+      <Flex flexBasis="0%" flexGrow={1} gap={2} alignItems={'center'}>
         {releaseTypeIcon}
         <span data-testid="release-type-label">{publishDateLabel}</span>
       </Flex>

--- a/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
@@ -1,7 +1,8 @@
 import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Card, type CardTone, Flex, Text} from '@sanity/ui'
+import {Card, type CardTone, Text} from '@sanity/ui'
 import {useEffect, useMemo, useState} from 'react'
+import {Flex} from 'ui5'
 
 import {ProgressIcon} from '../../../../ui-components/progressIcon/ProgressIcon'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'

--- a/packages/sanity/src/core/releases/tool/detail/components/ReleaseDocumentFilterTabs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/components/ReleaseDocumentFilterTabs.tsx
@@ -1,7 +1,7 @@
 import {type ReleaseState} from '@sanity/client'
-import {Container, Flex, Skeleton, TabList} from '@sanity/ui'
+import {Container, Skeleton, TabList} from '@sanity/ui'
 import {useMemo} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Tab} from '../../../../../ui-components/tab/Tab'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
@@ -41,7 +41,7 @@ export function ReleaseDocumentFilterTabs({
 
   if (isLoading) {
     const skeletons = (
-      <Flex align="center" gap={2}>
+      <Flex alignItems="center" gap={2}>
         {FILTER_TAB_CONFIGS.filter((config) => config.key !== 'errors').map((config) => (
           <Skeleton
             key={`loading-skeleton-${config.key}`}

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -2,14 +2,14 @@ import {type ReleaseState} from '@sanity/client'
 import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
 import {ClockIcon} from '@sanity/icons/Clock'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Badge, Card, Flex, Skeleton, Text} from '@sanity/ui'
+import {Badge, Card, Skeleton, Text} from '@sanity/ui'
 import {toString as pathToString} from '@sanity/util/paths'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
 import {type CSSProperties, memo, useCallback, useEffect, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
@@ -160,11 +160,11 @@ const documentActionColumn: (
   sortTransform: variantsEnabled ? (value) => getDocumentActionType(value) || '' : undefined,
   header: (props) =>
     variantsEnabled ? (
-      <Flex {...props.headerProps} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} paddingY={3}>
         <Headers.SortHeaderButton text={t('table-header.action')} {...props} />
       </Flex>
     ) : (
-      <Flex {...props.headerProps} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} paddingY={3}>
         <Headers.BasicHeader text={t('table-header.action')} />
       </Flex>
     ),
@@ -188,7 +188,7 @@ const documentActionColumn: (
     }
 
     return (
-      <Flex align="center" {...cellProps}>
+      <Flex alignItems="center" {...cellProps}>
         <Box paddingX={2}>{actionBadge()}</Box>
       </Flex>
     )
@@ -239,7 +239,7 @@ const VariantCell = memo(
           ) : undefined
         }
       >
-        <Flex align="center" gap={2} style={{minWidth: 0}}>
+        <Flex alignItems="center" gap={2}>
           <Card tone="suggest" padding={0} style={VARIANT_ICON_CARD_STYLE}>
             <Text size={2} style={VARIANT_ICON_STYLE}>
               <RhombusIcon />
@@ -299,13 +299,13 @@ export const getDocumentTableColumnDefs: (
       width: variantsEnabled ? 120 : 150,
       sorting: true,
       header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Flex {...props.headerProps} paddingY={3}>
           <Headers.SortHeaderButton text={t('table-header.type')} {...props} />
         </Flex>
       ),
       cell: ({cellProps, datum}) => (
-        <Flex align="center" {...cellProps}>
-          <Box paddingX={2} style={{minWidth: 0}}>
+        <Flex alignItems="center" {...cellProps}>
+          <Box paddingX={2}>
             {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
           </Box>
         </Flex>
@@ -326,13 +326,13 @@ export const getDocumentTableColumnDefs: (
               return variant ? getVariantTitle(variant).toLowerCase() : ''
             },
             header: (props) => (
-              <Flex {...props.headerProps} paddingY={3} sizing="border">
+              <Flex {...props.headerProps} paddingY={3}>
                 <Headers.SortHeaderButton text={t('table-header.variant')} {...props} />
               </Flex>
             ),
             cell: ({cellProps, datum}) => (
-              <Flex align="center" {...cellProps}>
-                <Box paddingX={2} style={{minWidth: 0}}>
+              <Flex alignItems="center" {...cellProps}>
+                <Box paddingX={2}>
                   {!datum.isLoading &&
                     (variantsLoading ? (
                       <Skeleton animated radius={1} style={{width: 60, height: 11}} />
@@ -365,7 +365,7 @@ export const getDocumentTableColumnDefs: (
         options?.searchInCommandLane ? (
           // Search moved to the command lane; the header is a plain sortable "Document" label that
           // grows to fill (flex) in both header and body.
-          <Flex {...props.headerProps} flex={1} paddingY={3} sizing="border">
+          <Flex {...props.headerProps} flexBasis="0%" flexGrow={1} paddingY={3}>
             <Headers.SortHeaderButton text={t('table-header.document')} {...props} />
           </Flex>
         ) : (
@@ -399,7 +399,7 @@ export const getDocumentTableColumnDefs: (
             sorting: true,
             width: 130,
             header: (props) => (
-              <Flex {...props.headerProps} paddingY={3} sizing="border">
+              <Flex {...props.headerProps} paddingY={3}>
                 <Headers.SortHeaderButton
                   paddingLeft={2}
                   text={t('table-header.last-edited')}
@@ -410,11 +410,12 @@ export const getDocumentTableColumnDefs: (
             cell: ({cellProps, datum}) => (
               <Flex
                 {...cellProps}
-                align="center"
+                alignItems="center"
                 paddingX={2}
                 paddingY={3}
-                style={{minWidth: 130}}
-                sizing="border"
+                style={{
+                  minWidth: 130,
+                }}
               >
                 {!datum.isLoading && datum.document._updatedAt && (
                   <Text muted size={1}>
@@ -433,7 +434,7 @@ export const getDocumentTableColumnDefs: (
             width: 170,
             style: {minWidth: 44, maxWidth: 170},
             header: ({headerProps}) => (
-              <Flex {...headerProps} align="center" paddingX={2} paddingY={3} sizing="border">
+              <Flex {...headerProps} alignItems="center" paddingX={2} paddingY={3}>
                 <Text muted size={1} textOverflow="ellipsis" weight="medium">
                   {t('table-header.edited-by')}
                 </Text>
@@ -448,7 +449,7 @@ export const getDocumentTableColumnDefs: (
             sorting: true,
             width: 130,
             header: (props) => (
-              <Flex {...props.headerProps} paddingY={3} sizing="border">
+              <Flex {...props.headerProps} paddingY={3}>
                 <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
               </Flex>
             ),
@@ -461,7 +462,7 @@ export const getDocumentTableColumnDefs: (
       sorting: false,
       width: 50,
       header: ({headerProps}) => (
-        <Flex {...headerProps} paddingY={3} sizing="border">
+        <Flex {...headerProps} paddingY={3}>
           <Headers.BasicHeader text={''} />
         </Flex>
       ),
@@ -499,11 +500,10 @@ export const getDocumentTableColumnDefs: (
           // width (flex:1 here would split the free space with Document and misalign the header/body).
           <Flex
             {...cellProps}
-            flex={options?.searchInCommandLane ? undefined : 1}
+            {...(options?.searchInCommandLane ? {} : {flexBasis: '0%', flexGrow: 1})}
             padding={1}
-            justify="center"
-            align="center"
-            sizing="border"
+            justifyContent="center"
+            alignItems="center"
           >
             {datum.validation.hasError && (
               <Tooltip
@@ -511,7 +511,7 @@ export const getDocumentTableColumnDefs: (
                 placement="bottom-end"
                 content={
                   <Text muted size={1}>
-                    <Flex align={'center'} gap={3} padding={1}>
+                    <Flex alignItems={'center'} gap={3} padding={1}>
                       <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
                       {errorLabel}
                     </Flex>
@@ -591,13 +591,14 @@ function UpdatedAtCell({
   return (
     <Flex
       {...cellProps}
-      align="center"
+      alignItems="center"
       paddingX={2}
       paddingY={3}
-      style={{minWidth: 130}}
-      sizing="border"
+      style={{
+        minWidth: 130,
+      }}
     >
-      <Flex align="center" gap={2}>
+      <Flex alignItems="center" gap={2}>
         {/* Skeleton only while the history is actually loading — NOT whenever there is no editor.
             A settled-but-empty or failed history has loading:false and no lastEditedBy, and must
             render just the timestamp (or nothing) rather than an endless skeleton. */}
@@ -636,7 +637,7 @@ function EditedByReleaseCell({
   const {documentHistory, loading} = useReleaseHistory(historyDocumentId, bundleId, document?._rev)
 
   return (
-    <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+    <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3}>
       <EditedByAvatar loading={isLoading || loading} userId={documentHistory?.lastEditedBy} />
     </Flex>
   )

--- a/packages/sanity/src/core/releases/tool/overview/CardinalityViewPicker.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/CardinalityViewPicker.tsx
@@ -2,9 +2,10 @@ import {type ReleaseDocument} from '@sanity/client'
 import {CalendarIcon} from '@sanity/icons/Calendar'
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {Menu} from '@sanity/ui/menu'
 import {useCallback, useMemo} from 'react'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
@@ -88,7 +89,7 @@ export const CardinalityViewPicker = ({
   //  If only one is enabled, show the label
   if (pickerView === 'contentReleases' || pickerView === 'singleDocReleases') {
     return (
-      <Flex align="center" gap={2}>
+      <Flex alignItems="center" gap={2}>
         <CalendarIcon />
         <Text size={1} weight="semibold">
           {pickerView === 'contentReleases' ? t('action.releases') : t('action.drafts')}

--- a/packages/sanity/src/core/releases/tool/overview/ConfirmActiveScheduledDraftsBanner.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ConfirmActiveScheduledDraftsBanner.tsx
@@ -1,8 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Card, Flex, Text} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -60,11 +60,11 @@ export function ConfirmActiveScheduledDraftsBanner({
     <>
       <Box flexBasis="auto" flexGrow={0} flexShrink={0} padding={1} marginBottom={4}>
         <Card radius={3} paddingX={2} paddingY={2} tone="caution">
-          <Flex align="center" gap={3} paddingX={2}>
+          <Flex alignItems="center" gap={3} paddingX={2}>
             <Text size={0}>
               <WarningOutlineIcon />
             </Text>
-            <Flex align="center" flex={1} gap={2} paddingY={2}>
+            <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={2} paddingY={2}>
               <Text size={1} weight="medium">
                 <Translate
                   t={t}
@@ -73,7 +73,7 @@ export function ConfirmActiveScheduledDraftsBanner({
                 />
               </Text>
             </Flex>
-            <Flex flex="none">
+            <Flex flexBasis="auto" flexGrow={0} flexShrink={0}>
               <Button text={buttonText} mode="bleed" tone="caution" onClick={handleClick} />
             </Flex>
           </Flex>

--- a/packages/sanity/src/core/releases/tool/overview/DraftsDisabledBanner.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/DraftsDisabledBanner.tsx
@@ -1,8 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Card, Flex, Text} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 import {useMemo} from 'react'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {isCardinalityOneRelease} from '../../../util/releaseUtils'
@@ -40,11 +40,11 @@ export const DraftsDisabledBanner = ({
   return (
     <Box padding={1} marginBottom={4}>
       <Card radius={3} paddingX={2} paddingY={2} tone="caution">
-        <Flex align="center" gap={3} paddingX={2}>
+        <Flex alignItems="center" gap={3} paddingX={2}>
           <Text size={0}>
             <WarningOutlineIcon />
           </Text>
-          <Flex align="center" flex={1} gap={2} paddingY={2}>
+          <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={2} paddingY={2}>
             <Text size={1} weight="medium">
               {getBannerMessage()}
             </Text>

--- a/packages/sanity/src/core/releases/tool/overview/ReleaseNotFoundBanner.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleaseNotFoundBanner.tsx
@@ -1,7 +1,7 @@
 import {CloseIcon} from '@sanity/icons/Close'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Card, Flex, Text} from '@sanity/ui'
-import {Box} from 'ui5'
+import {Card, Text} from '@sanity/ui'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -17,7 +17,7 @@ export function ReleaseNotFoundBanner({onDismiss}: ReleaseNotFoundBannerProps) {
   return (
     <Box flexBasis="auto" flexGrow={0} flexShrink={0} padding={1} marginBottom={4}>
       <Card radius={3} paddingX={2} paddingY={2} tone="caution">
-        <Flex align="center" gap={3} paddingX={2}>
+        <Flex alignItems="center" gap={3} paddingX={2}>
           <Text size={0}>
             <WarningOutlineIcon />
           </Text>

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesEmptyState.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesEmptyState.tsx
@@ -1,4 +1,5 @@
-import {Flex, Inline, Text} from '@sanity/ui'
+import {Inline, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -19,8 +20,14 @@ export const ReleasesEmptyState = ({createReleaseButton}: ReleasesEmptyStateProp
   }
 
   return (
-    <Flex direction="column" flex={1} justify={'center'} align={'center'}>
-      <Flex gap={3} direction="column" align="center" style={{maxWidth: '300px'}}>
+    <Flex
+      flexDirection="column"
+      flexBasis="0%"
+      flexGrow={1}
+      justifyContent={'center'}
+      alignItems={'center'}
+    >
+      <Flex gap={3} flexDirection="column" alignItems="center" style={{maxWidth: '300px'}}>
         <ReleaseIllustration />
         <Text as="h1" size={1} weight="semibold" data-testid="no-releases-info-text">
           {t('overview.title')}

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -2,7 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 import {AddIcon} from '@sanity/icons/Add'
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {EarthGlobeIcon} from '@sanity/icons/EarthGlobe'
-import {type ButtonMode, Card, Flex, Inline, useMediaIndex} from '@sanity/ui'
+import {type ButtonMode, Card, Inline, useMediaIndex} from '@sanity/ui'
 import {isSameDay} from 'date-fns/isSameDay'
 import {AnimatePresence, motion} from 'motion/react'
 import {
@@ -15,7 +15,7 @@ import {
   useState,
 } from 'react'
 import {useRouter} from 'sanity/router'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -480,7 +480,7 @@ export function ReleasesOverview() {
 
   const renderCalendarFilter = useMemo(
     () => (
-      <Flex flex="none">
+      <Flex flexBasis="auto" flexGrow={0} flexShrink={0}>
         <Card borderRight flex="none" disabled>
           {calendarFilterContent}
         </Card>
@@ -538,13 +538,13 @@ export function ReleasesOverview() {
   }
 
   return (
-    <Flex direction="row" flex={1} style={{height: '100%'}}>
-      <Flex flex={1}>
+    <Flex flexDirection="row" flexBasis="0%" flexGrow={1} style={{height: '100%'}}>
+      <Flex flexBasis="0%" flexGrow={1}>
         {showCalendar && renderCalendarFilter}
 
-        <Flex direction="column" flex={1} style={{position: 'relative'}}>
+        <Flex flexDirection="column" flexBasis="0%" flexGrow={1} style={{position: 'relative'}}>
           <Card flex="none" padding={3}>
-            <Flex align="center" flex={1} gap={3} wrap="wrap">
+            <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={3} flexWrap="wrap">
               <Inline>
                 {!showCalendar && (
                   <CalendarPopover content={calendarFilterContent} asDialog={isNarrowViewport} />
@@ -560,7 +560,7 @@ export function ReleasesOverview() {
                 />
               </Inline>
 
-              <Flex flex={1} gap={1} style={narrowFilterStyle}>
+              <Flex flexBasis="0%" flexGrow={1} gap={1} style={narrowFilterStyle}>
                 {loadingOrHasReleases &&
                   (releaseFilterDate ? (
                     <DateFilterButton filterDate={releaseFilterDate} onClear={clearFilterDate} />
@@ -568,7 +568,13 @@ export function ReleasesOverview() {
                     currentArchivedPicker
                   ))}
               </Flex>
-              <Flex flex="none" gap={2} style={narrowTimezoneStyle}>
+              <Flex
+                flexBasis="auto"
+                flexGrow={0}
+                flexShrink={0}
+                gap={2}
+                style={narrowTimezoneStyle}
+              >
                 <Button
                   icon={EarthGlobeIcon}
                   mode="bleed"

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -1,9 +1,10 @@
 import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Card, Flex, Text} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
+import {Flex} from 'ui5'
 
 import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -43,12 +44,12 @@ export const releasesOverviewColumnDefs: (
         header: (props) => (
           <Flex
             {...props.headerProps}
-            flex={1}
+            flexBasis="0%"
+            flexGrow={1}
             paddingLeft={6}
-            width={3}
+            width="80rem"
             paddingRight={2}
             paddingY={3}
-            sizing="border"
           >
             <Headers.SortHeaderButton {...props} text={t('table-header.title')} />
           </Flex>
@@ -71,7 +72,7 @@ export const releasesOverviewColumnDefs: (
         },
         width: 280,
         header: (props) => (
-          <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Flex {...props.headerProps} paddingY={3}>
             <Headers.SortHeaderButton text={t('table-header.when')} {...props} />
           </Flex>
         ),
@@ -79,7 +80,7 @@ export const releasesOverviewColumnDefs: (
           if (release.isLoading) return null
 
           return (
-            <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
+            <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3} gap={2}>
               <ReleaseTime release={release} />
             </Flex>
           )
@@ -118,12 +119,12 @@ export const releasesOverviewColumnDefs: (
         },
         width: 250,
         header: (props) => (
-          <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Flex {...props.headerProps} paddingY={3}>
             <Headers.SortHeaderButton text={t('table-header.published-at')} {...props} />
           </Flex>
         ),
         cell: ({cellProps, datum: release}) => (
-          <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
+          <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3} gap={2}>
             <Text muted size={1}>
               {release.publishedAt ? (
                 // Assuming releases are not updated after archiving.
@@ -153,12 +154,12 @@ export const releasesOverviewColumnDefs: (
         },
         width: 250,
         header: (props) => (
-          <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Flex {...props.headerProps} paddingY={3}>
             <Headers.SortHeaderButton text={t('table-header.archivedAt')} {...props} />
           </Flex>
         ),
         cell: ({cellProps, datum: release}) => (
-          <Flex {...cellProps} align="center" paddingX={2} paddingY={3} gap={2} sizing="border">
+          <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3} gap={2}>
             <Text muted size={1}>
               {release.state === 'archived' ? (
                 // Assuming releases are not updated after archiving.
@@ -180,14 +181,14 @@ export const releasesOverviewColumnDefs: (
         sorting: true,
         width: 150,
         header: (props) => (
-          <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Flex {...props.headerProps} paddingY={3}>
             <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
           </Flex>
         ),
         cell: ({datum: {documentsMetadata, _updatedAt}, cellProps}) => {
           const updatedAtDate = documentsMetadata?.updatedAt ?? _updatedAt
           return (
-            <Flex {...cellProps} align="center" gap={2} paddingX={2} paddingY={3} sizing="border">
+            <Flex {...cellProps} alignItems="center" gap={2} paddingX={2} paddingY={3}>
               <Text muted size={1}>
                 {updatedAtDate ? (
                   <RelativeTime time={updatedAtDate} useTemporalPhrase minimal />
@@ -206,7 +207,7 @@ export const releasesOverviewColumnDefs: (
         id: 'error',
         sorting: false,
         width: 40,
-        header: ({headerProps}) => <Flex {...headerProps} paddingY={3} sizing="border" />,
+        header: ({headerProps}) => <Flex {...headerProps} paddingY={3} />,
         cell: ({datum, cellProps}) => {
           const {error, state} = datum
           const hasError = typeof error !== 'undefined' && state === 'active'
@@ -215,11 +216,10 @@ export const releasesOverviewColumnDefs: (
           return (
             <Flex
               {...cellProps}
-              align="center"
+              alignItems="center"
               gap={2}
               paddingX={2}
               paddingY={3}
-              sizing="border"
               data-testid="error-indicator"
             >
               {hasError && (
@@ -248,7 +248,7 @@ export const releasesOverviewColumnDefs: (
         sorting: false,
         width: 120,
         header: ({headerProps}) => (
-          <Flex {...headerProps} paddingY={3} sizing="border">
+          <Flex {...headerProps} paddingY={3}>
             <Headers.BasicHeader text={t('table-header.documents')} />
           </Flex>
         ),
@@ -257,7 +257,7 @@ export const releasesOverviewColumnDefs: (
           cellProps,
         }) => {
           return (
-            <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border" gap={2}>
+            <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3} gap={2}>
               {state === 'active' && <ReleaseColumnValidationLoading releaseId={_id} />}
 
               {/**

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -47,7 +47,6 @@ export const releasesOverviewColumnDefs: (
             flexBasis="0%"
             flexGrow={1}
             paddingLeft={6}
-            width="80rem"
             paddingRight={2}
             paddingY={3}
           >

--- a/packages/sanity/src/core/releases/tool/overview/ScheduledDraftsEmptyState.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ScheduledDraftsEmptyState.tsx
@@ -1,4 +1,5 @@
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -13,8 +14,14 @@ export const ScheduledDraftsEmptyState = () => {
     return null
   }
   return (
-    <Flex direction="column" flex={1} justify={'center'} align={'center'}>
-      <Flex gap={3} direction="column" align="center" style={{maxWidth: '300px'}}>
+    <Flex
+      flexDirection="column"
+      flexBasis="0%"
+      flexGrow={1}
+      justifyContent={'center'}
+      alignItems={'center'}
+    >
+      <Flex gap={3} flexDirection="column" alignItems="center" style={{maxWidth: '300px'}}>
         <ReleaseIllustration />
         <Text as="h1" size={1} weight="semibold" data-testid="no-releases-info-text">
           {t('empty-state.title')}

--- a/packages/sanity/src/core/releases/tool/overview/ScheduledDraftsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ScheduledDraftsOverviewColumnDefs.tsx
@@ -1,6 +1,6 @@
-import {Flex} from '@sanity/ui'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
+import {Flex} from 'ui5'
 
 import {Headers} from '../components/Table/TableHeader'
 import {type Column} from '../components/Table/types'
@@ -21,7 +21,7 @@ export const scheduledDraftsOverviewColumnDefs: (
       width: null,
       style: {flex: 1},
       header: (props) => (
-        <Flex {...props.headerProps} paddingLeft={2} paddingRight={2} paddingY={3} sizing="border">
+        <Flex {...props.headerProps} paddingLeft={2} paddingRight={2} paddingY={3}>
           <Headers.BasicHeader text={t('table-header.document')} />
         </Flex>
       ),
@@ -32,7 +32,7 @@ export const scheduledDraftsOverviewColumnDefs: (
       sorting: true,
       width: 300,
       header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} paddingX={2} sizing="border">
+        <Flex {...props.headerProps} paddingY={3} paddingX={2}>
           <Headers.SortHeaderButton
             {...props}
             text={
@@ -51,7 +51,7 @@ export const scheduledDraftsOverviewColumnDefs: (
       id: 'warning',
       sorting: false,
       width: 40,
-      header: ({headerProps}) => <Flex {...headerProps} paddingY={3} sizing="border" />,
+      header: ({headerProps}) => <Flex {...headerProps} paddingY={3} />,
       cell: ScheduledDraftWarningCell,
     },
   ]

--- a/packages/sanity/src/core/releases/tool/overview/SchedulesUpsell.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/SchedulesUpsell.tsx
@@ -1,8 +1,8 @@
-import {Container, Flex} from '@sanity/ui'
+import {Container} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {useCallback} from 'react'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {useSingleDocReleaseEnabled} from '../../../singleDocRelease/context/SingleDocReleaseEnabledProvider'
 import {useSingleDocReleaseUpsell} from '../../../singleDocRelease/context/SingleDocReleaseUpsellProvider'
@@ -31,14 +31,20 @@ const SingleDocReleasesUpsell = () => {
     return null
   }
   return (
-    <Flex direction="column" flex={1} justify={'center'} align={'center'}>
+    <Flex
+      flexDirection="column"
+      flexBasis="0%"
+      flexGrow={1}
+      justifyContent={'center'}
+      alignItems={'center'}
+    >
       <motion.div
         initial={{opacity: 0}}
         animate={{opacity: 1}}
         transition={{duration: 0.3, ease: 'easeInOut'}}
       >
         <Panel width={0} padding={4} paddingY={1}>
-          <Flex align={'center'} direction="column">
+          <Flex alignItems={'center'} flexDirection="column">
             <ReleaseIllustration />
             <Box paddingTop={2}>
               <UpsellPanel
@@ -71,14 +77,20 @@ const ReleasesUpsell = () => {
     return null
   }
   return (
-    <Flex direction="column" flex={1} justify={'center'} align={'center'}>
+    <Flex
+      flexDirection="column"
+      flexBasis="0%"
+      flexGrow={1}
+      justifyContent={'center'}
+      alignItems={'center'}
+    >
       <motion.div
         initial={{opacity: 0}}
         animate={{opacity: 1}}
         transition={{duration: 0.3, ease: 'easeInOut'}}
       >
         <Panel width={0} padding={4} paddingY={1}>
-          <Flex align={'center'} direction="column">
+          <Flex alignItems={'center'} flexDirection="column">
             <ReleaseIllustration />
             <Box paddingTop={2}>
               <UpsellPanel

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
@@ -1,9 +1,9 @@
 import {PinIcon} from '@sanity/icons/Pin'
 import {PinFilledIcon} from '@sanity/icons/PinFilled'
-import {Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {Card, Skeleton, Stack, Text} from '@sanity/ui'
 import {useCallback} from 'react'
 import {useRouter} from 'sanity/router'
-import {Box} from 'ui5'
+import {Box, Flex} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
@@ -51,7 +51,7 @@ export const ReleaseNameCell: VisibleColumn<TableRelease>['cell'] = ({
   if (release.isLoading) {
     return (
       <Box {...cellProps} paddingLeft={3} flexBasis="0%" flexGrow={1} paddingY={1} paddingRight={2}>
-        <Flex align="center" gap={2}>
+        <Flex alignItems="center" gap={2}>
           <Skeleton animated radius={1} style={PREVIEW_SIZES.default.media} />
           <TitleSkeleton />
         </Flex>
@@ -81,7 +81,7 @@ export const ReleaseNameCell: VisibleColumn<TableRelease>['cell'] = ({
           </Text>
         }
       >
-        <Flex align="center" gap={3}>
+        <Flex alignItems="center" gap={3}>
           <Button
             tooltipProps={{
               disabled: isArchived || release.state === 'published',
@@ -104,12 +104,12 @@ export const ReleaseNameCell: VisibleColumn<TableRelease>['cell'] = ({
             aria-live="assertive"
           />
           <Card {...cardProps} padding={2} radius={2} flex={1}>
-            <Flex align="center" gap={2}>
+            <Flex alignItems="center" gap={2}>
               <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
                 <ReleaseAvatar release={release} size="small" fontSize={2} />
               </Box>
               <Stack flex={1} gap={2}>
-                <Flex align="center" gap={2} style={{minWidth: 0}}>
+                <Flex alignItems="center" gap={2}>
                   <ReleaseTitle
                     title={release.metadata.title}
                     fallback={tCore('release.placeholder-untitled-release')}

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ScheduledDraftDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ScheduledDraftDocumentPreview.tsx
@@ -1,6 +1,6 @@
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Card, Flex, Skeleton, Text} from '@sanity/ui'
-import {Box} from 'ui5'
+import {Card, Skeleton, Text} from '@sanity/ui'
+import {Box, Flex} from 'ui5'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
@@ -26,7 +26,7 @@ export const ScheduledDraftDocumentPreview: VisibleColumn<TableRelease>['cell'] 
 
   if (isLoading) {
     return (
-      <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+      <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3}>
         <Skeleton animated radius={2} style={{height: '32px', width: '100%'}} />
       </Flex>
     )
@@ -38,7 +38,7 @@ export const ScheduledDraftDocumentPreview: VisibleColumn<TableRelease>['cell'] 
   return (
     <Box {...cellProps} flexBasis="0%" flexGrow={1} padding={1} paddingLeft={2} paddingRight={2}>
       <Card tone={validationErrorCount ? 'critical' : 'inherit'} radius={2}>
-        <Flex align="center" gap={2}>
+        <Flex alignItems="center" gap={2}>
           <Box flexBasis="0%" flexGrow={1}>
             <ReleaseDocumentPreview
               documentId={firstDocument._id}
@@ -57,7 +57,7 @@ export const ScheduledDraftDocumentPreview: VisibleColumn<TableRelease>['cell'] 
                 placement="bottom-end"
                 content={
                   <Text muted size={1}>
-                    <Flex align="center" gap={3} padding={1}>
+                    <Flex alignItems="center" gap={3} padding={1}>
                       <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
                       {t('document-validation.error', {count: validationErrorCount})}
                     </Flex>

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ScheduledDraftMetadataCell.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ScheduledDraftMetadataCell.tsx
@@ -1,4 +1,5 @@
-import {Flex, Skeleton, Stack} from '@sanity/ui'
+import {Skeleton, Stack} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {AvatarSkeleton, UserAvatar} from '../../../../components/userAvatar/UserAvatar'
 import {ReleaseTime} from '../../components/ReleaseTime'
@@ -19,15 +20,15 @@ export const ScheduledDraftMetadataCell: VisibleColumn<TableRelease>['cell'] = (
 
   if (datum.isLoading || !datum.metadata) {
     return (
-      <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+      <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3}>
         <Skeleton animated radius={2} style={{height: '40px', width: '150px'}} />
       </Flex>
     )
   }
 
   return (
-    <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
-      <Flex align="center" gap={3}>
+    <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3}>
+      <Flex alignItems="center" gap={3}>
         {creatorLoading && <AvatarSkeleton $size={1} animated />}
         {!creatorLoading && createdBy && <UserAvatar user={createdBy} size={1} />}
         <Stack gap={1}>

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ScheduledDraftWarningCell.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ScheduledDraftWarningCell.tsx
@@ -1,5 +1,6 @@
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
@@ -19,11 +20,10 @@ export const ScheduledDraftWarningCell: VisibleColumn<TableRelease>['cell'] = ({
   return (
     <Flex
       {...cellProps}
-      align="center"
+      alignItems="center"
       gap={2}
       paddingX={2}
       paddingY={3}
-      sizing="border"
       data-testid="warning-indicator"
     >
       {hasWarning && (


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR migrates the Flex component from `@sanity/ui` v4 to v5 in the `packages/sanity/src/core/releases` directory. It updates Flex across 42 files containing 119 JSX or styled-component instances.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop updates look correct. I've also removed a few `boxSizing` and `minWidth` props since they're included by default now.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I did manual testing in the Releases tab.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical UI primitive migration with no auth, data, or release workflow logic changes; layout regressions are the main risk and were manually tested in the Releases tab.
> 
> **Overview**
> **Migrates layout `Flex` usage in `packages/sanity/src/core/releases` from `@sanity/ui` to the `ui5` package**, touching dialogs, document header menus, overview/detail dashboards, and shared table components (~42 files).
> 
> Prop names are updated to the v5-style API: `align`/`justify`/`direction`/`wrap` become `alignItems`/`justifyContent`/`flexDirection`/`flexWrap`; shorthand like `flex={1}` and `flex="none"` are spelled out with `flexBasis`/`flexGrow`/`flexShrink`; `height="fill"` becomes `height="100%"`. **`sizing="border"` is dropped** on many table header/cell flex wrappers, and a few redundant **`minWidth` / box-sizing props** are removed where defaults now cover them.
> 
> No release behavior, APIs, or business logic changes—only import source and flex layout props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f6aabf595e9aa2e39f1e2cd70ac678636d2635a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->