### PR TITLE
fix(types): add currentUser to ValidationContext

### DIFF
--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -14,6 +14,7 @@ import {
   type SlugSchemaType,
 } from '../schema/types'
 import {type SlugParent} from '../slug/types'
+import {type CurrentUser} from '../user/types'
 
 /** @public */
 export type RuleTypeConstraint = 'Array' | 'Boolean' | 'Date' | 'Number' | 'Object' | 'String'
@@ -286,6 +287,10 @@ export interface ValidationContext {
    * Whether this field is hidden for any reason (either itself or any of its ancestors).
    */
   hidden?: boolean
+  /**
+   * The current user, when available. Absent outside the Studio, eg CLI or headless validation.
+   */
+  currentUser?: Omit<CurrentUser, 'role'> | null
 }
 
 /**

--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -325,7 +325,7 @@ type ValidateItemOptions = {
   customValidationConcurrencyLimiter?: ConcurrencyLimiter
   hidden?: boolean
   currentUser?: Omit<CurrentUser, 'role'> | null
-} & ExplicitUndefined<Omit<ValidationContext, 'hidden'>>
+} & ExplicitUndefined<Omit<ValidationContext, 'hidden' | 'currentUser'>>
 
 export function validateItem(opts: ValidateItemOptions): Promise<ValidationMarker[]> {
   return lastValueFrom(validateItemObservable(opts))

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -356,6 +356,69 @@ describe('validateItem', () => {
       },
     ])
   })
+
+  it('passes currentUser to schema validation and custom validator contexts', async () => {
+    const currentUser: ValidationContext['currentUser'] = {
+      id: 'user-id',
+      name: 'Test User',
+      email: 'test@example.com',
+      roles: [{name: 'administrator', title: 'Administrator'}],
+    }
+
+    const schemaContexts: Array<ValidationContext['currentUser']> = []
+    const customContexts: Array<ValidationContext['currentUser']> = []
+
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        {
+          name: 'currentUserDoc',
+          type: 'document',
+          fields: [
+            {
+              name: 'title',
+              type: 'string',
+              validation: (rule: Rule, context?: ValidationContext) => {
+                schemaContexts.push(context?.currentUser)
+                return rule.custom((_value, customContext: ValidationContext) => {
+                  customContexts.push(customContext.currentUser)
+                  return true
+                })
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    const document: SanityDocument = {
+      _id: 'current-user-doc-id',
+      _type: 'currentUserDoc',
+      _createdAt: '2024-01-01T00:00:00.000Z',
+      _updatedAt: '2024-01-01T00:00:00.000Z',
+      _rev: 'current-user-doc-rev',
+      title: 'hello',
+    }
+
+    const result = await validateItem({
+      getClient,
+      schema,
+      value: document,
+      document,
+      parent: undefined,
+      path: [],
+      type: schema.get('currentUserDoc'),
+      i18n: getFallbackLocaleSource(),
+      environment: 'studio',
+      getDocumentExists: undefined,
+      currentUser,
+    })
+
+    expect(result).toHaveLength(0)
+    expect(schemaContexts).toEqual([currentUser])
+    expect(customContexts).toEqual([currentUser])
+  })
+
   it("runs nested validation on an undefined value for object types if it's required", async () => {
     const validation = (rule: Rule) => [
       rule.required().error('This is required!'),


### PR DESCRIPTION
### Description

`currentUser` reaches the validation context at runtime, but it was never added to the public `ValidationContext` type. Custom validators have to cast to read it.

#12050 added the threading in `validateDocument.ts` and added `hidden?: boolean` to the type. `currentUser` was not added alongside it. #12221 then threaded `currentUser` through the Studio stores. Neither PR touched the type.

Spotted by Mark Michon while writing a guide. Closes SAPP-4407: https://linear.app/sanity/issue/SAPP-4407/add-currentuser-to-validationcontext-type

### What to review

Types only. No runtime behaviour changes.

`packages/@sanity/types/src/validation/types.ts` - `currentUser` is optional because CLI and headless validation run without a user. `ConditionalPropertyCallbackContext` carries the same `Omit<CurrentUser, 'role'>` shape but declares it non-optional; matching that here would misdescribe the CLI path.

`packages/sanity/src/core/validation/validateDocument.ts` - `ValidateItemOptions` intersects `ExplicitUndefined<Omit<ValidationContext, 'hidden'>>`, which turns every optional key into a required-but-undefined one. Adding `currentUser` to that `Omit` keeps it optional for existing `validateItem` callers.

### Testing

New test in `packages/sanity/test/validation/validateDocument.test.ts`. It asserts `currentUser` arrives in both context shapes a schema author touches: the `validation: (rule, context)` callback and `Rule.custom((value, context))`.

### Notes for release

`context.currentUser` is now part of the `ValidationContext` type. The value was already passed to validators at runtime, but it was missing from the type, so reaching it meant casting.

```ts
defineField({
  name: 'title',
  type: 'string',
  validation: (rule) =>
    rule.custom((value, context) =>
      context.currentUser?.roles.some((role) => role.name === 'administrator')
        ? true
        : 'Only administrators can set a title',
    ),
})
```

`currentUser` is optional. The Studio populates it; CLI and headless validation leave it undefined.

---
