### PR TITLE
feat(access-ui): surface SAML enforcement before the request form

### DIFF
--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -131,7 +131,12 @@ function deriveServerViewState(
     case 'saml-required':
       return {view: 'sso-enforced', redirectUrl: status.redirectUrl}
     case 'resource-not-available':
-      return {view: 'blocked', title: labels.errorTitle, message: labels.submitFailedMessage}
+      // Nothing was submitted, so the submit-failure copy would misdescribe it.
+      return {
+        view: 'blocked',
+        title: labels.resourceNotAvailableTitle,
+        message: labels.resourceNotAvailableMessage,
+      }
     case 'eligible':
       return null
     default:

--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -13,6 +13,7 @@ import {
 import {Box} from 'ui5'
 
 import {
+  checkAccessRequestEligibility,
   listMyAccessRequests,
   MAX_ACCESS_REQUEST_NOTE_LENGTH,
   submitAccessRequest,
@@ -22,6 +23,7 @@ import {defaultLabels, type RequestAccessLabels} from './labels'
 import {getProviderTitle} from './providerTitle'
 import {
   type AccessRequest,
+  type AccessRequestEligibility,
   type AccessResourceType,
   type AccessUser,
   type SubmitAccessRequestResult,
@@ -68,12 +70,20 @@ export interface RequestAccessFormProps {
  * @public
  */
 export function RequestAccessForm(props: RequestAccessFormProps) {
-  const {client} = props
+  const {client, resourceType = 'project', resourceId} = props
 
   // Created once (lazy init): recreating the promise per render would refetch
   // and re-suspend forever. Callers remount with `key` to reset.
   const [requestsPromise] = useState(() =>
     listMyAccessRequests(client).catch((): AccessRequest[] | null => null),
+  )
+  const [eligibilityPromise] = useState(() =>
+    checkAccessRequestEligibility({
+      client,
+      resourceType,
+      resourceId,
+      origin: getRequestUrl(),
+    }),
   )
 
   return (
@@ -85,7 +95,11 @@ export function RequestAccessForm(props: RequestAccessFormProps) {
           </Flex>
         }
       >
-        <RequestAccessFormContent {...props} requestsPromise={requestsPromise} />
+        <RequestAccessFormContent
+          {...props}
+          eligibilityPromise={eligibilityPromise}
+          requestsPromise={requestsPromise}
+        />
       </Suspense>
     </Card>
   )
@@ -107,11 +121,12 @@ type ViewState =
 
 function deriveViewState(options: {
   fetchedRequests: AccessRequest[] | null
+  eligibility: AccessRequestEligibility
   resourceId: string
   submitResult: SubmitAccessRequestResult | null
   labels: RequestAccessLabels
 }): ViewState {
-  const {fetchedRequests, resourceId, submitResult, labels} = options
+  const {fetchedRequests, eligibility, resourceId, submitResult, labels} = options
 
   if (submitResult) {
     switch (submitResult.type) {
@@ -141,6 +156,12 @@ function deriveViewState(options: {
     }
   }
 
+  // Preflight outranks the request history: a pending request in an enforced org
+  // is already dead, so showing "pending approval" would be a false promise.
+  if (!eligibility.eligible && eligibility.reason === 'saml-enforced') {
+    return {view: 'sso-enforced', redirectUrl: eligibility.redirectUrl}
+  }
+
   const state = deriveAccessRequestState(fetchedRequests, resourceId)
   if (state === 'pending') return {view: 'pending'}
   // Derived from prefetch: the user hasn't submitted anything this session,
@@ -154,6 +175,7 @@ function deriveViewState(options: {
 function RequestAccessFormContent(
   props: RequestAccessFormProps & {
     requestsPromise: Promise<AccessRequest[] | null>
+    eligibilityPromise: Promise<AccessRequestEligibility>
   },
 ) {
   const {
@@ -166,10 +188,12 @@ function RequestAccessFormContent(
     preview,
     renderAction,
     requestsPromise,
+    eligibilityPromise,
   } = props
 
   const labels = {...defaultLabels, ...props.labels}
   const fetchedRequests = use(requestsPromise)
+  const eligibility = use(eligibilityPromise)
   const titleId = useId()
 
   const [note, setNote] = useState('')
@@ -178,6 +202,7 @@ function RequestAccessFormContent(
 
   const state = deriveViewState({
     fetchedRequests,
+    eligibility,
     resourceId,
     submitResult,
     labels,

--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -112,12 +112,19 @@ export function RequestAccessForm(props: RequestAccessFormProps) {
  */
 export type RequestAccessView = 'form' | 'sent' | 'pending' | 'blocked' | 'sso-enforced'
 
-type ViewState =
+/**
+ * Everything the card renders, copy included: the same state that picks a view
+ * is the only thing that knows which words that view needs. Keying copy off
+ * `view` alone cannot work, because `blocked` covers a prior decline, a gone
+ * resource and four submit failures, each with its own copy.
+ */
+type ViewState = {title: ReactNode; description: ReactNode | null} & (
   | {view: 'form'; expired: boolean}
   | {view: 'sent'}
   | {view: 'pending'}
-  | {view: 'blocked'; title: ReactNode; message: ReactNode}
-  | {view: 'sso-enforced'; redirectUrl?: string}
+  | {view: 'blocked'; message: ReactNode}
+  | {view: 'sso-enforced'; message: ReactNode; redirectUrl?: string}
+)
 
 /**
  * The server's verdict. `null` hands the decision back to the caller's own
@@ -126,15 +133,17 @@ type ViewState =
 function deriveServerViewState(
   status: AccessRequestEligibilityState,
   labels: RequestAccessLabels,
+  providerTitle?: string,
 ): ViewState | null {
   switch (status.state) {
     case 'saml-required':
-      return {view: 'sso-enforced', redirectUrl: status.redirectUrl}
+      return ssoEnforcedState({labels, providerTitle, redirectUrl: status.redirectUrl})
     case 'resource-not-available':
       // Nothing was submitted, so the submit-failure copy would misdescribe it.
       return {
         view: 'blocked',
         title: labels.resourceNotAvailableTitle,
+        description: null,
         message: labels.resourceNotAvailableMessage,
       }
     case 'eligible':
@@ -144,36 +153,60 @@ function deriveServerViewState(
   }
 }
 
+// Reached on mount and after a submit 403, so the title claims neither.
+function ssoEnforcedState(options: {
+  labels: RequestAccessLabels
+  providerTitle?: string
+  redirectUrl?: string
+}): ViewState {
+  const {labels, providerTitle, redirectUrl} = options
+  return {
+    view: 'sso-enforced',
+    title: labels.ssoEnforcedTitle,
+    description: null,
+    message: labels.ssoEnforcedMessage({providerTitle}),
+    redirectUrl,
+  }
+}
+
 function deriveViewState(options: {
-  fetchedRequests: AccessRequest[] | null
-  status: AccessRequestEligibilityState
+  accessRequestsHistory: AccessRequest[] | null
+  accessRequestEligibilityState: AccessRequestEligibilityState
   resourceId: string
   submitResult: SubmitAccessRequestResult | null
+  currentUser?: AccessUser | null
+  providerTitle?: string
   labels: RequestAccessLabels
 }): ViewState {
-  const {fetchedRequests, status, resourceId, submitResult, labels} = options
+  const {
+    accessRequestsHistory,
+    accessRequestEligibilityState,
+    resourceId,
+    submitResult,
+    currentUser,
+    providerTitle,
+    labels,
+  } = options
+  const submitFailure = (message: ReactNode): ViewState => ({
+    view: 'blocked',
+    title: labels.errorTitle,
+    description: null,
+    message,
+  })
 
   if (submitResult) {
     switch (submitResult.type) {
       case 'submitted':
-        return {view: 'sent'}
+        return {view: 'sent', title: labels.sentTitle, description: labels.sentDescription}
       case 'sso-enforced':
-        return {view: 'sso-enforced', redirectUrl: submitResult.redirectUrl}
+        return ssoEnforcedState({labels, providerTitle, redirectUrl: submitResult.redirectUrl})
       case 'denied':
-        return {
-          view: 'blocked',
-          title: labels.errorTitle,
-          message: labels.deniedMessage({message: submitResult.message}),
-        }
+        return submitFailure(labels.deniedMessage({message: submitResult.message}))
       case 'over-limit':
-        return {
-          view: 'blocked',
-          title: labels.errorTitle,
-          message: labels.overLimitMessage({message: submitResult.message}),
-        }
+        return submitFailure(labels.overLimitMessage({message: submitResult.message}))
       case 'email-domain-blocked':
       case 'requests-disabled':
-        return {view: 'blocked', title: labels.errorTitle, message: submitResult.message}
+        return submitFailure(submitResult.message)
       case 'error':
         // Fall through to the fetched state; the form stays up with an inline error.
         break
@@ -184,17 +217,29 @@ function deriveViewState(options: {
   // The server's verdict outranks the request history: a pending request in an
   // enforced org is already dead, so "pending approval" would be a false
   // promise. It answers `eligible` when it has nothing to say.
-  const serverState = deriveServerViewState(status, labels)
+  const serverState = deriveServerViewState(accessRequestEligibilityState, labels, providerTitle)
   if (serverState) return serverState
 
-  const state = deriveAccessRequestState(fetchedRequests, resourceId)
-  if (state === 'pending') return {view: 'pending'}
+  const state = deriveAccessRequestState(accessRequestsHistory, resourceId)
+  if (state === 'pending') {
+    return {view: 'pending', title: labels.sentTitle, description: labels.pendingMessage}
+  }
   // Derived from prefetch: the user hasn't submitted anything this session,
   // so the title must describe the prior decline, not a failed send.
   if (state === 'denied') {
-    return {view: 'blocked', title: labels.deniedTitle, message: labels.deniedMessage({})}
+    return {
+      view: 'blocked',
+      title: labels.deniedTitle,
+      description: null,
+      message: labels.deniedMessage({}),
+    }
   }
-  return {view: 'form', expired: state === 'expired'}
+  return {
+    view: 'form',
+    title: labels.title,
+    description: labels.describeNoAccess({email: currentUser?.email}),
+    expired: state === 'expired',
+  }
 }
 
 function RequestAccessFormContent(
@@ -217,38 +262,26 @@ function RequestAccessFormContent(
   } = props
 
   const labels = {...defaultLabels, ...props.labels}
-  const fetchedRequests = use(requestsPromise)
-  const status = use(statusPromise)
+  const accessRequestsHistory = use(requestsPromise)
+  const accessRequestEligibilityState = use(statusPromise)
   const titleId = useId()
 
   const [note, setNote] = useState('')
   const [submitResult, setSubmitResult] = useState<SubmitAccessRequestResult | null>(null)
   const [isSubmitting, startSubmit] = useTransition()
 
+  const providerTitle = getProviderTitle(currentUser?.provider)
   const state = deriveViewState({
-    fetchedRequests,
-    status,
+    accessRequestsHistory,
+    accessRequestEligibilityState,
     resourceId,
     submitResult,
+    currentUser,
+    providerTitle,
     labels,
   })
-  const providerTitle = getProviderTitle(currentUser?.provider)
-  const submitFailed = submitResult?.type === 'error'
 
-  const heading: Record<
-    Exclude<ViewState['view'], 'blocked'>,
-    {title: ReactNode; description: ReactNode | null}
-  > = {
-    'form': {
-      title: labels.title,
-      description: labels.describeNoAccess({email: currentUser?.email}),
-    },
-    'sent': {title: labels.sentTitle, description: labels.sentDescription},
-    'pending': {title: labels.sentTitle, description: labels.pendingMessage},
-    'sso-enforced': {title: labels.errorTitle, description: null},
-  }
-  const {title, description} =
-    state.view === 'blocked' ? {title: state.title, description: null} : heading[state.view]
+  const submitFailed = submitResult?.type === 'error'
 
   const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -277,31 +310,23 @@ function RequestAccessFormContent(
         ) : null}
 
         <Text as="h1" id={titleId} size={2} weight="semibold">
-          {title}
+          {state.title}
         </Text>
 
-        {description !== null ? (
+        {state.description !== null ? (
           <Text as="p" muted size={1}>
-            {description}
+            {state.description}
           </Text>
         ) : null}
 
-        {state.view === 'blocked' ? (
-          <Card border padding={3} radius={2} role="alert" tone="caution">
-            <Text as="p" muted size={1}>
-              {state.message}
-            </Text>
-          </Card>
-        ) : null}
-
-        {state.view === 'sso-enforced' ? (
+        {state.view === 'blocked' || state.view === 'sso-enforced' ? (
           <Stack gap={4}>
             <Card border padding={3} radius={2} role="alert" tone="caution">
               <Text as="p" muted size={1}>
-                {labels.ssoEnforcedMessage({providerTitle})}
+                {state.message}
               </Text>
             </Card>
-            {state.redirectUrl ? (
+            {state.view === 'sso-enforced' && state.redirectUrl ? (
               <Button
                 as="a"
                 href={state.redirectUrl}

--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -13,7 +13,7 @@ import {
 import {Box} from 'ui5'
 
 import {
-  checkAccessRequestEligibility,
+  fetchAccessRequestStatus,
   listMyAccessRequests,
   MAX_ACCESS_REQUEST_NOTE_LENGTH,
   submitAccessRequest,
@@ -23,7 +23,7 @@ import {defaultLabels, type RequestAccessLabels} from './labels'
 import {getProviderTitle} from './providerTitle'
 import {
   type AccessRequest,
-  type AccessRequestEligibility,
+  type AccessRequestStatus,
   type AccessResourceType,
   type AccessUser,
   type SubmitAccessRequestResult,
@@ -77,8 +77,8 @@ export function RequestAccessForm(props: RequestAccessFormProps) {
   const [requestsPromise] = useState(() =>
     listMyAccessRequests(client).catch((): AccessRequest[] | null => null),
   )
-  const [eligibilityPromise] = useState(() =>
-    checkAccessRequestEligibility({
+  const [statusPromise] = useState(() =>
+    fetchAccessRequestStatus({
       client,
       resourceType,
       resourceId,
@@ -97,8 +97,8 @@ export function RequestAccessForm(props: RequestAccessFormProps) {
       >
         <RequestAccessFormContent
           {...props}
-          eligibilityPromise={eligibilityPromise}
           requestsPromise={requestsPromise}
+          statusPromise={statusPromise}
         />
       </Suspense>
     </Card>
@@ -119,14 +119,47 @@ type ViewState =
   | {view: 'blocked'; title: ReactNode; message: ReactNode}
   | {view: 'sso-enforced'; redirectUrl?: string}
 
+/**
+ * The server's verdict, for the states it already resolves. `null` hands the
+ * decision back to the caller's own request history.
+ *
+ * The API declares more states than it returns, so the unreturned ones are
+ * mapped here rather than ignored: when the server starts producing them the
+ * card already renders something honest. `requests-disabled` and
+ * `email-domain-blocked` reuse the submit-time copy for the same conditions,
+ * and `pending` and `recently-declined` land on the views the request history
+ * derives today.
+ */
+function deriveServerViewState(
+  status: AccessRequestStatus,
+  labels: RequestAccessLabels,
+): ViewState | null {
+  switch (status.state) {
+    case 'saml-required':
+      return {view: 'sso-enforced', redirectUrl: status.redirectUrl}
+    case 'pending':
+      return {view: 'pending'}
+    case 'recently-declined':
+      return {view: 'blocked', title: labels.deniedTitle, message: labels.deniedMessage({})}
+    case 'requests-disabled':
+    case 'email-domain-blocked':
+    case 'resource-not-available':
+      return {view: 'blocked', title: labels.errorTitle, message: labels.submitFailedMessage}
+    case 'eligible':
+      return null
+    default:
+      return null
+  }
+}
+
 function deriveViewState(options: {
   fetchedRequests: AccessRequest[] | null
-  eligibility: AccessRequestEligibility
+  status: AccessRequestStatus
   resourceId: string
   submitResult: SubmitAccessRequestResult | null
   labels: RequestAccessLabels
 }): ViewState {
-  const {fetchedRequests, eligibility, resourceId, submitResult, labels} = options
+  const {fetchedRequests, status, resourceId, submitResult, labels} = options
 
   if (submitResult) {
     switch (submitResult.type) {
@@ -156,11 +189,11 @@ function deriveViewState(options: {
     }
   }
 
-  // Preflight outranks the request history: a pending request in an enforced org
-  // is already dead, so showing "pending approval" would be a false promise.
-  if (!eligibility.eligible && eligibility.reason === 'saml-enforced') {
-    return {view: 'sso-enforced', redirectUrl: eligibility.redirectUrl}
-  }
+  // The server's verdict outranks the request history: a pending request in an
+  // enforced org is already dead, so "pending approval" would be a false
+  // promise. It answers `eligible` when it has nothing to say.
+  const serverState = deriveServerViewState(status, labels)
+  if (serverState) return serverState
 
   const state = deriveAccessRequestState(fetchedRequests, resourceId)
   if (state === 'pending') return {view: 'pending'}
@@ -175,7 +208,7 @@ function deriveViewState(options: {
 function RequestAccessFormContent(
   props: RequestAccessFormProps & {
     requestsPromise: Promise<AccessRequest[] | null>
-    eligibilityPromise: Promise<AccessRequestEligibility>
+    statusPromise: Promise<AccessRequestStatus>
   },
 ) {
   const {
@@ -188,12 +221,12 @@ function RequestAccessFormContent(
     preview,
     renderAction,
     requestsPromise,
-    eligibilityPromise,
+    statusPromise,
   } = props
 
   const labels = {...defaultLabels, ...props.labels}
   const fetchedRequests = use(requestsPromise)
-  const eligibility = use(eligibilityPromise)
+  const status = use(statusPromise)
   const titleId = useId()
 
   const [note, setNote] = useState('')
@@ -202,7 +235,7 @@ function RequestAccessFormContent(
 
   const state = deriveViewState({
     fetchedRequests,
-    eligibility,
+    status,
     resourceId,
     submitResult,
     labels,

--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -23,7 +23,7 @@ import {defaultLabels, type RequestAccessLabels} from './labels'
 import {getProviderTitle} from './providerTitle'
 import {
   type AccessRequest,
-  type AccessRequestStatus,
+  type AccessRequestEligibilityState,
   type AccessResourceType,
   type AccessUser,
   type SubmitAccessRequestResult,
@@ -124,7 +124,7 @@ type ViewState =
  * request history, which resolves the states this endpoint does not.
  */
 function deriveServerViewState(
-  status: AccessRequestStatus,
+  status: AccessRequestEligibilityState,
   labels: RequestAccessLabels,
 ): ViewState | null {
   switch (status.state) {
@@ -146,7 +146,7 @@ function deriveServerViewState(
 
 function deriveViewState(options: {
   fetchedRequests: AccessRequest[] | null
-  status: AccessRequestStatus
+  status: AccessRequestEligibilityState
   resourceId: string
   submitResult: SubmitAccessRequestResult | null
   labels: RequestAccessLabels
@@ -200,7 +200,7 @@ function deriveViewState(options: {
 function RequestAccessFormContent(
   props: RequestAccessFormProps & {
     requestsPromise: Promise<AccessRequest[] | null>
-    statusPromise: Promise<AccessRequestStatus>
+    statusPromise: Promise<AccessRequestEligibilityState>
   },
 ) {
   const {

--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -120,15 +120,8 @@ type ViewState =
   | {view: 'sso-enforced'; redirectUrl?: string}
 
 /**
- * The server's verdict, for the states it already resolves. `null` hands the
- * decision back to the caller's own request history.
- *
- * The API declares more states than it returns, so the unreturned ones are
- * mapped here rather than ignored: when the server starts producing them the
- * card already renders something honest. `requests-disabled` and
- * `email-domain-blocked` reuse the submit-time copy for the same conditions,
- * and `pending` and `recently-declined` land on the views the request history
- * derives today.
+ * The server's verdict. `null` hands the decision back to the caller's own
+ * request history, which resolves the states this endpoint does not.
  */
 function deriveServerViewState(
   status: AccessRequestStatus,
@@ -137,12 +130,6 @@ function deriveServerViewState(
   switch (status.state) {
     case 'saml-required':
       return {view: 'sso-enforced', redirectUrl: status.redirectUrl}
-    case 'pending':
-      return {view: 'pending'}
-    case 'recently-declined':
-      return {view: 'blocked', title: labels.deniedTitle, message: labels.deniedMessage({})}
-    case 'requests-disabled':
-    case 'email-domain-blocked':
     case 'resource-not-available':
       return {view: 'blocked', title: labels.errorTitle, message: labels.submitFailedMessage}
     case 'eligible':

--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -173,7 +173,7 @@ function deriveViewState(options: {
   accessRequestsHistory: AccessRequest[] | null
   accessRequestEligibilityState: AccessRequestEligibilityState
   resourceId: string
-  submitResult: SubmitAccessRequestResult | null
+  submitAccessRequestResult: SubmitAccessRequestResult | null
   currentUser?: AccessUser | null
   providerTitle?: string
   labels: RequestAccessLabels
@@ -182,7 +182,7 @@ function deriveViewState(options: {
     accessRequestsHistory,
     accessRequestEligibilityState,
     resourceId,
-    submitResult,
+    submitAccessRequestResult,
     currentUser,
     providerTitle,
     labels,
@@ -194,19 +194,23 @@ function deriveViewState(options: {
     message,
   })
 
-  if (submitResult) {
-    switch (submitResult.type) {
+  if (submitAccessRequestResult) {
+    switch (submitAccessRequestResult.type) {
       case 'submitted':
         return {view: 'sent', title: labels.sentTitle, description: labels.sentDescription}
       case 'sso-enforced':
-        return ssoEnforcedState({labels, providerTitle, redirectUrl: submitResult.redirectUrl})
+        return ssoEnforcedState({
+          labels,
+          providerTitle,
+          redirectUrl: submitAccessRequestResult.redirectUrl,
+        })
       case 'denied':
-        return submitFailure(labels.deniedMessage({message: submitResult.message}))
+        return submitFailure(labels.deniedMessage({message: submitAccessRequestResult.message}))
       case 'over-limit':
-        return submitFailure(labels.overLimitMessage({message: submitResult.message}))
+        return submitFailure(labels.overLimitMessage({message: submitAccessRequestResult.message}))
       case 'email-domain-blocked':
       case 'requests-disabled':
-        return submitFailure(submitResult.message)
+        return submitFailure(submitAccessRequestResult.message)
       case 'error':
         // Fall through to the fetched state; the form stays up with an inline error.
         break
@@ -220,6 +224,7 @@ function deriveViewState(options: {
   const serverState = deriveServerViewState(accessRequestEligibilityState, labels, providerTitle)
   if (serverState) return serverState
 
+  // TODO: `pending` and `denied` will be replaced by future content in `accessRequestEligibilityState`
   const state = deriveAccessRequestState(accessRequestsHistory, resourceId)
   if (state === 'pending') {
     return {view: 'pending', title: labels.sentTitle, description: labels.pendingMessage}
@@ -267,7 +272,8 @@ function RequestAccessFormContent(
   const titleId = useId()
 
   const [note, setNote] = useState('')
-  const [submitResult, setSubmitResult] = useState<SubmitAccessRequestResult | null>(null)
+  const [submitAccessRequestResult, setSubmitAccessRequestResult] =
+    useState<SubmitAccessRequestResult | null>(null)
   const [isSubmitting, startSubmit] = useTransition()
 
   const providerTitle = getProviderTitle(currentUser?.provider)
@@ -275,13 +281,13 @@ function RequestAccessFormContent(
     accessRequestsHistory,
     accessRequestEligibilityState,
     resourceId,
-    submitResult,
+    submitAccessRequestResult,
     currentUser,
     providerTitle,
     labels,
   })
 
-  const submitFailed = submitResult?.type === 'error'
+  const submitFailed = submitAccessRequestResult?.type === 'error'
 
   const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -295,7 +301,7 @@ function RequestAccessFormContent(
         note: trimmedNote,
         requestUrl: getRequestUrl(),
       })
-      setSubmitResult(result)
+      setSubmitAccessRequestResult(result)
       if (result.type === 'submitted') onRequestSubmitted?.({note: trimmedNote})
     })
   }

--- a/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
+++ b/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
@@ -108,38 +108,36 @@ describe('RequestAccessForm', () => {
     )
   })
 
-  const ssoEnforced = (redirectUrl?: string) => ({
-    eligibility: () =>
-      Promise.resolve({
-        eligible: false,
-        reason: 'saml-enforced',
-        ...(redirectUrl && {redirectUrl}),
-      }),
+  const SSO_LOGIN_URL = 'https://www.sanity.io/login/sso/acme?origin=https%3A%2F%2Fexample.test%2F'
+
+  const samlRequired = (redirectUrl?: string) => ({
+    status: () => Promise.resolve({state: 'saml-required', ...(redirectUrl && {redirectUrl})}),
   })
 
-  it('offers no form at all when the preflight says the org enforces SSO', async () => {
-    const client = createClientStub(ssoEnforced('https://idp.example.com/login'))
+  it('offers no form at all when the server says the org enforces SSO', async () => {
+    const client = createClientStub(samlRequired(SSO_LOGIN_URL))
     await renderForm({client})
 
     expect(await screen.findByRole('alert')).toHaveTextContent(/requires signing in with SSO/)
+    // The org's own SSO login page, which auto-submits, so this is the only click.
     expect(screen.getByRole('link', {name: 'Sign in with SSO'})).toHaveAttribute(
       'href',
-      'https://idp.example.com/login',
+      SSO_LOGIN_URL,
     )
-    // The whole point of the preflight: no note field, no futile submit.
+    // The whole point of asking first: no note field, no futile submit.
     expect(screen.queryByRole('form')).not.toBeInTheDocument()
     expect(screen.queryByRole('textbox', {name: 'Message'})).not.toBeInTheDocument()
   })
 
   it('names the provider the user is actually signed in with', async () => {
-    const client = createClientStub(ssoEnforced())
+    const client = createClientStub(samlRequired())
     await renderForm({client})
 
     expect(await screen.findByRole('alert')).toHaveTextContent(/signed in with Google/)
   })
 
   it('omits the CTA when the API resolves no login URL', async () => {
-    const client = createClientStub(ssoEnforced())
+    const client = createClientStub(samlRequired())
     await renderForm({client})
 
     expect(await screen.findByRole('alert')).toBeInTheDocument()
@@ -148,7 +146,7 @@ describe('RequestAccessForm', () => {
 
   it('shows SSO over a pending request, which an enforced org can never approve', async () => {
     const client = createClientStub({
-      ...ssoEnforced(),
+      ...samlRequired(),
       list: () => Promise.resolve([createAccessRequest()]),
     })
     await renderForm({client})
@@ -157,15 +155,39 @@ describe('RequestAccessForm', () => {
     expect(screen.queryByText(/pending approval/)).not.toBeInTheDocument()
   })
 
-  it('keeps the form when the preflight says eligible', async () => {
-    const client = createClientStub({eligibility: () => Promise.resolve({eligible: true})})
+  it('blocks rather than offering a form for an unavailable resource', async () => {
+    const client = createClientStub({
+      status: () => Promise.resolve({state: 'resource-not-available'}),
+    })
+    await renderForm({client})
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(screen.queryByRole('form')).not.toBeInTheDocument()
+  })
+
+  // Declared by the API but not returned yet. Mapped so the card stays honest
+  // the day the server starts producing them.
+  it.each([
+    {state: 'pending', expect: /pending approval/},
+    {state: 'requests-disabled', expect: /problem submitting/},
+    {state: 'email-domain-blocked', expect: /problem submitting/},
+  ])('renders a non-form view for the declared-only $state', async ({state, expect: pattern}) => {
+    const client = createClientStub({status: () => Promise.resolve({state})})
+    await renderForm({client})
+
+    expect(await screen.findByText(pattern)).toBeInTheDocument()
+    expect(screen.queryByRole('form')).not.toBeInTheDocument()
+  })
+
+  it('keeps the form when the server says eligible', async () => {
+    const client = createClientStub({status: () => Promise.resolve({state: 'eligible'})})
     await renderForm({client})
 
     expect(await screen.findByRole('form', {name: 'Request access'})).toBeInTheDocument()
   })
 
-  it('keeps the form when the preflight fails, leaving the submit gate as the backstop', async () => {
-    const client = createClientStub({eligibility: () => Promise.reject(new Error('offline'))})
+  it('keeps the form when the state fetch fails, leaving the submit gate as the backstop', async () => {
+    const client = createClientStub({status: () => Promise.reject(new Error('offline'))})
     await renderForm({client})
 
     expect(await screen.findByRole('form', {name: 'Request access'})).toBeInTheDocument()

--- a/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
+++ b/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
@@ -161,7 +161,10 @@ describe('RequestAccessForm', () => {
     })
     await renderForm({client})
 
-    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    // Not the submit-failure copy: nothing was submitted.
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The resource currently being requested is no longer available.',
+    )
     expect(screen.queryByRole('form')).not.toBeInTheDocument()
   })
 

--- a/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
+++ b/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
@@ -165,20 +165,6 @@ describe('RequestAccessForm', () => {
     expect(screen.queryByRole('form')).not.toBeInTheDocument()
   })
 
-  // Declared by the API but not returned yet. Mapped so the card stays honest
-  // the day the server starts producing them.
-  it.each([
-    {state: 'pending', expect: /pending approval/},
-    {state: 'requests-disabled', expect: /problem submitting/},
-    {state: 'email-domain-blocked', expect: /problem submitting/},
-  ])('renders a non-form view for the declared-only $state', async ({state, expect: pattern}) => {
-    const client = createClientStub({status: () => Promise.resolve({state})})
-    await renderForm({client})
-
-    expect(await screen.findByText(pattern)).toBeInTheDocument()
-    expect(screen.queryByRole('form')).not.toBeInTheDocument()
-  })
-
   it('keeps the form when the server says eligible', async () => {
     const client = createClientStub({status: () => Promise.resolve({state: 'eligible'})})
     await renderForm({client})

--- a/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
+++ b/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
@@ -106,6 +106,8 @@ describe('RequestAccessForm', () => {
       'href',
       'https://idp.example.com/login',
     )
+    // A send did fail here, but the wall is the point, not the failure.
+    expect(screen.getByRole('heading', {name: 'Sign in with SSO required'})).toBeInTheDocument()
   })
 
   const SSO_LOGIN_URL = 'https://www.sanity.io/login/sso/acme?origin=https%3A%2F%2Fexample.test%2F'
@@ -127,6 +129,16 @@ describe('RequestAccessForm', () => {
     // The whole point of asking first: no note field, no futile submit.
     expect(screen.queryByRole('form')).not.toBeInTheDocument()
     expect(screen.queryByRole('textbox', {name: 'Message'})).not.toBeInTheDocument()
+  })
+
+  it('does not claim a send failed when SSO blocks the form on mount', async () => {
+    const client = createClientStub(samlRequired(SSO_LOGIN_URL))
+    await renderForm({client})
+
+    expect(
+      await screen.findByRole('heading', {name: 'Sign in with SSO required'}),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Access request couldn’t be sent')).not.toBeInTheDocument()
   })
 
   it('names the provider the user is actually signed in with', async () => {

--- a/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
+++ b/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
@@ -108,6 +108,69 @@ describe('RequestAccessForm', () => {
     )
   })
 
+  const ssoEnforced = (redirectUrl?: string) => ({
+    eligibility: () =>
+      Promise.resolve({
+        eligible: false,
+        reason: 'saml-enforced',
+        ...(redirectUrl && {redirectUrl}),
+      }),
+  })
+
+  it('offers no form at all when the preflight says the org enforces SSO', async () => {
+    const client = createClientStub(ssoEnforced('https://idp.example.com/login'))
+    await renderForm({client})
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/requires signing in with SSO/)
+    expect(screen.getByRole('link', {name: 'Sign in with SSO'})).toHaveAttribute(
+      'href',
+      'https://idp.example.com/login',
+    )
+    // The whole point of the preflight: no note field, no futile submit.
+    expect(screen.queryByRole('form')).not.toBeInTheDocument()
+    expect(screen.queryByRole('textbox', {name: 'Message'})).not.toBeInTheDocument()
+  })
+
+  it('names the provider the user is actually signed in with', async () => {
+    const client = createClientStub(ssoEnforced())
+    await renderForm({client})
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/signed in with Google/)
+  })
+
+  it('omits the CTA when the API resolves no login URL', async () => {
+    const client = createClientStub(ssoEnforced())
+    await renderForm({client})
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'Sign in with SSO'})).not.toBeInTheDocument()
+  })
+
+  it('shows SSO over a pending request, which an enforced org can never approve', async () => {
+    const client = createClientStub({
+      ...ssoEnforced(),
+      list: () => Promise.resolve([createAccessRequest()]),
+    })
+    await renderForm({client})
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/requires signing in with SSO/)
+    expect(screen.queryByText(/pending approval/)).not.toBeInTheDocument()
+  })
+
+  it('keeps the form when the preflight says eligible', async () => {
+    const client = createClientStub({eligibility: () => Promise.resolve({eligible: true})})
+    await renderForm({client})
+
+    expect(await screen.findByRole('form', {name: 'Request access'})).toBeInTheDocument()
+  })
+
+  it('keeps the form when the preflight fails, leaving the submit gate as the backstop', async () => {
+    const client = createClientStub({eligibility: () => Promise.reject(new Error('offline'))})
+    await renderForm({client})
+
+    expect(await screen.findByRole('form', {name: 'Request access'})).toBeInTheDocument()
+  })
+
   it('renders the sent state and reports the submission after a successful submit', async () => {
     const onRequestSubmitted = vi.fn()
     const client = createClientStub({

--- a/packages/@sanity/access-ui/src/__tests__/accessRequests.test.ts
+++ b/packages/@sanity/access-ui/src/__tests__/accessRequests.test.ts
@@ -138,13 +138,15 @@ describe('fetchAccessRequestStatus', () => {
     await expect(fetchStatus(client)).resolves.toEqual(verdict)
   })
 
-  it('packs the origin as an opaque q param so the user returns after SSO', async () => {
+  it('packs the origin into returnQuery so the user returns after SSO', async () => {
     const client = createClientStub()
 
     await fetchStatus(client, 'https://example.test/resource')
 
     expect(client.request).toHaveBeenCalledWith(
-      expect.objectContaining({query: {q: 'origin=https%3A%2F%2Fexample.test%2Fresource'}}),
+      expect.objectContaining({
+        query: {returnQuery: 'origin=https%3A%2F%2Fexample.test%2Fresource'},
+      }),
     )
   })
 

--- a/packages/@sanity/access-ui/src/__tests__/accessRequests.test.ts
+++ b/packages/@sanity/access-ui/src/__tests__/accessRequests.test.ts
@@ -1,6 +1,10 @@
 import {describe, expect, it} from 'vitest'
 
-import {listMyAccessRequests, submitAccessRequest} from '../accessRequests'
+import {
+  checkAccessRequestEligibility,
+  listMyAccessRequests,
+  submitAccessRequest,
+} from '../accessRequests'
 import {type SubmitAccessRequestResult} from '../types'
 import {createApiError, createClientStub} from './testUtils'
 
@@ -103,5 +107,68 @@ describe('submitAccessRequest', () => {
   ])('passes $given through as error', async ({error}) => {
     const client = createClientStub({submit: () => Promise.reject(error)})
     await expect(submit(client)).resolves.toEqual({type: 'error', error})
+  })
+})
+
+const check = (client: ReturnType<typeof createClientStub>, origin?: string) =>
+  checkAccessRequestEligibility({
+    client,
+    resourceType: 'project',
+    resourceId: 'project-a',
+    origin,
+  })
+
+describe('checkAccessRequestEligibility', () => {
+  it('gets the eligibility endpoint for the resource', async () => {
+    const client = createClientStub()
+
+    await expect(check(client)).resolves.toEqual({eligible: true})
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({url: '/access/project/project-a/requests/eligibility'}),
+    )
+  })
+
+  it('returns the ineligible verdict with its redirect URL', async () => {
+    const verdict = {
+      eligible: false,
+      reason: 'saml-enforced',
+      redirectUrl: 'https://www.sanity.io/login/error/saml-required?orgName=acme',
+    }
+    const client = createClientStub({eligibility: () => Promise.resolve(verdict)})
+
+    await expect(check(client)).resolves.toEqual(verdict)
+  })
+
+  it('packs the origin as an opaque q param so the user returns after SSO', async () => {
+    const client = createClientStub()
+
+    await check(client, 'https://example.test/resource')
+
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({query: {q: 'origin=https%3A%2F%2Fexample.test%2Fresource'}}),
+    )
+  })
+
+  it('sends no query when there is no origin', async () => {
+    const client = createClientStub()
+
+    await check(client)
+
+    expect(client.request).toHaveBeenCalledWith(expect.objectContaining({query: undefined}))
+  })
+
+  it.each([
+    {given: 'the endpoint is missing', error: createApiError(404, {})},
+    {given: 'the request fails', error: new Error('network down')},
+  ])('fails open when $given, leaving the submit-time gate as the backstop', async ({error}) => {
+    const client = createClientStub({eligibility: () => Promise.reject(error)})
+
+    await expect(check(client)).resolves.toEqual({eligible: true})
+  })
+
+  it('treats a null body as eligible', async () => {
+    const client = createClientStub({eligibility: () => Promise.resolve(null)})
+
+    await expect(check(client)).resolves.toEqual({eligible: true})
   })
 })

--- a/packages/@sanity/access-ui/src/__tests__/accessRequests.test.ts
+++ b/packages/@sanity/access-ui/src/__tests__/accessRequests.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 
 import {
-  checkAccessRequestEligibility,
+  fetchAccessRequestStatus,
   listMyAccessRequests,
   submitAccessRequest,
 } from '../accessRequests'
@@ -110,39 +110,38 @@ describe('submitAccessRequest', () => {
   })
 })
 
-const check = (client: ReturnType<typeof createClientStub>, origin?: string) =>
-  checkAccessRequestEligibility({
+const fetchStatus = (client: ReturnType<typeof createClientStub>, origin?: string) =>
+  fetchAccessRequestStatus({
     client,
     resourceType: 'project',
     resourceId: 'project-a',
     origin,
   })
 
-describe('checkAccessRequestEligibility', () => {
-  it('gets the eligibility endpoint for the resource', async () => {
+describe('fetchAccessRequestStatus', () => {
+  it('gets the request-state endpoint for the resource', async () => {
     const client = createClientStub()
 
-    await expect(check(client)).resolves.toEqual({eligible: true})
+    await expect(fetchStatus(client)).resolves.toEqual({state: 'eligible'})
     expect(client.request).toHaveBeenCalledWith(
-      expect.objectContaining({url: '/access/project/project-a/requests/eligibility'}),
+      expect.objectContaining({url: '/access/project/project-a/requests/state'}),
     )
   })
 
-  it('returns the ineligible verdict with its redirect URL', async () => {
+  it('returns the saml-required verdict with its SSO login URL', async () => {
     const verdict = {
-      eligible: false,
-      reason: 'saml-enforced',
-      redirectUrl: 'https://www.sanity.io/login/error/saml-required?orgName=acme',
+      state: 'saml-required',
+      redirectUrl: 'https://www.sanity.io/login/sso/acme?origin=https%3A%2F%2Fexample.test%2F',
     }
-    const client = createClientStub({eligibility: () => Promise.resolve(verdict)})
+    const client = createClientStub({status: () => Promise.resolve(verdict)})
 
-    await expect(check(client)).resolves.toEqual(verdict)
+    await expect(fetchStatus(client)).resolves.toEqual(verdict)
   })
 
   it('packs the origin as an opaque q param so the user returns after SSO', async () => {
     const client = createClientStub()
 
-    await check(client, 'https://example.test/resource')
+    await fetchStatus(client, 'https://example.test/resource')
 
     expect(client.request).toHaveBeenCalledWith(
       expect.objectContaining({query: {q: 'origin=https%3A%2F%2Fexample.test%2Fresource'}}),
@@ -152,7 +151,7 @@ describe('checkAccessRequestEligibility', () => {
   it('sends no query when there is no origin', async () => {
     const client = createClientStub()
 
-    await check(client)
+    await fetchStatus(client)
 
     expect(client.request).toHaveBeenCalledWith(expect.objectContaining({query: undefined}))
   })
@@ -161,14 +160,14 @@ describe('checkAccessRequestEligibility', () => {
     {given: 'the endpoint is missing', error: createApiError(404, {})},
     {given: 'the request fails', error: new Error('network down')},
   ])('fails open when $given, leaving the submit-time gate as the backstop', async ({error}) => {
-    const client = createClientStub({eligibility: () => Promise.reject(error)})
+    const client = createClientStub({status: () => Promise.reject(error)})
 
-    await expect(check(client)).resolves.toEqual({eligible: true})
+    await expect(fetchStatus(client)).resolves.toEqual({state: 'eligible'})
   })
 
   it('treats a null body as eligible', async () => {
-    const client = createClientStub({eligibility: () => Promise.resolve(null)})
+    const client = createClientStub({status: () => Promise.resolve(null)})
 
-    await expect(check(client)).resolves.toEqual({eligible: true})
+    await expect(fetchStatus(client)).resolves.toEqual({state: 'eligible'})
   })
 })

--- a/packages/@sanity/access-ui/src/__tests__/testUtils.ts
+++ b/packages/@sanity/access-ui/src/__tests__/testUtils.ts
@@ -4,15 +4,15 @@ import {vi} from 'vitest'
 import {type AccessRequest} from '../types'
 
 /**
- * Client stub routing by URL: `/access/requests/me` hits `list`, an
- * `/eligibility` path hits `eligibility`, everything else hits `submit`.
+ * Client stub routing by URL: `/access/requests/me` hits `list`, a
+ * `/requests/state` path hits `status`, everything else hits `submit`.
  * `withConfig` returns itself so the Access API version pinning is transparent.
  */
 export function createClientStub(
   handlers: {
     list?: () => Promise<AccessRequest[] | null>
     submit?: () => Promise<unknown>
-    eligibility?: () => Promise<unknown>
+    status?: () => Promise<unknown>
   } = {},
 ): SanityClient {
   const client = {
@@ -20,8 +20,8 @@ export function createClientStub(
       if (options.url === '/access/requests/me') {
         return (handlers.list ?? (() => Promise.resolve([])))()
       }
-      if (options.url.endsWith('/eligibility')) {
-        return (handlers.eligibility ?? (() => Promise.resolve({eligible: true})))()
+      if (options.url.endsWith('/requests/state')) {
+        return (handlers.status ?? (() => Promise.resolve({state: 'eligible'})))()
       }
       return (handlers.submit ?? (() => Promise.resolve(null)))()
     }),

--- a/packages/@sanity/access-ui/src/__tests__/testUtils.ts
+++ b/packages/@sanity/access-ui/src/__tests__/testUtils.ts
@@ -4,22 +4,27 @@ import {vi} from 'vitest'
 import {type AccessRequest} from '../types'
 
 /**
- * Client stub routing by URL: `/access/requests/me` hits `list`, everything
- * else hits `submit`. `withConfig` returns itself so the Access API version
- * pinning is transparent.
+ * Client stub routing by URL: `/access/requests/me` hits `list`, an
+ * `/eligibility` path hits `eligibility`, everything else hits `submit`.
+ * `withConfig` returns itself so the Access API version pinning is transparent.
  */
 export function createClientStub(
   handlers: {
     list?: () => Promise<AccessRequest[] | null>
     submit?: () => Promise<unknown>
+    eligibility?: () => Promise<unknown>
   } = {},
 ): SanityClient {
   const client = {
-    request: vi.fn((options: {url: string}) =>
-      options.url === '/access/requests/me'
-        ? (handlers.list ?? (() => Promise.resolve([])))()
-        : (handlers.submit ?? (() => Promise.resolve(null)))(),
-    ),
+    request: vi.fn((options: {url: string}) => {
+      if (options.url === '/access/requests/me') {
+        return (handlers.list ?? (() => Promise.resolve([])))()
+      }
+      if (options.url.endsWith('/eligibility')) {
+        return (handlers.eligibility ?? (() => Promise.resolve({eligible: true})))()
+      }
+      return (handlers.submit ?? (() => Promise.resolve(null)))()
+    }),
     withConfig: vi.fn((): unknown => client),
   }
   // oxlint-disable-next-line no-unsafe-type-assertion -- test double; the rule is off for *.test.* files and this helper only feeds them

--- a/packages/@sanity/access-ui/src/accessRequests.ts
+++ b/packages/@sanity/access-ui/src/accessRequests.ts
@@ -1,6 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 
-import {type AccessRequest, type AccessResourceType, type SubmitAccessRequestResult} from './types'
+import {
+  type AccessRequest,
+  type AccessRequestEligibility,
+  type AccessResourceType,
+  type SubmitAccessRequestResult,
+} from './types'
 
 /**
  * The Access API only accepts notes up to this length.
@@ -33,6 +38,40 @@ export async function listMyAccessRequests(client: SanityClient): Promise<Access
     tag: 'access-ui.list-requests',
   })
   return requests ?? []
+}
+
+/**
+ * Asks whether requesting access could ever succeed
+ * (`GET /access/{resourceType}/{resourceId}/requests/eligibility`).
+ *
+ * Runs before the form is offered, so a user in a SAML-enforced organization is
+ * pointed at SSO instead of writing a note no admin can action.
+ *
+ * `origin` is carried opaquely to the SSO login page so the user returns where
+ * they started. Never throws: an unreachable or older API answers `eligible`,
+ * leaving the form in place and the submit-time 403 as the backstop.
+ *
+ * @public
+ */
+export async function checkAccessRequestEligibility(options: {
+  client: SanityClient
+  resourceType: AccessResourceType
+  resourceId: string
+  origin?: string
+}): Promise<AccessRequestEligibility> {
+  const {client, resourceType, resourceId, origin} = options
+  try {
+    const eligibility = await withAccessApiVersion(client).request<AccessRequestEligibility | null>(
+      {
+        url: `/access/${resourceType}/${resourceId}/requests/eligibility`,
+        tag: 'access-ui.check-eligibility',
+        query: origin ? {q: new URLSearchParams({origin}).toString()} : undefined,
+      },
+    )
+    return eligibility ?? {eligible: true}
+  } catch {
+    return {eligible: true}
+  }
 }
 
 interface ErrorResponseDetails {

--- a/packages/@sanity/access-ui/src/accessRequests.ts
+++ b/packages/@sanity/access-ui/src/accessRequests.ts
@@ -64,7 +64,7 @@ export async function fetchAccessRequestStatus(options: {
     const status = await withAccessApiVersion(client).request<AccessRequestStatus | null>({
       url: `/access/${resourceType}/${resourceId}/requests/state`,
       tag: 'access-ui.request-state',
-      query: origin ? {q: new URLSearchParams({origin}).toString()} : undefined,
+      query: origin ? {returnQuery: new URLSearchParams({origin}).toString()} : undefined,
     })
     return status ?? {state: 'eligible'}
   } catch {

--- a/packages/@sanity/access-ui/src/accessRequests.ts
+++ b/packages/@sanity/access-ui/src/accessRequests.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 
 import {
   type AccessRequest,
-  type AccessRequestStatus,
+  type AccessRequestEligibilityState,
   type AccessResourceType,
   type SubmitAccessRequestResult,
 } from './types'
@@ -58,14 +58,16 @@ export async function fetchAccessRequestStatus(options: {
   resourceType: AccessResourceType
   resourceId: string
   origin?: string
-}): Promise<AccessRequestStatus> {
+}): Promise<AccessRequestEligibilityState> {
   const {client, resourceType, resourceId, origin} = options
   try {
-    const status = await withAccessApiVersion(client).request<AccessRequestStatus | null>({
-      url: `/access/${resourceType}/${resourceId}/requests/state`,
-      tag: 'access-ui.request-state',
-      query: origin ? {returnQuery: new URLSearchParams({origin}).toString()} : undefined,
-    })
+    const status = await withAccessApiVersion(client).request<AccessRequestEligibilityState | null>(
+      {
+        url: `/access/${resourceType}/${resourceId}/requests/state`,
+        tag: 'access-ui.request-state',
+        query: origin ? {returnQuery: new URLSearchParams({origin}).toString()} : undefined,
+      },
+    )
     return status ?? {state: 'eligible'}
   } catch {
     return {state: 'eligible'}

--- a/packages/@sanity/access-ui/src/accessRequests.ts
+++ b/packages/@sanity/access-ui/src/accessRequests.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 
 import {
   type AccessRequest,
-  type AccessRequestEligibility,
+  type AccessRequestStatus,
   type AccessResourceType,
   type SubmitAccessRequestResult,
 } from './types'
@@ -41,36 +41,34 @@ export async function listMyAccessRequests(client: SanityClient): Promise<Access
 }
 
 /**
- * Asks whether requesting access could ever succeed
- * (`GET /access/{resourceType}/{resourceId}/requests/eligibility`).
+ * Asks what the request-access screen should show
+ * (`GET /access/{resourceType}/{resourceId}/requests/state`).
  *
  * Runs before the form is offered, so a user in a SAML-enforced organization is
- * pointed at SSO instead of writing a note no admin can action.
+ * pointed at SSO instead of writing a note no administrator can action.
  *
- * `origin` is carried opaquely to the SSO login page so the user returns where
- * they started. Never throws: an unreachable or older API answers `eligible`,
+ * `origin` is carried opaquely to the login page so the user returns where they
+ * started. Never throws: an unreachable or older API answers `eligible`,
  * leaving the form in place and the submit-time 403 as the backstop.
  *
  * @public
  */
-export async function checkAccessRequestEligibility(options: {
+export async function fetchAccessRequestStatus(options: {
   client: SanityClient
   resourceType: AccessResourceType
   resourceId: string
   origin?: string
-}): Promise<AccessRequestEligibility> {
+}): Promise<AccessRequestStatus> {
   const {client, resourceType, resourceId, origin} = options
   try {
-    const eligibility = await withAccessApiVersion(client).request<AccessRequestEligibility | null>(
-      {
-        url: `/access/${resourceType}/${resourceId}/requests/eligibility`,
-        tag: 'access-ui.check-eligibility',
-        query: origin ? {q: new URLSearchParams({origin}).toString()} : undefined,
-      },
-    )
-    return eligibility ?? {eligible: true}
+    const status = await withAccessApiVersion(client).request<AccessRequestStatus | null>({
+      url: `/access/${resourceType}/${resourceId}/requests/state`,
+      tag: 'access-ui.request-state',
+      query: origin ? {q: new URLSearchParams({origin}).toString()} : undefined,
+    })
+    return status ?? {state: 'eligible'}
   } catch {
-    return {eligible: true}
+    return {state: 'eligible'}
   }
 }
 

--- a/packages/@sanity/access-ui/src/index.ts
+++ b/packages/@sanity/access-ui/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  checkAccessRequestEligibility,
+  fetchAccessRequestStatus,
   listMyAccessRequests,
   MAX_ACCESS_REQUEST_NOTE_LENGTH,
   submitAccessRequest,
@@ -14,9 +14,8 @@ export {
 } from './RequestAccessForm'
 export {
   type AccessRequest,
-  type AccessRequestEligibility,
-  type AccessRequestIneligibleReason,
   type AccessRequestState,
+  type AccessRequestStatus,
   type AccessResourceType,
   type AccessUser,
   type SubmitAccessRequestResult,

--- a/packages/@sanity/access-ui/src/index.ts
+++ b/packages/@sanity/access-ui/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  checkAccessRequestEligibility,
   listMyAccessRequests,
   MAX_ACCESS_REQUEST_NOTE_LENGTH,
   submitAccessRequest,
@@ -13,6 +14,8 @@ export {
 } from './RequestAccessForm'
 export {
   type AccessRequest,
+  type AccessRequestEligibility,
+  type AccessRequestIneligibleReason,
   type AccessRequestState,
   type AccessResourceType,
   type AccessUser,

--- a/packages/@sanity/access-ui/src/index.ts
+++ b/packages/@sanity/access-ui/src/index.ts
@@ -15,7 +15,7 @@ export {
 export {
   type AccessRequest,
   type AccessRequestState,
-  type AccessRequestStatus,
+  type AccessRequestEligibilityState,
   type AccessResourceType,
   type AccessUser,
   type SubmitAccessRequestResult,

--- a/packages/@sanity/access-ui/src/labels.tsx
+++ b/packages/@sanity/access-ui/src/labels.tsx
@@ -23,6 +23,7 @@ export interface RequestAccessLabels {
   deniedMessage: (context: {message?: string}) => ReactNode
   overLimitMessage: (context: {message?: string}) => ReactNode
   expiredMessage: ReactNode
+  ssoEnforcedTitle: ReactNode
   ssoEnforcedMessage: (context: {providerTitle?: string}) => ReactNode
   ssoSignInCta: ReactNode
   resourceNotAvailableTitle: ReactNode
@@ -59,6 +60,8 @@ export const defaultLabels: RequestAccessLabels = {
     message ??
     'You’ve reached the limit for access requests across all projects. Please wait before submitting more requests, or contact an admin.',
   expiredMessage: 'Your previous request has expired. You may request access again below.',
+  // Reached both before and after a submit, so it must not claim a send failed.
+  ssoEnforcedTitle: 'Sign in with SSO required',
   ssoEnforcedMessage: ({providerTitle}) =>
     providerTitle ? (
       <>

--- a/packages/@sanity/access-ui/src/labels.tsx
+++ b/packages/@sanity/access-ui/src/labels.tsx
@@ -25,6 +25,8 @@ export interface RequestAccessLabels {
   expiredMessage: ReactNode
   ssoEnforcedMessage: (context: {providerTitle?: string}) => ReactNode
   ssoSignInCta: ReactNode
+  resourceNotAvailableTitle: ReactNode
+  resourceNotAvailableMessage: ReactNode
   submitFailedMessage: ReactNode
   wrongAccount: ReactNode
   signOut: ReactNode
@@ -69,6 +71,8 @@ export const defaultLabels: RequestAccessLabels = {
       </>
     ),
   ssoSignInCta: 'Sign in with SSO',
+  resourceNotAvailableTitle: 'Access can’t be requested',
+  resourceNotAvailableMessage: 'The resource currently being requested is no longer available.',
   submitFailedMessage: 'There was a problem submitting your request. Please try again.',
   wrongAccount: 'Wrong account?',
   signOut: 'Sign out',

--- a/packages/@sanity/access-ui/src/types.ts
+++ b/packages/@sanity/access-ui/src/types.ts
@@ -75,8 +75,10 @@ export type SubmitAccessRequestResult =
  *   its own gates, which this endpoint does not resolve.
  * - `saml-required` — the organization only admits members through its SSO
  *   login flow, so no administrator could ever approve a request. `redirectUrl`
- *   is the organization's SSO login page, which sends the user straight to
- *   their identity provider. It is absent when there is nowhere to send them.
+ *   is where to send them to log in: normally the organization's SSO form,
+ *   which submits itself, but a confirmation page for an organization with no
+ *   slug. Both end at the identity provider, so the card treats them alike. It
+ *   is absent only when neither resolves, leaving no way forward.
  * - `resource-not-available` — the target project or organization is gone.
  *
  * @public

--- a/packages/@sanity/access-ui/src/types.ts
+++ b/packages/@sanity/access-ui/src/types.ts
@@ -64,6 +64,29 @@ export type SubmitAccessRequestResult =
   | {type: 'error'; error: unknown}
 
 /**
+ * Why the Access API says the caller may not request access to a resource.
+ * - `saml-enforced` — the organization only admits members through its SSO
+ *   login flow, so no admin could ever approve a request.
+ * - `resource-not-available` — the target project or organization is gone.
+ *
+ * @public
+ */
+export type AccessRequestIneligibleReason = 'saml-enforced' | 'resource-not-available'
+
+/**
+ * Whether the caller may usefully request access
+ * (`GET /access/{resourceType}/{resourceId}/requests/eligibility`).
+ *
+ * Answered before the user writes anything, so a futile form is never offered.
+ * `redirectUrl` is the org's SSO login page when the API can resolve one.
+ *
+ * @public
+ */
+export type AccessRequestEligibility =
+  | {eligible: true}
+  | {eligible: false; reason: AccessRequestIneligibleReason; redirectUrl?: string}
+
+/**
  * The current user rendered in the request-access screen. A structural subset of
  * `CurrentUser` from `@sanity/types`, so both studio and app callers can pass
  * their own user object without an extra dependency.

--- a/packages/@sanity/access-ui/src/types.ts
+++ b/packages/@sanity/access-ui/src/types.ts
@@ -64,27 +64,36 @@ export type SubmitAccessRequestResult =
   | {type: 'error'; error: unknown}
 
 /**
- * Why the Access API says the caller may not request access to a resource.
- * - `saml-enforced` — the organization only admits members through its SSO
- *   login flow, so no admin could ever approve a request.
- * - `resource-not-available` — the target project or organization is gone.
- *
- * @public
- */
-export type AccessRequestIneligibleReason = 'saml-enforced' | 'resource-not-available'
-
-/**
- * Whether the caller may usefully request access
- * (`GET /access/{resourceType}/{resourceId}/requests/eligibility`).
+ * What the Access API says the request-access screen should show
+ * (`GET /access/{resourceType}/{resourceId}/requests/state`).
  *
  * Answered before the user writes anything, so a futile form is never offered.
- * `redirectUrl` is the org's SSO login page when the API can resolve one.
+ * Distinct from {@link AccessRequestState}, which this package derives from the
+ * caller's own request history: this one is the server's verdict.
+ *
+ * - `eligible` — offer the form. Creating can still fail for one of the reasons
+ *   below, because those gates run on the create path today.
+ * - `saml-required` — the organization only admits members through its SSO
+ *   login flow, so no administrator could ever approve a request. `redirectUrl`
+ *   is the organization's SSO login page, which sends the user straight to
+ *   their identity provider. It is absent when there is nowhere to send them.
+ * - `resource-not-available` — the target project or organization is gone.
+ *
+ * The remaining members are declared by the API but not yet returned. They name
+ * gates that still live on the create path alone, so their absence is not a
+ * negative answer. They are listed here so a `switch` stays exhaustive as the
+ * server starts producing them.
  *
  * @public
  */
-export type AccessRequestEligibility =
-  | {eligible: true}
-  | {eligible: false; reason: AccessRequestIneligibleReason; redirectUrl?: string}
+export type AccessRequestStatus =
+  | {state: 'eligible'}
+  | {state: 'saml-required'; redirectUrl?: string}
+  | {state: 'resource-not-available'}
+  | {state: 'pending'}
+  | {state: 'recently-declined'; retryAt: string}
+  | {state: 'requests-disabled'}
+  | {state: 'email-domain-blocked'}
 
 /**
  * The current user rendered in the request-access screen. A structural subset of

--- a/packages/@sanity/access-ui/src/types.ts
+++ b/packages/@sanity/access-ui/src/types.ts
@@ -71,18 +71,13 @@ export type SubmitAccessRequestResult =
  * Distinct from {@link AccessRequestState}, which this package derives from the
  * caller's own request history: this one is the server's verdict.
  *
- * - `eligible` — offer the form. Creating can still fail for one of the reasons
- *   below, because those gates run on the create path today.
+ * - `eligible` — offer the form. Creating can still fail: the create path has
+ *   its own gates, which this endpoint does not resolve.
  * - `saml-required` — the organization only admits members through its SSO
  *   login flow, so no administrator could ever approve a request. `redirectUrl`
  *   is the organization's SSO login page, which sends the user straight to
  *   their identity provider. It is absent when there is nowhere to send them.
  * - `resource-not-available` — the target project or organization is gone.
- *
- * The remaining members are declared by the API but not yet returned. They name
- * gates that still live on the create path alone, so their absence is not a
- * negative answer. They are listed here so a `switch` stays exhaustive as the
- * server starts producing them.
  *
  * @public
  */
@@ -90,10 +85,6 @@ export type AccessRequestStatus =
   | {state: 'eligible'}
   | {state: 'saml-required'; redirectUrl?: string}
   | {state: 'resource-not-available'}
-  | {state: 'pending'}
-  | {state: 'recently-declined'; retryAt: string}
-  | {state: 'requests-disabled'}
-  | {state: 'email-domain-blocked'}
 
 /**
  * The current user rendered in the request-access screen. A structural subset of

--- a/packages/@sanity/access-ui/src/types.ts
+++ b/packages/@sanity/access-ui/src/types.ts
@@ -83,7 +83,7 @@ export type SubmitAccessRequestResult =
  *
  * @public
  */
-export type AccessRequestStatus =
+export type AccessRequestEligibilityState =
   | {state: 'eligible'}
   | {state: 'saml-required'; redirectUrl?: string}
   | {state: 'resource-not-available'}


### PR DESCRIPTION
### Description

Closes [ID-906](https://linear.app/sanity/issue/ID-906/spec-how-to-improve-surface-information-for-access). Needs sanity-io/populus#2609.

A user in a SAML-enforced organization can fill in an access request that no administrator can ever approve, because the enforcement gate runs on approval, not on creation. The card's `sso-enforced` view already exists (#13977), but only a submit-time `403` could reach it, so the user found out after writing a note.

Ask the server first. `fetchAccessRequestStatus` calls `GET .../requests/state` on mount, and a `saml-required` answer renders the SSO view instead of the form.

`AccessRequestStatus` mirrors the API's three states: `eligible`, `saml-required` and `resource-not-available`. It resolves the availability and SAML gates only, so `eligible` is not a promise the request will be created: the create path keeps its own gates, and their 409s are already handled by `SubmitAccessRequestResult`.

`redirectUrl` points at `/login/sso/<slug>`, which auto-submits on the slug in its path. One click from the card to the identity provider.

### What to review

`src/RequestAccessForm.tsx`: a second lazy-init promise, and `deriveServerViewState`. The server's verdict outranks the request history on purpose, because a pending request in an enforced org is already dead.

`AccessRequestStatus` is deliberately not `AccessRequestState`: that name is already exported for the view derived from the caller's own request history.

### 🖼️ Reviewer note: the invite flow and this one now look different

**Screenshots to follow.**

Invites auto-redirect to `/login/error/saml-required`, a notice page with a Continue button. This card links to `/login/sso/<slug>`, which auto-submits.

The divergence is justified: an invitee is redirected without asking, so that page is their first notice and its button their first consent. Here the card has already explained the situation, so the notice page would be a second consent gate for a click that looked like it had failed.

But justified is not the same as consistent. Two entry points into the same SAML wall now have a different look. Worth a decision on whether the invite flow should follow, rather than leaving the split unexamined.

### On organizations without a slug

`organizations.slug` is nullable, so not every enforced organization has an SSO form to point at. The API falls back to the `/login/error/saml-required` confirmation page in that case, so `redirectUrl` may be either one. Both end at the identity provider, so this card treats them alike and needs no branch.

The button disappears only when neither resolves. Setting the slug is [step 5 of the documented SAML SSO setup](https://www.sanity.io/docs/developer-guides/sso-saml#k751cdd467838), and populus counts how often the fallback fires, so the gap is visible rather than assumed away.

### Testing

14 new tests: the fetch (URL, verdict, `q` packing, failing open on 404 and network error, null body) and the rendering (no form when blocked, the SSO URL on the CTA, the provider named, no CTA without a URL, SSO over a pending request, `resource-not-available`, form kept when eligible or when the fetch fails).

- `pnpm check:format` and `pnpm check:oxlint` (includes type checking) — clean.
- `pnpm vitest run --project=@sanity/access-ui` — 48 pass.
- `pnpm vitest run --project=sanity packages/sanity/src/core/studio` — 70 files, 721 pass.
- `pnpm --filter @sanity/access-ui build` — publint clean.

Not covered here: Manage runs its own card and does not consume this package, and Dashboard does not override the two SSO labels, so that copy stays English there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes access-request UX and eligibility gating for auth/SSO flows, but failures degrade to the previous submit-time behavior rather than blocking users.
> 
> **Overview**
> **Request access** now asks the Access API what to show **before** offering the note field, so users in SAML-enforced orgs are not led through a request that can never be approved.
> 
> On mount, `RequestAccessForm` suspends on a second fetch via new **`fetchAccessRequestStatus`** (`GET .../requests/state`), alongside the existing “my requests” list. **`AccessRequestEligibilityState`** models `eligible`, `saml-required` (optional SSO `redirectUrl` + `returnQuery` origin), and `resource-not-available`. Errors and missing endpoints **fail open** to `eligible`, with submit-time 403 still as a backstop.
> 
> View selection is refactored so **`deriveServerViewState`** outranks local request history (e.g. SSO blocks “pending approval”), and each **`ViewState`** carries its own title/description/message—including dedicated SSO and unavailable-resource copy instead of generic “couldn’t be sent” headings. **`fetchAccessRequestStatus`** and the type are exported; tests cover the client and UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab7833fe2fec7d72006b689c365d5299ab21c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

