### PR TITLE
fix(releases): align release detail row menu gating with the document footer

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -177,6 +177,7 @@ const variantRow = {
   ...releaseDocuments[0],
   document: {
     ...releaseDocuments[0].document,
+    _id: 'versions.k7fh2qzs9m.123',
     publishedDocumentExists: false,
     _system: {
       bundleId: 'activeASAPRelease',
@@ -256,6 +257,7 @@ describe('ReleaseSummary', () => {
   setupVirtualListEnv()
 
   beforeEach(() => {
+    mockUseDocumentPairPermissions.mockReturnValue(useDocumentPairPermissionsMockReturn)
     setDocumentVersions([])
   })
 
@@ -446,7 +448,6 @@ describe('ReleaseSummary', () => {
     {tableShape: 'variants DocumentTable', variantsEnabled: true},
   ])('row action menu in the $tableShape', ({variantsEnabled}) => {
     beforeEach(() => {
-      mockUseDocumentPairPermissions.mockReturnValue(useDocumentPairPermissionsMockReturn)
       setDocumentVersions([variantPublishedSibling])
     })
 
@@ -507,8 +508,9 @@ describe('ReleaseSummary', () => {
       ).toBeDisabled()
     })
 
+    // The sibling is present, so the readiness gate is the only thing disabling the item.
     it('disables unpublish while the variant publish state resolves', async () => {
-      setDocumentVersions([], true)
+      setDocumentVersions([variantPublishedSibling], true)
 
       expect(
         getUnpublishMenuItem(await openFirstRowMenu({documents: [publishedBaseVariantRow]})),

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -12,6 +12,10 @@ import {route, RouterProvider} from 'sanity/router'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {
+  mockUseDocumentPairPermissions,
+  useDocumentPairPermissionsMockReturn,
+} from '../../../../../../test/mocks/useDocumentPairPermissions.mock'
+import {
   getAllByDataUi,
   getByDataUi,
   queryByDataUi,
@@ -26,7 +30,9 @@ import {
   archivedScheduledRelease,
   scheduledRelease,
 } from '../../../__fixtures__/release.fixture'
+import {mockUseDocumentVersions} from '../../../hooks/__tests__/__mocks__/useDocumentVersions.mock'
 import {releasesUsEnglishLocaleBundle} from '../../../i18n'
+import {type VersionInfoDocumentStub} from '../../../store/types'
 import {ReleaseSummary, type ReleaseSummaryProps} from '../ReleaseSummary'
 import {
   documentsInRelease,
@@ -106,6 +112,37 @@ vi.mock('../../../../store/connection-status/connection-status-store', async (im
   }
 })
 
+vi.mock('../../../hooks/useDocumentVersions', () => ({
+  useDocumentVersions: vi.fn(),
+}))
+
+vi.mock('../../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: vi.fn(() => useDocumentPairPermissionsMockReturn),
+}))
+
+const VARIANT_ID = 'variant-nordic'
+
+const variantPublishedSibling = {
+  _id: 'versions.p3n8xw2.123',
+  _rev: 'abc',
+  _type: 'document',
+  _createdAt: '',
+  _updatedAt: '',
+  _system: {
+    scopeId: 'p3n8xw2',
+    variant: {_ref: VARIANT_ID, _weak: true as const},
+    group: {_ref: '123', _weak: true as const},
+  },
+} as VersionInfoDocumentStub
+
+const setDocumentVersions = (versions: VersionInfoDocumentStub[], loading = false) =>
+  mockUseDocumentVersions.mockReturnValue({
+    data: versions.map(({_id}) => _id),
+    versions,
+    error: null,
+    loading,
+  })
+
 const releaseDocuments = [
   {
     ...documentsInRelease,
@@ -133,6 +170,27 @@ const releaseDocuments = [
     },
   },
 ]
+
+// A variant release version. `publishedDocumentExists` addresses the base published document, so
+// it is set against the variant's own publish state to keep the two apart.
+const variantRow = {
+  ...releaseDocuments[0],
+  document: {
+    ...releaseDocuments[0].document,
+    publishedDocumentExists: false,
+    _system: {
+      bundleId: 'activeASAPRelease',
+      scopeId: 'k7fh2qzs9m',
+      variant: {_ref: VARIANT_ID, _weak: true as const},
+      group: {_ref: '123', _weak: true as const},
+    },
+  },
+}
+
+const publishedBaseVariantRow = {
+  ...variantRow,
+  document: {...variantRow.document, publishedDocumentExists: true},
+}
 
 const ScrollContainer: FC<PropsWithChildren> = ({children}) => {
   const [ref, setRef] = useState<HTMLDivElement | null>(null)
@@ -177,6 +235,9 @@ const renderTest = async (
   )
 }
 
+const getUnpublishMenuItem = (openMenu: HTMLElement) =>
+  within(openMenu).getByRole('menuitem', {name: /Unpublish/, hidden: true})
+
 const publishOnly: DocumentActionsResolver = (prev) =>
   prev.filter(({action}) => action === 'publish')
 
@@ -193,6 +254,10 @@ const getOpenRowMenu = () => {
 
 describe('ReleaseSummary', () => {
   setupVirtualListEnv()
+
+  beforeEach(() => {
+    setDocumentVersions([])
+  })
 
   describe('for an active release', () => {
     const prerenderTest = async () => {
@@ -380,12 +445,27 @@ describe('ReleaseSummary', () => {
     {tableShape: 'default table', variantsEnabled: false},
     {tableShape: 'variants DocumentTable', variantsEnabled: true},
   ])('row action menu in the $tableShape', ({variantsEnabled}) => {
+    beforeEach(() => {
+      mockUseDocumentPairPermissions.mockReturnValue(useDocumentPairPermissionsMockReturn)
+      setDocumentVersions([variantPublishedSibling])
+    })
+
     const findFirstRowMenuButton = async (documentActions?: DocumentActionsResolver) => {
       await renderTest({}, {variantsEnabled, documentActions})
       await screen.findByTestId('document-table-card')
 
       const [firstDocumentRow] = screen.getAllByTestId('table-row')
       return queryByDataUi(firstDocumentRow, 'MenuButton')
+    }
+
+    const openFirstRowMenu = async (props: Partial<ReleaseSummaryProps> = {}) => {
+      await renderTest(props, {variantsEnabled})
+      await screen.findByTestId('document-table-card')
+
+      const [firstDocumentRow] = screen.getAllByTestId('table-row')
+      await userEvent.click(getByDataUi(firstDocumentRow, 'MenuButton'))
+
+      return getOpenRowMenu()
     }
 
     it('renders while discardVersion and unpublishVersion are configured', async () => {
@@ -411,6 +491,39 @@ describe('ReleaseSummary', () => {
       expect(
         within(openMenu).queryByRole('menuitem', {name: 'Unpublish', hidden: true}),
       ).not.toBeInTheDocument()
+    })
+
+    it('enables unpublish for a variant row whose variant is published', async () => {
+      setDocumentVersions([variantPublishedSibling])
+
+      expect(getUnpublishMenuItem(await openFirstRowMenu({documents: [variantRow]}))).toBeEnabled()
+    })
+
+    it('disables unpublish for a variant row with no published sibling', async () => {
+      setDocumentVersions([])
+
+      expect(
+        getUnpublishMenuItem(await openFirstRowMenu({documents: [publishedBaseVariantRow]})),
+      ).toBeDisabled()
+    })
+
+    it('disables unpublish while the variant publish state resolves', async () => {
+      setDocumentVersions([], true)
+
+      expect(
+        getUnpublishMenuItem(await openFirstRowMenu({documents: [publishedBaseVariantRow]})),
+      ).toBeDisabled()
+    })
+
+    it('explains a denied unpublish with the roles message', async () => {
+      mockUseDocumentPairPermissions.mockReturnValue([{granted: false, reason: 'nope'}, false])
+
+      const openMenu = await openFirstRowMenu({documents: [releaseDocuments[0]]})
+
+      expect(getUnpublishMenuItem(openMenu)).toBeDisabled()
+      expect(
+        screen.getByText('You do not have permission to unpublish this document.'),
+      ).toBeInTheDocument()
     })
   })
 

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -8,17 +8,115 @@ import {Box} from 'ui5'
 import {MenuButton} from '../../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {ContextMenuButton} from '../../../../components/contextMenuButton/ContextMenuButton'
+import {InsufficientPermissionsMessage} from '../../../../components/InsufficientPermissionsMessage'
 import {useConfiguredDocumentActionIds} from '../../../../config/document/useConfiguredDocumentActionIds'
 import {type DocumentActionsVersionType} from '../../../../config/types'
 import {useSchema} from '../../../../hooks/useSchema'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useDocumentPairPermissions} from '../../../../store/grants/documentPairPermissions'
+import {useCurrentUser} from '../../../../store/user/hooks'
 import {getPublishedId, getVersionFromId} from '../../../../util/draftUtils'
+import {getVariantPublishedSibling} from '../../../../util/getTargetDocument'
 import {DiscardVersionDialog} from '../../../components/dialog/DiscardVersionDialog'
 import {UnpublishVersionDialog} from '../../../components/dialog/UnpublishVersionDialog'
+import {useDocumentVersions} from '../../../hooks/useDocumentVersions'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {isGoingToUnpublish} from '../../../util/isGoingToUnpublish'
 import {type BundleDocumentRow} from '../ReleaseSummary'
+
+interface UnpublishMenuItemProps {
+  hasPermission: boolean
+  isAlreadyUnpublished: boolean
+  isPermissionsLoading: boolean
+  isPublished: boolean
+  isPublishStateResolving: boolean
+  onClick: () => void
+}
+
+function UnpublishMenuItem({
+  hasPermission,
+  isAlreadyUnpublished,
+  isPermissionsLoading,
+  isPublished,
+  isPublishStateResolving,
+  onClick,
+}: UnpublishMenuItemProps) {
+  const {t} = useTranslation(releasesLocaleNamespace)
+  const currentUser = useCurrentUser()
+  const insufficientPermissions = !isPermissionsLoading && !hasPermission
+
+  const tooltipContent = useMemo(() => {
+    if (insufficientPermissions) {
+      return (
+        <InsufficientPermissionsMessage context="unpublish-document" currentUser={currentUser} />
+      )
+    }
+    if (isPermissionsLoading || isPublishStateResolving) {
+      return null
+    }
+    if (!isPublished) {
+      return t('unpublish.no-published-version')
+    }
+    if (isAlreadyUnpublished) {
+      return t('unpublish.already-unpublished')
+    }
+
+    return null
+  }, [
+    currentUser,
+    insufficientPermissions,
+    isAlreadyUnpublished,
+    isPermissionsLoading,
+    isPublished,
+    isPublishStateResolving,
+    t,
+  ])
+
+  return (
+    <MenuItem
+      text={t('action.unpublish')}
+      icon={UnpublishIcon}
+      disabled={
+        isPermissionsLoading ||
+        !hasPermission ||
+        isPublishStateResolving ||
+        !isPublished ||
+        isAlreadyUnpublished
+      }
+      tooltipProps={tooltipContent ? {content: tooltipContent} : null}
+      onClick={onClick}
+    />
+  )
+}
+
+/**
+ * For a variant version, "is there something published to unpublish" is answered by the
+ * variant-of-published sibling. `publishedDocumentExists` on the row addresses the base published
+ * document, which says nothing about the variant.
+ */
+function VariantUnpublishMenuItem({
+  publishedId,
+  variantId,
+  ...menuItemProps
+}: Omit<UnpublishMenuItemProps, 'isPublished' | 'isPublishStateResolving'> & {
+  publishedId: string
+  variantId: string
+}) {
+  const {versions, loading} = useDocumentVersions({documentId: publishedId})
+
+  const publishedSibling = useMemo(
+    () => getVariantPublishedSibling({variant: variantId, documentVersions: versions}),
+    [variantId, versions],
+  )
+
+  return (
+    <UnpublishMenuItem
+      {...menuItemProps}
+      isPublished={publishedSibling !== undefined}
+      isPublishStateResolving={loading}
+    />
+  )
+}
 
 const DocumentActionsInner = memo(
   function DocumentActionsInner({
@@ -36,12 +134,14 @@ const DocumentActionsInner = memo(
     const [showUnpublishDialog, setShowUnpublishDialog] = useState(false)
     const {t: coreT} = useTranslation()
     const {t} = useTranslation(releasesLocaleNamespace)
+    const currentUser = useCurrentUser()
     const isAlreadyUnpublished = isGoingToUnpublish(document.document)
 
     const publishedId = getPublishedId(document.document._id)
     const type = document.document._type
     // Permission checks address the row's own version, keyed by the scope segment of its id.
     const version = getVersionFromId(document.document._id)
+    const variantId = document.document._system?.variant?._ref
 
     const [discardVersionPermission, isDiscardVersionPermissionsLoading] =
       useDocumentPairPermissions({
@@ -57,31 +157,10 @@ const DocumentActionsInner = memo(
       permission: 'unpublish',
     })
 
-    const isDiscardVersionActionDisabled =
-      !discardVersionPermission?.granted || isDiscardVersionPermissionsLoading
-    const noPermissionToUnpublish = !unpublishPermission?.granted || isUnpublishPermissionsLoading
-
-    const unPublishTooltipContent = useMemo(() => {
-      if (noPermissionToUnpublish) {
-        return t('permissions.error.unpublish')
-      }
-      if (!document.document.publishedDocumentExists) {
-        return t('unpublish.no-published-version')
-      }
-      if (isAlreadyUnpublished) {
-        return t('unpublish.already-unpublished')
-      }
-
-      return null
-    }, [
-      document.document.publishedDocumentExists,
-      isAlreadyUnpublished,
-      noPermissionToUnpublish,
-      t,
-    ])
-
-    const isUnpublishActionDisabled =
-      noPermissionToUnpublish || !document.document.publishedDocumentExists || isAlreadyUnpublished
+    const hasDiscardVersionPermission = Boolean(discardVersionPermission?.granted)
+    const hasUnpublishPermission = Boolean(unpublishPermission?.granted)
+    const insufficientDiscardPermissions =
+      !isDiscardVersionPermissionsLoading && !hasDiscardVersionPermission
 
     const configuredActionIds = useConfiguredDocumentActionIds({
       schemaType: type,
@@ -94,6 +173,13 @@ const DocumentActionsInner = memo(
     const hasConfiguredMenuItems = showDiscardVersion || showUnpublish
 
     if (!hasConfiguredMenuItems) return null
+
+    const unpublishMenuItemProps = {
+      hasPermission: hasUnpublishPermission,
+      isAlreadyUnpublished,
+      isPermissionsLoading: isUnpublishPermissionsLoading,
+      onClick: () => setShowUnpublishDialog(true),
+    }
 
     return (
       <>
@@ -108,11 +194,19 @@ const DocumentActionsInner = memo(
                     text={coreT('release.action.discard-version')}
                     icon={CloseIcon}
                     onClick={() => setShowDiscardDialog(true)}
-                    disabled={isDiscardVersionActionDisabled}
-                    tooltipProps={{
-                      disabled: !isDiscardVersionActionDisabled,
-                      content: t('permissions.error.discard-version'),
-                    }}
+                    disabled={isDiscardVersionPermissionsLoading || !hasDiscardVersionPermission}
+                    tooltipProps={
+                      insufficientDiscardPermissions
+                        ? {
+                            content: (
+                              <InsufficientPermissionsMessage
+                                context="discard-changes"
+                                currentUser={currentUser}
+                              />
+                            ),
+                          }
+                        : null
+                    }
                   />
                 )}
                 {showUnpublish && (
@@ -121,16 +215,19 @@ const DocumentActionsInner = memo(
                     <Box padding={3} paddingBottom={2}>
                       <Label size={1}>{t('menu.group.when-releasing')}</Label>
                     </Box>
-                    <MenuItem
-                      text={t('action.unpublish')}
-                      icon={UnpublishIcon}
-                      disabled={isUnpublishActionDisabled}
-                      tooltipProps={{
-                        disabled: !isUnpublishActionDisabled,
-                        content: unPublishTooltipContent,
-                      }}
-                      onClick={() => setShowUnpublishDialog(true)}
-                    />
+                    {variantId ? (
+                      <VariantUnpublishMenuItem
+                        {...unpublishMenuItemProps}
+                        publishedId={publishedId}
+                        variantId={variantId}
+                      />
+                    ) : (
+                      <UnpublishMenuItem
+                        {...unpublishMenuItemProps}
+                        isPublished={document.document.publishedDocumentExists}
+                        isPublishStateResolving={false}
+                      />
+                    )}
                   </>
                 )}
               </Menu>

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -83,16 +83,15 @@ function UnpublishMenuItem({
         !isPublished ||
         isAlreadyUnpublished
       }
-      tooltipProps={tooltipContent ? {content: tooltipContent} : null}
+      tooltipProps={{content: tooltipContent, disabled: !tooltipContent}}
       onClick={onClick}
     />
   )
 }
 
 /**
- * For a variant version, "is there something published to unpublish" is answered by the
- * variant-of-published sibling. `publishedDocumentExists` on the row addresses the base published
- * document, which says nothing about the variant.
+ * A variant's publish state is answered by its variant-of-published sibling; the row's
+ * `publishedDocumentExists` addresses the base published document.
  */
 function VariantUnpublishMenuItem({
   publishedId,
@@ -161,6 +160,9 @@ const DocumentActionsInner = memo(
     const hasUnpublishPermission = Boolean(unpublishPermission?.granted)
     const insufficientDiscardPermissions =
       !isDiscardVersionPermissionsLoading && !hasDiscardVersionPermission
+    const discardTooltipContent = insufficientDiscardPermissions ? (
+      <InsufficientPermissionsMessage context="discard-changes" currentUser={currentUser} />
+    ) : null
 
     const configuredActionIds = useConfiguredDocumentActionIds({
       schemaType: type,
@@ -195,18 +197,10 @@ const DocumentActionsInner = memo(
                     icon={CloseIcon}
                     onClick={() => setShowDiscardDialog(true)}
                     disabled={isDiscardVersionPermissionsLoading || !hasDiscardVersionPermission}
-                    tooltipProps={
-                      insufficientDiscardPermissions
-                        ? {
-                            content: (
-                              <InsufficientPermissionsMessage
-                                context="discard-changes"
-                                currentUser={currentUser}
-                              />
-                            ),
-                          }
-                        : null
-                    }
+                    tooltipProps={{
+                      content: discardTooltipContent,
+                      disabled: !discardTooltipContent,
+                    }}
                   />
                 )}
                 {showUnpublish && (

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
@@ -1,18 +1,29 @@
 import {render, screen} from '@testing-library/react'
-import {describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {useDocumentPairPermissionsMockReturn} from '../../../../../../../test/mocks/useDocumentPairPermissions.mock'
+import {
+  mockUseDocumentPairPermissions,
+  useDocumentPairPermissionsMockReturn,
+} from '../../../../../../../test/mocks/useDocumentPairPermissions.mock'
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
 import {type DocumentActionsResolver} from '../../../../../config/types'
 import {studioDefaultLocaleResources} from '../../../../../i18n/bundles/studio'
+import {mockUseDocumentVersions} from '../../../../hooks/__tests__/__mocks__/useDocumentVersions.mock'
 import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
+import {type VersionInfoDocumentStub} from '../../../../store/types'
 import {type BundleDocumentRow} from '../../ReleaseSummary'
 import {DocumentActions} from '../DocumentActions'
 
 vi.mock('../../../../../store/grants/documentPairPermissions', () => ({
   useDocumentPairPermissions: vi.fn(() => useDocumentPairPermissionsMockReturn),
 }))
+
+vi.mock('../../../../hooks/useDocumentVersions', () => ({
+  useDocumentVersions: vi.fn(),
+}))
+
+const VARIANT_ID = 'variant-nordic'
 
 const documentRow = {
   memoKey: 'memo-1',
@@ -27,47 +38,102 @@ const documentRow = {
   },
 } as unknown as BundleDocumentRow
 
+// A variant release version: its id carries an opaque scope hash and `_system.variant` names the
+// variant the row belongs to. `publishedDocumentExists` addresses the base published document, so
+// it is deliberately set against the variant's own publish state in these fixtures.
+const variantDocumentRow = {
+  ...documentRow,
+  document: {
+    ...documentRow.document,
+    _id: 'versions.k7fh2qzs9m.doc1',
+    publishedDocumentExists: false,
+    _system: {
+      bundleId: 'release1',
+      scopeId: 'k7fh2qzs9m',
+      variant: {_ref: VARIANT_ID, _weak: true},
+      group: {_ref: 'doc1', _weak: true},
+    },
+  },
+} as unknown as BundleDocumentRow
+
+const variantPublishedSibling = {
+  _id: 'versions.p3n8xw2.doc1',
+  _rev: 'rev1',
+  _type: 'author',
+  _createdAt: '',
+  _updatedAt: '',
+  _system: {
+    scopeId: 'p3n8xw2',
+    variant: {_ref: VARIANT_ID, _weak: true},
+    group: {_ref: 'doc1', _weak: true},
+  },
+} as VersionInfoDocumentStub
+
+const baseReleaseVersion = {
+  ...variantPublishedSibling,
+  _id: 'versions.release1.doc1',
+  _system: {bundleId: 'release1', scopeId: 'release1', group: {_ref: 'doc1', _weak: true}},
+} as VersionInfoDocumentStub
+
+const setDocumentVersions = (versions: VersionInfoDocumentStub[], loading = false) =>
+  mockUseDocumentVersions.mockReturnValue({
+    data: versions.map(({_id}) => _id),
+    versions,
+    error: null,
+    loading,
+  })
+
 const localeResources = [studioDefaultLocaleResources, releasesUsEnglishLocaleBundle]
 
-describe('DocumentActions', () => {
-  it('renders discard version and unpublish when document.actions is unfiltered', async () => {
-    const wrapper = await createTestProvider({resources: localeResources})
+const renderDocumentActions = async ({
+  document = documentRow,
+  documentActions,
+  versionType = 'version',
+}: {
+  document?: BundleDocumentRow
+  documentActions?: DocumentActionsResolver
+  versionType?: 'version' | 'scheduled-draft'
+} = {}) => {
+  const wrapper = await createTestProvider({
+    resources: localeResources,
+    config: documentActions ? {document: {actions: documentActions}} : undefined,
+  })
 
-    render(
-      <DocumentActions
-        document={documentRow}
-        releaseId="release1"
-        releaseTitle="Release 1"
-        versionType="version"
-      />,
-      {wrapper},
-    )
-    await flushMicrotasksThisIsACodeSmell()
+  render(
+    <DocumentActions
+      document={document}
+      releaseId="release1"
+      releaseTitle="Release 1"
+      versionType={versionType}
+    />,
+    {wrapper},
+  )
+  await flushMicrotasksThisIsACodeSmell()
+}
+
+const getUnpublishMenuItem = () => screen.getByRole('menuitem', {name: /Unpublish/, hidden: true})
+
+const getDiscardMenuItem = () =>
+  screen.getByRole('menuitem', {name: /Discard version/, hidden: true})
+
+describe('DocumentActions', () => {
+  beforeEach(() => {
+    mockUseDocumentPairPermissions.mockReturnValue(useDocumentPairPermissionsMockReturn)
+    mockUseDocumentVersions.mockClear()
+    setDocumentVersions([baseReleaseVersion, variantPublishedSibling])
+  })
+
+  it('renders discard version and unpublish when document.actions is unfiltered', async () => {
+    await renderDocumentActions()
 
     expect(screen.getByText('Discard version')).toBeInTheDocument()
     expect(screen.getByText('Unpublish')).toBeInTheDocument()
   })
 
   it('hides discard version and unpublish when both action ids are omitted', async () => {
-    const wrapper = await createTestProvider({
-      resources: localeResources,
-      config: {
-        document: {
-          actions: (prev) => prev.filter((action) => action.action === 'publish'),
-        },
-      },
+    await renderDocumentActions({
+      documentActions: (prev) => prev.filter((action) => action.action === 'publish'),
     })
-
-    render(
-      <DocumentActions
-        document={documentRow}
-        releaseId="release1"
-        releaseTitle="Release 1"
-        versionType="version"
-      />,
-      {wrapper},
-    )
-    await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
     expect(screen.queryByText('Unpublish')).not.toBeInTheDocument()
@@ -76,43 +142,16 @@ describe('DocumentActions', () => {
   // A cardinality-one release row is a scheduled draft, and that plugin's action list has no
   // `unpublishVersion`, so the row must not offer Unpublish where the footer cannot.
   it('drops unpublish on a scheduled draft row', async () => {
-    const wrapper = await createTestProvider({resources: localeResources})
-
-    render(
-      <DocumentActions
-        document={documentRow}
-        releaseId="release1"
-        releaseTitle="Release 1"
-        versionType="scheduled-draft"
-      />,
-      {wrapper},
-    )
-    await flushMicrotasksThisIsACodeSmell()
+    await renderDocumentActions({versionType: 'scheduled-draft'})
 
     expect(screen.getByText('Discard version')).toBeInTheDocument()
     expect(screen.queryByText('Unpublish')).not.toBeInTheDocument()
   })
 
   it('keeps unpublish when only discardVersion is omitted', async () => {
-    const wrapper = await createTestProvider({
-      resources: localeResources,
-      config: {
-        document: {
-          actions: (prev) => prev.filter((action) => action.action !== 'discardVersion'),
-        },
-      },
+    await renderDocumentActions({
+      documentActions: (prev) => prev.filter((action) => action.action !== 'discardVersion'),
     })
-
-    render(
-      <DocumentActions
-        document={documentRow}
-        releaseId="release1"
-        releaseTitle="Release 1"
-        versionType="version"
-      />,
-      {wrapper},
-    )
-    await flushMicrotasksThisIsACodeSmell()
 
     expect(screen.queryByText('Discard version')).not.toBeInTheDocument()
     expect(screen.getByText('Unpublish')).toBeInTheDocument()
@@ -121,30 +160,118 @@ describe('DocumentActions', () => {
   // A variant row's id carries a scope hash, not the release id the document footer resolves against.
   it('resolves row actions for the release id on a variant row', async () => {
     const documentActions = vi.fn<DocumentActionsResolver>((prev) => prev)
-    const wrapper = await createTestProvider({
-      resources: localeResources,
-      config: {document: {actions: documentActions}},
-    })
-
-    const variantDocumentRow = {
-      ...documentRow,
-      document: {...documentRow.document, _id: 'versions.k7fh2qzs9m.doc1'},
-    } as unknown as BundleDocumentRow
-
-    render(
-      <DocumentActions
-        document={variantDocumentRow}
-        releaseId="release1"
-        releaseTitle="Release 1"
-        versionType="version"
-      />,
-      {wrapper},
-    )
-    await flushMicrotasksThisIsACodeSmell()
+    await renderDocumentActions({document: variantDocumentRow, documentActions})
 
     expect(documentActions).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({releaseId: 'release1'}),
     )
+  })
+
+  describe('unpublish publish-state gating', () => {
+    it('enables unpublish for a non-variant row with a published document', async () => {
+      await renderDocumentActions()
+
+      expect(getUnpublishMenuItem()).toBeEnabled()
+    })
+
+    it('disables unpublish for a non-variant row with no published document', async () => {
+      await renderDocumentActions({
+        document: {
+          ...documentRow,
+          document: {...documentRow.document, publishedDocumentExists: false},
+        } as unknown as BundleDocumentRow,
+      })
+
+      expect(getUnpublishMenuItem()).toBeDisabled()
+      expect(
+        screen.getByText('There is no published version of this document.'),
+      ).toBeInTheDocument()
+    })
+
+    // The base published document is irrelevant to a variant: only the variant-of-published
+    // sibling says whether unpublishing has anything to remove.
+    it('enables unpublish for a variant row whose variant is published', async () => {
+      setDocumentVersions([baseReleaseVersion, variantPublishedSibling])
+      await renderDocumentActions({document: variantDocumentRow})
+
+      expect(getUnpublishMenuItem()).toBeEnabled()
+    })
+
+    it('disables unpublish for a variant row with no published sibling, even when the base document is published', async () => {
+      setDocumentVersions([baseReleaseVersion])
+      await renderDocumentActions({
+        document: {
+          ...variantDocumentRow,
+          document: {...variantDocumentRow.document, publishedDocumentExists: true},
+        } as unknown as BundleDocumentRow,
+      })
+
+      expect(getUnpublishMenuItem()).toBeDisabled()
+      expect(
+        screen.getByText('There is no published version of this document.'),
+      ).toBeInTheDocument()
+    })
+
+    it('disables unpublish while the variant publish state resolves', async () => {
+      setDocumentVersions([], true)
+      await renderDocumentActions({document: variantDocumentRow})
+
+      expect(getUnpublishMenuItem()).toBeDisabled()
+      expect(
+        screen.queryByText('There is no published version of this document.'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('disables unpublish for a document already marked for unpublishing', async () => {
+      await renderDocumentActions({
+        document: {
+          ...documentRow,
+          document: {...documentRow.document, _system: {delete: true}},
+        } as unknown as BundleDocumentRow,
+      })
+
+      expect(getUnpublishMenuItem()).toBeDisabled()
+      expect(screen.getByText('This document is already unpublished.')).toBeInTheDocument()
+    })
+
+    it('leaves the variant lookup alone for a non-variant row', async () => {
+      await renderDocumentActions()
+
+      expect(mockUseDocumentVersions).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('insufficient permissions', () => {
+    beforeEach(() => {
+      mockUseDocumentPairPermissions.mockReturnValue([{granted: false, reason: 'nope'}, false])
+    })
+
+    it('explains a denied discard version with the roles message', async () => {
+      await renderDocumentActions()
+
+      expect(getDiscardMenuItem()).toBeDisabled()
+      expect(
+        screen.getByText('You do not have permission to discard changes in this document.'),
+      ).toBeInTheDocument()
+    })
+
+    it('explains a denied unpublish with the roles message', async () => {
+      await renderDocumentActions()
+
+      expect(getUnpublishMenuItem()).toBeDisabled()
+      expect(
+        screen.getByText('You do not have permission to unpublish this document.'),
+      ).toBeInTheDocument()
+      expect(screen.getAllByText('Administrator').length).toBeGreaterThan(0)
+    })
+
+    it('shows no permissions message while the permission check is still loading', async () => {
+      mockUseDocumentPairPermissions.mockReturnValue([undefined, true])
+      await renderDocumentActions()
+
+      expect(getUnpublishMenuItem()).toBeDisabled()
+      expect(screen.queryByText('Insufficient permissions')).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentActions.test.tsx
@@ -213,8 +213,9 @@ describe('DocumentActions', () => {
       ).toBeInTheDocument()
     })
 
+    // The sibling is present, so the readiness gate is the only thing disabling the item.
     it('disables unpublish while the variant publish state resolves', async () => {
-      setDocumentVersions([], true)
+      setDocumentVersions([variantPublishedSibling], true)
       await renderDocumentActions({document: variantDocumentRow})
 
       expect(getUnpublishMenuItem()).toBeDisabled()


### PR DESCRIPTION
### Description

The release detail table's row menu mirrors the unpublish and discard actions from the document footer. #14244 made the two agree on the `document.actions` gate. Below that gate they still disagreed. This closes three of the four divergences in [SAPP-4403](https://linear.app/sanity/issue/SAPP-4403/release-detail-table-diverges-from-the-document-footer-on-unpublish).

**Unpublish now answers the variant's own publish state.** The row read `document.publishedDocumentExists`, which comes from a pair-availability check on `getPublishedId(versionId)` - the base published document. For a variant release version that says nothing about the variant. The footer reads `targetDocumentState.publishedSibling`. The row now looks up the variant-of-published sibling with the same helper (`getVariantPublishedSibling`) whenever the row carries `_system.variant`, and keeps `publishedDocumentExists` for every other row. A variant with no published sibling could previously be unpublished whenever the base document happened to be published.

**Unpublish is disabled while that lookup resolves.** The footer disables on `!isTargetReady`. The table had nothing to wait on until this change introduced the sibling lookup, so the gate lands with it.

**Denied permissions now render `InsufficientPermissionsMessage`.** Both items showed a plain tooltip string. They now show the same component the footer uses, naming the user's roles. It renders only once the check has definitively failed, matching the footer - a still-loading check disables the item with no message rather than claiming a denial.

**The tooltip stays mounted across those transitions.** `MenuItem` wraps its button in a `Tooltip` only when `tooltipProps` is set, so passing `null` while there is no message changes the element at that position and remounts the button. The first commit on this branch introduced that `null`; the second restores the pattern `main` already had, where both items always pass `tooltipProps` and toggle its `disabled` field. Otherwise a variant row's Unpublish button is replaced the moment the sibling lookup settles, dropping keyboard focus if the user has arrowed onto it.

Discard does not get an `isTargetReady` equivalent. The footer needs one because in the pane the target is resolved from the selected perspective; in the table the row *is* the target and `DiscardVersionDialog` receives `document.document._id` directly, so there is nothing to resolve and nothing to disable for.

The fourth divergence - the footer turns an already-unpublished version into Revert unpublish, the table only greys Unpublish out - is a missing capability rather than a gating fault, and copying the footer verbatim would put a one-click unconfirmed mutation next to two dialog-guarded ones. That needs a design call, so it is split into [SAPP-4404](https://linear.app/sanity/issue/SAPP-4404/release-detail-table-cannot-revert-an-unpublish) and left unchanged here.

### What to review

`DocumentActions.tsx` is the whole change. The unpublish item moved into its own component so the variant sibling lookup mounts only for variant rows. `@sanity/ui` renders closed menu content inside a hidden `<Activity>`, which does not run effects, so the lookup subscribes on menu open and a non-variant row subscribes to nothing at all.

**A `beta.variants` release detail row does carry `_system.variant` wherever the lookup relies on it.** The row's `document` comes from `unstable_observeDocument`, which fetches `*[_id in $ids]` with no projection, so `_system` arrives verbatim. `core/variants/EDITING.md` states the invariant: every variant document carries authoritative metadata in `_system`, with `variant` referencing the variant definition. Variant documents are only ever created by the `sanity.action.variant.*` backend actions, so no shape predates the field - the "until the documents are migrated" caveat in `useDocumentVersions` covers base release and draft versions, which is why it notes that variants already include `_system`. `_system.variant._ref` is the definition id, the same value `useTargetDocumentState` hands `getVariantPublishedSibling` for the footer. Both residual cases fail closed. A row arriving without `_system.variant` falls back to `publishedDocumentExists`, which is the behaviour on `main`. A sibling stub arriving without `_system.group` gets a `bundleId` synthesized from its id shape, stops matching, and leaves Unpublish disabled.

The two release i18n keys that lost their last reference (`permissions.error.unpublish`, `permissions.error.discard-version`) stay in place. i18n bundles are append-only: older released Studio versions still resolve those keys at runtime. This branch does not touch `releases/i18n/resources.ts` at all.

### Testing

`DocumentActions.test.tsx` covers the gating directly; `ReleaseSummary.test.tsx` proves it through both table shapes via the existing `describe.each` (default `Table` and the `beta.variants` `DocumentTable`). Both shapes carry variant rows in practice - rows come from the server-side `sanity::partOfRelease` filter, so a release holding variant documents yields variant rows whichever table the workspace renders.

Two mutation checks, both authored against the fix and neither re-run for this description:

- Reverting the variant-aware `isPublished` to `publishedDocumentExists` breaks the variant tests in both files and leaves the rest green. Fixtures set the variant row's own publish state against the base document in both directions, so the tests catch a regression either way.
- Dropping `isPublishStateResolving` from the `disabled` expression breaks the resolving tests. Those fixtures carry a published sibling, so the readiness gate is the only thing disabling the item.

`pnpm vitest run --project=sanity packages/sanity/src/core/releases` - 56 files, 634 passed, 2 skipped, 1 todo, no type errors. `oxfmt --check` is clean on the three changed files and `oxlint` reports one `unicorn/prefer-array-find` warning in `ReleaseSummary.test.tsx`, present on `main` in the same untouched function.

### Notes for release

In a release's document list, Unpublish and Discard version now name your roles when you do not have permission to use them, matching the document footer.

---
