### PR TITLE
feat(storybook): compose the upstream sanity ui storybook

### DIFF
--- a/dev/storybook/.storybook/main.ts
+++ b/dev/storybook/.storybook/main.ts
@@ -10,10 +10,11 @@ const config: StorybookConfig = {
   // own sidebar tree, so the design system the studio builds on is browsable
   // from here. The manager fetches the remote `index.json` and renders its
   // stories from the remote `iframe.html` at runtime — nothing is bundled, and
-  // Chromatic does not snapshot composed refs.
+  // Chromatic does not snapshot composed refs. "(upstream)" keeps the tree
+  // apart from the local `Sanity UI/` tone sentinels in `src/ui-components`.
   refs: {
     'sanity-ui': {
-      title: 'Sanity UI',
+      title: 'Sanity UI (upstream)',
       url: 'https://sanity-ui-storybook.sanity.dev',
     },
   },

--- a/dev/storybook/.storybook/main.ts
+++ b/dev/storybook/.storybook/main.ts
@@ -6,6 +6,17 @@ import {defaultClientConditions, mergeConfig} from 'vite'
 const config: StorybookConfig = {
   stories: ['../../../packages/{sanity,groq,@repo/*,@sanity/*}/src/**/*.stories.@(ts|tsx)'],
   addons: ['@chromatic-com/storybook', '@storybook/addon-vitest'],
+  // Storybook composition: the upstream `@sanity/ui` stories show up as their
+  // own sidebar tree, so the design system the studio builds on is browsable
+  // from here. The manager fetches the remote `index.json` and renders its
+  // stories from the remote `iframe.html` at runtime — nothing is bundled, and
+  // Chromatic does not snapshot composed refs.
+  refs: {
+    'sanity-ui': {
+      title: 'Sanity UI',
+      url: 'https://sanity-ui-storybook.sanity.dev',
+    },
+  },
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/dev/storybook/README.md
+++ b/dev/storybook/README.md
@@ -39,8 +39,9 @@ pnpm chromatic           # publish + snapshot manually (needs CHROMATIC_PROJECT_
 [.storybook/main.ts](.storybook/main.ts) composes the upstream
 [`@sanity/ui` Storybook](https://sanity-ui-storybook.sanity.dev) (deployed from
 [sanity-io/ui](https://github.com/sanity-io/ui)) through Storybook's `refs`, so the design system
-the studio builds on is browsable from the same sidebar — it appears as a separate "Sanity UI" tree
-below the local stories.
+the studio builds on is browsable from the same sidebar — it appears as a separate
+"Sanity UI (upstream)" tree below the local stories. The suffix keeps it apart from the local
+`Sanity UI/` tone sentinels in `packages/sanity/src/ui-components`.
 
 - Composition is a **runtime** link: the manager fetches `index.json` from the remote Storybook and
   renders its stories in the remote `iframe.html`. Nothing is bundled here, so it costs the local

--- a/dev/storybook/README.md
+++ b/dev/storybook/README.md
@@ -34,6 +34,24 @@ pnpm chromatic           # publish + snapshot manually (needs CHROMATIC_PROJECT_
   `ui-components` wrapper variants (the `@sanity/ui` → `ui5` surface, with card/tone coverage
   prioritized) and vanilla-extract-migrated components.
 
+## Composed Storybooks
+
+[.storybook/main.ts](.storybook/main.ts) composes the upstream
+[`@sanity/ui` Storybook](https://sanity-ui-storybook.sanity.dev) (deployed from
+[sanity-io/ui](https://github.com/sanity-io/ui)) through Storybook's `refs`, so the design system
+the studio builds on is browsable from the same sidebar — it appears as a separate "Sanity UI" tree
+below the local stories.
+
+- Composition is a **runtime** link: the manager fetches `index.json` from the remote Storybook and
+  renders its stories in the remote `iframe.html`. Nothing is bundled here, so it costs the local
+  build nothing and never fails it — a ref that is unreachable degrades to an error inside its own
+  sidebar tree.
+- Composed stories are **not** snapshotted by Chromatic and are not picked up by
+  `@storybook/addon-vitest`; both only see the local `stories` globs.
+- The remote tracks `sanity-io/ui` `main`, which is the same `@sanity/ui` major this repo depends on
+  (catalog `@sanity/ui`). It does **not** cover `ui5` (`@sanity/ui@alpha`), the other side of the
+  ongoing migration.
+
 The Vite config in [.storybook/main.ts](.storybook/main.ts) mirrors
 `packages/sanity/vitest.browser.config.mts`: the `monorepo` exports condition resolves workspace
 packages to TypeScript source, plus the vanilla-extract plugin and the React Compiler transform,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Most of what the studio renders is `@sanity/ui`, but its stories live in a different repo and a different deploy, so answering "what tones does Badge support" meant leaving this Storybook. Storybook composition puts them in the same sidebar at zero build cost — `refs` is a runtime link, so the manager fetches the remote `index.json` and renders remote stories from the remote `iframe.html`.

The composed tree is titled **Sanity UI (upstream)** rather than "Sanity UI" because the local stories already own a `Sanity UI/` root group (the ui5 tone sentinels in `src/ui-components`), and two adjacent identically-named trees is exactly the confusion this change is meant to remove.

Why not vendor or mirror the stories instead: they would have to track `sanity-io/ui` releases by hand, and Chromatic would start snapshotting a dependency's UI as if it were ours.

### What to review

- `dev/storybook/.storybook/main.ts` — the whole functional change is the `refs` entry.
- `dev/storybook/README.md` — new "Composed Storybooks" section, including the caveats that matter: composed stories are invisible to Chromatic and to `@storybook/addon-vitest`, and the remote covers `@sanity/ui` v4 (catalog `@sanity/ui`), not `ui5` (`@sanity/ui@alpha`).

Only `dev/storybook` is affected; no package code changes.

### Testing

No automated test — the change is one Storybook config field, and the thing worth verifying (that a remote Storybook composes and renders) is inherently a manual/integration check. What was verified locally:

- `pnpm dev:storybook` → the "Sanity UI (upstream)" tree appears at the bottom of the sidebar and expands into the remote's `primitives` / `components` / `hooks` / `utils` / `logos` / `tokens` groups. `primitives/Button` and `tokens/Colors` both render real content in the canvas, and the local `Sanity UI/Card Tones` story still renders correctly.
- `pnpm exec storybook build` succeeds and embeds the ref in `storybook-static/index.html` with `"type": "server-checked"` — so the Vercel and Chromatic path works.
- **Build resilience:** repeating that build against a deliberately unresolvable ref URL still exits `0`, downgrading the ref to `"type": "unknown"`; the failure stays inside the sidebar tree at runtime. An outage of the upstream deploy cannot break CI or a Vercel deploy.
- `pnpm --filter sanity-storybook test` → 33 files / 37 tests passed (unchanged; composed refs are not collected).
- `pnpm check:format` and `pnpm check:oxlint` clean.

[browsing_composed_sanity_ui_storybook.mp4](https://cursor.com/agents/bc-260b81cd-2b64-4cac-9535-7f17285aa86e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowsing_composed_sanity_ui_storybook.mp4)

[Upstream primitives/Button story rendering inside the monorepo Storybook](https://cursor.com/agents/bc-260b81cd-2b64-4cac-9535-7f17285aa86e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_upstream_button_story.webp)

[Upstream tokens/Colors story rendering inside the monorepo Storybook](https://cursor.com/agents/bc-260b81cd-2b64-4cac-9535-7f17285aa86e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_upstream_color_tokens.webp)

### Notes for release

N/A – Internal only (dev tooling)

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-260b81cd-2b64-4cac-9535-7f17285aa86e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-260b81cd-2b64-4cac-9535-7f17285aa86e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

