### PR TITLE
refactor(workbench): rename workbench entrypoint

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.dashboard.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.dashboard.test-d.ts
@@ -7,10 +7,10 @@ import type {
   AssetSourceComponentProps,
   unstable_defineService,
   unstable_defineView,
-} from 'sanity/workbench'
+} from 'sanity/dashboard'
 import {describe, expectTypeOf, test} from 'vitest'
 
-describe('sanity/workbench', () => {
+describe('sanity/dashboard', () => {
   test('AssetSource', () => {
     expectTypeOf<AssetSource>().toBeObject()
   })

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -59,6 +59,10 @@
       "monorepo": "./src/_exports/cli.ts",
       "default": "./lib/cli.js"
     },
+    "./dashboard": {
+      "monorepo": "./src/_exports/dashboard.ts",
+      "default": "./lib/dashboard.js"
+    },
     "./desk": {
       "monorepo": "./src/_exports/desk.ts",
       "default": "./lib/desk.js"
@@ -83,10 +87,6 @@
       "monorepo": "./src/_exports/structure.ts",
       "default": "./lib/structure.js"
     },
-    "./workbench": {
-      "monorepo": "./src/_exports/workbench.ts",
-      "default": "./lib/workbench.js"
-    },
     "./bundle.css": {
       "types": "./lib/bundle-css.d.ts",
       "browser": "./lib/bundle.css",
@@ -104,13 +104,13 @@
       "./_singletons": "./lib/_singletons.js",
       "./_unstable-embedded": "./lib/_unstable-embedded.js",
       "./cli": "./lib/cli.js",
+      "./dashboard": "./lib/dashboard.js",
       "./desk": "./lib/desk.js",
       "./media-library": "./lib/media-library.js",
       "./migrate": "./lib/migrate.js",
       "./presentation": "./lib/presentation.js",
       "./router": "./lib/router.js",
       "./structure": "./lib/structure.js",
-      "./workbench": "./lib/workbench.js",
       "./bundle.css": {
         "types": "./lib/bundle-css.d.ts",
         "browser": "./lib/bundle.css",

--- a/packages/sanity/src/_exports/dashboard.ts
+++ b/packages/sanity/src/_exports/dashboard.ts
@@ -1,0 +1,2 @@
+export {unstable_defineService, unstable_defineView} from '@sanity/cli/runtime'
+export type {AssetSource, AssetSourceComponentProps} from '@sanity/types'

--- a/packages/sanity/src/_exports/workbench.ts
+++ b/packages/sanity/src/_exports/workbench.ts
@@ -1,5 +1,0 @@
-export {unstable_defineService, unstable_defineView} from '@sanity/cli/runtime'
-// Props an `asset_source` view component receives. Sourced from `@sanity/types`
-// directly (same shape `@sanity/cli/runtime` re-exports) so authors can type an
-// `unstable_defineView('asset_source', …)` component from `sanity/workbench`.
-export type {AssetSource, AssetSourceComponentProps} from '@sanity/types'

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -922,6 +922,10 @@ exports[`exports snapshot 1`] = `
     "getStudioEnvironmentVariables": "function",
     "unstable_defineMediaLibrary": "function",
   },
+  "./dashboard": {
+    "unstable_defineService": "function",
+    "unstable_defineView": "function",
+  },
   "./desk": {
     "ComponentBuilder": "function",
     "ComponentViewBuilder": "function",
@@ -1103,10 +1107,6 @@ exports[`exports snapshot 1`] = `
     "usePaneOptions": "function",
     "usePaneRouter": "function",
     "useStructureTool": "function",
-  },
-  "./workbench": {
-    "unstable_defineService": "function",
-    "unstable_defineView": "function",
   },
 }
 `;

--- a/packages/sanity/tsdown.config.ts
+++ b/packages/sanity/tsdown.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     'presentation.js',
     'router.js',
     'structure.js',
-    'workbench.js',
+    'dashboard.js',
   ],
   // `transform: 'oxc'` runs the React Compiler through `oxc-transform-react` (the native Rust
   // port) in the same pass that strips TypeScript and lowers JSX, instead of a separate


### PR DESCRIPTION
### Description

"workbench" disappears as product surface. Rename `sanity/workbench` to `sanity/dashboard` with is in line with that we are doing in the SDK.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking rename of a published package export path; impact is limited to consumers of that subpath but will fail at resolve time without a codemod or alias.
> 
> **Overview**
> Renames the public **`sanity/workbench`** subpath to **`sanity/dashboard`** so extension authors align with the SDK naming; **`sanity/workbench` is removed** from `package.json` exports (including `publishConfig`).
> 
> The new **`src/_exports/dashboard.ts`** barrel mirrors the old surface: **`unstable_defineService`** / **`unstable_defineView`** from `@sanity/cli/runtime` and **`AssetSource`** / **`AssetSourceComponentProps`** types from `@sanity/types`. Build output switches from **`workbench.js`** to **`dashboard.js`** in **`tsdown.config.ts`**, and generated DTS/export snapshot tests point at **`sanity/dashboard`**.
> 
> **Migration:** change imports from `sanity/workbench` to `sanity/dashboard`; there is no re-export alias in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c280151b0304328beacba387ae0782952020eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->