### PR TITLE
feat(cli): expose typed view and web worker helpers

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.cli.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.cli.test-d.ts
@@ -7,13 +7,17 @@ import type {
   CliConfig,
   createCliConfig,
   DefineAppInput,
+  defineApplication,
   defineCliConfig,
   DefineMediaLibraryInput,
+  definePanelView,
+  defineTileView,
+  defineWebWorker,
+  defineWindowView,
   getCliClient,
   getStudioEnvironmentVariables,
   MediaLibraryField,
   StudioEnvVariablesOptions,
-  unstable_defineApp,
   unstable_defineMediaLibrary,
 } from 'sanity/cli'
 import {describe, expectTypeOf, test} from 'vitest'
@@ -31,11 +35,26 @@ describe('sanity/cli', () => {
   test('DefineAppInput', () => {
     expectTypeOf<DefineAppInput>().not.toBeNever()
   })
+  test('defineApplication', () => {
+    expectTypeOf<typeof defineApplication>().toBeFunction()
+  })
   test('defineCliConfig', () => {
     expectTypeOf<typeof defineCliConfig>().toBeFunction()
   })
   test('DefineMediaLibraryInput', () => {
     expectTypeOf<DefineMediaLibraryInput>().toBeObject()
+  })
+  test('definePanelView', () => {
+    expectTypeOf<typeof definePanelView>().toBeFunction()
+  })
+  test('defineTileView', () => {
+    expectTypeOf<typeof defineTileView>().toBeFunction()
+  })
+  test('defineWebWorker', () => {
+    expectTypeOf<typeof defineWebWorker>().toBeFunction()
+  })
+  test('defineWindowView', () => {
+    expectTypeOf<typeof defineWindowView>().toBeFunction()
   })
   test('getCliClient', () => {
     expectTypeOf<typeof getCliClient>().not.toBeNever()
@@ -48,9 +67,6 @@ describe('sanity/cli', () => {
   })
   test('StudioEnvVariablesOptions', () => {
     expectTypeOf<StudioEnvVariablesOptions>().toBeObject()
-  })
-  test('unstable_defineApp', () => {
-    expectTypeOf<typeof unstable_defineApp>().toBeFunction()
   })
   test('unstable_defineMediaLibrary', () => {
     expectTypeOf<typeof unstable_defineMediaLibrary>().toBeFunction()

--- a/packages/sanity/src/_exports/cli.ts
+++ b/packages/sanity/src/_exports/cli.ts
@@ -3,11 +3,15 @@ export {
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   createCliConfig,
   type DefineAppInput,
+  defineApplication,
   defineCliConfig,
   type DefineMediaLibraryInput,
+  definePanelView,
+  defineTileView,
+  defineWebWorker,
+  defineWindowView,
   getCliClient,
   type MediaLibraryField,
-  unstable_defineApp,
   unstable_defineMediaLibrary,
 } from '@sanity/cli'
 export {getStudioEnvironmentVariables, type StudioEnvVariablesOptions} from '@sanity/cli/_internal'

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -911,10 +911,14 @@ exports[`exports snapshot 1`] = `
   },
   "./cli": {
     "createCliConfig": "function",
+    "defineApplication": "function",
     "defineCliConfig": "function",
+    "definePanelView": "function",
+    "defineTileView": "function",
+    "defineWebWorker": "function",
+    "defineWindowView": "function",
     "getCliClient": "function",
     "getStudioEnvironmentVariables": "function",
-    "unstable_defineApp": "function",
     "unstable_defineMediaLibrary": "function",
   },
   "./desk": {


### PR DESCRIPTION
### Description

Export the new typed helpers for `views` and `webWorkers` from `sanity/cli`:

- `defineWindowView`
- `defineTileView`
- `definePanelView`
- `defineWebWorker`

The CLI still exports `unstable_defineApp` but we are ready to stabilize it and therefore now re-export `defineApplication`.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removes `unstable_defineApp` from `sanity/cli` in favor of `defineApplication`, which is a breaking change for consumers on the old symbol; otherwise limited to export wiring and test fixtures.
> 
> **Overview**
> Updates the public **`sanity/cli`** export surface to ship typed configuration helpers for apps, views, and web workers.
> 
> **`defineApplication`** is now re-exported from `sanity/cli`, and **`unstable_defineApp`** is dropped from that entry point (callers should switch to `defineApplication`). New exports **`defineWindowView`**, **`defineTileView`**, **`definePanelView`**, and **`defineWebWorker`** are added alongside existing CLI utilities.
> 
> Export snapshot and auto-generated DTS export tests are refreshed to match the new public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104eebe59ec9b6b7d6cf17acb2844a680f46f08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->