### PR TITLE
chore: migrate flex in core scheduled-publishing and variants

### DIFF
--- a/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/Calendar.tsx
@@ -3,7 +3,6 @@ import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
 import {
   // oxlint-disable-next-line no-restricted-imports
   Button,
-  Flex,
   Select,
   Text,
 } from '@sanity/ui'
@@ -25,7 +24,7 @@ import {
   useRef,
   type RefAttributes,
 } from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {type TimeZoneScope, useTimeZone} from '../../../../../hooks/useTimeZone'
 import {CalendarMonth} from './CalendarMonth'
@@ -236,8 +235,8 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
       {/* Select time */}
       {selectTime && (
         <Box padding={2} style={{borderTop: '1px solid var(--card-border-color)'}}>
-          <Flex align="center">
-            <Flex align="center" flex={1}>
+          <Flex alignItems="center">
+            <Flex alignItems="center" flexBasis="0%" flexGrow={1}>
               <Box>
                 <Select
                   aria-label="Select hour"
@@ -277,7 +276,12 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
           </Flex>
 
           {features.timePresets && (
-            <Flex direction="row" justify="center" align="center" style={{marginTop: 5}}>
+            <Flex
+              flexDirection="row"
+              justifyContent="center"
+              alignItems="center"
+              style={{marginTop: 5}}
+            >
               {DEFAULT_TIME_PRESETS.map(([hours, minutes]) => {
                 return (
                   <CalendarTimePresetButton
@@ -334,7 +338,7 @@ function CalendarMonthSelect(props: {
   const handleNextMonthClick = useCallback(() => moveFocusedDate(1), [moveFocusedDate])
 
   return (
-    <Flex flex={1}>
+    <Flex flexBasis="0%" flexGrow={1}>
       <Button
         aria-label="Go to previous month"
         onClick={handlePrevMonthClick}

--- a/packages/sanity/src/core/scheduled-publishing/components/dialogs/DialogFooter.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dialogs/DialogFooter.tsx
@@ -1,5 +1,6 @@
-import {type ButtonTone, Flex} from '@sanity/ui'
+import {type ButtonTone} from '@sanity/ui'
 import {type ComponentType, type ReactNode} from 'react'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 
@@ -15,7 +16,7 @@ interface Props {
 const DialogFooter = (props: Props) => {
   const {buttonText = 'Action', disabled, icon, onAction, onComplete, tone = 'positive'} = props
   return (
-    <Flex gap={3} justify="flex-end">
+    <Flex gap={3} justifyContent="flex-end">
       <Button mode="bleed" onClick={onComplete} text="Cancel" />
       {onAction && (
         <Button disabled={disabled} icon={icon} onClick={onAction} text={buttonText} tone={tone} />

--- a/packages/sanity/src/core/scheduled-publishing/components/dialogs/DialogHeader.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dialogs/DialogHeader.tsx
@@ -1,5 +1,4 @@
-import {Flex} from '@sanity/ui'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {TimeZoneButton} from '../../../components/timeZone/timeZoneButton/TimeZoneButton'
 import {type TimeZoneScope, useTimeZone} from '../../../hooks/useTimeZone'
@@ -17,7 +16,7 @@ const DialogHeader = (props: Props) => {
   const {t} = useTranslation()
   return (
     <TimeZoneButtonElementQuery>
-      <Flex align="center">
+      <Flex alignItems="center">
         {title}
         {/*
         HACK: Sanity UI will attempt to focus the first 'focusable' descendant of any dialog.

--- a/packages/sanity/src/core/scheduled-publishing/components/documentWrapper/ScheduleBanner.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/documentWrapper/ScheduleBanner.tsx
@@ -1,9 +1,9 @@
 import {CalendarIcon} from '@sanity/icons/Calendar'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {type ValidationMarker} from '@sanity/types'
-import {Badge, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
+import {Badge, Card, Inline, Stack, Text} from '@sanity/ui'
 import {format} from 'date-fns/format'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {useScheduledPublishingEnabled} from '../../../scheduledPublishing/contexts/ScheduledPublishingEnabledProvider'
 import {DATE_FORMAT} from '../../../studio/timezones/constants'
@@ -33,7 +33,7 @@ export function ScheduleBanner(props: Props) {
     <Box marginBottom={4}>
       {mode === 'upsell' && (
         <Card tone="caution" padding={3} radius={3} shadow={1} marginBottom={3}>
-          <Flex align="center" gap={3} padding={1}>
+          <Flex alignItems="center" gap={3} padding={1}>
             <Text muted size={1}>
               <WarningOutlineIcon />
             </Text>
@@ -51,7 +51,7 @@ export function ScheduleBanner(props: Props) {
         style={mode === 'upsell' ? {opacity: 0.7} : undefined}
       >
         <Stack gap={2}>
-          <Flex align="center" gap={3} marginBottom={1} padding={1}>
+          <Flex alignItems="center" gap={3} marginBottom={1} padding={1}>
             <Text muted size={1}>
               <CalendarIcon />
             </Text>

--- a/packages/sanity/src/core/scheduled-publishing/components/errorCallout/ErrorCallout.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/errorCallout/ErrorCallout.tsx
@@ -1,5 +1,6 @@
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Card, Flex, Inline, Text} from '@sanity/ui'
+import {Card, Inline, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 interface Props {
   description?: string
@@ -11,7 +12,7 @@ const ErrorCallout = (props: Props) => {
 
   return (
     <Card overflow="hidden" padding={4} radius={2} shadow={1} tone="critical">
-      <Flex align="center" gap={4}>
+      <Flex alignItems="center" gap={4}>
         <Text size={2}>
           <ErrorOutlineIcon />
         </Text>

--- a/packages/sanity/src/core/scheduled-publishing/components/infoCallout/InfoCallout.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/infoCallout/InfoCallout.tsx
@@ -1,5 +1,6 @@
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
-import {Card, Flex, Inline, Stack, Text} from '@sanity/ui'
+import {Card, Inline, Stack, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {RELEASES_DOCS_URL} from '../../constants'
 
@@ -8,7 +9,7 @@ import {RELEASES_DOCS_URL} from '../../constants'
 const InfoCallout = () => {
   return (
     <Card overflow="hidden" padding={4} radius={2} shadow={1} tone="suggest">
-      <Flex align="center" gap={4}>
+      <Flex alignItems="center" gap={4}>
         <Text size={2}>
           <InfoOutlineIcon />
         </Text>

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/PreviewWrapper.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/PreviewWrapper.tsx
@@ -1,8 +1,8 @@
 import {type SchemaType} from '@sanity/types'
-import {Badge, Card, Flex, Stack, Text} from '@sanity/ui'
+import {Badge, Card, Stack, Text} from '@sanity/ui'
 import {type ComponentPropsWithoutRef, type ElementType, type ReactNode, useState} from 'react'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {DocumentVersionsStatus} from '../../../components/documentStatus/DocumentVersionsStatus'
@@ -69,7 +69,7 @@ function PreviewWrapper<TLink extends ElementType | undefined = undefined>(props
       tone={validationTone}
       style={mode === 'upsell' && schedule.state === 'scheduled' ? {opacity: 0.7} : undefined}
     >
-      <Flex align="center" gap={1} justify="space-between">
+      <Flex alignItems="center" gap={1} justifyContent="space-between">
         <Tooltip
           delay={{open: 400}}
           placement="bottom-end"
@@ -92,7 +92,12 @@ function PreviewWrapper<TLink extends ElementType | undefined = undefined>(props
             tabIndex={0}
             tone={validationTone}
           >
-            <Flex align="center" gap={3} justify="flex-start" paddingLeft={children ? 0 : [1, 2]}>
+            <Flex
+              alignItems="center"
+              gap={3}
+              justifyContent="flex-start"
+              paddingLeft={children ? 0 : [1, 2]}
+            >
               {children && <Box style={{flexBasis: 'auto', flexGrow: 1}}>{children}</Box>}
 
               {/* Badge */}
@@ -141,7 +146,7 @@ function PreviewWrapper<TLink extends ElementType | undefined = undefined>(props
                 </Box>
               )}
 
-              <Flex align="center" style={{flexShrink: 0, marginLeft: 'auto'}}>
+              <Flex alignItems="center" style={{flexShrink: 0, marginLeft: 'auto'}}>
                 {/* Avatar */}
                 <Box display={['none', 'none', 'block']} marginX={3} style={{flexShrink: 0}}>
                   <User id={schedule?.author} />
@@ -160,7 +165,7 @@ function PreviewWrapper<TLink extends ElementType | undefined = undefined>(props
           </Card>
         </Tooltip>
 
-        <Flex justify="center" style={{width: '38px'}}>
+        <Flex justifyContent="center" style={{width: '38px'}}>
           {/* Validation status (only displayed on upcoming schedules) */}
           {schedule.state === 'scheduled' && (
             <Box>

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/StateReasonFailedInfo.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/StateReasonFailedInfo.tsx
@@ -1,7 +1,8 @@
 import {red} from '@sanity/color'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {type CardTone, Container, Flex, Text} from '@sanity/ui'
+import {type CardTone, Container, Text} from '@sanity/ui'
 import {Menu} from '@sanity/ui/menu'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'

--- a/packages/sanity/src/core/scheduled-publishing/components/validation/ValidationListItem.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/validation/ValidationListItem.tsx
@@ -2,12 +2,12 @@ import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {type Path, type ValidationMarker} from '@sanity/types'
-import {type ButtonTone, Flex, Stack, Text} from '@sanity/ui'
+import {type ButtonTone, Stack, Text} from '@sanity/ui'
 // oxlint-disable-next-line no-restricted-imports
 import {MenuItem} from '@sanity/ui/menu'
 import {useCallback} from 'react'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 const StyledText = styled(Text)`
   white-space: initial;

--- a/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/NewScheduleInfo.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/NewScheduleInfo.tsx
@@ -1,4 +1,5 @@
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {useValidationStatus} from '../../../../hooks/useValidationStatus'
 import {getDraftId, getPublishedId} from '../../../../util/draftUtils'
@@ -42,7 +43,7 @@ function ValidationWarning({id, type}: {id: string; type: string}) {
 
   return (
     <Card padding={2} radius={1} shadow={1} tone="critical">
-      <Flex gap={1} align="center">
+      <Flex gap={1} alignItems="center">
         <ValidationInfo
           markers={validationStatus.validation}
           type={schema}

--- a/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilter.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilter.tsx
@@ -1,10 +1,10 @@
 import {
   // oxlint-disable-next-line no-restricted-imports
   Button,
-  Flex,
   Text,
 } from '@sanity/ui'
 import {useStateLink} from 'sanity/router'
+import {Flex} from 'ui5'
 
 import {SCHEDULE_STATE_DICTIONARY} from '../../constants'
 import {useFilteredSchedules} from '../../hooks/useFilteredSchedules'
@@ -39,7 +39,7 @@ const ScheduleFilter = (props: Props) => {
       tone={critical ? 'critical' : 'default'}
       padding={2}
     >
-      <Flex gap={2} align={'center'}>
+      <Flex gap={2} alignItems={'center'}>
         <Text size={1} weight="medium">
           {SCHEDULE_STATE_DICTIONARY[state].title}
         </Text>

--- a/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilters.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilters.tsx
@@ -1,11 +1,10 @@
 import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {CloseIcon} from '@sanity/icons/Close'
 import {SelectIcon} from '@sanity/icons/Select'
-import {Flex} from '@sanity/ui'
 import {Menu} from '@sanity/ui/menu'
 import {format} from 'date-fns/format'
 import {useRouter} from 'sanity/router'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/EmptySchedules.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/EmptySchedules.tsx
@@ -1,5 +1,6 @@
-import {Card, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {Card, Heading, Stack, Text} from '@sanity/ui'
 import {format} from 'date-fns/format'
+import {Flex} from 'ui5'
 
 import {type ScheduleState} from '../../types'
 import BigIconComingSoon from './BigIconComingSoon'
@@ -52,7 +53,7 @@ const EmptySchedules = (props: Props) => {
   return (
     <Card paddingX={6} paddingBottom={8} paddingTop={7} radius={2} shadow={1}>
       <Stack gap={4}>
-        <Flex justify="center">{BigIcon && <BigIcon />}</Flex>
+        <Flex justifyContent="center">{BigIcon && <BigIcon />}</Flex>
         <Stack gap={4}>
           {heading && (
             <Heading align="center" size={1}>

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/Schedules.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/Schedules.tsx
@@ -1,7 +1,7 @@
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Card, Container, Flex, Text} from '@sanity/ui'
+import {Card, Container, Text} from '@sanity/ui'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {useScheduledPublishingEnabled} from '../../../scheduledPublishing/contexts/ScheduledPublishingEnabledProvider'
 import {UpsellPanel} from '../../../studio/upsell/UpsellPanel'
@@ -39,7 +39,7 @@ export const Schedules = () => {
         <>
           {showWarning && (
             <Card margin={4} marginBottom={2} padding={3} tone="caution" radius={3} shadow={1}>
-              <Flex gap={3} align={'center'}>
+              <Flex gap={3} alignItems={'center'}>
                 <Text size={1}>
                   <WarningOutlineIcon />
                 </Text>

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
@@ -1,8 +1,7 @@
 import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
-import {Flex} from '@sanity/ui'
 import {useVirtualizer} from '@tanstack/react-virtual'
 import {useEffect, useMemo, useRef} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import useScheduleOperation from '../../hooks/useScheduleOperation'
@@ -52,7 +51,7 @@ const VirtualList = () => {
       </Box>
       {/* Clear completed schedules */}
       {scheduleState === 'succeeded' && (
-        <Flex justify="center" marginTop={6}>
+        <Flex justifyContent="center" marginTop={6}>
           <Button
             icon={CheckmarkCircleIcon}
             mode="ghost"

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualListItem.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualListItem.tsx
@@ -1,7 +1,7 @@
-import {Card, Flex, Label} from '@sanity/ui'
+import {Card, Label} from '@sanity/ui'
 import {type VirtualItem, type Virtualizer} from '@tanstack/react-virtual'
 import {type CSSProperties, useEffect, useMemo, useState} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
 import {ScheduleItem} from '../../components/scheduleItem'
@@ -81,7 +81,7 @@ function DelayedScheduleItem({schedule}: {schedule: Schedule}) {
 
 function MonthHeading({content}: {content: string}) {
   return (
-    <Flex align="flex-end" paddingBottom={2} paddingTop={4}>
+    <Flex alignItems="flex-end" paddingBottom={2} paddingTop={4}>
       <Label muted size={1}>
         {content}
       </Label>

--- a/packages/sanity/src/core/scheduled-publishing/tool/toolCalendar/CalendarDay.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/toolCalendar/CalendarDay.tsx
@@ -1,9 +1,9 @@
 import {CloseIcon} from '@sanity/icons/Close'
-import {Badge, Card, type CardTone, Flex, Inline, Label, Stack, Text} from '@sanity/ui'
+import {Badge, Card, type CardTone, Inline, Label, Stack, Text} from '@sanity/ui'
 import {format} from 'date-fns/format'
 import {isWeekend} from 'date-fns/isWeekend'
 import {useCallback, useMemo} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {useTimeZone} from '../../../hooks/useTimeZone'
@@ -101,7 +101,7 @@ export function CalendarDay(props: CalendarDayProps) {
               right: 2,
             }}
           >
-            <Flex align="center" gap={1} justify="center">
+            <Flex alignItems="center" gap={1} justifyContent="center">
               {completed.length > 0 && <Pip selected={selected} />}
               {upcoming.length > 0 && <Pip selected={selected} />}
               {failed.length > 0 && <Pip mode="failed" selected={selected} />}
@@ -172,7 +172,7 @@ function TooltipContent(props: TooltipContentProps) {
                         </Box>
                         {/* HACK: Hide non unpublish schedules to maintain layout */}
                         <Flex
-                          align="center"
+                          alignItems="center"
                           style={{flexShrink: 0, opacity: schedule.action === 'unpublish' ? 1 : 0}}
                         >
                           <Badge

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -1,9 +1,9 @@
 import {at, set} from '@sanity/mutate'
 import {applyPatches} from '@sanity/mutate/_unstable_apply'
-import {Card, Flex} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {type FormEvent, useCallback, useState} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
@@ -102,7 +102,7 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
               value={variant}
             />
           </Box>
-          <Flex gap={2} justify="flex-end" paddingTop={5}>
+          <Flex gap={2} justifyContent="flex-end" paddingTop={5}>
             {renderCancelButton && (
               <Button
                 disabled={isSubmitting}

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -4,10 +4,10 @@ import {HelpCircleIcon} from '@sanity/icons/HelpCircle'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {type Path} from '@sanity/mutate'
 import {type PortableTextBlock} from '@sanity/types'
-import {Flex, Inline, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+import {Inline, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -335,7 +335,7 @@ export function VariantForm(props: {
 
             return (
               <Stack key={row.id} gap={2}>
-                <Flex align="center" gap={2}>
+                <Flex alignItems="center" gap={2}>
                   <Box flexBasis="0%" flexGrow={1}>
                     <ConditionAutocompleteInput
                       autoFocus={index > 0}

--- a/packages/sanity/src/core/variants/plugin/components/PerspectiveFilter.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/PerspectiveFilter.tsx
@@ -1,7 +1,7 @@
 import {RemoveIcon} from '@sanity/icons/Remove'
-import {Card, Flex, Text, type CardTone} from '@sanity/ui'
+import {Card, Text, type CardTone} from '@sanity/ui'
 import {type ReactNode} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {AnimatedTextWidth} from '../../../perspective/navbar/AnimatedTextWidth'
@@ -38,12 +38,12 @@ export function PerspectiveFilter({
   label,
 }: PerspectiveFilterProps): React.JSX.Element {
   return (
-    <Flex align="center" data-ui="PerspectiveFilter">
+    <Flex alignItems="center" data-ui="PerspectiveFilter">
       <Box paddingX={2}>
         <Text size={1}>{prefix}</Text>
       </Box>
       <Card tone={tone} radius={2} border>
-        <Flex align="center">
+        <Flex alignItems="center">
           {label ? <AnimatedTextWidth text={label}>{children}</AnimatedTextWidth> : children}
           {onRemove && removeLabel ? (
             <>

--- a/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
@@ -1,9 +1,9 @@
-import {Text, TextInput, Flex} from '@sanity/ui'
+import {Text, TextInput} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
 import {useCallback, useMemo, useState, type JSX} from 'react'
 import {useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'

--- a/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
@@ -1,7 +1,8 @@
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
-import {Card, Flex} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 import {useRouter} from 'sanity/router'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {RhombusIcon} from '../../../components/temporary-icons/Rhombus'
@@ -55,7 +56,7 @@ export function VariantsStudioNavbar(props: NavbarProps) {
   }, [setVariant])
 
   return (
-    <Flex direction="column">
+    <Flex flexDirection="column">
       {props.renderDefault(props)}
       <Card
         tone={hasVariantSelection ? 'suggest' : 'neutral'}
@@ -63,7 +64,7 @@ export function VariantsStudioNavbar(props: NavbarProps) {
         paddingX={3}
         borderBottom
       >
-        <Flex align="center" justify="center" gap={2} wrap="wrap">
+        <Flex alignItems="center" justifyContent="center" gap={2} flexWrap="wrap">
           <PerspectiveFilter
             prefix={t('navbar.version')}
             tone={getReleaseTone(selectedPerspective)}

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/PerspectiveFilter.stories.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/PerspectiveFilter.stories.tsx
@@ -1,7 +1,8 @@
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {CircleIcon} from '@sanity/icons/Circle'
-import {Card, Flex, Stack, Text, type CardTone} from '@sanity/ui'
+import {Card, Stack, Text, type CardTone} from '@sanity/ui'
 import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {PerspectiveFilter} from '../PerspectiveFilter'
@@ -51,7 +52,7 @@ export const Enabled: Story = {
     <Card padding={4}>
       <Stack gap={4}>
         {CASES.map(({tone, label, caption}) => (
-          <Flex key={tone} align="center" gap={4}>
+          <Flex key={tone} alignItems="center" gap={4}>
             <PerspectiveFilter prefix="Version" tone={tone}>
               <TriggerButton text={label} />
             </PerspectiveFilter>
@@ -72,7 +73,7 @@ export const Selected: Story = {
     <Card padding={4}>
       <Stack gap={4}>
         {CASES.map(({tone, label, caption}) => (
-          <Flex key={tone} align="center" gap={4}>
+          <Flex key={tone} alignItems="center" gap={4}>
             <PerspectiveFilter
               prefix="Version"
               tone={tone}
@@ -96,7 +97,7 @@ export const Disabled: Story = {
   args: {prefix: 'Variant', tone: 'default', children: null},
   render: () => (
     <Card padding={4}>
-      <Flex align="center" gap={4}>
+      <Flex alignItems="center" gap={4}>
         <PerspectiveFilter prefix="Variant" tone="default">
           <TriggerButton text="All users (Default)" disabled />
         </PerspectiveFilter>

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -2,10 +2,10 @@ import {DocumentsIcon} from '@sanity/icons/Documents'
 import {EditIcon} from '@sanity/icons/Edit'
 import {SortIcon} from '@sanity/icons/Sort'
 import {UserIcon} from '@sanity/icons/User'
-import {Card, Container, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {Card, Container, Skeleton, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
 import {useRouter} from 'sanity/router'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {
   DetailBackButton,
@@ -181,7 +181,7 @@ export function VariantDetail() {
 
   if (!variant) {
     return (
-      <Flex direction="column" flex={1} height="fill">
+      <Flex flexDirection="column" flexBasis="0%" flexGrow={1} height="100%">
         <Card borderBottom flex="none" padding={3}>
           <DetailBackButton onClick={() => router.navigate({})} text={t('detail.back')} />
         </Card>
@@ -204,7 +204,7 @@ export function VariantDetail() {
   const description = getVariantDescription(variant)
 
   return (
-    <Flex direction="column" flex={1} height="fill" overflow="hidden">
+    <Flex flexDirection="column" flexBasis="0%" flexGrow={1} height="100%" overflow="hidden">
       {/* Header region — the shared detail spine: a top rail (back on the left, action rail on the
           right), then a two-zone body (identity on the left, a bordered properties panel on the
           right). Matches the Releases detail page so the two read as one family. No borderBottom:
@@ -218,15 +218,20 @@ export function VariantDetail() {
               actions line up with the row content below. */}
           <Box paddingX={2}>
             <Stack gap={4}>
-              <Flex align="center" gap={3}>
-                <Flex align="center" flex={1} style={{minWidth: 0}}>
+              <Flex alignItems="center" gap={3}>
+                <Flex alignItems="center" flexBasis="0%" flexGrow={1}>
                   <DetailBackButton
                     onClick={() => router.navigate({})}
                     testId="back-to-variants-button"
                     text={t('detail.back')}
                   />
                 </Flex>
-                <Flex data-testid="variant-detail-actions" flex="none">
+                <Flex
+                  data-testid="variant-detail-actions"
+                  flexBasis="auto"
+                  flexGrow={0}
+                  flexShrink={0}
+                >
                   <VariantActionRail
                     documentCount={tableRows.length}
                     documentsLoading={documentsLoading}
@@ -234,7 +239,7 @@ export function VariantDetail() {
                   />
                 </Flex>
               </Flex>
-              <Flex align="flex-start" gap={4} wrap="wrap">
+              <Flex alignItems="flex-start" gap={4} flexWrap="wrap">
                 <Box flexBasis="0%" flexGrow={1} style={{minWidth: 280}}>
                   <DetailIdentity
                     description={description || undefined}
@@ -262,7 +267,7 @@ export function VariantDetail() {
           </Box>
         </Container>
       </Card>
-      <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
+      <Flex flexDirection="column" flexBasis="0%" flexGrow={1} height="100%" overflow="hidden">
         {variantDocumentsError ? (
           <Box padding={4}>
             <Text muted size={1}>

--- a/packages/sanity/src/core/variants/tool/detail/VariantReleaseLane.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantReleaseLane.tsx
@@ -1,4 +1,5 @@
-import {Flex, TabList} from '@sanity/ui'
+import {TabList} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {Tab} from '../../../../ui-components/tab/Tab'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -34,7 +35,7 @@ export function VariantReleaseLane({
   const {t: tCore} = useTranslation()
 
   return (
-    <Flex align="center" wrap="nowrap" data-testid="variant-release-lane">
+    <Flex alignItems="center" flexWrap="nowrap" data-testid="variant-release-lane">
       {/* No leading icon/label: the tabs (All, Published, Drafts, release names) are self-evidently
           bundle filters. A filter icon here read as a clickable control that wasn't one. */}
       <TabList gap={1}>

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,8 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Badge, Flex, Stack, Text} from '@sanity/ui'
+import {Badge, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
@@ -120,9 +120,9 @@ export function VariantDocumentBundleChips({
   const overflow = chips.slice(MAX_VISIBLE_CHIPS)
 
   return (
-    <Flex align="center" gap={2} style={{minWidth: 0, overflow: 'hidden'}} wrap="nowrap">
+    <Flex alignItems="center" gap={2} style={{overflow: 'hidden'}} flexWrap="nowrap">
       {visible.map((chip) => (
-        <Box key={chip.key} style={{minWidth: 0, overflow: 'hidden'}}>
+        <Box key={chip.key} style={{overflow: 'hidden'}}>
           <VisibleChip chip={chip} label={getLabel(chip)} />
         </Box>
       ))}
@@ -135,7 +135,7 @@ export function VariantDocumentBundleChips({
               </Text>
               <Stack gap={2}>
                 {overflow.map((chip) => (
-                  <Flex align="center" gap={2} key={chip.key}>
+                  <Flex alignItems="center" gap={2} key={chip.key}>
                     <Text size={0}>
                       <ChipIcon chip={chip} />
                     </Text>

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -1,8 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Card, Flex, Text} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 import {useMemo, type RefAttributes} from 'react'
 import {IntentLink} from 'sanity/router'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {type PreviewLayoutKey} from '../../../../components/previews/types'
 import {DocumentPreviewPresence} from '../../../../presence/DocumentPreviewPresence'
@@ -151,7 +151,7 @@ export function VariantDocumentPreview({
   })
 
   return (
-    <Flex align="center" gap={2}>
+    <Flex alignItems="center" gap={2}>
       <PrimaryBundleIcon releasesById={releasesById} row={row} />
       <Card
         tone="inherit"

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -2,11 +2,11 @@ import {type ReleaseDocument} from '@sanity/client'
 import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
 import {ClockIcon} from '@sanity/icons/Clock'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
 import {memo} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
@@ -83,7 +83,7 @@ function ValidationStatusIndicator({
         placement="bottom-end"
         content={
           <Text muted size={1}>
-            <Flex align="center" gap={3} padding={1}>
+            <Flex alignItems="center" gap={3} padding={1}>
               <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
               {t(
                 validationErrorCount === 1
@@ -161,7 +161,7 @@ export const getVariantDocumentTableColumnDefs = (
     sorting: true,
     sortTransform: (row) => getRowBundleSortKey(row, releasesById),
     header: (props) => (
-      <Flex {...props.headerProps} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} paddingY={3}>
         <Headers.SortHeaderButton
           paddingLeft={2}
           text={t('detail.documents.table.appears-in')}
@@ -171,7 +171,7 @@ export const getVariantDocumentTableColumnDefs = (
     ),
     cell: ({cellProps, datum}) => (
       <Flex
-        align="center"
+        alignItems="center"
         {...cellProps}
         style={{...cellProps.style, flex: '0 1 auto', minWidth: 0, overflow: 'hidden'}}
       >
@@ -190,7 +190,7 @@ export const getVariantDocumentTableColumnDefs = (
     style: {minWidth: 110, maxWidth: 130},
     sorting: true,
     header: (props) => (
-      <Flex {...props.headerProps} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} paddingY={3}>
         <Headers.SortHeaderButton
           paddingLeft={2}
           text={t('detail.documents.table.type')}
@@ -199,7 +199,7 @@ export const getVariantDocumentTableColumnDefs = (
       </Flex>
     ),
     cell: ({cellProps, datum}) => (
-      <Flex align="center" {...cellProps}>
+      <Flex alignItems="center" {...cellProps}>
         <Box paddingX={2}>
           {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
         </Box>
@@ -219,7 +219,7 @@ export const getVariantDocumentTableColumnDefs = (
     sorting: true,
     sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
     header: (props) => (
-      <Flex {...props.headerProps} flex={1} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} flexBasis="0%" flexGrow={1} paddingY={3}>
         <Headers.SortHeaderButton
           paddingLeft={2}
           text={t('detail.documents.table.document')}
@@ -230,12 +230,12 @@ export const getVariantDocumentTableColumnDefs = (
     cell: ({cellProps, datum}) => (
       <Flex
         {...cellProps}
-        align="center"
-        flex={1}
+        alignItems="center"
+        flexBasis="0%"
+        flexGrow={1}
         gap={2}
         padding={1}
         paddingRight={2}
-        sizing="border"
       >
         <Box flexBasis="0%" flexGrow={1} style={{minWidth: 0}}>
           {datum.isLoading ? (
@@ -260,7 +260,7 @@ export const getVariantDocumentTableColumnDefs = (
     sorting: true,
     width: 130,
     header: (props) => (
-      <Flex {...props.headerProps} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} paddingY={3}>
         <Headers.SortHeaderButton
           paddingLeft={2}
           text={t('detail.documents.table.last-edited')}
@@ -271,11 +271,12 @@ export const getVariantDocumentTableColumnDefs = (
     cell: ({cellProps, datum}) => (
       <Flex
         {...cellProps}
-        align="center"
+        alignItems="center"
         paddingX={2}
         paddingY={3}
-        style={{minWidth: 130}}
-        sizing="border"
+        style={{
+          minWidth: 130,
+        }}
       >
         {!datum.isLoading && datum.document._updatedAt && (
           <Text muted size={1}>
@@ -294,14 +295,14 @@ export const getVariantDocumentTableColumnDefs = (
     width: 170,
     style: {minWidth: 44, maxWidth: 170},
     header: (props) => (
-      <Flex {...props.headerProps} align="center" paddingX={2} paddingY={3} sizing="border">
+      <Flex {...props.headerProps} alignItems="center" paddingX={2} paddingY={3}>
         <Text muted size={1} textOverflow="ellipsis" weight="medium">
           {t('detail.documents.table.edited-by')}
         </Text>
       </Flex>
     ),
     cell: ({cellProps, datum}) => (
-      <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+      <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3}>
         {!datum.isLoading && (
           <EditedByCell documentId={datum.document._id} revision={datum.document._rev} />
         )}
@@ -318,9 +319,9 @@ export const getVariantDocumentTableColumnDefs = (
     style: {minWidth: 44, maxWidth: 44},
     sorting: true,
     sortTransform: (row) => (row.validation.hasError ? 0 : 1),
-    header: (props) => <Flex {...props.headerProps} paddingY={3} sizing="border" />,
+    header: (props) => <Flex {...props.headerProps} paddingY={3} />,
     cell: ({cellProps, datum}) => (
-      <Flex {...cellProps} align="center" justify="center" paddingY={3} sizing="border">
+      <Flex {...cellProps} alignItems="center" justifyContent="center" paddingY={3}>
         {!datum.isLoading && <ValidationStatusIndicator datum={datum} t={t} />}
       </Flex>
     ),

--- a/packages/sanity/src/core/variants/tool/overview/VariantConditionFilters.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantConditionFilters.tsx
@@ -3,9 +3,9 @@ import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {CloseIcon} from '@sanity/icons/Close'
 import {FilterIcon} from '@sanity/icons/Filter'
 import {SearchIcon} from '@sanity/icons/Search'
-import {Card, Flex, Stack, Text, TextInput, useClickOutsideEvent} from '@sanity/ui'
+import {Card, Stack, Text, TextInput, useClickOutsideEvent} from '@sanity/ui'
 import {type ComponentType, useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Popover} from '../../../../ui-components/popover/Popover'
@@ -129,7 +129,7 @@ function AddFilterMenu({
               })}
             </Stack>
           ) : (
-            <Flex align="center" height="fill" justify="center" padding={4}>
+            <Flex alignItems="center" height="100%" justifyContent="center" padding={4}>
               <Text align="center" muted size={1}>
                 {t('overview.filter.pick-dimension-hint')}
               </Text>
@@ -191,7 +191,7 @@ function FilterChip({
   const Icon = chip.icon
   const body = (
     <Card border padding={1} radius={2} style={{flex: 'none'}} tone="primary">
-      <Flex align="center" gap={2}>
+      <Flex alignItems="center" gap={2}>
         <Box paddingLeft={1}>
           <Text size={1}>
             <Icon />
@@ -259,7 +259,7 @@ function ActiveChips({
       ref={containerRef}
       style={{minWidth: 0, overflow: 'hidden', position: 'relative'}}
     >
-      <Flex align="center" gap={2} wrap="nowrap">
+      <Flex alignItems="center" gap={2} flexWrap="nowrap">
         {chips.map((chip) => (
           <FilterChip
             chip={chip}
@@ -281,7 +281,7 @@ function ActiveChips({
           top: 0,
           visibility: 'hidden',
         }}
-        wrap="nowrap"
+        flexWrap="nowrap"
       >
         {chips.map((chip) => (
           <FilterChip
@@ -345,7 +345,7 @@ export function VariantConditionFilters({
     // Fill the lane when there are chips (so Clear pins right and the chips zone can measure its
     // available width); shrink to content when there are none, so the empty bar stays compact.
     <Card border padding={1} radius={2} style={hasActive ? undefined : {display: 'inline-flex'}}>
-      <Flex align="center" gap={2} wrap="nowrap">
+      <Flex alignItems="center" gap={2} flexWrap="nowrap">
         <Box paddingX={1} style={{flex: 'none'}}>
           <Text muted size={1}>
             <FilterIcon />

--- a/packages/sanity/src/core/variants/tool/overview/VariantsEmptyState.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsEmptyState.tsx
@@ -1,4 +1,5 @@
-import {Flex, rem, Text} from '@sanity/ui'
+import {rem, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -16,10 +17,11 @@ export const VariantsEmptyState = ({createVariantButton}: VariantsEmptyStateProp
 
   return (
     <Flex
-      align="center"
+      alignItems="center"
       data-testid="variants-empty-state"
-      flex={1}
-      direction="column"
+      flexBasis="0%"
+      flexGrow={1}
+      flexDirection="column"
       gap={3}
       style={{maxWidth: rem(300)}}
       paddingBottom={5}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -1,7 +1,8 @@
 import {AddIcon} from '@sanity/icons/Add'
-import {Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Container, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {useRouter} from 'sanity/router'
+import {Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -98,7 +99,13 @@ export function VariantsOverview(): React.JSX.Element {
   const tableEmptyState = useCallback(() => {
     if (error && !hasVariants) {
       return (
-        <Flex align="center" direction="column" gap={3} justify="center" padding={4}>
+        <Flex
+          alignItems="center"
+          flexDirection="column"
+          gap={3}
+          justifyContent="center"
+          padding={4}
+        >
           <Text muted size={1}>
             {t('overview.error')}
           </Text>
@@ -108,7 +115,13 @@ export function VariantsOverview(): React.JSX.Element {
 
     if (hasVariants && hasActiveConditionFilters && rows.length === 0) {
       return (
-        <Flex align="center" direction="column" gap={3} justify="center" padding={4}>
+        <Flex
+          alignItems="center"
+          flexDirection="column"
+          gap={3}
+          justifyContent="center"
+          padding={4}
+        >
           <Text data-testid="variants-filter-empty-state" muted size={1}>
             {t('overview.filter.no-matching-definitions')}
           </Text>
@@ -120,13 +133,13 @@ export function VariantsOverview(): React.JSX.Element {
   }, [createVariantButton, error, hasActiveConditionFilters, hasVariants, rows.length, t])
 
   return (
-    <Flex direction="column" flex={1} height="fill">
+    <Flex flexDirection="column" flexBasis="0%" flexGrow={1} height="100%">
       {/* Same container width as the releases document table (`container[3]`), so the page header
           aligns with the table's row content below. */}
       <Container flex="none" width={3}>
-        <Flex direction="column" paddingX={3}>
+        <Flex flexDirection="column" paddingX={3}>
           <Card flex="none" paddingBottom={4} paddingTop={5}>
-            <Flex align="flex-start" gap={4} justify="space-between">
+            <Flex alignItems="flex-start" gap={4} justifyContent="space-between">
               <Stack gap={2}>
                 <Text as="h1" size={4} weight="bold">
                   {t('overview.title')}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -1,7 +1,7 @@
-import {Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {Card, Skeleton, Stack, Text} from '@sanity/ui'
 import {type HTMLProps, useMemo, type RefAttributes} from 'react'
 import {StateLink} from 'sanity/router'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {useTranslation, type UseTranslationResponse} from '../../../i18n/hooks/useTranslation'
 import {Headers} from '../../../releases/tool/components/Table/TableHeader'
@@ -25,7 +25,7 @@ export interface TableVariant extends SystemVariant {
 const VariantDocumentsCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum}) => {
   if (datum.isLoading || datum.documentCount === undefined) {
     return (
-      <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+      <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3}>
         <Text size={1}>
           <Skeleton animated radius={1} style={{width: '4ch'}} />
         </Text>
@@ -34,7 +34,7 @@ const VariantDocumentsCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, d
   }
 
   return (
-    <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+    <Flex {...cellProps} alignItems="center" paddingX={2} paddingY={3}>
       <Text muted size={1}>
         {datum.documentCount === null ? '-' : datum.documentCount}
       </Text>
@@ -77,9 +77,9 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
 
   return (
     <Box {...cellProps} flexBasis="0%" flexGrow={1} paddingLeft={3} paddingRight={2} paddingY={1}>
-      <Flex align="center" gap={3}>
+      <Flex alignItems="center" gap={3}>
         <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
-          <Flex align="center" gap={3}>
+          <Flex alignItems="center" gap={3}>
             {/* min-width: 0 lets the flex child shrink below its content width so a long name
                 truncates with a trailing ellipsis instead of overflowing on narrow viewports. */}
             <Stack flex={1} gap={2} style={{minWidth: 0}}>
@@ -109,11 +109,11 @@ export function variantsOverviewColumnDefs(
       header: (props) => (
         <Flex
           {...props.headerProps}
-          flex={1}
+          flexBasis="0%"
+          flexGrow={1}
           paddingLeft={3}
           paddingRight={2}
           paddingY={3}
-          sizing="border"
         >
           <Headers.SortHeaderButton {...props} text={t('overview.table.variant')} />
         </Flex>
@@ -126,7 +126,7 @@ export function variantsOverviewColumnDefs(
       sorting: false,
       width: 120,
       header: ({headerProps}) => (
-        <Flex {...headerProps} paddingY={3} sizing="border">
+        <Flex {...headerProps} paddingY={3}>
           <Headers.BasicHeader text={t('overview.table.documents')} />
         </Flex>
       ),


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR migrates the Flex component from `@sanity/ui` v4 to v5 in the `packages/sanity/src/core/scheduled-publishing` and  `packages/sanity/src/core/variants` directories. It updates Flex across 32 files containing 82 JSX or styled-component instances.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop updates look correct. I've also removed a few `boxSizing` and `minWidth` props since they're included by default now.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I did some manual testing in the Schedules and Variants tabs in the Test Studio.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical layout-component migration with no auth, API, or data changes; main risk is subtle flex regressions in Schedules and Variants UI, mitigated by manual testing.
> 
> **Overview**
> This PR moves **`Flex`** from `@sanity/ui` to **`ui5`** across **scheduled-publishing** and **variants** (dialogs, schedule tool, variant overview/detail tables, perspective navbar, and related Storybook stories).
> 
> Layout props are updated to the v5 API: **`align` → `alignItems`**, **`justify` → `justifyContent`**, **`direction` → `flexDirection`**, **`wrap` → `flexWrap`**, and shorthand **`flex={1}`** is replaced with **`flexBasis="0%" flexGrow={1}`** where needed. **`height="fill"`** becomes **`height="100%"`** on several full-height shells.
> 
> In variant document/overview table column defs, **`sizing="border"`** is dropped from **`Flex`** headers and cells (no longer used on the v5 component). A few redundant **`minWidth`** styles on chip rows are removed where defaults are enough.
> 
> Behavior and data flow are unchanged; this is an import and prop rename pass for the UI5 layout stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8189ee499d31b9571cd6492d4d7e1023136f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->