### PR TITLE
fix(releases): keep row action menu visible on smaller screens

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -10,7 +10,7 @@ import {TableEmptyState} from './TableEmptyState'
 import {TableHeader} from './TableHeader'
 import {TableLayout} from './TableLayout'
 import {TableProvider, type TableSort, useTableContext} from './TableProvider'
-import {type Column} from './types'
+import {TABLE_ROW_ACTIONS_WIDTH, type Column} from './types'
 
 type RowDatum<TableData, AdditionalRowTableData> = (AdditionalRowTableData extends undefined
   ? TableData
@@ -47,8 +47,6 @@ export interface TableProps<TableData, AdditionalRowTableData> {
 
 const ITEM_HEIGHT = 59
 const LOADING_ROW_COUNT = 3
-
-export const TABLE_ROW_ACTIONS_WIDTH = 50
 
 const TableInner = <TableData, AdditionalRowTableData>({
   columnDefs,

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -219,9 +219,10 @@ const TableInner = <TableData, AdditionalRowTableData>({
 
   const theme = useTheme()
   const maxInlineSize = (!hideTableInlinePadding && theme.sanity.v2?.container[3]) || 0
+  const paddingInline = rem(theme.sanity.v2?.space[3] ?? 0)
   const tableInlinePadding = hideTableInlinePadding
     ? '0px'
-    : `max(0px, calc((100% - var(--maxInlineSize)) / 2))`
+    : `max(${paddingInline}, calc((100% - var(--maxInlineSize)) / 2))`
 
   const renderLoadingRows = (
     rowRenderer: (

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -113,11 +113,10 @@ const TableInner = <TableData, AdditionalRowTableData>({
     () => ({
       id: 'actions',
       sorting: false,
-      // Header and body rows are independent flexboxes: this trailing gutter must be the SAME width
-      // in both, otherwise the flex:1 "Document" column absorbs the difference in the body only and
-      // every column to its right (Last edited, Edited by) drifts out of alignment with its header.
-      // The body cell below is content-box (width:25px + padding:3 => ~50px actual), so reserve 50
-      // here and size the header (border-box) to 50px to match — under-reserving clips the ⋯.
+      // Header and body are independent flexboxes, so this trailing gutter must be the same
+      // width in both. The cell is border-box: padding 3 (12px) + a 25px bleed button needs
+      // 50px. A 25px width (the old content-box assumption) overflowed by 12px and clipped
+      // the … (SAPP-3249).
       width: 50,
       header: ({headerProps: {id}}) => (
         <Flex
@@ -143,7 +142,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
           flexGrow={0}
           flexShrink={0}
           padding={3}
-          style={{width: '25px'}}
+          style={{width: '50px'}}
         >
           {(!datum.isLoading && rowActions?.({datum})) || <Box style={{width: '25px'}} />}
         </Flex>

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -113,10 +113,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
     () => ({
       id: 'actions',
       sorting: false,
-      // Header and body are independent flexboxes, so this trailing gutter must be the same
-      // width in both. The cell is border-box: padding 3 (12px) + a 25px bleed button needs
-      // 50px. A 25px width (the old content-box assumption) overflowed by 12px and clipped
-      // the … (SAPP-3249).
+      // Header and body are independent flexboxes — keep this gutter the same width in both.
       width: 50,
       header: ({headerProps: {id}}) => (
         <Flex
@@ -188,9 +185,6 @@ const TableInner = <TableData, AdditionalRowTableData>({
               left: 0,
               right: 0,
               transform: `translateY(${datum.virtualRow.start}px)`,
-              // Centering gutter lives in --tableInlinePadding. A 12px *minimum* here overflowed
-              // the row-action … by exactly that amount whenever the table was already full-bleed
-              // (SAPP-3249).
               paddingInline: 'var(--tableInlinePadding)',
               // Consumer-supplied row styles are merged (not clobbered) so they can tint/flag a row
               // without dropping the virtualization layout (height/position/transform).
@@ -235,8 +229,6 @@ const TableInner = <TableData, AdditionalRowTableData>({
 
   const theme = useTheme()
   const maxInlineSize = (!hideTableInlinePadding && theme.sanity.v2?.container[3]) || 0
-  // Full-bleed tables (hideTableInlinePadding) must not keep a leftover gutter — it clips the
-  // trailing … . Otherwise only pad when the row is wider than the max inline size (centering).
   const tableInlinePadding = hideTableInlinePadding
     ? '0px'
     : `max(0px, calc((100% - var(--maxInlineSize)) / 2))`

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -48,6 +48,8 @@ export interface TableProps<TableData, AdditionalRowTableData> {
 const ITEM_HEIGHT = 59
 const LOADING_ROW_COUNT = 3
 
+export const TABLE_ROW_ACTIONS_WIDTH = 50
+
 const TableInner = <TableData, AdditionalRowTableData>({
   columnDefs,
   data,
@@ -114,32 +116,22 @@ const TableInner = <TableData, AdditionalRowTableData>({
       id: 'actions',
       sorting: false,
       // Header and body are independent flexboxes — keep this gutter the same width in both.
-      width: 50,
-      header: ({headerProps: {id}}) => (
-        <Flex
-          as="th"
-          id={id}
-          paddingY={3}
-          paddingX={3}
-          style={{
-            width: '50px',
-          }}
-        >
+      width: TABLE_ROW_ACTIONS_WIDTH,
+      header: ({headerProps}) => (
+        <Flex {...headerProps} paddingY={3} paddingX={3}>
           <Text muted size={1} weight="medium">
             &nbsp;
           </Text>
         </Flex>
       ),
-      cell: ({datum, cellProps: {id}}) => (
+      cell: ({datum, cellProps}) => (
         <Flex
-          as="td"
-          id={id}
+          {...cellProps}
           alignItems="center"
           flexBasis="auto"
           flexGrow={0}
           flexShrink={0}
           padding={3}
-          style={{width: '50px'}}
         >
           {(!datum.isLoading && rowActions?.({datum})) || <Box style={{width: '25px'}} />}
         </Flex>

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -189,10 +189,10 @@ const TableInner = <TableData, AdditionalRowTableData>({
               left: 0,
               right: 0,
               transform: `translateY(${datum.virtualRow.start}px)`,
-              paddingInline: `max(
-                calc((100% - var(--maxInlineSize)) / 2),
-                var(--paddingInline)
-              )`,
+              // Centering gutter lives in --tableInlinePadding. A 12px *minimum* here overflowed
+              // the row-action … by exactly that amount whenever the table was already full-bleed
+              // (SAPP-3249).
+              paddingInline: 'var(--tableInlinePadding)',
               // Consumer-supplied row styles are merged (not clobbered) so they can tint/flag a row
               // without dropping the virtualization layout (height/position/transform).
               ...rowPropsStyle,
@@ -235,8 +235,12 @@ const TableInner = <TableData, AdditionalRowTableData>({
   )
 
   const theme = useTheme()
-
   const maxInlineSize = (!hideTableInlinePadding && theme.sanity.v2?.container[3]) || 0
+  // Full-bleed tables (hideTableInlinePadding) must not keep a leftover gutter — it clips the
+  // trailing … . Otherwise only pad when the row is wider than the max inline size (centering).
+  const tableInlinePadding = hideTableInlinePadding
+    ? '0px'
+    : `max(0px, calc((100% - var(--maxInlineSize)) / 2))`
 
   const renderLoadingRows = (
     rowRenderer: (
@@ -297,7 +301,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
             'height': '100%',
             'position': 'relative',
             '--maxInlineSize': rem(maxInlineSize),
-            '--paddingInline': rem(theme.sanity.v2?.space[3] ?? 0),
+            '--tableInlinePadding': tableInlinePadding,
           } as CSSProperties
         }
       >

--- a/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
@@ -102,10 +102,7 @@ export const TableHeader = ({headers, searchDisabled}: TableHeaderProps) => {
       <Flex
         as="tr"
         style={{
-          paddingInline: `max(
-          calc((100% - var(--maxInlineSize)) / 2),
-          var(--paddingInline)
-        )`,
+          paddingInline: 'var(--tableInlinePadding)',
         }}
       >
         {headers.map(

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/Table.browser.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/Table.browser.test.tsx
@@ -29,9 +29,6 @@ describe('Table (virtualized)', () => {
     expect(firstRow.contains(hit)).toBe(true)
   })
 
-  // Regression for SAPP-3249: a viewport-locked title column overflowed the table
-  // and clipped the row-action … . With a shrinkable title min-width the button
-  // stays fully inside a 1100px table area (1280 window minus calendar chrome).
   it('keeps the row-action button fully visible at a constrained desktop width', async () => {
     void render(<TableStory containerWidth={1100} showRowActions />)
 

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/Table.browser.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/Table.browser.test.tsx
@@ -28,4 +28,25 @@ describe('Table (virtualized)', () => {
     const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2)
     expect(firstRow.contains(hit)).toBe(true)
   })
+
+  // Regression for SAPP-3249: a viewport-locked title column overflowed the table
+  // and clipped the row-action … . With a shrinkable title min-width the button
+  // stays fully inside a 1100px table area (1280 window minus calendar chrome).
+  it('keeps the row-action button fully visible at a constrained desktop width', async () => {
+    void render(<TableStory containerWidth={1100} showRowActions />)
+
+    await expect.poll(() => document.querySelectorAll('[data-testid="table-row"]').length).toBe(4)
+
+    const container = document.querySelector('[data-testid="table-scroll-container"]')
+    const button = document.querySelector('[data-testid="release-menu-button"]')
+    expect(container).toBeTruthy()
+    expect(button).toBeTruthy()
+
+    const containerRect = container!.getBoundingClientRect()
+    const buttonRect = button!.getBoundingClientRect()
+
+    expect(buttonRect.right).toBeLessThanOrEqual(containerRect.right + 1)
+    expect(buttonRect.left).toBeGreaterThanOrEqual(containerRect.left - 1)
+    expect(container!.scrollWidth).toBeLessThanOrEqual(container!.clientWidth + 1)
+  })
 })

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
@@ -3,7 +3,6 @@ import {buildTheme} from '@sanity/ui/theme'
 import {useState} from 'react'
 import {Flex} from 'ui5'
 
-import {RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH} from '../../../overview/ReleasesOverviewColumnDefs'
 import {Table} from '../Table'
 import {Headers} from '../TableHeader'
 import {type Column} from '../types'
@@ -27,7 +26,7 @@ function createColumns(showRowActions: boolean): Column<Datum>[] {
   const titleColumn: Column<Datum> = {
     id: 'title',
     width: null,
-    style: showRowActions ? {minWidth: RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH} : undefined,
+    style: showRowActions ? {minWidth: 200} : undefined,
     header: (props) => (
       <Flex {...props.headerProps} flexBasis="0%" flexGrow={1} paddingY={3}>
         <Headers.BasicHeader text="Title" />

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
@@ -120,7 +120,11 @@ export function TableStory({containerWidth, showRowActions = false}: TableStoryP
           rowActions={
             showRowActions
               ? () => (
-                  <button type="button" data-testid="release-menu-button">
+                  <button
+                    type="button"
+                    data-testid="release-menu-button"
+                    style={{width: 25, height: 25, padding: 0, border: 0, boxSizing: 'border-box'}}
+                  >
                     ...
                   </button>
                 )

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
@@ -116,6 +116,7 @@ export function TableStory({containerWidth, showRowActions = false}: TableStoryP
           rowId="id"
           columnDefs={columns}
           scrollContainerRef={scrollContainer}
+          hideTableInlinePadding={showRowActions}
           rowActions={
             showRowActions
               ? () => (

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
@@ -3,6 +3,7 @@ import {buildTheme} from '@sanity/ui/theme'
 import {useState} from 'react'
 import {Flex} from 'ui5'
 
+import {RELEASES_OVERVIEW_TITLE_COLUMN_STYLE} from '../../../overview/ReleasesOverviewColumnDefs'
 import {Table} from '../Table'
 import {Headers} from '../TableHeader'
 import {type Column} from '../types'
@@ -12,42 +13,118 @@ interface Datum {
   title: string
 }
 
+interface TableStoryProps {
+  containerWidth?: number
+  showRowActions?: boolean
+}
+
 const data: Datum[] = Array.from({length: 4}, (_, index) => ({
   id: `doc-${index}`,
   title: `Document ${index}`,
 }))
 
-const columns: Column<Datum>[] = [
-  {
+function createColumns(showRowActions: boolean): Column<Datum>[] {
+  const titleColumn: Column<Datum> = {
     id: 'title',
     width: null,
+    style: showRowActions ? RELEASES_OVERVIEW_TITLE_COLUMN_STYLE : undefined,
     header: (props) => (
-      <Flex {...props.headerProps} paddingY={3}>
+      <Flex {...props.headerProps} flexBasis="0%" flexGrow={1} paddingY={3}>
         <Headers.BasicHeader text="Title" />
       </Flex>
     ),
     cell: ({cellProps, datum}) => (
-      <Flex alignItems="center" paddingX={2} {...cellProps}>
+      <Flex alignItems="center" flexBasis="0%" flexGrow={1} paddingX={2} {...cellProps}>
         <Text size={1}>{datum.title}</Text>
       </Flex>
     ),
-  },
-]
+  }
+
+  if (!showRowActions) {
+    return [titleColumn]
+  }
+
+  return [
+    titleColumn,
+    {
+      id: 'when',
+      width: 280,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3}>
+          <Headers.BasicHeader text="When" />
+        </Flex>
+      ),
+      cell: ({cellProps}) => (
+        <Flex alignItems="center" paddingX={2} {...cellProps}>
+          <Text size={1}>As soon as possible</Text>
+        </Flex>
+      ),
+    },
+    {
+      id: 'edited',
+      width: 150,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3}>
+          <Headers.BasicHeader text="Edited" />
+        </Flex>
+      ),
+      cell: ({cellProps}) => (
+        <Flex alignItems="center" paddingX={2} {...cellProps}>
+          <Text size={1}>5 days ago</Text>
+        </Flex>
+      ),
+    },
+    {
+      id: 'error',
+      width: 40,
+      header: ({headerProps}) => <Flex {...headerProps} paddingY={3} />,
+      cell: ({cellProps}) => <Flex {...cellProps} paddingX={2} paddingY={3} />,
+    },
+    {
+      id: 'documents',
+      width: 120,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3}>
+          <Headers.BasicHeader text="Documents" />
+        </Flex>
+      ),
+      cell: ({cellProps}) => (
+        <Flex alignItems="center" paddingX={2} {...cellProps}>
+          <Text size={1}>12</Text>
+        </Flex>
+      ),
+    },
+  ]
+}
 
 const theme = buildTheme()
 
-export function TableStory() {
+export function TableStory({containerWidth, showRowActions = false}: TableStoryProps = {}) {
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null)
+  const columns = createColumns(showRowActions)
 
   return (
     <ThemeProvider theme={theme}>
-      <div ref={setScrollContainer} style={{height: '400px', overflow: 'auto'}}>
+      <div
+        ref={setScrollContainer}
+        data-testid="table-scroll-container"
+        style={{height: '400px', width: containerWidth, overflow: 'auto'}}
+      >
         <Table<Datum>
           data={data}
           emptyState="No documents"
           rowId="id"
           columnDefs={columns}
           scrollContainerRef={scrollContainer}
+          rowActions={
+            showRowActions
+              ? () => (
+                  <button type="button" data-testid="release-menu-button">
+                    ...
+                  </button>
+                )
+              : undefined
+          }
         />
       </div>
     </ThemeProvider>

--- a/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/__tests__/TableStory.tsx
@@ -3,7 +3,7 @@ import {buildTheme} from '@sanity/ui/theme'
 import {useState} from 'react'
 import {Flex} from 'ui5'
 
-import {RELEASES_OVERVIEW_TITLE_COLUMN_STYLE} from '../../../overview/ReleasesOverviewColumnDefs'
+import {RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH} from '../../../overview/ReleasesOverviewColumnDefs'
 import {Table} from '../Table'
 import {Headers} from '../TableHeader'
 import {type Column} from '../types'
@@ -27,7 +27,7 @@ function createColumns(showRowActions: boolean): Column<Datum>[] {
   const titleColumn: Column<Datum> = {
     id: 'title',
     width: null,
-    style: showRowActions ? RELEASES_OVERVIEW_TITLE_COLUMN_STYLE : undefined,
+    style: showRowActions ? {minWidth: RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH} : undefined,
     header: (props) => (
       <Flex {...props.headerProps} flexBasis="0%" flexGrow={1} paddingY={3}>
         <Headers.BasicHeader text="Title" />

--- a/packages/sanity/src/core/releases/tool/components/Table/types.ts
+++ b/packages/sanity/src/core/releases/tool/components/Table/types.ts
@@ -1,5 +1,7 @@
 import {type CSSProperties} from 'react'
 
+export const TABLE_ROW_ACTIONS_WIDTH = 50
+
 export interface InjectedTableProps {
   as?: React.ElementType | keyof React.JSX.IntrinsicElements
   id: string

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -12,7 +12,6 @@ import {RelativeTime} from '../../../components/RelativeTime'
 import {getIsScheduledDateInPast} from '../../util/getIsScheduledDateInPast'
 import {getPublishDateFromRelease} from '../../util/util'
 import {ReleaseTime} from '../components/ReleaseTime'
-import {TABLE_ROW_ACTIONS_WIDTH} from '../components/Table/Table'
 import {Headers} from '../components/Table/TableHeader'
 import {type Column} from '../components/Table/types'
 import {ReleaseColumnValidationLoading} from './columnCells/ReleaseColumnValidationLoading'
@@ -26,18 +25,6 @@ export const RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH = 200
 const RELEASES_OVERVIEW_TITLE_COLUMN_STYLE = {
   minWidth: RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
 } as const
-
-export function getReleasesOverviewMinContentWidth(columns: Column<TableRelease>[]): number {
-  const columnWidth = columns
-    .filter((column) => !column.hidden)
-    .reduce((sum, column) => {
-      if (typeof column.width === 'number') return sum + column.width
-      const minWidth = column.style?.minWidth
-      return sum + (typeof minWidth === 'number' ? minWidth : 0)
-    }, 0)
-
-  return columnWidth + TABLE_ROW_ACTIONS_WIDTH
-}
 
 const enableColumnFormMode =
   (currentMode: Mode) => (column: Column<TableRelease>, expectedMode: Mode | 'all') => {

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -27,7 +27,7 @@ import {type TableRelease} from './ReleasesOverview'
  */
 export const RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH = 200
 
-export const RELEASES_OVERVIEW_TITLE_COLUMN_STYLE = {
+const RELEASES_OVERVIEW_TITLE_COLUMN_STYLE = {
   minWidth: RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
 } as const
 

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -12,6 +12,7 @@ import {RelativeTime} from '../../../components/RelativeTime'
 import {getIsScheduledDateInPast} from '../../util/getIsScheduledDateInPast'
 import {getPublishDateFromRelease} from '../../util/util'
 import {ReleaseTime} from '../components/ReleaseTime'
+import {TABLE_ROW_ACTIONS_WIDTH} from '../components/Table/Table'
 import {Headers} from '../components/Table/TableHeader'
 import {type Column} from '../components/Table/types'
 import {ReleaseColumnValidationLoading} from './columnCells/ReleaseColumnValidationLoading'
@@ -26,8 +27,6 @@ const RELEASES_OVERVIEW_TITLE_COLUMN_STYLE = {
   minWidth: RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
 } as const
 
-export const RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH = 50
-
 export function getReleasesOverviewMinContentWidth(columns: Column<TableRelease>[]): number {
   const columnWidth = columns
     .filter((column) => !column.hidden)
@@ -37,7 +36,7 @@ export function getReleasesOverviewMinContentWidth(columns: Column<TableRelease>
       return sum + (typeof minWidth === 'number' ? minWidth : 0)
     }, 0)
 
-  return columnWidth + RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH
+  return columnWidth + TABLE_ROW_ACTIONS_WIDTH
 }
 
 const enableColumnFormMode =

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -20,25 +20,14 @@ import {ReleaseNameCell} from './columnCells/ReleaseName'
 import {type Mode} from './queryParamUtils'
 import {type TableRelease} from './ReleasesOverview'
 
-/**
- * Title fills leftover space via flexGrow, but must be allowed to shrink. Locking it to 50% of
- * the viewport (`min(50%, calc(100vw - 80px))`) plus the fixed When/Edited/Documents/actions
- * columns overflowed the table below ~1491px and clipped the row-action … (SAPP-3249).
- */
 export const RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH = 200
 
 const RELEASES_OVERVIEW_TITLE_COLUMN_STYLE = {
   minWidth: RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
 } as const
 
-/** Trailing actions column reserved by `Table` when `rowActions` is set. */
 export const RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH = 50
 
-/**
- * Minimum width the overview table needs for its columns plus the row-action … .
- * Kept below the table area available at 1280px with the calendar sidebar mounted
- * so the action button is not the first thing clipped.
- */
 export function getReleasesOverviewMinContentWidth(columns: Column<TableRelease>[]): number {
   const columnWidth = columns
     .filter((column) => !column.hidden)

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -20,6 +20,37 @@ import {ReleaseNameCell} from './columnCells/ReleaseName'
 import {type Mode} from './queryParamUtils'
 import {type TableRelease} from './ReleasesOverview'
 
+/**
+ * Title fills leftover space via flexGrow, but must be allowed to shrink. Locking it to 50% of
+ * the viewport (`min(50%, calc(100vw - 80px))`) plus the fixed When/Edited/Documents/actions
+ * columns overflowed the table below ~1491px and clipped the row-action … (SAPP-3249).
+ */
+export const RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH = 200
+
+export const RELEASES_OVERVIEW_TITLE_COLUMN_STYLE = {
+  minWidth: RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
+} as const
+
+/** Trailing actions column reserved by `Table` when `rowActions` is set. */
+export const RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH = 50
+
+/**
+ * Minimum width the overview table needs for its columns plus the row-action … .
+ * Kept below the table area available at 1280px with the calendar sidebar mounted
+ * so the action button is not the first thing clipped.
+ */
+export function getReleasesOverviewMinContentWidth(columns: Column<TableRelease>[]): number {
+  const columnWidth = columns
+    .filter((column) => !column.hidden)
+    .reduce((sum, column) => {
+      if (typeof column.width === 'number') return sum + column.width
+      const minWidth = column.style?.minWidth
+      return sum + (typeof minWidth === 'number' ? minWidth : 0)
+    }, 0)
+
+  return columnWidth + RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH
+}
+
 const enableColumnFormMode =
   (currentMode: Mode) => (column: Column<TableRelease>, expectedMode: Mode | 'all') => {
     if (!currentMode) throw new Error('currentMode is required')
@@ -40,7 +71,7 @@ export const releasesOverviewColumnDefs: (
         id: 'metadata.title',
         sorting: true,
         width: null,
-        style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+        style: RELEASES_OVERVIEW_TITLE_COLUMN_STYLE,
         header: (props) => (
           <Flex
             {...props.headerProps}

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
@@ -1,13 +1,25 @@
 import {describe, expect, it} from 'vitest'
 
-import {TABLE_ROW_ACTIONS_WIDTH} from '../../components/Table/Table'
+import {TABLE_ROW_ACTIONS_WIDTH, type Column} from '../../components/Table/types'
+import {type TableRelease} from '../ReleasesOverview'
 import {
-  getReleasesOverviewMinContentWidth,
   RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
   releasesOverviewColumnDefs,
 } from '../ReleasesOverviewColumnDefs'
 
 const t = ((key: string) => key) as Parameters<typeof releasesOverviewColumnDefs>[0]
+
+function getMinContentWidth(columns: Column<TableRelease>[]): number {
+  const columnWidth = columns
+    .filter((column) => !column.hidden)
+    .reduce((sum, column) => {
+      if (typeof column.width === 'number') return sum + column.width
+      const minWidth = column.style?.minWidth
+      return sum + (typeof minWidth === 'number' ? minWidth : 0)
+    }, 0)
+
+  return columnWidth + TABLE_ROW_ACTIONS_WIDTH
+}
 
 describe('releasesOverviewColumnDefs', () => {
   it('lets the title column shrink instead of locking it to half the viewport', () => {
@@ -22,9 +34,7 @@ describe('releasesOverviewColumnDefs', () => {
   })
 
   it('keeps the active-table minimum width inside a 1280px window with the calendar open', () => {
-    const minContentWidth = getReleasesOverviewMinContentWidth(
-      releasesOverviewColumnDefs(t, 'active'),
-    )
+    const minContentWidth = getMinContentWidth(releasesOverviewColumnDefs(t, 'active'))
 
     expect(minContentWidth).toBe(
       RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH + 280 + 150 + 40 + 120 + TABLE_ROW_ACTIONS_WIDTH,
@@ -33,10 +43,6 @@ describe('releasesOverviewColumnDefs', () => {
   })
 
   it('keeps the archived-table minimum width inside the same window', () => {
-    const minContentWidth = getReleasesOverviewMinContentWidth(
-      releasesOverviewColumnDefs(t, 'archived'),
-    )
-
-    expect(minContentWidth).toBeLessThan(1000)
+    expect(getMinContentWidth(releasesOverviewColumnDefs(t, 'archived'))).toBeLessThan(1000)
   })
 })

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
@@ -1,8 +1,8 @@
 import {describe, expect, it} from 'vitest'
 
+import {TABLE_ROW_ACTIONS_WIDTH} from '../../components/Table/Table'
 import {
   getReleasesOverviewMinContentWidth,
-  RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH,
   RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
   releasesOverviewColumnDefs,
 } from '../ReleasesOverviewColumnDefs'
@@ -27,12 +27,7 @@ describe('releasesOverviewColumnDefs', () => {
     )
 
     expect(minContentWidth).toBe(
-      RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH +
-        280 +
-        150 +
-        40 +
-        120 +
-        RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH,
+      RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH + 280 + 150 + 40 + 120 + TABLE_ROW_ACTIONS_WIDTH,
     )
     expect(minContentWidth).toBeLessThan(1000)
   })

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  getReleasesOverviewMinContentWidth,
+  RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH,
+  RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH,
+  releasesOverviewColumnDefs,
+} from '../ReleasesOverviewColumnDefs'
+
+const t = ((key: string) => key) as Parameters<typeof releasesOverviewColumnDefs>[0]
+
+describe('releasesOverviewColumnDefs', () => {
+  it('lets the title column shrink instead of locking it to half the viewport', () => {
+    const titleColumn = releasesOverviewColumnDefs(t, 'active').find(
+      (column) => column.id === 'metadata.title',
+    )
+
+    expect(titleColumn?.style?.minWidth).toBe(RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH)
+    expect(titleColumn?.style?.maxWidth).toBeUndefined()
+    expect(String(titleColumn?.style?.minWidth)).not.toContain('100vw')
+    expect(String(titleColumn?.style?.minWidth)).not.toContain('%')
+  })
+
+  it('keeps the active-table minimum width inside a 1280px window with the calendar open', () => {
+    const minContentWidth = getReleasesOverviewMinContentWidth(
+      releasesOverviewColumnDefs(t, 'active'),
+    )
+
+    expect(minContentWidth).toBe(
+      RELEASES_OVERVIEW_TITLE_COLUMN_MIN_WIDTH +
+        280 +
+        150 +
+        40 +
+        120 +
+        RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH,
+    )
+    // 1280 viewport minus calendar (~280px) and studio chrome still has ~1000px for the table.
+    expect(minContentWidth).toBeLessThan(1000)
+  })
+
+  it('keeps the archived-table minimum width inside the same window', () => {
+    const minContentWidth = getReleasesOverviewMinContentWidth(
+      releasesOverviewColumnDefs(t, 'archived'),
+    )
+
+    expect(minContentWidth).toBeLessThan(1000)
+  })
+})

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverviewColumnDefs.test.ts
@@ -34,7 +34,6 @@ describe('releasesOverviewColumnDefs', () => {
         120 +
         RELEASES_OVERVIEW_ROW_ACTIONS_WIDTH,
     )
-    // 1280 viewport minus calendar (~280px) and studio chrome still has ~1000px for the table.
     expect(minContentWidth).toBeLessThan(1000)
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The 12px clip of the Releases overview row-action … (reported at &lt;1491px in [SAPP-3249](https://linear.app/sanity/issue/SAPP-3249/the-ellipse-in-the-releases-menu-gets-cut-off-on-smaller-screens)) is not a title-column overflow. The action cell was `width: 25px` with `box-sizing: border-box` and 12px padding, so the 25px bleed button painted 12px past the cell. Header already reserved 50px; body did not.

The title-column `min(50%, calc(100vw - 80px))` lock was a red herring for that clip, but it still fights the shrink path, so it is removed. A leftover 12px floor on `--tableInlinePadding` is also gone so a full-bleed table cannot add the same gutter again.

Sticky actions were ruled out: overview rows are `position: absolute` for virtualisation, so sticky would pin to the overflowing row, not the scrollport.

At 1024px with the calendar open, the table still needs horizontal scroll (fixed When / Edited / Documents columns). That is separate from the 12px “hard to see the …” clip.

### What to review

- `Table.tsx` — action cell sized 50px for border-box padding (this is the actual fix)
- `ReleasesOverviewColumnDefs.tsx` — title column no longer locked to 50% / `100vw`
- Unit tests for column min-width; browser test that the action button stays inside a 1100px table

### Testing

Reproduced on test studio `/test/releases` (calendar visible) with Playwright viewports. Before: 12px overflow at 1491 and 1280 (third dot clipped). After the 50px cell: overflow 0 and the button sits 13px inside the viewport at 1600 / 1491 / 1280. 1024 still overflows ~111px.

Unit tests: `ReleasesOverviewColumnDefs.test.ts`. Browser: `Table.browser.test.tsx` (button fully inside a 1100px container). Desktop: 1280×800, hover + open the first-row menu.

[Before: 1491px row-action ellipsis clipped](https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro_1491px_ellipsis_clipped.webp)
[After: 1491px row-action ellipsis fully visible](https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_1491px_ellipsis_after_action_cell_fix.png)
[After: 1491px right-edge close-up](https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_1491px_row_action_right_edge_after_fix.png)
[After: 1280px right-edge close-up](https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_1280px_row_action_right_edge_after_fix.png)
[After: 1280 desktop row-action menu open](https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_1280px_row_action_menu_open.webp)
[releases-row-action-menu-open-at-1280-after-fix.mp4](https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freleases-row-action-menu-open-at-1280-after-fix.mp4)

[ellipsis_overflow_metrics.log](https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fellipsis_overflow_metrics.log)

### Notes for release

The Releases overview row-action menu (the … at the end of each row) stays fully visible on narrower desktop windows instead of losing its last dot at the table edge.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79ce6efe-47dd-45e5-b30c-4a149999e1e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

