### PR TITLE
fix(scheduled-publishing): honour document.actions for publish now in the schedules tool

### DIFF
--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/ContextMenuItems.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/ContextMenuItems.tsx
@@ -25,6 +25,12 @@ interface Props {
   schemaType: SchemaType
 }
 
+/**
+ * Edit, Delete and Clear stay ungated by `document.actions`: they call the schedules HTTP API, the
+ * document survives a delete, and legacy schedules are not versions, so none of them has an honest
+ * action id. Edit's in-pane call site is already behind `useScheduleAction.action = 'schedule'`.
+ * Publish now is a document publish, so its call site gates it on `publish`.
+ */
 const ContextMenuItems = (props: Props) => {
   const {actions, onDelete, onEdit, schedule, schemaType} = props
   const {mode} = useScheduledPublishingEnabled()

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/FallbackContextMenu.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/FallbackContextMenu.tsx
@@ -15,6 +15,9 @@ interface Props {
 /**
  * 'Fallback' context menu used with schedules that don't have any valid associated documentType.
  * Currently, all users can delete schedules that don't have any associated documents, so we don't need to check for permissions here.
+ *
+ * Ungated by `document.actions`: with no `schemaType` there is no context to resolve against, and
+ * delete-schedule has no honest action id.
  */
 export const FallbackContextMenu = (props: Props) => {
   const {onDelete, schedule} = props

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
@@ -2,13 +2,14 @@ import {type SchemaType} from '@sanity/types'
 import {type ComponentType} from 'react'
 import {IntentLink} from 'sanity/router'
 
+import {useConfiguredDocumentActionIds} from '../../../config/document/useConfiguredDocumentActionIds'
 import {Preview} from '../../../preview/components/Preview'
 import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
 import {getPublishedId} from '../../../util/draftUtils'
 import {SCHEDULED_PUBLISHING_TIME_ZONE_SCOPE} from '../../constants'
 import useDialogScheduleEdit from '../../hooks/useDialogScheduleEdit'
 import {type Schedule} from '../../types'
-import {type PaneItemPreviewState} from '../../utils/paneItemHelpers'
+import {getScheduledDocumentId, type PaneItemPreviewState} from '../../utils/paneItemHelpers'
 import {ScheduleContextMenu} from '../scheduleContextMenu'
 import PreviewWrapper from './PreviewWrapper'
 
@@ -32,6 +33,14 @@ const ToolPreview = (props: Props) => {
   )
   const publishedDocId = visibleDocument ? getPublishedId(visibleDocument._id) : undefined
 
+  // Publish now publishes this document's draft, the context the footer Publish resolves under.
+  const configuredActionIds = useConfiguredDocumentActionIds({
+    schemaType: schemaType.name,
+    documentId: getScheduledDocumentId(schedule),
+    versionType: 'draft',
+    releaseId: undefined,
+  })
+
   return (
     <>
       {/* Dialogs (rendered outside of cards so they don't infer card colors) */}
@@ -43,7 +52,7 @@ const ToolPreview = (props: Props) => {
               clear: isCompleted,
               delete: !isCompleted,
               edit: isScheduled,
-              execute: isScheduled,
+              execute: isScheduled && configuredActionIds.has('publish'),
             }}
             onEdit={dialogScheduleEditShow}
             schedule={schedule}

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/__tests__/ToolPreview.test.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/__tests__/ToolPreview.test.tsx
@@ -1,0 +1,117 @@
+import {type SanityDocument} from '@sanity/client'
+import {type SchemaType} from '@sanity/types'
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {type ReactNode} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {useDocumentPairPermissionsMockReturn} from '../../../../../../test/mocks/useDocumentPairPermissions.mock'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentActionComponent} from '../../../../config/document/actions'
+import {type SingleWorkspace} from '../../../../config/types'
+import {type Schedule} from '../../../types'
+import ToolPreview from '../ToolPreview'
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  IntentLink: ({children}: {children: ReactNode}) => <div>{children}</div>,
+}))
+
+vi.mock('../../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(() => useDocumentPairPermissionsMockReturn),
+}))
+
+vi.mock('../PreviewWrapper', () => ({
+  default: ({contextMenu}: {contextMenu: ReactNode}) => <div>{contextMenu}</div>,
+}))
+
+// `publish` is contributed by the structure tool, which the core test harness does not load.
+const publishAction: DocumentActionComponent = Object.assign(() => null, {
+  action: 'publish' as const,
+})
+
+const withPublishConfigured: Partial<SingleWorkspace> = {
+  document: {actions: (prev) => [...prev, publishAction]},
+}
+
+const withPublishFiltered: Partial<SingleWorkspace> = {
+  document: {
+    actions: (prev) => [...prev, publishAction].filter((action) => action.action !== 'publish'),
+  },
+}
+
+const authorSchemaType = {name: 'author', title: 'Author', jsonType: 'object'} as SchemaType
+
+const draftDocument = {_id: 'drafts.author-1', _type: 'author'} as SanityDocument
+
+const scheduledSchedule: Schedule = {
+  author: 'doug',
+  action: 'publish',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  dataset: 'mock-data-set',
+  description: '',
+  documents: [{documentId: 'drafts.author-1', documentType: 'author'}],
+  executeAt: '2026-09-01T00:00:00.000Z',
+  id: 'schedule-1',
+  name: 'schedule-1',
+  projectId: 'mock-project-id',
+  state: 'scheduled',
+  stateReason: '',
+}
+
+const completedSchedule: Schedule = {...scheduledSchedule, state: 'succeeded'}
+
+async function renderContextMenu(config: Partial<SingleWorkspace>, schedule: Schedule) {
+  const wrapper = await createTestProvider({config})
+
+  render(
+    <ToolPreview
+      previewState={{isLoading: false, draft: draftDocument, published: null}}
+      schedule={schedule}
+      schemaType={authorSchemaType}
+    />,
+    {wrapper},
+  )
+
+  await userEvent.click(screen.getByRole('button'))
+}
+
+describe('ToolPreview', () => {
+  it('offers Publish now while publish is configured', async () => {
+    await renderContextMenu(withPublishConfigured, scheduledSchedule)
+
+    expect(screen.getByText('Publish now')).toBeInTheDocument()
+  })
+
+  it('hides Publish now when publish is omitted from document.actions', async () => {
+    await renderContextMenu(withPublishFiltered, scheduledSchedule)
+
+    expect(screen.queryByText('Publish now')).not.toBeInTheDocument()
+  })
+
+  it('keeps Edit schedule and Delete schedule while publish is configured', async () => {
+    await renderContextMenu(withPublishConfigured, scheduledSchedule)
+
+    expect(screen.getByText('Edit schedule')).toBeInTheDocument()
+    expect(screen.getByText('Delete schedule')).toBeInTheDocument()
+  })
+
+  it('keeps Edit schedule and Delete schedule when publish is omitted', async () => {
+    await renderContextMenu(withPublishFiltered, scheduledSchedule)
+
+    expect(screen.getByText('Edit schedule')).toBeInTheDocument()
+    expect(screen.getByText('Delete schedule')).toBeInTheDocument()
+  })
+
+  it('keeps Clear completed schedule while publish is configured', async () => {
+    await renderContextMenu(withPublishConfigured, completedSchedule)
+
+    expect(screen.getByText('Clear completed schedule')).toBeInTheDocument()
+  })
+
+  it('keeps Clear completed schedule when publish is omitted', async () => {
+    await renderContextMenu(withPublishFiltered, completedSchedule)
+
+    expect(screen.getByText('Clear completed schedule')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Description

A studio that filters `publish` out of `document.actions` lost the Publish action from the document footer but kept Publish now on every scheduled row in the Schedules tool, and clicking it published the document immediately. `ToolPreview` derived the whole menu from `schedule.state` and consulted `document.actions` nowhere.

`execute` is now gated on `publish` being present in the resolved action set for the scheduled document. Edit, Delete and Clear stay exempt, as SAPP-4342 decided: they call the schedules HTTP API, the document survives a delete, and legacy schedules are not versions, so none of them has an honest action id. Publish now is a document publish, which is the gap SAPP-4342 did not cover.

The grant check on `useDocumentPairPermissions({permission: 'publish'})` is unchanged. This was a config-intent leak, not a permissions hole.

Resolves SAPP-4400.

### What to review

The `versionType` passed to `useConfiguredDocumentActionIds`. A Schedules tool row holds a `Schedule`, not a document version, so the context has to be constructed. `draft` is the value here: Publish now publishes the document's draft through `/schedules/.../publish`, which is what the footer Publish action does for the same document, and the footer resolves that action under `versionType: 'draft'`. Gating a mirror on the context its mirrored action resolves under is the invariant #14244 established. `scheduled-draft` reads plausible but is wrong - the pane's version-type derivation only returns it for a cardinality-one release, and a legacy schedule has no release. `releaseId` is `undefined` for the same reason.

The JSDoc on `ContextMenuItems.tsx` and `FallbackContextMenu.tsx`. #14268 records the SAPP-4342 exemption in those two blocks and is still open. Both branches carry the same Publish-now sentence and both scope the exemption to Edit, Delete and Clear, so the two agree in substance and conflict only textually. Whichever lands second keeps either wording.

Merge order. #14269 documents this gate in `docs/CORE_CONCEPTS.md` and states that Publish now is gated in the Schedules tool, so this PR has to merge first.

The gate is presence-only, the ceiling #14244 accepted. A `publish` action left in the config array that returns `null` from its hook still keeps the item on the row.

### Testing

`packages/sanity/src/core/scheduled-publishing/components/scheduleItem/__tests__/ToolPreview.test.tsx` covers both directions: Publish now present when `publish` is configured, absent when it is filtered out, and Edit schedule, Delete schedule and Clear completed schedule unaffected by a `publish` filter in either case. 1 file, 6 tests passed, no type errors.

The absence test fails against the unfixed component, which derived `execute` from `isScheduled` alone.

`publish` comes from the structure tool, which the core test harness does not load, so the test contributes a stub `publish` action the way the `VersionContextMenu` tests contribute `discardChanges`.

### Notes for release

Filtering `publish` out of `document.actions` now also removes Publish now from rows in the Schedules tool of the deprecated `sanity/scheduled-publishing` plugin. Edit schedule, Delete schedule and Clear completed schedule are unaffected by that filter, because they act on the schedule rather than the document.

---
