### PR TITLE
fix(releases): clarify discard drafts copy in publish dialog

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -309,12 +309,12 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   /** Title for the dialog confirming the publish of a release */
   'publish-dialog.confirm-publish.title':
     'Are you sure you want to publish the release and all document versions?',
-  /** Label for the checkbox in the publish confirmation dialog for also updating existing drafts to match the release */
-  'publish-dialog.confirm-publish.update-drafts-checkbox': 'Update existing drafts',
-  /** Description for the update existing drafts checkbox when one document has an existing draft */
+  /** Label for the checkbox in the publish confirmation dialog for discarding overlaid drafts so they match the published release */
+  'publish-dialog.confirm-publish.update-drafts-checkbox': 'Remove overlaid drafts',
+  /** Description for the remove overlaid drafts checkbox when one document has an existing draft */
   'publish-dialog.confirm-publish.update-drafts-description_one':
     'The existing draft of {{draftDocumentsLength}} document will be discarded so that drafts match the published release. Unpublished draft changes will be lost.',
-  /** Description for the update existing drafts checkbox when multiple documents have existing drafts */
+  /** Description for the remove overlaid drafts checkbox when multiple documents have existing drafts */
   'publish-dialog.confirm-publish.update-drafts-description_other':
     'The existing drafts of {{draftDocumentsLength}} documents will be discarded so that drafts match the published release. Unpublished draft changes will be lost.',
   /** Description for the dialog confirming the publish of a release with one document */
@@ -515,9 +515,9 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'toast.duplicate.success-link': 'View duplicated release',
   /** Text for toast when release failed to publish */
   'toast.publish.error': "Failed to publish '<strong>{{title}}</strong>': {{error}}",
-  /** Text for toast when the release was published but the existing drafts could not be updated */
+  /** Text for toast when the release was published but the existing drafts could not be discarded */
   'toast.publish.update-drafts-error':
-    'The release was published, but existing drafts could not be updated: {{error}}',
+    'The release was published, but existing drafts could not be discarded: {{error}}',
   /** Text for toast when release failed to schedule */
   'toast.schedule.error': "Failed to schedule '<strong>{{title}}</strong>': {{error}}",
   /** Text for toast when release has been scheduled */

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -208,24 +208,24 @@ export const ReleasePublishAllButton = ({
             }
           </Text>
           {showUpdateDraftsOption && (
-            <Stack gap={3}>
-              <Flex align="center" gap={3} as="label">
-                <Checkbox
-                  checked={shouldUpdateDrafts}
-                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                    setShouldUpdateDrafts(event.currentTarget.checked)
-                  }
-                  data-testid="update-drafts-checkbox"
-                />
+            <Flex align="flex-start" gap={3} as="label">
+              <Checkbox
+                checked={shouldUpdateDrafts}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  setShouldUpdateDrafts(event.currentTarget.checked)
+                }
+                data-testid="update-drafts-checkbox"
+              />
+              <Stack flex={1} gap={2}>
                 <Text size={1}>{t('publish-dialog.confirm-publish.update-drafts-checkbox')}</Text>
-              </Flex>
-              <Text muted size={1}>
-                {t('publish-dialog.confirm-publish.update-drafts-description', {
-                  count: draftDocumentsCount,
-                  draftDocumentsLength: draftDocumentsCount,
-                })}
-              </Text>
-            </Stack>
+                <Text muted size={1}>
+                  {t('publish-dialog.confirm-publish.update-drafts-description', {
+                    count: draftDocumentsCount,
+                    draftDocumentsLength: draftDocumentsCount,
+                  })}
+                </Text>
+              </Stack>
+            </Flex>
           )}
         </Stack>
       </Dialog>

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/__tests__/ReleasePublishAllButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/__tests__/ReleasePublishAllButton.test.tsx
@@ -87,7 +87,7 @@ describe('ReleasePublishAllButton', () => {
   describe('when no document in the release has an existing draft', () => {
     const documents = [createDocumentInRelease('versions.rASAP.doc1')]
 
-    test('does not show the update drafts option', async () => {
+    test('does not show the remove overlaid drafts option', async () => {
       await openConfirmPublishDialog(documents)
 
       expect(screen.queryByTestId('update-drafts-checkbox')).not.toBeInTheDocument()
@@ -114,10 +114,28 @@ describe('ReleasePublishAllButton', () => {
       createDocumentInRelease('versions.rASAP.doc3', {draftDocumentExists: true}),
     ]
 
-    test('shows the update drafts option, unchecked by default', async () => {
+    test('shows the remove overlaid drafts option, unchecked by default', async () => {
       await openConfirmPublishDialog(documents)
 
       expect(screen.getByTestId('update-drafts-checkbox')).not.toBeChecked()
+      expect(screen.getByText('Remove overlaid drafts')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'The existing drafts of 2 documents will be discarded so that drafts match the published release. Unpublished draft changes will be lost.',
+        ),
+      ).toBeInTheDocument()
+    })
+
+    test('checks the option when the helper text is clicked', async () => {
+      await openConfirmPublishDialog(documents)
+
+      await userEvent.click(
+        screen.getByText(
+          'The existing drafts of 2 documents will be discarded so that drafts match the published release. Unpublished draft changes will be lost.',
+        ),
+      )
+
+      expect(screen.getByTestId('update-drafts-checkbox')).toBeChecked()
     })
 
     test('publishes the release without discarding drafts when the option is left unchecked', async () => {
@@ -179,7 +197,7 @@ describe('ReleasePublishAllButton', () => {
       createDocumentInRelease('versions.rASAP.doc2'),
     ]
 
-    test('does not show the update drafts option', async () => {
+    test('does not show the remove overlaid drafts option', async () => {
       await openConfirmPublishDialog(documents)
 
       expect(screen.queryByTestId('update-drafts-checkbox')).not.toBeInTheDocument()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The publish confirmation dialog warned that existing drafts would be discarded even when the optional checkbox was off, because that copy sat at dialog level under a label that said "Update existing drafts". The action is discard, not update, so the label contradicted the warning.

The option is now "Remove overlaid drafts", and the discard warning is nested under the checkbox so it reads as the consequence of that choice. Helper text stays visible while unchecked so the option is still explained (hiding it until checked was considered, but then the checkbox would be unexplained).

### What to review

- Copy in `packages/sanity/src/core/releases/i18n/resources.ts` (checkbox label, helper text, failure toast)
- Layout in `ReleasePublishAllButton` (checkbox + stacked label/helper as one label)

### Testing

- Unit tests in `ReleasePublishAllButton.test.tsx` cover the new label, helper text while unchecked, and clicking the helper text to check the option
- Manual check of the publish confirmation dialog with documents that already have drafts

### Notes for release

The publish release confirmation dialog now labels the optional draft cleanup as "Remove overlaid drafts" and shows the discard warning as part of that checkbox, so unpublished draft changes are not implied to be lost unless the option is selected.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63d4b7e3-c18f-4e50-a021-5bb9f0e12a7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63d4b7e3-c18f-4e50-a021-5bb9f0e12a7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

