### PR TITLE
fix(form): constrain pte annotation reference picker width and results height

### DIFF
--- a/packages/sanity/src/_singletons/context/EditDialogOuterBoundaryContext.ts
+++ b/packages/sanity/src/_singletons/context/EditDialogOuterBoundaryContext.ts
@@ -9,9 +9,9 @@ import type {EditDialogOuterBoundaryContextValue} from '../../core/form/componen
  *
  * Edit dialogs constrain descendant popovers to their own scroll container through a generic
  * `BoundaryElementProvider` (see #12721). Popovers that should be allowed to overflow the dialog
- * (currently only the array insert menu) can read this context to constrain themselves to the
- * boundary the dialog itself sits in, instead of the dialog. `null` means "not inside an edit
- * dialog".
+ * (the array insert menu, and reference autocomplete results) can read this context to constrain
+ * themselves to the boundary the dialog itself sits in, instead of the dialog. `null` means "not
+ * inside an edit dialog".
  *
  * @internal
  */

--- a/packages/sanity/src/core/form/components/EditDialogOuterBoundaryProvider.tsx
+++ b/packages/sanity/src/core/form/components/EditDialogOuterBoundaryProvider.tsx
@@ -18,9 +18,10 @@ export interface EditDialogOuterBoundaryContextValue {
  * shadows it with its own scroll container (`BoundaryElementProvider`). Render it *around* the
  * dialog's `BoundaryElementProvider`.
  *
- * Popovers that are allowed to overflow the dialog (currently only the array insert menu) use the
- * captured element — typically the document pane's scroll container — as their floating boundary,
- * so they can escape the dialog while still respecting the pane header and footer.
+ * Popovers that are allowed to overflow the dialog (the array insert menu, and reference
+ * autocomplete results) use the captured element — typically the document pane's scroll
+ * container — as their floating boundary, so they can escape the dialog while still respecting
+ * the pane header and footer.
  *
  * When edit dialogs are stacked, the value captured by the outermost dialog is inherited, so
  * popovers in nested dialogs are not constrained to the (hidden) parent dialog's content box.

--- a/packages/sanity/src/core/form/hooks/useReferenceAutocompletePopoverBoundary.ts
+++ b/packages/sanity/src/core/form/hooks/useReferenceAutocompletePopoverBoundary.ts
@@ -5,26 +5,12 @@ import {EditDialogOuterBoundaryContext} from 'sanity/_singletons'
 import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../inputs/referenceAutocompletePopoverBoundary'
 
 /**
- * Pick the right Floating UI boundary for a reference autocomplete popover.
+ * Floating UI boundary for a reference autocomplete popover.
  *
- * Document pane installs a `BoundaryElementProvider` on the scroll container. When the reference
- * input is rendered inside that subtree we want to reuse that boundary so the popover is
- * constrained by the scroll container (respects the sticky pane header, version chips /
- * document actions, and the bottom footer).
- *
- * Edit dialogs and PTE annotation popovers install a nested `BoundaryElementProvider` on their
- * own scroll box. Constraining autocomplete results to that box leaves only ~one row of height
- * (SAPP-4329). Prefer the boundary captured by `EditDialogOuterBoundaryProvider` when it still
- * contains the input; otherwise fall back to {@link AUTOCOMPLETE_POPOVER_BOUNDARY} (the document
- * root) so portaled popovers can use the viewport. Same overflow exception as the array insert
- * menu.
- *
- * Portaled dialogs (e.g. the Media Library, Create-new document) render outside the document
- * pane's scroll container, so the inherited context element no longer contains the reference
- * input. In that case fall back to {@link AUTOCOMPLETE_POPOVER_BOUNDARY} so the popover is
- * anchored against the viewport.
- *
- * Shared by same-dataset, cross-dataset, and global-document reference autocompletes.
+ * Prefer the edit-dialog outer boundary when present so results can overflow the dialog's own
+ * scroll box. If that element does not contain the input (portaled dialogs), use the document
+ * root — using the pane would mark the reference `referenceHidden`. Otherwise reuse the nearest
+ * `BoundaryElementProvider` that contains the input.
  *
  * @internal
  */
@@ -45,8 +31,6 @@ export function useReferenceAutocompletePopoverBoundary(
     return AUTOCOMPLETE_POPOVER_BOUNDARY ?? null
   }
 
-  // Prefer the nearest `BoundaryElementProvider` element when it actually contains the reference
-  // element in the DOM (typically the document pane scroll container).
   if (contextElement && referenceElement && contextElement.contains(referenceElement)) {
     return contextElement
   }

--- a/packages/sanity/src/core/form/hooks/useReferenceAutocompletePopoverBoundary.ts
+++ b/packages/sanity/src/core/form/hooks/useReferenceAutocompletePopoverBoundary.ts
@@ -1,4 +1,6 @@
 import {useBoundaryElement} from '@sanity/ui'
+import {useContext} from 'react'
+import {EditDialogOuterBoundaryContext} from 'sanity/_singletons'
 
 import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../inputs/referenceAutocompletePopoverBoundary'
 
@@ -10,10 +12,17 @@ import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../inputs/referenceAutocompletePopo
  * constrained by the scroll container (respects the sticky pane header, version chips /
  * document actions, and the bottom footer).
  *
+ * Edit dialogs and PTE annotation popovers install a nested `BoundaryElementProvider` on their
+ * own scroll box. Constraining autocomplete results to that box leaves only ~one row of height
+ * (SAPP-4329). Prefer the boundary captured by `EditDialogOuterBoundaryProvider` when it still
+ * contains the input; otherwise fall back to {@link AUTOCOMPLETE_POPOVER_BOUNDARY} (the document
+ * root) so portaled popovers can use the viewport. Same overflow exception as the array insert
+ * menu.
+ *
  * Portaled dialogs (e.g. the Media Library, Create-new document) render outside the document
  * pane's scroll container, so the inherited context element no longer contains the reference
- * input. In that case fall back to {@link AUTOCOMPLETE_POPOVER_BOUNDARY} (the document root) so
- * the popover is anchored against the viewport.
+ * input. In that case fall back to {@link AUTOCOMPLETE_POPOVER_BOUNDARY} so the popover is
+ * anchored against the viewport.
  *
  * Shared by same-dataset, cross-dataset, and global-document reference autocompletes.
  *
@@ -23,6 +32,18 @@ export function useReferenceAutocompletePopoverBoundary(
   referenceElement: HTMLElement | null,
 ): HTMLElement | null {
   const {element: contextElement} = useBoundaryElement()
+  const editDialogOuterBoundary = useContext(EditDialogOuterBoundaryContext)
+
+  if (editDialogOuterBoundary) {
+    if (
+      editDialogOuterBoundary.element &&
+      referenceElement &&
+      editDialogOuterBoundary.element.contains(referenceElement)
+    ) {
+      return editDialogOuterBoundary.element
+    }
+    return AUTOCOMPLETE_POPOVER_BOUNDARY ?? null
+  }
 
   // Prefer the nearest `BoundaryElementProvider` element when it actually contains the reference
   // element in the DOM (typically the document pane scroll container).

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
@@ -8,6 +8,10 @@
  *  - In portaled dialogs (e.g. the Media Library) where the reference element is not inside the
  *    inherited boundary element, we fall back to `document.documentElement` so the popover is
  *    positioned against the viewport (avoids `referenceHidden` / misalignment).
+ *  - Inside an edit dialog / PTE annotation popover (`EditDialogOuterBoundaryContext` is set) we
+ *    must not use the dialog's own scroll box: it only has ~one row of height for results
+ *    (SAPP-4329). Prefer the captured outer boundary when it contains the input; otherwise the
+ *    document root (portaled annotation popovers).
  *
  * `ReferenceInput/ReferenceAutocomplete` (same-dataset), GDR, and Cross-dataset
  * `CrossDatasetReferenceInput/ReferenceAutocomplete` share this Popover wiring. Same-dataset needs
@@ -17,6 +21,7 @@
 import {type Autocomplete, type AutocompleteProps} from '@sanity/ui/autocomplete'
 import {render, waitFor} from '@testing-library/react'
 import {type ReactNode, type Ref, useLayoutEffect, useRef, useState} from 'react'
+import {EditDialogOuterBoundaryContext} from 'sanity/_singletons'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 
 import {type PopoverProps as UIPopoverProps} from '../../../../ui-components/popover/Popover'
@@ -307,6 +312,85 @@ describe('ReferenceAutocomplete popover boundaries', () => {
       })
 
       expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+      expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+    })
+  })
+
+  describe('inside an edit dialog, prefers the captured outer boundary over the dialog scroll box (SAPP-4329)', () => {
+    test('uses the outer boundary when it contains the reference', async () => {
+      const {boundary: innerBoundary, referenceElement} = setupContainedBoundary()
+      const outerBoundary = document.createElement('div')
+      outerBoundary.append(innerBoundary)
+      document.body.append(outerBoundary)
+      const editDialogOuterBoundary = {element: outerBoundary}
+
+      render(
+        <EditDialogOuterBoundaryContext.Provider value={editDialogOuterBoundary}>
+          <SameDatasetReferenceAutocomplete
+            path={[...sameDatasetFieldPath]}
+            loading={false}
+            options={[]}
+            onQueryChange={() => undefined}
+            referenceElement={referenceElement}
+            searchString=""
+            id="same-dataset-ref-ac-edit-dialog-outer"
+          />
+        </EditDialogOuterBoundaryContext.Provider>,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps?.floatingBoundary).toBe(outerBoundary)
+      })
+      expect(lastPopoverProps?.referenceBoundary).toBe(outerBoundary)
+    })
+
+    test('falls back to documentElement when the outer boundary does not contain the reference (portaled PTE popover)', async () => {
+      const {referenceElement} = setupContainedBoundary()
+      const outerBoundary = document.createElement('div')
+      document.body.append(outerBoundary)
+      const editDialogOuterBoundary = {element: outerBoundary}
+
+      render(
+        <EditDialogOuterBoundaryContext.Provider value={editDialogOuterBoundary}>
+          <SameDatasetReferenceAutocomplete
+            path={[...sameDatasetFieldPath]}
+            loading={false}
+            options={[]}
+            onQueryChange={() => undefined}
+            referenceElement={referenceElement}
+            searchString=""
+            id="same-dataset-ref-ac-edit-dialog-portaled"
+          />
+        </EditDialogOuterBoundaryContext.Provider>,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+      })
+      expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+    })
+
+    test('falls back to documentElement when the edit dialog captured no outer boundary', async () => {
+      const {referenceElement} = setupContainedBoundary()
+      const editDialogOuterBoundary = {element: null}
+
+      render(
+        <EditDialogOuterBoundaryContext.Provider value={editDialogOuterBoundary}>
+          <SameDatasetReferenceAutocomplete
+            path={[...sameDatasetFieldPath]}
+            loading={false}
+            options={[]}
+            onQueryChange={() => undefined}
+            referenceElement={referenceElement}
+            searchString=""
+            id="same-dataset-ref-ac-edit-dialog-no-outer"
+          />
+        </EditDialogOuterBoundaryContext.Provider>,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+      })
       expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
     })
   })

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
@@ -8,10 +8,9 @@
  *  - In portaled dialogs (e.g. the Media Library) where the reference element is not inside the
  *    inherited boundary element, we fall back to `document.documentElement` so the popover is
  *    positioned against the viewport (avoids `referenceHidden` / misalignment).
- *  - Inside an edit dialog / PTE annotation popover (`EditDialogOuterBoundaryContext` is set) we
- *    must not use the dialog's own scroll box: it only has ~one row of height for results
- *    (SAPP-4329). Prefer the captured outer boundary when it contains the input; otherwise the
- *    document root (portaled annotation popovers).
+ *  - Inside an edit dialog, prefer the captured outer boundary over the dialog scroll box so
+ *    results can overflow the dialog; fall back to the document root when that outer boundary
+ *    does not contain the input.
  *
  * `ReferenceInput/ReferenceAutocomplete` (same-dataset), GDR, and Cross-dataset
  * `CrossDatasetReferenceInput/ReferenceAutocomplete` share this Popover wiring. Same-dataset needs
@@ -316,7 +315,7 @@ describe('ReferenceAutocomplete popover boundaries', () => {
     })
   })
 
-  describe('inside an edit dialog, prefers the captured outer boundary over the dialog scroll box (SAPP-4329)', () => {
+  describe('inside an edit dialog, prefers the captured outer boundary over the dialog scroll box', () => {
     test('uses the outer boundary when it contains the reference', async () => {
       const {boundary: innerBoundary, referenceElement} = setupContainedBoundary()
       const outerBoundary = document.createElement('div')

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
@@ -22,7 +22,8 @@ describe('_getModalOption', () => {
   })
 
   it('returns an undefined width (not an empty array) for an explicit empty width array', () => {
-    // An empty responsive array still falls through to the edit dialog width defaults.
+    // An empty responsive array still falls through to the edit dialog width defaults
+    // (container index 1, ~640px — matching the PTE column).
     const result = _getModalOption(withModal({type: 'popover', width: []}))
     expect(result?.width).toBeUndefined()
   })

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
@@ -13,17 +13,12 @@ describe('_getModalOption', () => {
   })
 
   it('returns the default width (1) when modal is set without a width', () => {
-    // Regression test for the narrow annotation popover: an unspecified width must
-    // resolve to a real container width — previously an empty array bypassed the edit
-    // dialog width defaults and collapsed the popover to auto width.
     const result = _getModalOption(withModal({type: 'popover'}))
     expect(result?.type).toBe('popover')
     expect(result?.width).toEqual([1])
   })
 
   it('returns an undefined width (not an empty array) for an explicit empty width array', () => {
-    // An empty responsive array still falls through to the edit dialog width defaults
-    // (container index 1, ~640px — matching the PTE column).
     const result = _getModalOption(withModal({type: 'popover', width: []}))
     expect(result?.width).toBeUndefined()
   })

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
@@ -23,11 +23,8 @@ export function _getModalOption(
   const width = parseResponsiveWidth(raw.width)
   return {
     type: parseModalType(raw.type),
-    // Return `undefined` (not an empty array) when no width is configured, so the
-    // edit modal components fall back to their own width defaults (popover and
-    // dialog both use container index 1, ~640px). An empty array is "defined" and
-    // would otherwise collapse the popover to content/auto width — making e.g. a
-    // reference field inside an annotation render uselessly narrow.
+    // Empty arrays are defined, so they skip the edit-modal width defaults and
+    // collapse the popover to content/auto width.
     width: width.length > 0 ? width : undefined,
   }
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
@@ -24,10 +24,10 @@ export function _getModalOption(
   return {
     type: parseModalType(raw.type),
     // Return `undefined` (not an empty array) when no width is configured, so the
-    // edit modal components fall back to their own width defaults (popover 960px /
-    // dialog 640px). An empty array is "defined" and would otherwise collapse the
-    // popover to content/auto width — making e.g. a reference field inside an
-    // annotation render uselessly narrow.
+    // edit modal components fall back to their own width defaults (popover and
+    // dialog both use container index 1, ~640px). An empty array is "defined" and
+    // would otherwise collapse the popover to content/auto width — making e.g. a
+    // reference field inside an annotation render uselessly narrow.
     width: width.length > 0 ? width : undefined,
   }
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -61,7 +61,7 @@ export function ObjectEditModal(props: {
         referenceBoundary={referenceBoundary}
         referenceElement={referenceElement}
         title={<>{modalTitle}</>}
-        width={modalWidth}
+        width={modalWidth ?? 1}
         data-testid="popover-edit-dialog"
       >
         {props.children}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -48,9 +48,6 @@ const NoopContainer = ({children, ...props}: ComponentProps<'div'>) => (
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 export function PopoverEditDialog(props: PopoverEditDialogProps): ReactNode {
-  // Container index 1 (~640px) matches the PTE column (`container[1]`) and the
-  // dialog default. Index 2 (~960px) overshoots the form and leaves the nested
-  // reference autocomplete with almost no vertical room (SAPP-4329).
   const {floatingBoundary, referenceBoundary, referenceElement, width = 1} = props
   return (
     <RootPopover

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -48,7 +48,10 @@ const NoopContainer = ({children, ...props}: ComponentProps<'div'>) => (
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 export function PopoverEditDialog(props: PopoverEditDialogProps): ReactNode {
-  const {floatingBoundary, referenceBoundary, referenceElement, width = 2} = props
+  // Container index 1 (~640px) matches the PTE column (`container[1]`) and the
+  // dialog default. Index 2 (~960px) overshoots the form and leaves the nested
+  // reference autocomplete with almost no vertical room (SAPP-4329).
+  const {floatingBoundary, referenceBoundary, referenceElement, width = 1} = props
   return (
     <RootPopover
       content={<Content {...props} />}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

SAPP-3617 / #12975 stopped annotation edit popovers collapsing to auto width by falling through to the popover default. That default was container index 2 (~960px), which overshoots the PTE column (~640px) and, because the nested reference autocomplete is constrained to the popover’s own scroll box, leaves only about one result row of height.

Fixes [SAPP-4329](https://linear.app/sanity/issue/SAPP-4329/studio-pte-reference-picker-annotation-excessively-wide-and-vertically).

Why this shape:
- Changing only the width still leaves the autocomplete clipped to the popover header+field leftover space.
- Using the document pane for every nested popover would re-break portaled dialogs (`referenceHidden`). The insert-menu overflow exception (`EditDialogOuterBoundaryContext`) is the existing pattern: outer pane when it contains the input, otherwise `document.documentElement`.

What changed: default annotation popover width is now container index 1, and reference autocomplete results inside edit dialogs/popovers use that overflow exception.

### What to review

- `PopoverModal.tsx` / `ObjectEditModal.tsx` — popover default width 1 (~640px), matching the PTE column and dialog default. Explicit `options.modal.width` is unchanged.
- `useReferenceAutocompletePopoverBoundary.ts` — edit-dialog overflow exception. Same-dataset, GDR, and cross-dataset autocompletes share this hook.
- Confirm we did not reintroduce the SAPP-3617 auto-width collapse (unspecified width still resolves to a real container width, not `[]`).

### Testing

- Unit tests in `ReferenceAutocomplete.test.tsx` for the edit-dialog boundary cases (outer contains input; portaled popover; no outer boundary). `pnpm vitest run --project=sanity` on those files: 17 passed.
- Existing `_getModalOption` tests still cover the SAPP-3617 unspecified-width case (`[1]`, not `[]`).
- Desktop verification in test studio on a `ptReference` annotation (measured popover width 906px → 648px; visible autocomplete rows 1 → 6).

Before (popover ~906px, one result row):

[Before: annotation popover about 906 pixels wide](https://cursor.com/agents/bc-2458251d-1ebd-445d-88ba-5e92dba20675/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_annotation_popover_too_wide.webp)
[Before: autocomplete shows one result row](https://cursor.com/agents/bc-2458251d-1ebd-445d-88ba-5e92dba20675/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_annotation_autocomplete_one_row.webp)

After (popover ~648px, six result rows):

[After: annotation popover matches the PTE column width](https://cursor.com/agents/bc-2458251d-1ebd-445d-88ba-5e92dba20675/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_annotation_popover_column_width.webp)
[After: autocomplete shows six author results](https://cursor.com/agents/bc-2458251d-1ebd-445d-88ba-5e92dba20675/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_annotation_autocomplete_six_rows.webp)

[after_pte_annotation_reference_picker_layout-2.mp4](https://cursor.com/agents/bc-2458251d-1ebd-445d-88ba-5e92dba20675/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_pte_annotation_reference_picker_layout-2.mp4)

### Notes for release

Portable Text annotation edit popovers that contain a reference field now use the same ~640px width as the PTE column, and the reference search results list can show several documents at once instead of a single cramped row.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2458251d-1ebd-445d-88ba-5e92dba20675?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2458251d-1ebd-445d-88ba-5e92dba20675&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

