### PR TITLE
fix(form): keep portable text fullscreen when resizing the browser

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.test.tsx
@@ -1,0 +1,51 @@
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {useState} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {FullscreenPTEProvider} from './FullscreenPTEProvider'
+import {useFullscreenPTE} from './useFullscreenPTE'
+
+vi.mock('@sanity/telemetry/react', () => ({
+  useTelemetry: () => ({log: vi.fn()}),
+}))
+
+function Reader() {
+  const {getFullscreenPath, setFullscreenPath} = useFullscreenPTE()
+
+  return (
+    <>
+      <button type="button" onClick={() => setFullscreenPath(['body'], true)}>
+        open
+      </button>
+      <div data-testid="fullscreen-path">{getFullscreenPath(['body']) ?? ''}</div>
+    </>
+  )
+}
+
+function Harness() {
+  const [childKey, setChildKey] = useState('a')
+
+  return (
+    <FullscreenPTEProvider>
+      <button type="button" onClick={() => setChildKey('b')}>
+        remount
+      </button>
+      <Reader key={childKey} />
+    </FullscreenPTEProvider>
+  )
+}
+
+describe('FullscreenPTEProvider', () => {
+  it('keeps fullscreen paths when a child remounts under a stable provider', async () => {
+    const wrapper = await createTestProvider()
+    render(<Harness />, {wrapper})
+
+    await userEvent.click(screen.getByRole('button', {name: 'open'}))
+    expect(screen.getByTestId('fullscreen-path')).toHaveTextContent('body')
+
+    await userEvent.click(screen.getByRole('button', {name: 'remount'}))
+    expect(screen.getByTestId('fullscreen-path')).toHaveTextContent('body')
+  })
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -410,11 +410,18 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     () => ({documentScrollElement: documentScrollElement}),
     [documentScrollElement],
   )
+  // Keep the form mounted when the inspector takes over a collapsed layout.
+  // Unmounting FormBuilder resets FullscreenPTEProvider, so a PTE that was in
+  // full-pane mode comes back inline after the window is widened again.
   const showFormView = features.resizablePanes || !showInspector
   return (
     <PaneContent>
       <Flex height="fill">
-        {showFormView && (
+        <div
+          data-testid="document-panel-form-view"
+          hidden={!showFormView}
+          style={{display: showFormView ? 'contents' : 'none'}}
+        >
           <Flex height="fill" direction="column" flex={2}>
             <LegacyLayerProvider zOffset="paneHeader">
               {banners}
@@ -450,7 +457,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
             {footer}
           </Flex>
-        )}
+        </div>
         {showInspector && (
           <BoundaryElementProvider element={rootElement}>
             <DocumentInspectorPanel

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -123,10 +123,18 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     [activeViewId, views],
   )
 
-  // Use a local portal container when split panes is supported
-  const portalElement: HTMLElement | null = features.splitPanes
-    ? _portalElement || parentPortal.element
-    : parentPortal.element
+  const showInspector = Boolean(!collapsed && inspector)
+  // Keep the form mounted when the inspector takes over a collapsed layout.
+  // Unmounting FormBuilder resets FullscreenPTEProvider, so a PTE that was in
+  // full-pane mode comes back inline after the window is widened again.
+  const showFormView = features.resizablePanes || !showInspector
+
+  // Fullscreen PTE portals to this element. When the form is hidden, keep that
+  // target inside the hidden subtree so the editor cannot cover the inspector.
+  const portalElement: HTMLElement | null =
+    features.splitPanes || !showFormView
+      ? _portalElement || parentPortal.element
+      : parentPortal.element
 
   // Calculate the height of the header
   const margins: [number, number, number, number] = useMemo(() => {
@@ -193,7 +201,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     ) : null
   }, [isInspectOpen, displayed, value])
 
-  const showInspector = Boolean(!collapsed && inspector)
   const {selectedReleaseId, selectedPerspectiveName, selectedPerspective} = usePerspective()
 
   const hasDocumentInRelease =
@@ -410,10 +417,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     () => ({documentScrollElement: documentScrollElement}),
     [documentScrollElement],
   )
-  // Keep the form mounted when the inspector takes over a collapsed layout.
-  // Unmounting FormBuilder resets FullscreenPTEProvider, so a PTE that was in
-  // full-pane mode comes back inline after the window is widened again.
-  const showFormView = features.resizablePanes || !showInspector
   return (
     <PaneContent>
       <Flex height="fill">

--- a/packages/sanity/src/structure/panes/document/documentPanel/__tests__/DocumentPanel.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/__tests__/DocumentPanel.test.tsx
@@ -1,0 +1,145 @@
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {useState} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../../i18n'
+import {useStructureTool} from '../../../../useStructureTool'
+import {useDocumentPane} from '../../useDocumentPane'
+import {DocumentPanel} from '../DocumentPanel'
+
+vi.mock('../../../../components/pane/usePane', () => ({
+  usePane: vi.fn(() => ({collapsed: false})),
+}))
+
+vi.mock('../../../../components/pane/usePaneLayout', () => ({
+  usePaneLayout: vi.fn(() => ({collapsed: false})),
+}))
+
+vi.mock('../../../../components/paneRouter/usePaneRouter', () => ({
+  usePaneRouter: vi.fn(() => ({params: {}})),
+}))
+
+vi.mock('../../../../useStructureTool', () => ({
+  useStructureTool: vi.fn(() => ({features: {resizablePanes: true}})),
+}))
+
+vi.mock('../../useDocumentPane', () => ({
+  useDocumentPane: vi.fn(),
+}))
+
+vi.mock('../../../../hasObsoleteDraft', () => ({
+  hasObsoleteDraft: vi.fn(() => ({result: false})),
+}))
+
+vi.mock('../../../../mustChooseNewDocumentDestination', () => ({
+  mustChooseNewDocumentDestination: vi.fn(() => false),
+}))
+
+vi.mock('../header/DocumentPanelSubHeader', () => ({
+  DocumentPanelSubHeader: () => null,
+}))
+
+vi.mock('../documentViews/FormView', () => ({
+  FormView: function MockFormView() {
+    const [count, setCount] = useState(0)
+    return (
+      <div data-testid="document-panel-scroller">
+        <button
+          type="button"
+          data-testid="form-state"
+          onClick={() => setCount((value) => value + 1)}
+        >
+          {count}
+        </button>
+      </div>
+    )
+  },
+}))
+
+vi.mock('../../documentInspector/DocumentInspectorPanel', () => ({
+  DocumentInspectorPanel: () => <aside data-ui="DocumentInspectorPanel">Inspector</aside>,
+}))
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useArchivedReleases: vi.fn(() => ({data: []})),
+  useFilteredReleases: vi.fn(() => ({currentReleases: [], notCurrentReleases: []})),
+  usePausedScheduledDraft: vi.fn(() => ({isPaused: false})),
+}))
+
+const mockUseDocumentPane = vi.mocked(useDocumentPane)
+const mockUseStructureTool = vi.mocked(useStructureTool)
+
+function documentPaneValue() {
+  return {
+    activeViewId: 'form',
+    displayed: {_id: 'doc-1', _type: 'simpleBlock'},
+    documentId: 'doc-1',
+    editState: {ready: true, draft: null, published: null, version: undefined},
+    inspector: {name: 'sanity/comments', component: () => null},
+    value: {_id: 'doc-1', _type: 'simpleBlock', _createdAt: '2020-01-01T00:00:00Z'},
+    views: [{id: 'form', type: 'form'}],
+    ready: true,
+    schemaType: {name: 'simpleBlock'},
+    permissions: {granted: true},
+    isPermissionsLoading: true,
+    targetDocumentState: {status: 'ready', targetDocument: {_id: 'doc-1'}},
+  } as unknown as ReturnType<typeof useDocumentPane>
+}
+
+function renderDocumentPanel() {
+  return (
+    <DocumentPanel
+      footerHeight={0}
+      headerHeight={0}
+      isInspectOpen={false}
+      rootElement={null}
+      setDocumentPanelPortalElement={vi.fn()}
+      footer={<div />}
+    />
+  )
+}
+
+async function renderPanel() {
+  mockUseDocumentPane.mockReturnValue(documentPaneValue())
+  const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+  return render(renderDocumentPanel(), {wrapper})
+}
+
+describe('DocumentPanel form persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseStructureTool.mockReturnValue({
+      features: {resizablePanes: true},
+    } as ReturnType<typeof useStructureTool>)
+  })
+
+  it('keeps the form mounted when an inspector takes over a collapsed layout', async () => {
+    const {rerender} = await renderPanel()
+
+    await userEvent.click(screen.getByTestId('form-state'))
+    expect(screen.getByTestId('form-state')).toHaveTextContent('1')
+    expect(screen.getByTestId('document-panel-form-view')).toBeVisible()
+
+    mockUseStructureTool.mockReturnValue({
+      features: {resizablePanes: false},
+    } as ReturnType<typeof useStructureTool>)
+    rerender(renderDocumentPanel())
+
+    const formView = screen.getByTestId('document-panel-form-view')
+    expect(formView).not.toBeVisible()
+    expect(formView).toHaveAttribute('hidden')
+    expect(screen.getByTestId('form-state')).toHaveTextContent('1')
+    expect(screen.getByText('Inspector')).toBeInTheDocument()
+
+    mockUseStructureTool.mockReturnValue({
+      features: {resizablePanes: true},
+    } as ReturnType<typeof useStructureTool>)
+    rerender(renderDocumentPanel())
+
+    expect(screen.getByTestId('document-panel-form-view')).toBeVisible()
+    expect(screen.getByTestId('form-state')).toHaveTextContent('1')
+  })
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/__tests__/DocumentPanel.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/__tests__/DocumentPanel.test.tsx
@@ -1,6 +1,5 @@
 import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {useState} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
@@ -22,7 +21,7 @@ vi.mock('../../../../components/paneRouter/usePaneRouter', () => ({
 }))
 
 vi.mock('../../../../useStructureTool', () => ({
-  useStructureTool: vi.fn(() => ({features: {resizablePanes: true}})),
+  useStructureTool: vi.fn(() => ({features: {resizablePanes: true, splitPanes: true}})),
 }))
 
 vi.mock('../../useDocumentPane', () => ({
@@ -41,22 +40,32 @@ vi.mock('../header/DocumentPanelSubHeader', () => ({
   DocumentPanelSubHeader: () => null,
 }))
 
-vi.mock('../documentViews/FormView', () => ({
-  FormView: function MockFormView() {
-    const [count, setCount] = useState(0)
-    return (
-      <div data-testid="document-panel-scroller">
-        <button
-          type="button"
-          data-testid="form-state"
-          onClick={() => setCount((value) => value + 1)}
-        >
-          {count}
-        </button>
-      </div>
-    )
-  },
-}))
+vi.mock('../documentViews/FormView', async () => {
+  const {useState} = await import('react')
+  const {createPortal} = await import('react-dom')
+  const {usePortal} = await import('@sanity/ui')
+
+  return {
+    FormView: function MockFormView() {
+      const [count, setCount] = useState(0)
+      const portal = usePortal()
+      return (
+        <div data-testid="document-panel-scroller">
+          <button
+            type="button"
+            data-testid="form-state"
+            onClick={() => setCount((value) => value + 1)}
+          >
+            {count}
+          </button>
+          {portal.element
+            ? createPortal(<div data-testid="fullscreen-pte">fullscreen</div>, portal.element)
+            : null}
+        </div>
+      )
+    },
+  }
+})
 
 vi.mock('../../documentInspector/DocumentInspectorPanel', () => ({
   DocumentInspectorPanel: () => <aside data-ui="DocumentInspectorPanel">Inspector</aside>,
@@ -71,6 +80,9 @@ vi.mock('sanity', async (importOriginal) => ({
 
 const mockUseDocumentPane = vi.mocked(useDocumentPane)
 const mockUseStructureTool = vi.mocked(useStructureTool)
+
+const splitPanesFeatures = {resizablePanes: true, splitPanes: true}
+const collapsedLayoutFeatures = {resizablePanes: false, splitPanes: false}
 
 function documentPaneValue() {
   return {
@@ -112,7 +124,7 @@ describe('DocumentPanel form persistence', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseStructureTool.mockReturnValue({
-      features: {resizablePanes: true},
+      features: splitPanesFeatures,
     } as ReturnType<typeof useStructureTool>)
   })
 
@@ -124,7 +136,7 @@ describe('DocumentPanel form persistence', () => {
     expect(screen.getByTestId('document-panel-form-view')).toBeVisible()
 
     mockUseStructureTool.mockReturnValue({
-      features: {resizablePanes: false},
+      features: collapsedLayoutFeatures,
     } as ReturnType<typeof useStructureTool>)
     rerender(renderDocumentPanel())
 
@@ -132,14 +144,19 @@ describe('DocumentPanel form persistence', () => {
     expect(formView).not.toBeVisible()
     expect(formView).toHaveAttribute('hidden')
     expect(screen.getByTestId('form-state')).toHaveTextContent('1')
-    expect(screen.getByText('Inspector')).toBeInTheDocument()
+    expect(screen.getByText('Inspector')).toBeVisible()
+
+    const fullscreenPte = screen.getByTestId('fullscreen-pte')
+    expect(formView).toContainElement(fullscreenPte)
+    expect(fullscreenPte).not.toBeVisible()
 
     mockUseStructureTool.mockReturnValue({
-      features: {resizablePanes: true},
+      features: splitPanesFeatures,
     } as ReturnType<typeof useStructureTool>)
     rerender(renderDocumentPanel())
 
     expect(screen.getByTestId('document-panel-form-view')).toBeVisible()
     expect(screen.getByTestId('form-state')).toHaveTextContent('1')
+    expect(screen.getByTestId('fullscreen-pte')).toBeVisible()
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Resizing the studio below the collapsed-layout breakpoint (`600px`) with a document inspector open unmounted `FormBuilder`. Full-pane Portable Text state lives in `FullscreenPTEProvider` inside that tree, so the editor came back inline after the window was widened again ([SAPP-4327](https://linear.app/sanity/issue/SAPP-4327/keep-full-pane-pte-mode-when-resizing-browser)).

The form stays mounted (hidden) so that state survives. The fullscreen editor portals to `portal.element`, and collapsed layout used to retarget that to the structure-tool portal outside the hidden subtree — covering the inspector. When the form is hidden, the portal target now stays on `document-panel-portal` inside that subtree.

Lifting `FullscreenPTEProvider` was rejected: it would persist fullscreen across document changes unless we added extra reset logic.

### What to review

- Hidden form + local portal when `resizablePanes` is false and an inspector is open
- Regression coverage in `DocumentPanel.test.tsx` (form state and portaled fullscreen content stay hidden under the inspector, then restore)

### Testing

- Unit: `pnpm vitest run --project=sanity packages/sanity/src/structure/panes/document/documentPanel/__tests__/DocumentPanel.test.tsx`
- Playwright: inspector open, PTE expanded, `1600 → 500 → 1600` — at 500px `formDisplay=none`, `editorVisible=false`, inspector visible; at 1600px `data-fullscreen=true` and collapse control remain
- Desktop: comments inspector takes over on collapse; `Collapse editor` tooltip still present after widening

[PTE full-pane with comments inspector before collapse](https://cursor.com/agents/bc-3e721d9f-e8ce-4c60-af45-82d613b4dd48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpte_fullscreen_inspector_wide_before.webp)
[Comments inspector takes over under 600px without the PTE covering it](https://cursor.com/agents/bc-3e721d9f-e8ce-4c60-af45-82d613b4dd48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpte_fullscreen_inspector_takes_over_narrow.webp)
[PTE still full-pane after widening](https://cursor.com/agents/bc-3e721d9f-e8ce-4c60-af45-82d613b4dd48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpte_fullscreen_inspector_wide_after.webp)
[pte_fullscreen_hides_for_inspector_on_collapse.mp4](https://cursor.com/agents/bc-3e721d9f-e8ce-4c60-af45-82d613b4dd48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpte_fullscreen_hides_for_inspector_on_collapse.mp4)

### Notes for release

Portable Text editors that are in full-pane mode stay in full-pane mode after the browser window is resized. On a collapsed layout with an inspector open, the inspector still takes over until the window is widened again.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e721d9f-e8ce-4c60-af45-82d613b4dd48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e721d9f-e8ce-4c60-af45-82d613b4dd48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

