### PR TITLE
chore(radar): link vercel preview build from releases tool

### DIFF
--- a/dev/radar/SPEC.md
+++ b/dev/radar/SPEC.md
@@ -4,7 +4,7 @@ One place to answer repo-health questions without opening CI logs: **is
 studio performance drifting on main?** (Trends), **what did a specific run
 look like?** (run detail), **did anything change that needs a human?**
 (drift feed), **which commit broke it?** (Bisect), **what shipped when, and
-what regressed?** (Studio Releases). Primary users: studio engineers checking the
+what regressed?** (Studio releases). Primary users: studio engineers checking the
 effect of merged work; secondary: leads scanning health weekly.
 
 ## Data reality
@@ -261,7 +261,7 @@ effect of merged work; secondary: leads scanning health weekly.
    view (hard delete behind a confirm — they're the only user-owned documents
    here).
 
-8. **Studio Releases** — every synced release tag, newest first: current
+8. **Studio releases** — every synced release tag, newest first: current
    dist-tags, weekly downloads, publish time, links out (GitHub release,
    sanity.io changelog, npmx.dev), and the version linking to the gitTag
    document in the structure tool. The changelog link is derived from the

--- a/dev/radar/tools/bisect/sessions.ts
+++ b/dev/radar/tools/bisect/sessions.ts
@@ -54,7 +54,7 @@ export interface ManualRegressionInput {
 }
 
 /**
- * A regression reported by hand from the Studio Releases tool — no bisect was
+ * A regression reported by hand from the Studio releases tool — no bisect was
  * run, only the introducing release is known. Stored as a bisectSession that
  * is converged from birth: releases-only endpoints at the blamed release and
  * its base, no marks, and the verdict written at creation. That keeps one

--- a/dev/radar/tools/releases/ReleasesTool.tsx
+++ b/dev/radar/tools/releases/ReleasesTool.tsx
@@ -31,9 +31,10 @@ interface LiveState<T> {
 
 /**
  * Every release, newest first: when it shipped (npm publish time when known),
- * which dist-tags point at it, weekly downloads, links out (GitHub release,
- * sanity.io changelog, npmx.dev), and how many confirmed regressions bisect
- * sessions have attributed to it (blamed on the INTRODUCING release). The
+ * which dist-tags point at it, weekly downloads, links out (Vercel preview
+ * build of dev/test-studio at the tagged commit, GitHub release, sanity.io
+ * changelog, npmx.dev), and how many confirmed regressions bisect sessions
+ * have attributed to it (blamed on the INTRODUCING release). The
  * changelog link needs the release's base version — the previous release on
  * the first-parent chain — so off-mainline releases (maintenance lines) may
  * lack it. Regressions found outside a bisect are added by hand via
@@ -151,7 +152,7 @@ export function ReleasesTool() {
             <Box flex={1}>
               <Stack gap={3}>
                 <Text size={3} weight="semibold">
-                  Studio Releases
+                  Studio releases
                 </Text>
                 <Text size={1} muted>
                   Every synced release tag with its npm state and the regressions bisect sessions
@@ -192,6 +193,7 @@ export function ReleasesTool() {
               tag={tag}
               baseVersion={baseVersions.get(tag.tag)}
               regressions={regressionCounts.get(tag.tag) ?? 0}
+              previewUrl={commitsBySha.get(tag.sha)?.testStudioUrl}
             />
           ))}
         </Stack>
@@ -210,8 +212,13 @@ export function ReleasesTool() {
   )
 }
 
-function ReleaseRow(props: {tag: TagSlice; baseVersion: string | undefined; regressions: number}) {
-  const {tag, baseVersion, regressions} = props
+function ReleaseRow(props: {
+  tag: TagSlice
+  baseVersion: string | undefined
+  regressions: number
+  previewUrl: string | undefined
+}) {
+  const {tag, baseVersion, regressions, previewUrl} = props
   const version = tag.tag.replace(/^v/, '')
   // The version opens the gitTag document in the structure tool — the raw
   // synced record behind the row
@@ -245,6 +252,13 @@ function ReleaseRow(props: {tag: TagSlice; baseVersion: string | undefined; regr
         )}
         <RelativeDate dateTime={tag.npm?.publishedAt ?? tag.taggedAt} size={0} muted />
         <Flex gap={3}>
+          {previewUrl && (
+            <Text size={1}>
+              <a href={previewUrl} target="_blank" rel="noreferrer">
+                Preview
+              </a>
+            </Text>
+          )}
           <Text size={1}>
             <a href={releaseUrl(tag.tag)} target="_blank" rel="noreferrer">
               GitHub

--- a/dev/radar/tools/releases/index.ts
+++ b/dev/radar/tools/releases/index.ts
@@ -6,7 +6,7 @@ import {ReleasesTool} from './ReleasesTool'
 /** Release tags with npm state, links out, and attributed regressions — see ReleasesTool. */
 export const releasesTool: Tool = {
   name: 'releases',
-  title: 'Studio Releases',
+  title: 'Studio releases',
   icon: PackageIcon,
   component: ReleasesTool,
 }


### PR DESCRIPTION
### Description

Small QoL improvement to Radar: Adds a link to test studio preview url for each release listed in the Studio releases tool.  Also renames the tool title to "Studio releases" for consistency (and ocd relief)

### Testing
See preview build: https://studio-radar-git-radar-releases-preview-link.sanity.dev/releases

### Notes for release
n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only UI links and label text; no auth, data writes, or bisect logic changes.
> 
> **Overview**
> Adds a **Preview** outbound link on each release row in the **Studio releases** tool when the tagged commit has a synced `testStudioUrl` (the immutable Vercel deploy of `dev/test-studio` at that SHA—the same field Bisect uses for preview builds).
> 
> Renames the tool and related copy from **Studio Releases** to **Studio releases** in the nav title, page heading, spec, and comments for consistent casing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e750e550a49f1eaa4732cc97afe331e7e3227c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->