### PR TITLE
chore(core): history events to support variants

### DIFF
--- a/packages/sanity/src/core/store/events/createEventsStore.test.ts
+++ b/packages/sanity/src/core/store/events/createEventsStore.test.ts
@@ -1,0 +1,34 @@
+import {firstValueFrom, of, toArray} from 'rxjs'
+import {describe, expect, it} from 'vitest'
+
+import {collectEmissions} from './__fixtures__/collect.fixture'
+import {publishDocumentVersionEvent} from './__fixtures__/events.fixture'
+import {createMockClient} from './__fixtures__/mockClient'
+import {createEventsStore} from './createEventsStore'
+
+describe('createEventsStore', () => {
+  it('returns an idle empty store without fetching when documentId is missing', async () => {
+    const {client, requests} = createMockClient()
+    const store = createEventsStore({
+      client,
+      documentId: undefined,
+      documentType: 'author',
+      isLiveEdit: false,
+    })
+
+    const {values, subscription} = collectEmissions(store.eventsObservable$)
+    expect(values).toEqual([{events: [], nextCursor: '', loading: false, error: null}])
+    subscription.unsubscribe()
+
+    const diffs = await firstValueFrom(store.getDocumentChanges(of(null), of(null)).pipe(toArray()))
+    expect(diffs).toEqual([{diff: null, loading: false, error: null}])
+
+    store.loadMoreEvents()
+    store.reloadEvents()
+    await store.handleExpandEvent(publishDocumentVersionEvent())
+    const listener = store.remoteTransactionsListener()
+    listener.unsubscribe()
+
+    expect(requests).toHaveLength(0)
+  })
+})

--- a/packages/sanity/src/core/store/events/createEventsStore.ts
+++ b/packages/sanity/src/core/store/events/createEventsStore.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {type Observable} from 'rxjs'
+import {type Observable, of, Subscription} from 'rxjs'
 
 import {createEventsObservable} from './createEventsObservable'
 import {getDocumentChanges} from './getDocumentChanges'
@@ -10,9 +10,27 @@ import {type EventsStoreRevision} from './types'
 
 interface EventsStoreOptions {
   client: SanityClient
-  documentId: string
+  documentId: string | undefined
   documentType: string
   isLiveEdit: boolean
+}
+
+const IDLE_EVENTS = {events: [], nextCursor: '', loading: false, error: null}
+
+/**
+ * Idle store used when there is no document to observe (e.g. a missing variant with no
+ * creatable target). No events, translog, or history requests are made.
+ */
+function createIdleEventsStore() {
+  const eventsObservable$ = of(IDLE_EVENTS)
+  return {
+    eventsObservable$,
+    getDocumentChanges: () => of({diff: null, loading: false, error: null}),
+    handleExpandEvent: async () => {},
+    loadMoreEvents: () => {},
+    reloadEvents: () => {},
+    remoteTransactionsListener: () => new Subscription(),
+  }
 }
 
 /**
@@ -21,6 +39,9 @@ interface EventsStoreOptions {
  * - `getExpandEvents`: on-demand expansion of publish/delete events,
  * - `getRemoteTransactionsSubscription`: real-time remote mutations (append or trigger refetch),
  * - `createEventsObservable`: merge, sort and per-variant post-processing.
+ *
+ * When `documentId` is missing, returns an idle store (`events: []`, `loading: false`) and does
+ * not subscribe to the document pair or hit the events/history APIs.
  *
  * Returns:
  * - `eventsObservable$`: the final `{events, nextCursor, loading, error}` stream for the UI.
@@ -37,6 +58,10 @@ export function createEventsStore({
   documentType,
   isLiveEdit,
 }: EventsStoreOptions) {
+  if (!documentId) {
+    return createIdleEventsStore()
+  }
+
   const initialEvents = getInitialFetchEvents({client, documentId})
   const {expandedEvents$, handleExpandEvent} = getExpandEvents({client, documentId})
   const {remoteEdits$, remoteTransactions$, subscribe} = getRemoteTransactionsSubscription({

--- a/packages/sanity/src/core/store/events/getEditEvents.test.ts
+++ b/packages/sanity/src/core/store/events/getEditEvents.test.ts
@@ -60,7 +60,6 @@ describe('getEditEvents()', () => {
       timestamp: '2024-11-19T08:27:33.251404Z',
       author: 'p8xDvUMxC',
       contributors: ['p8xDvUMxC'],
-      releaseId: 'rkaihDvC1',
       revisionId: 'edit-tx-2',
       documentVariantType: 'version',
       transactions: [
@@ -108,7 +107,6 @@ describe('getEditEvents()', () => {
         id: 'new-tx',
         author: 'p8xDvUMxC',
         contributors: ['p8xDvUMxC'],
-        releaseId: 'rkaihDvC1',
         revisionId: 'new-tx',
         documentVariantType: 'version',
         transactions: [
@@ -172,10 +170,10 @@ describe('getEditEvents()', () => {
       expect(events).toEqual([expectedEvent])
     })
 
-    it('fails soft for variant-scoped version ids (opaque scope hash as bundle segment)', () => {
+    it('does not populate releaseId for variant-scoped version ids', () => {
       // Variant document ids are `versions.<scopeId>.<groupId>` where the scope id is an opaque
-      // server-generated hash, not a release id. Attribution must not throw or misclassify —
-      // `releaseId` simply carries the hash (it will never match a real release downstream).
+      // server-generated hash, not a release id. Synthesized edits must not throw or treat the
+      // hash as a releaseId.
       const variantDocumentId = 'versions.a1b2c3d4e5f6.f8dece19-c458-4cff-bf76-732b00617183'
       const variantTx = {
         id: 'variant-edit-tx',
@@ -197,9 +195,9 @@ describe('getEditEvents()', () => {
       expect(events[0]).toMatchObject({
         type: 'editDocumentVersion',
         documentId: variantDocumentId,
-        releaseId: 'a1b2c3d4e5f6',
         documentVariantType: 'version',
       })
+      expect(events[0]).not.toHaveProperty('releaseId')
     })
   })
   describe('when the document is liveEdit', () => {

--- a/packages/sanity/src/core/store/events/getEditEvents.ts
+++ b/packages/sanity/src/core/store/events/getEditEvents.ts
@@ -4,7 +4,6 @@ import {
   type TransactionLogEventWithEffects,
 } from '@sanity/types'
 
-import {getVersionFromId} from '../../util/draftUtils'
 import {getDocumentVariantType} from '../../util/getDocumentVariantType'
 import {
   type EditDocumentVersionEvent,
@@ -130,7 +129,6 @@ export function getEditEvents(
           timestamp: transaction.timestamp,
           author: transaction.author,
           contributors: [transaction.author],
-          releaseId: getVersionFromId(documentId),
           revisionId: transaction.id,
           transactions: [getEditTransaction(transaction)],
           documentVariantType: getDocumentVariantType(documentId),

--- a/packages/sanity/src/core/store/events/getInitialFetchEvents.test.ts
+++ b/packages/sanity/src/core/store/events/getInitialFetchEvents.test.ts
@@ -3,6 +3,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {collectEmissions} from './__fixtures__/collect.fixture'
 import {
   createDocumentVersionEvent,
+  deleteDocumentVersionEvent,
   DOCUMENT_ID,
   DRAFT_ID,
   minutesAfterBase,
@@ -65,6 +66,46 @@ describe('getInitialFetchEvents', () => {
     // Ids are (re)assigned client-side per variant.
     expect(result.events[1].id).toBe(apiCreate.versionRevisionId)
     expect(result.error).toBeNull()
+  })
+
+  it('version: does not duplicate a delete that shares its id with a synthesized edit', async () => {
+    // Delete events often reuse the last edit's revision as versionRevisionId, so the
+    // synthesized edit and the delete get the same client-side id.
+    const lastEditRevision = '6bffe811-d5cc-4c73-995f-8b742d3a77f9'
+    const apiDelete = deleteDocumentVersionEvent({
+      versionId: VERSION_ID,
+      versionRevisionId: lastEditRevision,
+      timestamp: '2026-08-26T09:51:12Z',
+      documentVariantType: 'version',
+    })
+    const apiCreate = createDocumentVersionEvent({
+      versionId: VERSION_ID,
+      versionRevisionId: 'HyFGxFe6HLdujEBXb2YLpb',
+      timestamp: '2026-08-26T09:47:08Z',
+      documentVariantType: 'version',
+    })
+    const {client} = createMockClient({
+      respond: eventsResponse(VERSION_ID, [apiDelete, apiCreate]),
+    })
+    mockGetDocumentTransactions.mockResolvedValue([
+      editTransaction({
+        id: lastEditRevision,
+        documentId: VERSION_ID,
+        timestamp: '2026-08-26T09:50:00Z',
+      }),
+    ])
+
+    const {events$} = getInitialFetchEvents({client, documentId: VERSION_ID})
+    const {values, subscription} = collectEmissions(events$)
+    await vi.waitFor(() => expect(values.at(-1)?.loading).toBe(false))
+    subscription.unsubscribe()
+
+    const events = values.at(-1)!.events
+    expect(events.filter((event) => event.type === 'deleteDocumentVersion')).toHaveLength(1)
+    expect(events.map((event) => event.type)).toEqual([
+      'deleteDocumentVersion',
+      'createDocumentVersion',
+    ])
   })
 
   it('version: uses the creation event as the baseline for edit synthesis', async () => {

--- a/packages/sanity/src/core/store/events/types.ts
+++ b/packages/sanity/src/core/store/events/types.ts
@@ -435,6 +435,10 @@ export interface EditDocumentVersionEvent extends BaseEvent {
   documentId: string
   // Given this event could be a result of multiple edits, we could have more than one author.
   contributors: string[]
+  /**
+   * @deprecated No longer populated by the events store. Resolve membership from the version document's
+   * `_system.release` instead. Will be removed in the next major.
+   */
   releaseId?: string
   /**
    * One edit event could contain multiple transactions that are merged together.

--- a/packages/sanity/src/core/store/events/useEventsStore.ts
+++ b/packages/sanity/src/core/store/events/useEventsStore.ts
@@ -71,7 +71,7 @@ export function useEventsStore({
   rev,
   since,
 }: {
-  documentId: string
+  documentId: string | undefined
   documentType: string
   rev?: string | '@lastEdited' | '@lastPublished'
   since?: string | '@lastPublished'
@@ -151,6 +151,7 @@ export function useEventsStore({
 
   const getDocumentAtRevision = useCallback(
     (revision: string) => {
+      if (!documentId) return of(null)
       return getDocumentAtRevisionFunction({
         client,
         documentId,
@@ -205,7 +206,7 @@ export function useEventsStore({
 
   const sinceRevision = useSyncObservable(since$, null)
 
-  const documentVariantType = getDocumentVariantType(documentId)
+  const documentVariantType = documentId ? getDocumentVariantType(documentId) : undefined
   const findRangeForRevision = useCallback(
     (nextRev: string): [string | null, string | null] => {
       if (!events) return [null, null]

--- a/packages/sanity/src/core/store/events/utils.test.ts
+++ b/packages/sanity/src/core/store/events/utils.test.ts
@@ -450,14 +450,13 @@ describe('removeDupes', () => {
   })
 
   it('replaces an existing edit event with a non-edit event sharing the same id', () => {
-    // A publish event and the last edit before that publish share the same id.
+    // A publish/delete event and the last edit before it share the same id.
     const edit = editDocumentVersionEvent({id: 'shared', revisionId: 'shared'})
     const publish = publishDocumentVersionEvent({id: 'shared'})
+    const deleted = deleteDocumentVersionEvent({id: 'shared'})
 
-    const result = removeDupes([edit], [publish])
-    // Known quirk: because the types also differ, the publish is stored under both the plain id
-    // key and the synthetic `${id}-${type}` key, so it appears twice in the output.
-    expect(result).toEqual([publish, publish])
+    expect(removeDupes([edit], [publish])).toEqual([publish])
+    expect(removeDupes([edit], [deleted])).toEqual([deleted])
   })
 
   it('keeps both events when two non-edit events share an id but differ in type', () => {

--- a/packages/sanity/src/core/store/events/utils.ts
+++ b/packages/sanity/src/core/store/events/utils.ts
@@ -44,8 +44,8 @@ export function removeDupes(
     if (acc.has(event.id)) {
       const existingEvent = acc.get(event.id) as DocumentGroupEvent
       if (isEditDocumentVersionEvent(existingEvent) && !isEditDocumentVersionEvent(event)) {
-        // Replaces the edit event with the none edit event, the publish/delete event and the last
-        // edit event before it have the same id.
+        // Replaces the edit event with the non-edit event; the publish/delete event and the last
+        // edit event before it has the same id.
         acc.set(event.id, event)
         return acc
       }

--- a/packages/sanity/src/core/store/events/utils.ts
+++ b/packages/sanity/src/core/store/events/utils.ts
@@ -24,18 +24,17 @@ import {
  * Main cases covered:
  * - Events with unseen ids are appended in encounter order.
  * - If an existing *edit* event shares its id with an incoming *non-edit* event, the non-edit event
- *   replaces it — a publish event and the last edit before that publish share the same id.
- * - If two events share an id but have *different* types, both are kept: the second one is stored
- *   under a synthetic `${id}-${type}` map key (can happen when a document is created and published
- *   with the same revision id, e.g. in e2e tests).
+ *   replaces it — a publish or delete event and the last edit before that event share the same id
+ *   (delete events reuse the last edit's `versionRevisionId`).
+ * - If two *non-edit* events share an id but have *different* types, both are kept: the second one
+ *   is stored under a synthetic `${id}-${type}` map key (can happen when a document is created and
+ *   published with the same revision id, e.g. in e2e tests).
  *
  * Known quirks (current behavior, relied upon by tests):
  * - Events with an empty-string id (see {@link addEventId}) all collide on the same map key, so
  *   only the first one survives unless their types differ.
  * - The synthetic `${id}-${type}` key only disambiguates one extra event per id; a third event
  *   with the same id and same type as the second overwrites it.
- * - The edit-replacement and different-type branches both run: an edit + non-edit pair sharing an
- *   id stores the non-edit event under *both* keys, so it appears twice in the output.
  */
 export function removeDupes(
   events: DocumentGroupEvent[],
@@ -45,8 +44,10 @@ export function removeDupes(
     if (acc.has(event.id)) {
       const existingEvent = acc.get(event.id) as DocumentGroupEvent
       if (isEditDocumentVersionEvent(existingEvent) && !isEditDocumentVersionEvent(event)) {
-        // Replaces the edit event with the none edit event, the publish event and the last edit event before the publish have the same id.
+        // Replaces the edit event with the none edit event, the publish/delete event and the last
+        // edit event before it have the same id.
         acc.set(event.id, event)
+        return acc
       }
 
       if (existingEvent.type !== event.type) {

--- a/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
@@ -68,6 +68,11 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
     ) {
       return targetDocumentState.targetDocument._id
     }
+    if (targetDocumentState.status === 'variant-missing' && targetDocumentState.creatableTarget) {
+      // When it's a creatable target (viewing a published document on a draft perspective), we need to use the id of the creatable target
+      // Which is the draft that will be created when the user edits the variant.
+      return targetDocumentState.creatableTarget.id
+    }
     if (typeof selectedPerspectiveName === 'undefined') {
       return getDraftId(options.id)
     }

--- a/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentEventsPane.tsx
@@ -43,7 +43,6 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
   const showingPublishedOnDraft = liveEdit && selectedPerspective === 'drafts' && !draftVersion
   const {rev, since} = params
   const historyVersion = params.historyVersion
-
   const documentId = useMemo(() => {
     if (showingPublishedOnDraft) {
       return getPublishedId(options.id)
@@ -68,10 +67,13 @@ export const DocumentEventsPane = (props: DocumentPaneProviderProps) => {
     ) {
       return targetDocumentState.targetDocument._id
     }
-    if (targetDocumentState.status === 'variant-missing' && targetDocumentState.creatableTarget) {
-      // When it's a creatable target (viewing a published document on a draft perspective), we need to use the id of the creatable target
-      // Which is the draft that will be created when the user edits the variant.
-      return targetDocumentState.creatableTarget.id
+    if (targetDocumentState.status === 'variant-missing') {
+      // Creatable targets (e.g. viewing published on a draft perspective) use the id of the
+      // document that will be created on edit. Otherwise there is no document to fetch events
+      // for — `useEventsStore` idles with an empty list.
+      // TODO: Find a way to get the id of the variant when the document is missing.
+      // This will allow us to show the history for deleted documents.
+      return targetDocumentState.creatableTarget?.id
     }
     if (typeof selectedPerspectiveName === 'undefined') {
       return getDraftId(options.id)


### PR DESCRIPTION
### Description
**Final support needs some changes in content lake, see SAPP-4022** 

This PR fixes some issues to prepare history events for variants.

- **Pass correct variant document id**: When seeing a published document from the draft view, when a published exists but not a draft, we should show the history for that draft, and not the published doc history. https://github.com/sanity-io/sanity/commit/d5616108ac4e31b85eb04a6a627f1ab9e265ae01
- **Fix duplicated discard events**: Discard events were duplicated for variants, this fixes it https://github.com/sanity-io/sanity/commit/cba36bcd1fa55e45f2cdeba42525e2209ea7f764
- **Deprecates `releaseId` in `EditDocumentVersionEvent`** : In edit events we were exposing `releaseId` because it was a simple `getVersionFromId()` invocation, but that it's not true for variants. `EditEvents.releaseId` was not used anywhere in the studio, this deprecates it and let users know how to handle it if they need it, but I don't expect any external user to depend on this https://github.com/sanity-io/sanity/commit/429e050833d1784f3092ad0de1a4946aa5273188
- **Support undefined ids in events store**: In some cases we won't have the variant document id, so the events store needs to support undefined ids to handle it. https://github.com/sanity-io/sanity/commit/7581d4d6b237826556b02268d85d3b7d4ec951aa


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Deprecates `releaseId` in `EditDocumentVersionEvent` 
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches document history merging, event identity, and pane document-id resolution for variants; behavior changes for undefined ids and duplicate delete handling, with limited blast radius outside the events timeline.
> 
> **Overview**
> Improves **document history / events** for **variants** (opaque `versions.<scope>.<id>` documents) and edge cases where no variant document exists yet.
> 
> **Events store idle mode:** `createEventsStore` and `useEventsStore` accept `documentId: string | undefined`. When missing, they return an idle store (empty events, no API/translog calls). `DocumentEventsPane` resolves the id from `useTargetDocumentState`—including `creatableTarget?.id` when status is `variant-missing`—so draft perspective can load the right history instead of falling back to published.
> 
> **Discard / delete deduplication:** `removeDupes` now **returns early** after replacing a synthesized **edit** with a **publish or delete** that shares the same id (delete reuses the last edit’s `versionRevisionId`), fixing duplicate discard events for variants.
> 
> **Edit event `releaseId`:** Synthesized `editDocumentVersion` events **no longer set `releaseId`** from the document id segment (wrong for variant scope hashes). The field is **deprecated** on `EditDocumentVersionEvent`; consumers should use `_system.release` on the version document.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7581d4d6b237826556b02268d85d3b7d4ec951aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->