### PR TITLE
fix(releases): honour the publish and discard grants on scheduled draft actions

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/ScheduledDraftContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/ScheduledDraftContextMenu.test.tsx
@@ -1,0 +1,118 @@
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {useScheduledDraftMenuActions} from '../../../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
+import {
+  type DocumentPermission,
+  useDocumentPairPermissions,
+} from '../../../../../store/grants/documentPairPermissions'
+import {activeCardinalityOneRelease} from '../../../../__fixtures__/release.fixture'
+import {ScheduledDraftContextMenu} from '../ScheduledDraftContextMenu'
+
+vi.mock('../../../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(),
+}))
+
+vi.mock('../../../../../singleDocRelease/hooks/useScheduledDraftDocument', () => ({
+  useScheduledDraftDocument: () => ({
+    firstDocument: null,
+    firstDocumentPreview: undefined,
+    loading: false,
+  }),
+}))
+
+vi.mock('../CopyToDraftsMenuItem', () => ({
+  useHasCopyToDraftOption: () => false,
+}))
+
+const mockUseDocumentPairPermissions = useDocumentPairPermissions as MockedFunction<
+  typeof useDocumentPairPermissions
+>
+
+const withholdPermission = (withheld?: DocumentPermission) =>
+  mockUseDocumentPairPermissions.mockImplementation(({permission}) => [
+    {granted: permission !== withheld, reason: ''},
+    false,
+  ])
+
+// `activeCardinalityOneRelease` is paused, which hides the edit schedule item.
+const scheduledDraftRelease = {
+  ...activeCardinalityOneRelease,
+  state: 'scheduled' as const,
+  publishAt: '2023-10-10T10:00:00.000Z',
+}
+
+function MenuDriver() {
+  const scheduledDraftMenuActions = useScheduledDraftMenuActions({
+    release: scheduledDraftRelease,
+    documentType: 'author',
+    documentId: 'doc1',
+  })
+
+  return (
+    <ScheduledDraftContextMenu
+      releases={[]}
+      bundleId="rCardinalityOne"
+      onCreateRelease={vi.fn()}
+      onCopyToDrafts={vi.fn()}
+      onCreateVersion={vi.fn()}
+      hasCreatePermission
+      scheduledDraftMenuActions={scheduledDraftMenuActions}
+      documentType="author"
+      release={scheduledDraftRelease}
+      showPublishNow
+      showEditSchedule
+      showDeleteSchedule
+    />
+  )
+}
+
+const renderMenu = async () => {
+  const wrapper = await createTestProvider()
+
+  render(<MenuDriver />, {wrapper})
+}
+
+describe('ScheduledDraftContextMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withholdPermission()
+  })
+
+  it('enables every scheduled draft item when both grants are present', async () => {
+    await renderMenu()
+
+    expect(screen.getByTestId('publish-now-menu-item')).toBeEnabled()
+    expect(screen.getByTestId('edit-schedule-menu-item')).toBeEnabled()
+    expect(screen.getByTestId('delete-schedule-menu-item')).toBeEnabled()
+
+    expect(screen.queryByText('Insufficient permissions')).not.toBeInTheDocument()
+  })
+
+  it('disables publish now and edit schedule when the publish grant is absent', async () => {
+    withholdPermission('publish')
+
+    await renderMenu()
+
+    expect(screen.getByTestId('publish-now-menu-item')).toBeDisabled()
+    expect(screen.getByTestId('edit-schedule-menu-item')).toBeDisabled()
+    expect(screen.getByTestId('delete-schedule-menu-item')).toBeEnabled()
+
+    expect(
+      screen.getByText('You do not have permission to publish this document.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('You do not have permission to edit schedules.')).toBeInTheDocument()
+  })
+
+  it('disables delete schedule when the discardVersion grant is absent', async () => {
+    withholdPermission('discardVersion')
+
+    await renderMenu()
+
+    expect(screen.getByTestId('delete-schedule-menu-item')).toBeDisabled()
+    expect(screen.getByTestId('publish-now-menu-item')).toBeEnabled()
+
+    expect(screen.getByText('You do not have permission to delete schedules.')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/ScheduledDraftContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/ScheduledDraftContextMenu.test.tsx
@@ -30,13 +30,15 @@ const mockUseDocumentPairPermissions = useDocumentPairPermissions as MockedFunct
   typeof useDocumentPairPermissions
 >
 
+const grantEveryPermission = () =>
+  mockUseDocumentPairPermissions.mockImplementation(() => [{granted: true, reason: ''}, false])
+
 const withholdPermission = (withheld?: DocumentPermission) =>
   mockUseDocumentPairPermissions.mockImplementation(({permission}) => [
     {granted: permission !== withheld, reason: ''},
     false,
   ])
 
-// `activeCardinalityOneRelease` is paused, which hides the edit schedule item.
 const scheduledDraftRelease = {
   ...activeCardinalityOneRelease,
   state: 'scheduled' as const,
@@ -77,7 +79,7 @@ const renderMenu = async () => {
 describe('ScheduledDraftContextMenu', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    withholdPermission()
+    grantEveryPermission()
   })
 
   it('enables every scheduled draft item when both grants are present', async () => {

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -43,6 +43,7 @@ const createScheduledDraftMenuActions = () => ({
       'tone': 'default' as const,
       'onClick': vi.fn(),
       'disabled': false,
+      'tooltipProps': null,
       'data-testid': 'publish-now-menu-item',
     },
     editSchedule: {
@@ -51,6 +52,7 @@ const createScheduledDraftMenuActions = () => ({
       'tone': 'default' as const,
       'onClick': vi.fn(),
       'disabled': false,
+      'tooltipProps': null,
       'data-testid': 'edit-schedule-menu-item',
     },
     schedulePublish: {
@@ -59,6 +61,7 @@ const createScheduledDraftMenuActions = () => ({
       'tone': 'default' as const,
       'onClick': vi.fn(),
       'disabled': false,
+      'tooltipProps': null,
       'data-testid': 'schedule-publish-menu-item',
     },
     deleteSchedule: {
@@ -67,6 +70,7 @@ const createScheduledDraftMenuActions = () => ({
       'tone': 'critical' as const,
       'onClick': vi.fn(),
       'disabled': false,
+      'tooltipProps': null,
       'data-testid': 'delete-schedule-menu-item',
     },
   },

--- a/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
@@ -41,7 +41,7 @@ export const ScheduledDraftMenuButtonWrapper = ({release}: {release: ReleaseDocu
   const {actions, dialogs, isPerformingOperation} = useScheduledDraftMenuActions({
     release,
     documentType: scheduledDraftDocument?._type,
-    documentId: scheduledDraftDocument?._id,
+    documentId: scheduledDraftDocument ? getPublishedId(scheduledDraftDocument._id) : undefined,
     disabled: !scheduledDraftDocument,
     onActionComplete: handleActionComplete,
   })

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ScheduledDraftMenuButtonWrapper.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ScheduledDraftMenuButtonWrapper.test.tsx
@@ -1,9 +1,14 @@
 import {render, screen} from '@testing-library/react'
-import {describe, expect, it, vi} from 'vitest'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {type DocumentActionsResolver} from '../../../../config/types'
+import {
+  type DocumentPermission,
+  useDocumentPairPermissions,
+} from '../../../../store/grants/documentPairPermissions'
 import {activeCardinalityOneRelease} from '../../../__fixtures__/release.fixture'
 import {releasesUsEnglishLocaleBundle} from '../../../i18n'
 import {ScheduledDraftMenuButtonWrapper} from '../ScheduledDraftMenuButtonWrapper'
@@ -25,6 +30,20 @@ vi.mock('../../../../singleDocRelease/hooks/useScheduledDraftDocument', () => ({
   })),
 }))
 
+vi.mock('../../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(),
+}))
+
+const mockUseDocumentPairPermissions = useDocumentPairPermissions as MockedFunction<
+  typeof useDocumentPairPermissions
+>
+
+const withholdPermission = (withheld?: DocumentPermission) =>
+  mockUseDocumentPairPermissions.mockImplementation(({permission}) => [
+    {granted: permission !== withheld, reason: ''},
+    false,
+  ])
+
 const renderMenu = async (documentActions?: DocumentActionsResolver) => {
   const wrapper = await createTestProvider({
     resources: [releasesUsEnglishLocaleBundle],
@@ -35,7 +54,17 @@ const renderMenu = async (documentActions?: DocumentActionsResolver) => {
   await flushMicrotasksThisIsACodeSmell()
 }
 
+const openMenu = async () => {
+  await renderMenu()
+  await userEvent.click(screen.getByTestId('scheduled-draft-menu-button'))
+}
+
 describe('ScheduledDraftMenuButtonWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withholdPermission()
+  })
+
   it('renders the menu button while the scheduled draft actions are configured', async () => {
     await renderMenu()
 
@@ -52,5 +81,35 @@ describe('ScheduledDraftMenuButtonWrapper', () => {
     await renderMenu((prev) => prev.filter(({action}) => action === 'publish'))
 
     expect(screen.getByTestId('scheduled-draft-menu-button')).toBeInTheDocument()
+  })
+
+  it('offers publish now and delete schedule when both grants are present', async () => {
+    await openMenu()
+
+    expect(screen.getByTestId('publish-now-menu-item')).toBeEnabled()
+    expect(screen.getByTestId('delete-schedule-menu-item')).toBeEnabled()
+    expect(screen.queryByText('Insufficient permissions')).not.toBeInTheDocument()
+  })
+
+  it('disables publish now with an explanation when the publish grant is absent', async () => {
+    withholdPermission('publish')
+
+    await openMenu()
+
+    expect(screen.getByTestId('publish-now-menu-item')).toBeDisabled()
+    expect(screen.getByTestId('delete-schedule-menu-item')).toBeEnabled()
+    expect(
+      screen.getByText('You do not have permission to publish this document.'),
+    ).toBeInTheDocument()
+  })
+
+  it('disables delete schedule with an explanation when the discardVersion grant is absent', async () => {
+    withholdPermission('discardVersion')
+
+    await openMenu()
+
+    expect(screen.getByTestId('delete-schedule-menu-item')).toBeDisabled()
+    expect(screen.getByTestId('publish-now-menu-item')).toBeEnabled()
+    expect(screen.getByText('You do not have permission to delete schedules.')).toBeInTheDocument()
   })
 })

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ScheduledDraftMenuButtonWrapper.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ScheduledDraftMenuButtonWrapper.test.tsx
@@ -38,6 +38,9 @@ const mockUseDocumentPairPermissions = useDocumentPairPermissions as MockedFunct
   typeof useDocumentPairPermissions
 >
 
+const grantEveryPermission = () =>
+  mockUseDocumentPairPermissions.mockImplementation(() => [{granted: true, reason: ''}, false])
+
 const withholdPermission = (withheld?: DocumentPermission) =>
   mockUseDocumentPairPermissions.mockImplementation(({permission}) => [
     {granted: permission !== withheld, reason: ''},
@@ -62,7 +65,7 @@ const openMenu = async () => {
 describe('ScheduledDraftMenuButtonWrapper', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    withholdPermission()
+    grantEveryPermission()
   })
 
   it('renders the menu button while the scheduled draft actions are configured', async () => {

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -471,6 +471,43 @@ describe('useScheduledDraftMenuActions', () => {
       expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('true')
       expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('true')
       expect(screen.getByTestId('publish-now-reason')).toBeEmptyDOMElement()
+      expect(screen.getByTestId('delete-schedule-reason')).toBeEmptyDOMElement()
+    })
+
+    it('asks for a type that denies without a lookup until the release resolves', () => {
+      render(
+        <TestProvider>
+          <TestComponent options={{...baseOptions, release: undefined}} />
+        </TestProvider>,
+      )
+
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: 'doc1',
+        type: '*',
+        version: undefined,
+        permission: 'publish',
+      })
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: 'doc1',
+        type: '*',
+        version: undefined,
+        permission: 'discardVersion',
+      })
+    })
+
+    it('asks for a type that denies without a lookup when the document id is missing', () => {
+      render(
+        <TestProvider>
+          <TestComponent options={{...baseOptions, documentId: undefined}} />
+        </TestProvider>,
+      )
+
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: '',
+        type: '*',
+        version: 'rScheduled',
+        permission: 'publish',
+      })
     })
   })
 })

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -363,12 +363,15 @@ describe('useScheduledDraftMenuActions', () => {
     })
   })
   describe('grants', () => {
-    it('enables every action when both grants are present', () => {
+    const renderActions = (optionsOverride: Partial<UseScheduledDraftMenuActionsOptions> = {}) =>
       render(
         <TestProvider>
-          <TestComponent options={baseOptions} />
+          <TestComponent options={{...baseOptions, ...optionsOverride}} />
         </TestProvider>,
       )
+
+    it('enables every action when both grants are present', () => {
+      renderActions()
 
       expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('false')
       expect(screen.getByTestId('edit-schedule-disabled')).toHaveTextContent('false')
@@ -384,11 +387,7 @@ describe('useScheduledDraftMenuActions', () => {
     it('disables the publish grant actions with an explanation when publish is withheld', () => {
       withholdPermission('publish')
 
-      render(
-        <TestProvider>
-          <TestComponent options={baseOptions} />
-        </TestProvider>,
-      )
+      renderActions()
 
       expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('true')
       expect(screen.getByTestId('publish-now-reason')).toHaveTextContent('Insufficient permissions')
@@ -410,11 +409,7 @@ describe('useScheduledDraftMenuActions', () => {
     it('keeps delete schedule available when only publish is withheld', () => {
       withholdPermission('publish')
 
-      render(
-        <TestProvider>
-          <TestComponent options={baseOptions} />
-        </TestProvider>,
-      )
+      renderActions()
 
       expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('false')
       expect(screen.getByTestId('delete-schedule-reason')).toBeEmptyDOMElement()
@@ -423,11 +418,7 @@ describe('useScheduledDraftMenuActions', () => {
     it('disables delete schedule with an explanation when discardVersion is withheld', () => {
       withholdPermission('discardVersion')
 
-      render(
-        <TestProvider>
-          <TestComponent options={baseOptions} />
-        </TestProvider>,
-      )
+      renderActions()
 
       expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('true')
       expect(screen.getByTestId('delete-schedule-reason')).toHaveTextContent(
@@ -439,11 +430,7 @@ describe('useScheduledDraftMenuActions', () => {
     })
 
     it('checks the grants against the scheduled draft version of the document', () => {
-      render(
-        <TestProvider>
-          <TestComponent options={baseOptions} />
-        </TestProvider>,
-      )
+      renderActions()
 
       expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
         id: 'doc1',
@@ -462,11 +449,7 @@ describe('useScheduledDraftMenuActions', () => {
     it('does not offer an action while the grant is still loading', () => {
       mockUseDocumentPairPermissions.mockImplementation(() => [undefined, true])
 
-      render(
-        <TestProvider>
-          <TestComponent options={baseOptions} />
-        </TestProvider>,
-      )
+      renderActions()
 
       expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('true')
       expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('true')
@@ -475,11 +458,7 @@ describe('useScheduledDraftMenuActions', () => {
     })
 
     it('asks for a type that denies without a lookup until the release resolves', () => {
-      render(
-        <TestProvider>
-          <TestComponent options={{...baseOptions, release: undefined}} />
-        </TestProvider>,
-      )
+      renderActions({release: undefined})
 
       expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
         id: 'doc1',
@@ -496,17 +475,36 @@ describe('useScheduledDraftMenuActions', () => {
     })
 
     it('asks for a type that denies without a lookup when the document id is missing', () => {
-      render(
-        <TestProvider>
-          <TestComponent options={{...baseOptions, documentId: undefined}} />
-        </TestProvider>,
-      )
+      renderActions({documentId: undefined})
 
       expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
         id: '',
         type: '*',
         version: 'rScheduled',
         permission: 'publish',
+      })
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: '',
+        type: '*',
+        version: 'rScheduled',
+        permission: 'discardVersion',
+      })
+    })
+
+    it('asks for a type that denies without a lookup when the document type is missing', () => {
+      renderActions({documentType: undefined})
+
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: 'doc1',
+        type: '*',
+        version: 'rScheduled',
+        permission: 'publish',
+      })
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: 'doc1',
+        type: '*',
+        version: 'rScheduled',
+        permission: 'discardVersion',
       })
     })
   })

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -7,6 +7,10 @@ import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 import {createTestProvider} from '../../../../test/testUtils/TestProvider'
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {scheduledRelease} from '../../releases/__fixtures__/release.fixture'
+import {
+  type DocumentPermission,
+  useDocumentPairPermissions,
+} from '../../store/grants/documentPairPermissions'
 import {DeleteScheduledDraftDialog} from '../components/DeleteScheduledDraftDialog'
 import {PublishScheduledDraftDialog} from '../components/PublishScheduledDraftDialog'
 import {ScheduleDraftDialog} from '../components/ScheduleDraftDialog'
@@ -38,6 +42,29 @@ vi.mock('./useScheduledDraftDocument', () => ({
     firstDocument: null,
   }),
 }))
+
+vi.mock('../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(),
+}))
+
+const mockUseDocumentPairPermissions = useDocumentPairPermissions as MockedFunction<
+  typeof useDocumentPairPermissions
+>
+
+const grantEveryPermission = () =>
+  mockUseDocumentPairPermissions.mockImplementation(() => [{granted: true, reason: ''}, false])
+
+const withholdPermission = (withheld: DocumentPermission) =>
+  mockUseDocumentPairPermissions.mockImplementation(({permission}) => [
+    {granted: permission !== withheld, reason: ''},
+    false,
+  ])
+
+const baseOptions = {
+  release: scheduledRelease,
+  documentType: 'author',
+  documentId: 'doc1',
+}
 
 // Mock operations that will be used by the hook
 const mockOperations = {
@@ -94,16 +121,29 @@ function TestComponent({options}: TestComponentProps) {
         <div data-testid="publish-now-props">
           <span data-testid="publish-now-text">{actions.publishNow.text}</span>
           <span data-testid="publish-now-disabled">{String(actions.publishNow.disabled)}</span>
+          <div data-testid="publish-now-reason">{actions.publishNow.tooltipProps?.content}</div>
         </div>
         <div data-testid="edit-schedule-props">
           <span data-testid="edit-schedule-text">{actions.editSchedule.text}</span>
           <span data-testid="edit-schedule-disabled">{String(actions.editSchedule.disabled)}</span>
+          <div data-testid="edit-schedule-reason">{actions.editSchedule.tooltipProps?.content}</div>
+        </div>
+        <div data-testid="schedule-publish-props">
+          <span data-testid="schedule-publish-disabled">
+            {String(actions.schedulePublish.disabled)}
+          </span>
+          <div data-testid="schedule-publish-reason">
+            {actions.schedulePublish.tooltipProps?.content}
+          </div>
         </div>
         <div data-testid="delete-schedule-props">
           <span data-testid="delete-schedule-text">{actions.deleteSchedule.text}</span>
           <span data-testid="delete-schedule-disabled">
             {String(actions.deleteSchedule.disabled)}
           </span>
+          <div data-testid="delete-schedule-reason">
+            {actions.deleteSchedule.tooltipProps?.content}
+          </div>
         </div>
       </div>
       <div data-testid="dialogs">{dialogs}</div>
@@ -116,6 +156,8 @@ describe('useScheduledDraftMenuActions', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+
+    grantEveryPermission()
 
     // Setup mock implementations
     mockUseScheduleDraftOperations.mockReturnValue(mockOperations)
@@ -182,7 +224,7 @@ describe('useScheduledDraftMenuActions', () => {
   it('should render all three menu items in the correct order', () => {
     render(
       <TestProvider>
-        <TestComponent options={{release: scheduledRelease}} />
+        <TestComponent options={baseOptions} />
       </TestProvider>,
     )
 
@@ -206,7 +248,7 @@ describe('useScheduledDraftMenuActions', () => {
   it('should provide menu item props with correct values', () => {
     render(
       <TestProvider>
-        <TestComponent options={{release: scheduledRelease}} />
+        <TestComponent options={baseOptions} />
       </TestProvider>,
     )
 
@@ -219,7 +261,7 @@ describe('useScheduledDraftMenuActions', () => {
     it('should open dialog and call operation on success', async () => {
       render(
         <TestProvider>
-          <TestComponent options={{release: scheduledRelease}} />
+          <TestComponent options={baseOptions} />
         </TestProvider>,
       )
 
@@ -241,7 +283,7 @@ describe('useScheduledDraftMenuActions', () => {
 
       render(
         <TestProvider>
-          <TestComponent options={{release: scheduledRelease}} />
+          <TestComponent options={baseOptions} />
         </TestProvider>,
       )
 
@@ -263,7 +305,7 @@ describe('useScheduledDraftMenuActions', () => {
     it('should call pauseScheduledDraft operation on success', async () => {
       render(
         <TestProvider>
-          <TestComponent options={{release: scheduledRelease}} />
+          <TestComponent options={baseOptions} />
         </TestProvider>,
       )
 
@@ -282,7 +324,7 @@ describe('useScheduledDraftMenuActions', () => {
 
       render(
         <TestProvider>
-          <TestComponent options={{release: scheduledRelease}} />
+          <TestComponent options={baseOptions} />
         </TestProvider>,
       )
 
@@ -304,7 +346,7 @@ describe('useScheduledDraftMenuActions', () => {
     it('should open dialog and call operation on success', async () => {
       render(
         <TestProvider>
-          <TestComponent options={{release: scheduledRelease}} />
+          <TestComponent options={baseOptions} />
         </TestProvider>,
       )
 
@@ -318,6 +360,117 @@ describe('useScheduledDraftMenuActions', () => {
       await waitFor(() => {
         expect(mockOperations.deleteScheduledDraft).toHaveBeenCalledWith(scheduledRelease)
       })
+    })
+  })
+  describe('grants', () => {
+    it('enables every action when both grants are present', () => {
+      render(
+        <TestProvider>
+          <TestComponent options={baseOptions} />
+        </TestProvider>,
+      )
+
+      expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('false')
+      expect(screen.getByTestId('edit-schedule-disabled')).toHaveTextContent('false')
+      expect(screen.getByTestId('schedule-publish-disabled')).toHaveTextContent('false')
+      expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('false')
+
+      expect(screen.getByTestId('publish-now-reason')).toBeEmptyDOMElement()
+      expect(screen.getByTestId('edit-schedule-reason')).toBeEmptyDOMElement()
+      expect(screen.getByTestId('schedule-publish-reason')).toBeEmptyDOMElement()
+      expect(screen.getByTestId('delete-schedule-reason')).toBeEmptyDOMElement()
+    })
+
+    it('disables the publish grant actions with an explanation when publish is withheld', () => {
+      withholdPermission('publish')
+
+      render(
+        <TestProvider>
+          <TestComponent options={baseOptions} />
+        </TestProvider>,
+      )
+
+      expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('true')
+      expect(screen.getByTestId('publish-now-reason')).toHaveTextContent('Insufficient permissions')
+      expect(screen.getByTestId('publish-now-reason')).toHaveTextContent(
+        'You do not have permission to publish this document.',
+      )
+
+      expect(screen.getByTestId('edit-schedule-disabled')).toHaveTextContent('true')
+      expect(screen.getByTestId('edit-schedule-reason')).toHaveTextContent(
+        'You do not have permission to edit schedules.',
+      )
+
+      expect(screen.getByTestId('schedule-publish-disabled')).toHaveTextContent('true')
+      expect(screen.getByTestId('schedule-publish-reason')).toHaveTextContent(
+        'You do not have permission to edit schedules.',
+      )
+    })
+
+    it('keeps delete schedule available when only publish is withheld', () => {
+      withholdPermission('publish')
+
+      render(
+        <TestProvider>
+          <TestComponent options={baseOptions} />
+        </TestProvider>,
+      )
+
+      expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('false')
+      expect(screen.getByTestId('delete-schedule-reason')).toBeEmptyDOMElement()
+    })
+
+    it('disables delete schedule with an explanation when discardVersion is withheld', () => {
+      withholdPermission('discardVersion')
+
+      render(
+        <TestProvider>
+          <TestComponent options={baseOptions} />
+        </TestProvider>,
+      )
+
+      expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('true')
+      expect(screen.getByTestId('delete-schedule-reason')).toHaveTextContent(
+        'You do not have permission to delete schedules.',
+      )
+
+      expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('false')
+      expect(screen.getByTestId('publish-now-reason')).toBeEmptyDOMElement()
+    })
+
+    it('checks the grants against the scheduled draft version of the document', () => {
+      render(
+        <TestProvider>
+          <TestComponent options={baseOptions} />
+        </TestProvider>,
+      )
+
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: 'doc1',
+        type: 'author',
+        version: 'rScheduled',
+        permission: 'publish',
+      })
+      expect(mockUseDocumentPairPermissions).toHaveBeenCalledWith({
+        id: 'doc1',
+        type: 'author',
+        version: 'rScheduled',
+        permission: 'discardVersion',
+      })
+    })
+
+    it('does not offer an action while the grant is still loading', () => {
+      mockUseDocumentPairPermissions.mockImplementation(() => [undefined, true])
+
+      render(
+        <TestProvider>
+          <TestComponent options={baseOptions} />
+        </TestProvider>,
+      )
+
+      expect(screen.getByTestId('publish-now-disabled')).toHaveTextContent('true')
+      expect(screen.getByTestId('delete-schedule-disabled')).toHaveTextContent('true')
+      expect(screen.getByTestId('publish-now-reason')).toBeEmptyDOMElement()
     })
   })
 })

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -7,8 +7,15 @@ import {useToast} from '@sanity/ui/toast'
 import {type ComponentProps, useCallback, useMemo, useState} from 'react'
 
 import {type MenuItem} from '../../../ui-components/menuItem/MenuItem'
+import {
+  InsufficientPermissionsMessage,
+  type InsufficientPermissionsMessageProps,
+} from '../../components/InsufficientPermissionsMessage'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {Translate} from '../../i18n/Translate'
+import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {useDocumentPairPermissions} from '../../store/grants/documentPairPermissions'
+import {useCurrentUser} from '../../store/user/hooks'
 import {getErrorMessage} from '../../util/getErrorMessage'
 import {DeleteScheduledDraftDialog} from '../components/DeleteScheduledDraftDialog'
 import {PublishScheduledDraftDialog} from '../components/PublishScheduledDraftDialog'
@@ -37,6 +44,8 @@ interface ScheduledDraftActionProps {
   tone: ComponentProps<typeof MenuItem>['tone']
   onClick: () => void
   disabled: ComponentProps<typeof MenuItem>['disabled']
+  /** Carries the insufficient permissions explanation when the grant is missing. */
+  tooltipProps: ComponentProps<typeof MenuItem>['tooltipProps']
 }
 
 export interface UseScheduledDraftMenuActionsReturn {
@@ -78,6 +87,28 @@ export function useScheduledDraftMenuActions(
   const {firstDocumentPreview, loading: documentLoading} = useScheduledDraftDocument(release?._id, {
     includePreview: true,
   })
+
+  const currentUser = useCurrentUser()
+  // '*' denies without a lookup; every surface hides these items until the release and its document resolve.
+  const permissionType = release && documentType ? documentType : '*'
+  const permissionVersion = release ? getReleaseIdFromReleaseDocumentId(release._id) : undefined
+
+  const [publishPermission, publishPermissionLoading] = useDocumentPairPermissions({
+    id: documentId ?? '',
+    type: permissionType,
+    version: permissionVersion,
+    permission: 'publish',
+  })
+  const [discardVersionPermission, discardVersionPermissionLoading] = useDocumentPairPermissions({
+    id: documentId ?? '',
+    type: permissionType,
+    version: permissionVersion,
+    permission: 'discardVersion',
+  })
+
+  const canPublish = publishPermissionLoading || Boolean(publishPermission?.granted)
+  const canDiscardVersion =
+    discardVersionPermissionLoading || Boolean(discardVersionPermission?.granted)
 
   const handleEditSchedule = useCallback(async () => {
     if (!release) return
@@ -153,7 +184,18 @@ export function useScheduledDraftMenuActions(
   )
 
   const actions = useMemo(() => {
-    const baseDisabled = disabled || isPerformingOperation || documentLoading
+    const baseDisabled =
+      disabled ||
+      isPerformingOperation ||
+      documentLoading ||
+      publishPermissionLoading ||
+      discardVersionPermissionLoading
+
+    const insufficientPermissions = (
+      context: InsufficientPermissionsMessageProps['context'],
+    ): ComponentProps<typeof MenuItem>['tooltipProps'] => ({
+      content: <InsufficientPermissionsMessage context={context} currentUser={currentUser} />,
+    })
 
     return {
       publishNow: {
@@ -161,7 +203,8 @@ export function useScheduledDraftMenuActions(
         'text': t('release.action.publish-now'),
         'tone': 'default' as const,
         'onClick': () => handleMenuItemClick('publish-now'),
-        'disabled': baseDisabled,
+        'disabled': baseDisabled || !canPublish,
+        'tooltipProps': canPublish ? null : insufficientPermissions('publish-document'),
         'data-testid': 'publish-now-menu-item',
       },
       editSchedule: {
@@ -169,7 +212,8 @@ export function useScheduledDraftMenuActions(
         'text': t('release.action.edit-schedule'),
         'tone': 'default' as const,
         'onClick': handleEditSchedule,
-        'disabled': baseDisabled,
+        'disabled': baseDisabled || !canPublish,
+        'tooltipProps': canPublish ? null : insufficientPermissions('edit-schedules'),
         'data-testid': 'edit-schedule-menu-item',
       },
       schedulePublish: {
@@ -177,7 +221,8 @@ export function useScheduledDraftMenuActions(
         'text': t('release.action.schedule-publish'),
         'tone': 'default' as const,
         'onClick': () => handleMenuItemClick('schedule-publish'),
-        'disabled': baseDisabled,
+        'disabled': baseDisabled || !canPublish,
+        'tooltipProps': canPublish ? null : insufficientPermissions('edit-schedules'),
         'data-testid': 'schedule-publish-menu-item',
       },
       deleteSchedule: {
@@ -185,11 +230,24 @@ export function useScheduledDraftMenuActions(
         'text': t('release.action.delete-schedule'),
         'tone': 'critical' as const,
         'onClick': () => handleMenuItemClick('delete-schedule'),
-        'disabled': baseDisabled,
+        'disabled': baseDisabled || !canDiscardVersion,
+        'tooltipProps': canDiscardVersion ? null : insufficientPermissions('delete-schedules'),
         'data-testid': 'delete-schedule-menu-item',
       },
     }
-  }, [t, handleMenuItemClick, handleEditSchedule, disabled, isPerformingOperation, documentLoading])
+  }, [
+    t,
+    handleMenuItemClick,
+    handleEditSchedule,
+    disabled,
+    isPerformingOperation,
+    documentLoading,
+    publishPermissionLoading,
+    discardVersionPermissionLoading,
+    canPublish,
+    canDiscardVersion,
+    currentUser,
+  ])
 
   const dialogs = useMemo(() => {
     if (!selectedAction || !release) return null

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -32,6 +32,7 @@ export type ScheduledDraftAction =
 export interface UseScheduledDraftMenuActionsOptions {
   release: ReleaseDocument | undefined
   documentType?: string
+  /** The published / document-group id, not the version id. */
   documentId?: string
   disabled?: boolean
   onActionComplete?: () => void
@@ -89,7 +90,7 @@ export function useScheduledDraftMenuActions(
   })
 
   const currentUser = useCurrentUser()
-  // '*' denies without a lookup; every surface hides these items until the release and its document resolve.
+  // '*' denies without a document lookup.
   const permissionType = release && documentType && documentId ? documentType : '*'
   const permissionVersion = release ? getReleaseIdFromReleaseDocumentId(release._id) : undefined
 

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -90,7 +90,7 @@ export function useScheduledDraftMenuActions(
 
   const currentUser = useCurrentUser()
   // '*' denies without a lookup; every surface hides these items until the release and its document resolve.
-  const permissionType = release && documentType ? documentType : '*'
+  const permissionType = release && documentType && documentId ? documentType : '*'
   const permissionVersion = release ? getReleaseIdFromReleaseDocumentId(release._id) : undefined
 
   const [publishPermission, publishPermissionLoading] = useDocumentPairPermissions({

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.test.tsx
@@ -1,0 +1,203 @@
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {type DocumentActionProps} from '../../../config/document/actions'
+import {useValidationStatus} from '../../../hooks/useValidationStatus'
+import {studioDefaultLocaleResources} from '../../../i18n/bundles/studio'
+import {usePerspective} from '../../../perspective/usePerspective'
+import {useActiveReleases} from '../../../releases/store/useActiveReleases'
+import {
+  type DocumentPermission,
+  useDocumentPairPermissions,
+} from '../../../store/grants/documentPairPermissions'
+import {useSingleDocReleaseEnabled} from '../../context/SingleDocReleaseEnabledProvider'
+import {useSingleDocRelease} from '../../context/SingleDocReleaseProvider'
+import {useSingleDocReleaseUpsell} from '../../context/SingleDocReleaseUpsellProvider'
+import {useHasCardinalityOneReleaseVersions} from '../../hooks/useHasCardinalityOneReleaseVersions'
+import {useScheduleDraftOperations} from '../../hooks/useScheduleDraftOperations'
+import {singleDocReleaseUsEnglishLocaleBundle} from '../../i18n'
+import {useSchedulePublishAction} from './SchedulePublishAction'
+
+vi.mock('../../../hooks/useValidationStatus', () => ({
+  useValidationStatus: vi.fn(),
+}))
+
+vi.mock('../../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(),
+}))
+
+vi.mock('../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(),
+}))
+
+vi.mock('../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(),
+}))
+
+vi.mock('../../context/SingleDocReleaseEnabledProvider', () => ({
+  useSingleDocReleaseEnabled: vi.fn(),
+}))
+
+vi.mock('../../context/SingleDocReleaseProvider', () => ({
+  useSingleDocRelease: vi.fn(),
+}))
+
+vi.mock('../../context/SingleDocReleaseUpsellProvider', () => ({
+  useSingleDocReleaseUpsell: vi.fn(),
+}))
+
+vi.mock('../../hooks/useHasCardinalityOneReleaseVersions', () => ({
+  useHasCardinalityOneReleaseVersions: vi.fn(),
+}))
+
+vi.mock('../../hooks/useScheduleDraftOperations', () => ({
+  useScheduleDraftOperations: vi.fn(),
+}))
+
+const mockUseValidationStatus = useValidationStatus as MockedFunction<typeof useValidationStatus>
+const mockUsePerspective = usePerspective as MockedFunction<typeof usePerspective>
+const mockUseActiveReleases = useActiveReleases as MockedFunction<typeof useActiveReleases>
+const mockUseDocumentPairPermissions = useDocumentPairPermissions as MockedFunction<
+  typeof useDocumentPairPermissions
+>
+const mockUseSingleDocReleaseEnabled = useSingleDocReleaseEnabled as MockedFunction<
+  typeof useSingleDocReleaseEnabled
+>
+const mockUseSingleDocRelease = useSingleDocRelease as MockedFunction<typeof useSingleDocRelease>
+const mockUseSingleDocReleaseUpsell = useSingleDocReleaseUpsell as MockedFunction<
+  typeof useSingleDocReleaseUpsell
+>
+const mockUseHasCardinalityOneReleaseVersions =
+  useHasCardinalityOneReleaseVersions as MockedFunction<typeof useHasCardinalityOneReleaseVersions>
+const mockUseScheduleDraftOperations = useScheduleDraftOperations as MockedFunction<
+  typeof useScheduleDraftOperations
+>
+
+const grantEveryPermission = () =>
+  mockUseDocumentPairPermissions.mockReturnValue([{granted: true, reason: ''}, false])
+
+const withholdPermission = (withheld: DocumentPermission) =>
+  mockUseDocumentPairPermissions.mockImplementation(({permission}) => [
+    {granted: permission !== withheld, reason: ''},
+    false,
+  ])
+
+const loadPermission = () => mockUseDocumentPairPermissions.mockReturnValue([undefined, true])
+
+const actionProps = {
+  id: 'doc1',
+  type: 'author',
+  draft: {_id: 'drafts.doc1', _type: 'author'},
+} as DocumentActionProps
+
+function ActionProbe() {
+  const description = useSchedulePublishAction(actionProps)
+
+  if (!description) return <div data-testid="no-action" />
+
+  return (
+    <>
+      <span data-testid="disabled">{String(description.disabled)}</span>
+      <div data-testid="title">{description.title}</div>
+    </>
+  )
+}
+
+describe('useSchedulePublishAction', () => {
+  let TestProvider: React.ComponentType<{children: React.ReactNode}>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    mockUseValidationStatus.mockReturnValue({validation: [], isValidating: false})
+
+    mockUsePerspective.mockReturnValue({
+      selectedPerspectiveName: undefined,
+      selectedReleaseId: undefined,
+      selectedPerspective: 'drafts',
+      perspectiveStack: ['drafts'],
+      excludedPerspectives: [],
+      selectedVariantName: undefined,
+      selectedVariant: undefined,
+      bundle: 'drafts',
+    })
+
+    mockUseActiveReleases.mockReturnValue({
+      data: [],
+      error: undefined,
+      loading: false,
+      dispatch: vi.fn(),
+      byId: new Map(),
+    })
+
+    mockUseSingleDocReleaseEnabled.mockReturnValue({enabled: true, mode: 'default'})
+    mockUseSingleDocRelease.mockReturnValue({onSetScheduledDraftPerspective: vi.fn()})
+    mockUseSingleDocReleaseUpsell.mockReturnValue({
+      upsellDialogOpen: false,
+      handleOpenDialog: vi.fn(),
+      handleClose: vi.fn(),
+      upsellData: null,
+      telemetryLogs: {
+        dialogSecondaryClicked: vi.fn(),
+        dialogPrimaryClicked: vi.fn(),
+        panelViewed: vi.fn(),
+        panelDismissed: vi.fn(),
+        panelPrimaryClicked: vi.fn(),
+        panelSecondaryClicked: vi.fn(),
+      },
+    })
+    mockUseHasCardinalityOneReleaseVersions.mockReturnValue(false)
+    mockUseScheduleDraftOperations.mockReturnValue({
+      createScheduledDraft: vi.fn(),
+      publishScheduledDraft: vi.fn(),
+      deleteScheduledDraft: vi.fn(),
+      rescheduleScheduledDraft: vi.fn(),
+      pauseScheduledDraft: vi.fn(),
+    })
+
+    grantEveryPermission()
+
+    TestProvider = await createTestProvider({
+      resources: [studioDefaultLocaleResources, singleDocReleaseUsEnglishLocaleBundle],
+    })
+  })
+
+  // `createTestProvider` renders a loading block until its i18n resources resolve.
+  const renderAction = async () => {
+    render(
+      <TestProvider>
+        <ActionProbe />
+      </TestProvider>,
+    )
+
+    await screen.findByTestId('disabled')
+  }
+
+  it('is enabled with its normal title when the publish grant is present', async () => {
+    await renderAction()
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('false')
+    expect(screen.getByTestId('title')).toHaveTextContent('Schedule publish')
+  })
+
+  it('is disabled with the insufficient-permissions explanation when the publish grant is absent', async () => {
+    withholdPermission('publish')
+
+    await renderAction()
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('true')
+    expect(screen.getByTestId('title')).toHaveTextContent(
+      'You do not have permission to edit schedules.',
+    )
+  })
+
+  it('is disabled with no permissions explanation while the grant is loading', async () => {
+    loadPermission()
+
+    await renderAction()
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('true')
+    expect(screen.getByTestId('title')).not.toHaveTextContent('You do not have permission')
+  })
+})

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
@@ -3,6 +3,7 @@ import {isValidationErrorMarker} from '@sanity/types'
 import {useToast} from '@sanity/ui/toast'
 import {useCallback, useMemo, useState} from 'react'
 
+import {InsufficientPermissionsMessage} from '../../../components/InsufficientPermissionsMessage'
 import {
   type DocumentActionComponent,
   type DocumentActionDescription,
@@ -13,6 +14,8 @@ import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {useActiveReleases} from '../../../releases/store/useActiveReleases'
 import {getReleaseIdFromReleaseDocumentId} from '../../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {useDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
+import {useCurrentUser} from '../../../store/user/hooks'
 import {getDraftId} from '../../../util/draftUtils'
 import {isPausedCardinalityOneRelease} from '../../../util/releaseUtils'
 import {ScheduleDraftDialog} from '../../components/ScheduleDraftDialog'
@@ -66,6 +69,20 @@ export const useSchedulePublishAction: DocumentActionComponent = (
   )
 
   const isPaused = isPausedCardinalityOneRelease(currentRelease)
+
+  const [publishPermission, isPublishPermissionLoading] = useDocumentPairPermissions({
+    id,
+    type,
+    version:
+      isPaused && currentRelease
+        ? getReleaseIdFromReleaseDocumentId(currentRelease._id)
+        : undefined,
+    permission: 'publish',
+  })
+  const isPublishGranted = Boolean(publishPermission?.granted)
+  const isPublishDenied = !isPublishPermissionLoading && !isPublishGranted
+  const currentUser = useCurrentUser()
+
   const initialDate =
     isPaused && currentRelease?.metadata.intendedPublishAt
       ? new Date(currentRelease.metadata.intendedPublishAt)
@@ -125,12 +142,18 @@ export const useSchedulePublishAction: DocumentActionComponent = (
   )
 
   const disabled =
+    isPublishPermissionLoading ||
+    !isPublishGranted ||
     isVariantSelected ||
     (isPaused
       ? hasValidationErrors // Only check validation errors for paused drafts
       : hasCardinalityOneReleaseVersions || hasValidationErrors) // Full check for regular drafts
 
   const title = useMemo(() => {
+    if (isPublishDenied) {
+      return <InsufficientPermissionsMessage context="edit-schedules" currentUser={currentUser} />
+    }
+
     if (isVariantSelected) {
       return t('action.schedule-publish.disabled.variant')
     }
@@ -148,7 +171,15 @@ export const useSchedulePublishAction: DocumentActionComponent = (
     }
 
     return t('action.schedule-publish')
-  }, [isVariantSelected, isPaused, hasValidationErrors, hasCardinalityOneReleaseVersions, t])
+  }, [
+    isPublishDenied,
+    currentUser,
+    isVariantSelected,
+    isPaused,
+    hasValidationErrors,
+    hasCardinalityOneReleaseVersions,
+    t,
+  ])
 
   if (!singleDocReleaseEnabled) {
     return null

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.test.tsx
@@ -1,0 +1,153 @@
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {type DocumentActionProps} from '../../../config/document/actions'
+import {activeCardinalityOneRelease} from '../../../releases/__fixtures__/release.fixture'
+import {useAllReleases} from '../../../releases/store/useAllReleases'
+import {
+  type DocumentPermission,
+  useDocumentPairPermissions,
+} from '../../../store/grants/documentPairPermissions'
+import {
+  DeleteScheduledDraftAction,
+  EditScheduledDraftAction,
+  PublishScheduledDraftAction,
+} from './ScheduledDraftDocumentActions'
+
+vi.mock('../../../releases/store/useAllReleases', () => ({
+  useAllReleases: vi.fn(),
+}))
+
+vi.mock('../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(),
+}))
+
+vi.mock('../../hooks/useScheduledDraftDocument', () => ({
+  useScheduledDraftDocument: () => ({
+    firstDocument: null,
+    firstDocumentPreview: undefined,
+    loading: false,
+  }),
+}))
+
+vi.mock('../../hooks/useClearScheduledDraftPerspectiveOnDelete', () => ({
+  useClearScheduledDraftPerspectiveOnDelete: () => vi.fn(),
+}))
+
+const mockUseAllReleases = useAllReleases as MockedFunction<typeof useAllReleases>
+const mockUseDocumentPairPermissions = useDocumentPairPermissions as MockedFunction<
+  typeof useDocumentPairPermissions
+>
+
+const withholdPermission = (withheld?: DocumentPermission) =>
+  mockUseDocumentPairPermissions.mockImplementation(({permission}) => [
+    {granted: permission !== withheld, reason: ''},
+    false,
+  ])
+
+// `activeCardinalityOneRelease` is paused, which hides the edit schedule action.
+const scheduledDraftRelease = {
+  ...activeCardinalityOneRelease,
+  state: 'scheduled' as const,
+  publishAt: '2023-10-10T10:00:00.000Z',
+}
+
+const actionProps = {
+  id: 'doc1',
+  type: 'author',
+  release: 'rCardinalityOne',
+} as DocumentActionProps
+
+function createActionProbe(useAction: typeof PublishScheduledDraftAction) {
+  function ActionProbe() {
+    const description = useAction(actionProps)
+
+    if (!description) return <div data-testid="no-action" />
+
+    return (
+      <>
+        <span data-testid="disabled">{String(description.disabled)}</span>
+        <div data-testid="title">{description.title}</div>
+      </>
+    )
+  }
+
+  return ActionProbe
+}
+
+describe('scheduled draft document actions', () => {
+  let TestProvider: React.ComponentType<{children: React.ReactNode}>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    mockUseAllReleases.mockReturnValue({
+      data: [scheduledDraftRelease],
+      error: undefined,
+      loading: false,
+      map: new Map(),
+    })
+    withholdPermission()
+
+    TestProvider = await createTestProvider()
+  })
+
+  const renderIn = (useAction: typeof PublishScheduledDraftAction) => {
+    const ActionProbe = createActionProbe(useAction)
+    render(
+      <TestProvider>
+        <ActionProbe />
+      </TestProvider>,
+    )
+  }
+
+  it('offers publish now with its own label when the publish grant is present', () => {
+    renderIn(PublishScheduledDraftAction)
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('false')
+    expect(screen.getByTestId('title')).toHaveTextContent('Publish now')
+  })
+
+  it('disables publish now with an explanation when the publish grant is absent', () => {
+    withholdPermission('publish')
+
+    renderIn(PublishScheduledDraftAction)
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('true')
+    expect(screen.getByTestId('title')).toHaveTextContent(
+      'You do not have permission to publish this document.',
+    )
+  })
+
+  it('disables edit schedule with an explanation when the publish grant is absent', () => {
+    withholdPermission('publish')
+
+    renderIn(EditScheduledDraftAction)
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('true')
+    expect(screen.getByTestId('title')).toHaveTextContent(
+      'You do not have permission to edit schedules.',
+    )
+  })
+
+  it('disables delete schedule with an explanation when the discardVersion grant is absent', () => {
+    withholdPermission('discardVersion')
+
+    renderIn(DeleteScheduledDraftAction)
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('true')
+    expect(screen.getByTestId('title')).toHaveTextContent(
+      'You do not have permission to delete schedules.',
+    )
+  })
+
+  it('keeps delete schedule available when only the publish grant is absent', () => {
+    withholdPermission('publish')
+
+    renderIn(DeleteScheduledDraftAction)
+
+    expect(screen.getByTestId('disabled')).toHaveTextContent('false')
+    expect(screen.getByTestId('title')).toHaveTextContent('Delete schedule')
+  })
+})

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
@@ -63,7 +63,7 @@ const createScheduledDraftAction = (
       disabled: actionProps.disabled || loading,
       icon: actionProps.icon,
       label: actionProps.text,
-      title: actionProps.text,
+      title: actionProps.tooltipProps?.content ?? actionProps.text,
       tone: actionProps.tone,
       dialog: dialogs
         ? {

--- a/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
+++ b/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from '@sanity/types'
-import {of, Subject} from 'rxjs'
+import {firstValueFrom, of, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createMockSanityClient} from '../../../../../test/mocks/mockSanityClient'
@@ -188,5 +188,24 @@ describe('getDocumentPairPermissions (Pattern-B memoization)', () => {
     expect(grantsStore.checkDocumentPermission).toHaveBeenCalledTimes(3)
 
     subscriptions.forEach((subscription) => subscription.unsubscribe())
+  })
+
+  it('denies without a document lookup when the type is a wildcard', async () => {
+    const grantsStore = createGrantsStore()
+    const id = `book-${Math.random().toString(36).slice(2)}`
+
+    const result = await firstValueFrom(
+      getDocumentPairPermissions({
+        client,
+        schema,
+        grantsStore,
+        id,
+        type: '*',
+        permission: 'publish',
+      }),
+    )
+
+    expect(result).toEqual({granted: false, reason: 'Type specified was `*`'})
+    expect(mockedSnapshotPair).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### Description

Publishing a scheduled draft was offered to users who lack the publish grant. `useScheduledDraftMenuActions` guarded only on `disabled`, `isPerformingOperation` and `documentLoading`, so the document footer, the version context menu and the Scheduled drafts overview all rendered an enabled Publish now. The refusal arrived as an error toast after the click. Edit schedule, Schedule and Delete schedule carried the same gap, since they come from the same hook.

This PR moves the grant check into the shared hook, so all three surfaces pick it up at once, and applies the same check to `useSchedulePublishAction`, which is a separate document action rather than a consumer of the hook. A withheld grant greys the item out and attaches `InsufficientPermissionsMessage`, matching `usePublishAction` and the other built-in actions that grey out rather than hide.

Grants per operation:

| Action | Grant | Message context |
|---|---|---|
| Publish now | `publish` | `publish-document` |
| Edit schedule | `publish` | `edit-schedules` |
| Schedule (menu item) | `publish` | `edit-schedules` |
| Schedule (document action) | `publish` | `edit-schedules` |
| Delete schedule | `discardVersion` | `delete-schedules` |

Delete schedule discards the version document, so it takes `discardVersion`. That matches the grant `useDiscardVersionAction` uses and the `discardVersion` action id `DeleteScheduledDraftAction` already declares. A user who can delete a scheduled draft but not publish it keeps Delete schedule.

The grants are read against the scheduled draft's version of the document, with `version` set to the release id, the same way `usePublishAction` and `useDiscardVersionAction` scope theirs. `useSchedulePublishAction` scopes to the release id only when resuming a paused draft, and to the draft and published pair otherwise, since no version exists before the draft is first scheduled. No new i18n keys: all three message contexts already exist. Legacy scheduled publishing maps its Edit schedule and Delete schedule items onto `edit-schedules` and `delete-schedules` the same way; it uses `execute-schedules` for its Publish now, where `publish-document` reads truer here because the item publishes the document immediately.

Resolves SAPP-4401.

### What to review

- `useScheduledDraftMenuActions.tsx` carries the fix for the three menu surfaces. The returned action props gain `tooltipProps`, which `ScheduledDraftContextMenu` and `ScheduledDraftMenuButtonWrapper` already spread into `MenuItem`, so neither needed a change.
- `ScheduledDraftDocumentActions.tsx` is the one surface that did. A document footer action carries its disabled reason in `title`, not in `tooltipProps`, so it reads the tooltip content into `title`.
- `SchedulePublishAction.tsx` is gated separately. It is the primary action for a paused scheduled draft and the entry point that creates one from a plain draft, and it took no grant check before. Without this, a user lacking the publish grant saw an enabled primary Schedule button beside a disabled Publish now and Delete schedule. The operation is server-enforced, so the click failed with a toast rather than writing anything, but the three items are one control and should read the same way.
- The grant lookup is skipped with `type: '*'` until the release, the document type and the document id are all resolved. `getDocumentPairPermissions` short-circuits `'*'` to a denial without touching the schema or opening a pair listener, and `documentPairPermissions.test.ts` now pins both halves of that. The comment on the short-circuit frames it as a guard for `S.documentList()` without a `schemaType`, so it was worth asserting before depending on it. `'*'` is also the only safe sentinel here: `type` is a required string, hooks cannot be called conditionally, and any other placeholder reaches `getSchemaType` and throws.
- Whether `useDocumentPairPermissions` is the right authority. Publishing a scheduled draft is a release publish action, and `ReleasePublishAllButton` guards the equivalent release-wide operation with `useReleasePermissions().checkWithPermissionGuard` instead. The document-pair check was chosen because it is per document, synchronous with the render, and is what every other document action uses. The release-permission store caches one boolean per action name for the whole session, so it cannot distinguish one scheduled draft from another.
- Whether Edit schedule should take `publish`. It calls `pauseScheduledDraft`, which unschedules the release. Under a grant set that allows `discardVersion` and withholds `publish`, the user keeps Delete schedule but loses Edit schedule, so they can destroy a schedule and cannot pause it. Keeping `publish` was the deliberate call: both schedule items are two halves of one control, every surface shows them behind the same `schedule` action id, and `useScheduleAction` in legacy scheduled publishing gates both its Schedule and its Edit Schedule state on `publish` already. Splitting them would let a draft-only contributor quietly unschedule a publish an editor set up.
- `ScheduledDraftMenuButtonWrapper` now passes the published id rather than the version id. Both resolve to the same lookup, because `getPublishedId` and `getIdPair` normalise a `versions.` id, but the other two call sites pass the published id and the option is now documented as such.

One limit, accepted: `getPairPermissions` reads `draft` and `published` for the `publish` permission and never the version document, and `grantsPermissionOn` returns granted for a null document. A scheduled draft whose document has no draft and no published counterpart therefore resolves `publish` as granted for everyone. That ceiling belongs to the shared permission primitive and applies equally to `usePublishAction`; closing it means changing `getPairPermissions`, which is beyond this fix.

### Testing

Seven suites, both directions on every surface.

- `useScheduledDraftMenuActions.test.tsx` - granted enables all four actions with no reason attached; withholding `publish` disables Publish now, Edit schedule and Schedule with the right message each and leaves Delete schedule alone; withholding `discardVersion` does the inverse. Also asserts the grants are looked up against the version, that a pending lookup disables without claiming a permission problem, and that an unresolved release, a missing document type or a missing document id each falls back to `type: '*'` for both lookups.
- `ScheduledDraftDocumentActions.test.tsx` (new) - the document footer actions, both directions, for all three.
- `SchedulePublishAction.test.tsx` (new) - the Schedule document action: enabled with its own label when granted, disabled with the explanation when withheld, disabled without an explanation while the lookup is pending.
- `ScheduledDraftContextMenu.test.tsx` (new) - the version context menu driven by the real hook, both directions.
- `ScheduledDraftMenuButtonWrapper.test.tsx` - the Scheduled drafts overview, both directions.
- `VersionContextMenu.test.tsx` - fixture updated for the new `tooltipProps` field.
- `documentPairPermissions.test.ts` - `type: '*'` resolves to a denial and never calls `snapshotPair`.

Those seven files: 54 tests passed, no skipped or todo, no type errors. Each new assertion was checked against a deliberately reverted gate to confirm it fails without the fix.

Repo-wide, `oxfmt --check`, `oxlint` (with type checking) and `turbo run build` are clean. The full `vitest --run` reports four unrelated failures, in `isUsingLegacyHttp`, the two `deriveSearchWeightsFromType` suites and `CreateVariantDialog`. `isUsingLegacyHttp` fails the same way on a clean checkout of this branch's base; the other three pass when run on their own, so they look like full-suite interference rather than anything here. None of them import from the files this PR touches.

### Notes for release

Scheduled drafts now grey out Publish now, Edit schedule, Schedule and Delete schedule for users without the grant the operation needs, with an explanation of why, on the document footer, the version context menu and the Scheduled drafts overview. Previously these were offered to everyone and failed with an error toast after the click.

---
