### PR TITLE
fix(core): stop reporting teardown aborts to Sentry

### DIFF
--- a/packages/sanity/src/core/error/sentry/__tests__/sentryErrorReporter.test.ts
+++ b/packages/sanity/src/core/error/sentry/__tests__/sentryErrorReporter.test.ts
@@ -1,0 +1,105 @@
+import {type ErrorEvent} from '@sentry/react'
+import {describe, expect, test} from 'vitest'
+
+import {beforeSend} from '../sentryErrorReporter'
+
+const UNHANDLED_REJECTION = 'auto.browser.global_handlers.onunhandledrejection'
+
+function eventWith(
+  exception: {type: string; value: string; mechanism?: string},
+  tags?: Record<string, string>,
+): ErrorEvent {
+  return {
+    type: undefined,
+    tags,
+    exception: {
+      values: [
+        {
+          type: exception.type,
+          value: exception.value,
+          mechanism: {type: exception.mechanism ?? UNHANDLED_REJECTION, handled: true},
+        },
+      ],
+    },
+  }
+}
+
+describe('#beforeSend', () => {
+  // The DOMException `AbortController.abort()` creates carries a stack, so Sentry types it
+  // as `AbortError`. This is what `eventsource`'s `close()` produces.
+  test('drops an abort typed as AbortError', () => {
+    const event = eventWith(
+      {type: 'AbortError', value: 'signal is aborted without reason'},
+      {'DOMException.code': '20'},
+    )
+    expect(beforeSend(event)).toBeNull()
+  })
+
+  // A DOMException without a stack gets flattened into `Error`, with the name folded into
+  // the value. Same abort, different shape.
+  test('drops an abort flattened into Error', () => {
+    const event = eventWith(
+      {type: 'Error', value: 'AbortError: The user aborted a request.'},
+      {'DOMException.code': '20'},
+    )
+    expect(beforeSend(event)).toBeNull()
+  })
+
+  test('drops an abort even without the DOMException.code tag', () => {
+    const event = eventWith({type: 'AbortError', value: 'Fetch is aborted'})
+    expect(beforeSend(event)).toBeNull()
+  })
+
+  // Studios on older releases ship Sentry v8, which named the mechanism without a prefix.
+  test('drops an abort reported by the older SDK mechanism name', () => {
+    const event = eventWith(
+      {
+        type: 'AbortError',
+        value: 'signal is aborted without reason',
+        mechanism: 'onunhandledrejection',
+      },
+      {'DOMException.code': '20'},
+    )
+    expect(beforeSend(event)).toBeNull()
+  })
+
+  // `linkedErrors` splits a cause chain across entries, so the mechanism is not always first.
+  test('drops an abort where the mechanism is on a later exception value', () => {
+    const event: ErrorEvent = {
+      type: undefined,
+      exception: {
+        values: [
+          {type: 'Error', value: 'some underlying cause', mechanism: {type: 'chained'}},
+          {
+            type: 'AbortError',
+            value: 'signal is aborted without reason',
+            mechanism: {type: UNHANDLED_REJECTION},
+          },
+        ],
+      },
+    }
+    expect(beforeSend(event)).toBeNull()
+  })
+
+  test('keeps an abort that did not come from an unhandled rejection', () => {
+    const event = eventWith(
+      {type: 'AbortError', value: 'signal is aborted without reason', mechanism: 'generic'},
+      {'DOMException.code': '20'},
+    )
+    expect(beforeSend(event)).not.toBeNull()
+  })
+
+  test('keeps an unrelated unhandled rejection', () => {
+    const event = eventWith({type: 'TypeError', value: 'Failed to fetch'})
+    expect(beforeSend(event)).not.toBeNull()
+  })
+
+  test('marks kept errors as unhandled and scrubs pii', () => {
+    const event = eventWith({type: 'TypeError', value: 'Failed to fetch'})
+    const sent = beforeSend(event)
+
+    expect(sent?.exception?.values?.[0]?.mechanism?.handled).toBe(false)
+    expect(sent?.user).toEqual({ip_address: '0.0.0.0'})
+    expect(sent?.request).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
+++ b/packages/sanity/src/core/error/sentry/sentryErrorReporter.ts
@@ -280,16 +280,63 @@ function setAsUnhandled(event: ErrorEvent) {
 }
 
 /**
- * "Before send" event handler, which sets the error as unhandled.
- * @see setAsUnhandled for a clearer rationale.
+ * "Before send" event handler, which drops teardown aborts and sets the error as unhandled.
+ * @see isTeardownAbort and setAsUnhandled for clearer rationales.
  *
  * @param event - The event to be sent
- * @returns The event to be sent
+ * @returns The event to be sent, or `null` to drop it
  * @internal
  */
-function beforeSend(event: ErrorEvent): ErrorEvent {
+export function beforeSend(event: ErrorEvent): ErrorEvent | null {
+  if (isTeardownAbort(event)) {
+    return null
+  }
+
   setAsUnhandled(event)
   return scrubPii(event)
+}
+
+/**
+ * Aborting an in-flight request on teardown is routine, not a crash: `AbortController.abort()`
+ * rejects the pending fetch with an `AbortError`, and our abort sites handle it. Chrome still
+ * fires `unhandledrejection` at the microtask checkpoint and only retracts it afterwards with
+ * `rejectionhandled`, which the Sentry SDK never listens for, so the rejection gets reported
+ * even though it was handled. These reports have no user impact and drown out real errors.
+ *
+ * Matched on the mechanism and the `DOMException.code` tag rather than the message, because
+ * the message is engine-specific: "signal is aborted without reason" (Chromium), "The operation
+ * was aborted." (Firefox), "Fetch is aborted" (WebKit).
+ *
+ * @param event - The event to check
+ * @returns True if the event is an abort surfaced as an unhandled rejection, false otherwise
+ * @internal
+ */
+function isTeardownAbort(event: ErrorEvent): boolean {
+  const exceptions = event.exception?.values || []
+
+  // Suffix match because the mechanism has been renamed across SDK majors (`onunhandledrejection`
+  // in v8, `auto.browser.global_handlers.onunhandledrejection` in v10). Checking every entry
+  // because `linkedErrors` splits a cause chain across several of them. Deliberate reports go
+  // through `captureException` with a `generic` mechanism and are intentionally left alone.
+  const fromUnhandledRejection = exceptions.some((exception) =>
+    exception.mechanism?.type?.endsWith('onunhandledrejection'),
+  )
+
+  if (!fromUnhandledRejection) {
+    return false
+  }
+
+  // `DOMException.code` 20 is `ABORT_ERR`. Sentry tags it for both shapes an abort takes: the
+  // DOMException that `abort()` creates carries a stack and is typed `AbortError`, while one
+  // without a stack is flattened into `Error` with the name folded into the value. The type and
+  // value checks are a fallback in case the tag ever stops being set.
+  return (
+    event.tags?.['DOMException.code'] === '20' ||
+    exceptions.some(
+      (exception) =>
+        exception.type === 'AbortError' || (exception.value || '').startsWith('AbortError:'),
+    )
+  )
 }
 
 /**


### PR DESCRIPTION
### Description

> [!WARNING]
> Authored by Opus 5 with very little oversight from yours truly, but it's a fairly minor change

Aborting an in-flight request on teardown is routine, but it lands in Sentry as an unhandled crash. `AbortController.abort()` rejects the pending fetch with an `AbortError`, and our abort sites do handle it: `eventsource` swallows it in `#onFetchError`, and `event-source-polyfill` swallows it too (it even calls `reader.cancel()` first, working around an old Firefox streams bug). Chrome still fires `unhandledrejection` at the microtask checkpoint and only retracts it afterwards with `rejectionhandled`. The Sentry SDK installs no `rejectionhandled` listener anywhere, so it reports the rejection and never learns it was handled.

The volume is the problem. STUDIO-21Y sits at 48632 occurrences and STUDIO-21P at 42764, both with 0 users impacted, plus a dozen or so smaller groups from unrelated abort sites (`createAgentBundlesStore`, `useTasksStore`, `useCommentsStore`, `useVercelBypassSecret` and friends). Seer rates all of them "super low" actionability.

So this drops them in `beforeSend`.

One thing to be upfront about: I have not reproduced the retraction in the `eventsource` path specifically. I did confirm that Sentry reports a late-handled rejection - fire `unhandledrejection`, attach `.catch` one macrotask later, and Sentry still captures it with exactly the mechanism and `DOMException.code` we see in production - and I confirmed both libraries swallow their own aborts. But a batch of production-like teardown scenarios against the real stack in Chromium (unsubscribe before open, mid-stream, during a slow connect, during reconnect loops, cross-origin with a delayed preflight) all came back clean. Late attach is the best explanation I have, not a proven one. It doesn't change what to do about the reports either way.

### What to review

`isTeardownAbort` is the whole change. Two things worth a second pair of eyes:

An abort takes two shapes in Sentry, and I only found the second by checking. The DOMException that `abort()` creates carries a stack, so it's typed `AbortError` with value `signal is aborted without reason` (STUDIO-21Y). One without a stack gets flattened into `Error` with the name folded into the value, `AbortError: The user aborted a request.` (STUDIO-21P). Both carry `DOMException.code: 20`, which is `ABORT_ERR`, so that's the primary match with type and value as fallbacks. Matching on `type === 'AbortError'` alone would have silently missed half the volume.

The mechanism check is a suffix match because Sentry renamed it between majors: `onunhandledrejection` in v8, `auto.browser.global_handlers.onunhandledrejection` in v10. Studios still on 4.x/5.x report the old name.

I deliberately left the `generic` mechanism alone. That's the `captureException` path we use for `reportError()` and error boundary catches, and an abort that reaches a boundary is the one case where it might actually mean something. Only 2 events on 6.11.0 land there. Happy to widen it if you'd rather have the quiet.

Separately, the init path around line 104 reuses an already-initialized client as-is, so it never picks up this `beforeSend`. I left it alone, but the filter has that gap. It's also where `hasThirdPartySentry` reads inverted from the comment right below it, which might be worth a look on its own.

### Testing

Unit tests for the predicate cover both drop shapes, the old SDK mechanism name, a chained event where the mechanism isn't on the first value, and the two keep cases.

The event shapes in those tests aren't guesses. I ran the real `@sentry/browser` 10.70.0 with this integration list in headless Chromium, triggered both kinds of abort, and read the shape back out of `beforeSend`.

### Notes for release

N/A: Internal only, no user-facing change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only filtering in Sentry beforeSend; deliberate aborts via captureException are preserved, with a small chance of hiding a rare meaningful abort on the unhandled-rejection path.
> 
> **Overview**
> Sentry’s `beforeSend` hook now **drops** routine `AbortController` teardown noise that arrives as unhandled rejections, while still sending real errors after marking them unhandled and scrubbing PII.
> 
> The new **`isTeardownAbort`** predicate returns `null` when the event came from an `onunhandledrejection` global handler (suffix match for Sentry v8/v10 mechanism names, including chained exception values) **and** looks like an abort (`DOMException.code` 20, `AbortError` type, or `AbortError:` value prefix). Aborts reported via **`generic`** / `captureException` are **not** dropped.
> 
> **`beforeSend`** is exported for tests; a Vitest suite covers both abort shapes, legacy mechanism names, chained exceptions, keep cases, and unchanged scrub/unhandled behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400a73beeb3d46d3a62755a59f2607f1f28de572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->