### PR TITLE
fix(studio): link studio registration docs from the cors interstitial

### DIFF
--- a/packages/sanity/src/core/studio/workspaces/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/workspaces/CorsOriginErrorScreen.tsx
@@ -1,12 +1,15 @@
 /* eslint-disable i18next/no-literal-string,@sanity/i18n/no-attribute-string-literals */
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {Card, Flex, Grid, Heading, Stack, Text} from '@sanity/ui'
-import {useMemo} from 'react'
+import {type ReactNode, useMemo} from 'react'
 import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {Button} from '../../../ui-components/button/Button'
 import {isProd} from '../../environment'
+
+const CORS_DOCS_URL = 'https://www.sanity.io/docs/cors'
+const STUDIO_REGISTRATION_DOCS_URL = 'https://www.sanity.io/docs/dashboard/dashboard-configure'
 
 interface CorsOriginErrorScreenProps {
   projectId?: string
@@ -66,6 +69,29 @@ const HelpLink = styled.a`
 // form fails silently. Keep in sync with the Manage validator.
 const STUDIO_HOST_PATTERN = /^(https?:\/\/)?[\w-]+(\.[\w-]+)+([/?#].*)?$/
 const STUDIO_HOST_DENYLIST = ['127.0.0.1', '0.0.0.0']
+
+interface DocsHelpLinkProps {
+  children: ReactNode
+  href: string
+  testId: string
+}
+
+function DocsHelpLink(props: DocsHelpLinkProps) {
+  const {children, href, testId} = props
+  return (
+    <Text size={1}>
+      <HelpLink
+        data-testid={testId}
+        href={href}
+        rel="noopener noreferrer"
+        style={{textDecoration: 'none'}}
+        target="_blank"
+      >
+        {children}
+      </HelpLink>
+    </Text>
+  )
+}
 
 function canRegisterStudioForOrigin(origin: string): boolean {
   // The registration form takes the URL the user types in, but here we
@@ -152,16 +178,9 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
               </Flex>
 
               <Flex justify="flex-end">
-                <Text size={1}>
-                  <HelpLink
-                    href="https://www.sanity.io/docs/cors"
-                    rel="noopener noreferrer"
-                    style={{textDecoration: 'none'}}
-                    target="_blank"
-                  >
-                    Need help with CORS? &rarr;
-                  </HelpLink>
-                </Text>
+                <DocsHelpLink href={CORS_DOCS_URL} testId="cors-docs-link">
+                  Need help with CORS? &rarr;
+                </DocsHelpLink>
               </Flex>
             </Stack>
           </ContentWrapper>
@@ -246,17 +265,16 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
               </Card>
             </Grid>
 
-            <Flex justify="flex-end">
-              <Text size={1}>
-                <HelpLink
-                  href="https://www.sanity.io/docs/cors"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{textDecoration: 'none'}}
-                >
-                  Need help with CORS? &rarr;
-                </HelpLink>
-              </Text>
+            <Flex gap={4} justify="flex-end" wrap="wrap">
+              <DocsHelpLink
+                href={STUDIO_REGISTRATION_DOCS_URL}
+                testId="studio-registration-docs-link"
+              >
+                Learn about Studio registration &rarr;
+              </DocsHelpLink>
+              <DocsHelpLink href={CORS_DOCS_URL} testId="cors-docs-link">
+                Learn about CORS &rarr;
+              </DocsHelpLink>
             </Flex>
           </Stack>
         </ContentWrapper>

--- a/packages/sanity/src/core/studio/workspaces/__tests__/CorsOriginErrorScreen.test.tsx
+++ b/packages/sanity/src/core/studio/workspaces/__tests__/CorsOriginErrorScreen.test.tsx
@@ -1,0 +1,80 @@
+import {ThemeProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
+import {render, screen, within} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+
+import {CorsOriginErrorScreen} from '../CorsOriginErrorScreen'
+
+const theme = buildTheme()
+const CORS_DOCS_URL = 'https://www.sanity.io/docs/cors'
+const STUDIO_REGISTRATION_DOCS_URL = 'https://www.sanity.io/docs/dashboard/dashboard-configure'
+
+function renderScreen(
+  props: Partial<Parameters<typeof CorsOriginErrorScreen>[0]> &
+    Pick<Parameters<typeof CorsOriginErrorScreen>[0], 'origin'>,
+) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <CorsOriginErrorScreen
+        isStaging={false}
+        primaryProjectId="abc123"
+        projectId="abc123"
+        {...props}
+      />
+    </ThemeProvider>,
+  )
+}
+
+describe('CorsOriginErrorScreen', () => {
+  it('links Studio registration docs next to CORS docs on the connect screen', () => {
+    renderScreen({origin: 'https://studio.example.com'})
+
+    const screenRoot = screen.getByTestId('studio-error-screen')
+    expect(screenRoot).toHaveAttribute('data-error', 'CORS origin error')
+    expect(
+      within(screenRoot).getByRole('heading', {name: 'Connect this Studio to your project'}),
+    ).toBeInTheDocument()
+    expect(within(screenRoot).getByRole('link', {name: 'Register Studio'})).toBeInTheDocument()
+
+    const registrationLink = screen.getByTestId('studio-registration-docs-link')
+    expect(registrationLink).toHaveTextContent('Learn about Studio registration')
+    expect(registrationLink).toHaveAttribute('href', STUDIO_REGISTRATION_DOCS_URL)
+    expect(registrationLink).toHaveAttribute('target', '_blank')
+
+    const corsLink = screen.getByTestId('cors-docs-link')
+    expect(corsLink).toHaveTextContent('Learn about CORS')
+    expect(corsLink).toHaveAttribute('href', CORS_DOCS_URL)
+    expect(screen.queryByText('Need help with CORS?')).not.toBeInTheDocument()
+  })
+
+  it('still offers both docs links when the origin cannot be registered', () => {
+    renderScreen({origin: 'http://localhost:3333'})
+
+    expect(screen.queryByRole('link', {name: 'Register Studio'})).not.toBeInTheDocument()
+    expect(screen.getByRole('link', {name: 'Add CORS origin'})).toBeInTheDocument()
+    expect(screen.getByTestId('studio-registration-docs-link')).toHaveAttribute(
+      'href',
+      STUDIO_REGISTRATION_DOCS_URL,
+    )
+    expect(screen.getByTestId('cors-docs-link')).toHaveAttribute('href', CORS_DOCS_URL)
+  })
+
+  it('keeps CORS-only help on the credentials-disabled screen', () => {
+    renderScreen({
+      allowed: true,
+      origin: 'https://studio.example.com',
+      withCredentials: false,
+    })
+
+    expect(screen.getByTestId('studio-error-screen')).toHaveAttribute(
+      'data-error',
+      'CORS credentials disabled',
+    )
+    expect(
+      screen.getByRole('heading', {name: 'Enable credentials for this Studio'}),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('cors-docs-link')).toHaveAttribute('href', CORS_DOCS_URL)
+    expect(screen.getByTestId('cors-docs-link')).toHaveTextContent('Need help with CORS?')
+    expect(screen.queryByTestId('studio-registration-docs-link')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The "Connect this Studio to your project" interstitial recommends Register Studio, but its only help link said "Need help with CORS?" and pointed at the CORS docs. That made the recommended path look undocumented.

This adds a Dashboard setup docs link next to the CORS one and rewords the footer so it covers both paths. The credentials-disabled screen stays CORS-only because that branch is only about re-adding credentials.

Linear: [SAPP-4205](https://linear.app/sanity/issue/SAPP-4205/link-studio-registration-docs-from-the-cors-interstitial)

Why not a link only on the Register card: the ticket asked for a docs link alongside the existing CORS footer help, and the CORS-only credentials screen should not grow a registration link.

### What to review

- `packages/sanity/src/core/studio/workspaces/CorsOriginErrorScreen.tsx` — footer copy and hrefs
- `packages/sanity/src/core/studio/workspaces/__tests__/CorsOriginErrorScreen.test.tsx` — connect vs credentials-disabled help links

### Testing

Desktop reproduction used the test-studio Error playground custom-domain preview (`/test/error-reporting-test`). Before the change, the recommended Register Studio path only offered "Need help with CORS?" → `https://www.sanity.io/docs/cors`.

[Before: CORS interstitial with CORS-only help](https://cursor.com/agents/bc-bdf40374-00ef-43b2-a29c-04936303beeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_before_cors_only_help.webp)

[Before: help link points at docs/cors](https://cursor.com/agents/bc-bdf40374-00ef-43b2-a29c-04936303beeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_before_help_link_hover.webp)

After the change, the same preview shows both docs links with the expected hrefs:

- Learn about Studio registration → `https://www.sanity.io/docs/dashboard/dashboard-configure`
- Learn about CORS → `https://www.sanity.io/docs/cors`

[After: both Studio registration and CORS docs links](https://cursor.com/agents/bc-bdf40374-00ef-43b2-a29c-04936303beeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_after_both_docs_links.webp)

[cors_interstitial_registration_docs_after.mp4](https://cursor.com/agents/bc-bdf40374-00ef-43b2-a29c-04936303beeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_registration_docs_after.mp4)

Unit tests: `pnpm vitest run --project=sanity packages/sanity/src/core/studio/workspaces/__tests__/CorsOriginErrorScreen.test.tsx` — 3 passed (connect screen with both links, localhost still has both links, credentials-disabled stays CORS-only).

[cors_interstitial_unit_tests.log](https://cursor.com/agents/bc-bdf40374-00ef-43b2-a29c-04936303beeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_unit_tests.log)

### Notes for release

The "Connect this Studio to your project" screen now links to both Studio registration docs and CORS docs, instead of a CORS-only help link.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf40374-00ef-43b2-a29c-04936303beeb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf40374-00ef-43b2-a29c-04936303beeb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

