### PR TITLE
fix(calendar): align weekday headers with locale week start

### DIFF
--- a/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarMonth.tsx
@@ -4,8 +4,8 @@ import {isSameMonth} from 'date-fns/isSameMonth'
 import {Box} from 'ui5'
 
 import {type TimeZoneScope, useTimeZone} from '../../../../hooks/useTimeZone'
-import {DEFAULT_WEEK_DAY_NAMES} from '../../DateInputs/calendar/constants'
-import {useWeeksOfMonth} from '../../DateInputs/calendar/utils'
+import {useCurrentLocale} from '../../../../i18n/hooks/useLocale'
+import {getWeekDayNames, useWeeksOfMonth} from '../../DateInputs/calendar/utils'
 import {CalendarDay as DefaultCalendarDay} from './CalendarDay'
 import {type CalendarProps} from './CalendarFilter'
 
@@ -25,6 +25,10 @@ export function CalendarMonth(props: CalendarMonthProps) {
   const {getCurrentZoneDate} = useTimeZone(timeZoneScope)
   const CalendarDay = renderCalendarDay || DefaultCalendarDay
   const weeksOfMonth = useWeeksOfMonth(date)
+  const {
+    weekInfo: {firstDay},
+  } = useCurrentLocale()
+  const weekDayNames = getWeekDayNames(firstDay)
 
   return (
     <Box aria-hidden={hidden || false} data-ui="CalendarMonth">
@@ -35,7 +39,7 @@ export function CalendarMonth(props: CalendarMonthProps) {
         }}
       >
         {/* Header */}
-        {DEFAULT_WEEK_DAY_NAMES.map((weekday) => (
+        {weekDayNames.map((weekday) => (
           <Card key={weekday} paddingY={3}>
             <Label size={1} style={{textAlign: 'center'}}>
               {weekday.slice(0, 1)}

--- a/packages/sanity/src/core/components/inputs/DateFilters/calendar/__tests__/CalendarMonth.test.tsx
+++ b/packages/sanity/src/core/components/inputs/DateFilters/calendar/__tests__/CalendarMonth.test.tsx
@@ -1,0 +1,53 @@
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getAllByDataUi} from '../../../../../../../test/setup/customQueries'
+import {useCurrentLocale} from '../../../../../i18n/hooks/useLocale'
+import {type CalendarDayProps} from '../CalendarDay'
+import {CalendarMonth} from '../CalendarMonth'
+
+vi.mock('../../../../../hooks/useTimeZone', () => ({
+  useTimeZone: () => ({getCurrentZoneDate: () => new Date('2026-08-27T12:00:00Z')}),
+}))
+
+vi.mock('../../../../../i18n/hooks/useLocale', () => ({
+  useCurrentLocale: vi.fn(),
+}))
+
+const useCurrentLocaleMock = vi.mocked(useCurrentLocale)
+
+const renderCalendarDay = ({date}: CalendarDayProps) => (
+  <span data-testid="calendar-day">{date.getDay()}</span>
+)
+
+describe('CalendarMonth', () => {
+  beforeEach(() => {
+    useCurrentLocaleMock.mockReturnValue({
+      id: 'nb-NO',
+      title: 'Norsk bokmål',
+      weekInfo: {firstDay: 1, weekend: [6, 7]},
+    })
+  })
+
+  it('aligns weekday headers and dates with the locale week start', () => {
+    const {container} = render(
+      <CalendarMonth
+        date={new Date('2026-08-01T12:00:00Z')}
+        onSelect={vi.fn()}
+        renderCalendarDay={renderCalendarDay}
+        timeZoneScope={{type: 'contentReleases'}}
+      />,
+    )
+
+    expect(getAllByDataUi(container, 'Label').map((label) => label.textContent)).toEqual([
+      'M',
+      'T',
+      'W',
+      'T',
+      'F',
+      'S',
+      'S',
+    ])
+    expect(screen.getAllByTestId('calendar-day')[0]).toHaveTextContent('1')
+  })
+})

--- a/packages/sanity/src/core/components/inputs/DateFilters/calendar/__tests__/CalendarMonth.test.tsx
+++ b/packages/sanity/src/core/components/inputs/DateFilters/calendar/__tests__/CalendarMonth.test.tsx
@@ -1,3 +1,5 @@
+import {ThemeProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
 import {render, screen} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -15,6 +17,7 @@ vi.mock('../../../../../i18n/hooks/useLocale', () => ({
 }))
 
 const useCurrentLocaleMock = vi.mocked(useCurrentLocale)
+const theme = buildTheme()
 
 const renderCalendarDay = ({date}: CalendarDayProps) => (
   <span data-testid="calendar-day">{date.getDay()}</span>
@@ -31,12 +34,14 @@ describe('CalendarMonth', () => {
 
   it('aligns weekday headers and dates with the locale week start', () => {
     const {container} = render(
-      <CalendarMonth
-        date={new Date('2026-08-01T12:00:00Z')}
-        onSelect={vi.fn()}
-        renderCalendarDay={renderCalendarDay}
-        timeZoneScope={{type: 'contentReleases'}}
-      />,
+      <ThemeProvider theme={theme}>
+        <CalendarMonth
+          date={new Date('2026-08-01T12:00:00Z')}
+          onSelect={vi.fn()}
+          renderCalendarDay={renderCalendarDay}
+          timeZoneScope={{type: 'contentReleases'}}
+        />
+      </ThemeProvider>,
     )
 
     expect(getAllByDataUi(container, 'Label').map((label) => label.textContent)).toEqual([

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/utils.test.ts
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/utils.test.ts
@@ -1,0 +1,13 @@
+import {describe, expect, it} from 'vitest'
+
+import {getWeekDayNames} from '../utils'
+
+describe('getWeekDayNames', () => {
+  it.each([
+    [1, ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']],
+    [6, ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri']],
+    [7, ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']],
+  ] as const)('orders weekday names for first day %s', (firstDay, expected) => {
+    expect(getWeekDayNames(firstDay)).toEqual(expected)
+  })
+})

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/utils.ts
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/utils.ts
@@ -5,7 +5,7 @@ import {lastDayOfMonth} from 'date-fns/lastDayOfMonth'
 import {startOfMonth} from 'date-fns/startOfMonth'
 
 import {useCurrentLocale} from '../../../../i18n/hooks/useLocale'
-import {TAIL_WEEKDAYS} from './constants'
+import {DEFAULT_WEEK_DAY_NAMES, TAIL_WEEKDAYS} from './constants'
 
 /**
  * NOTE: `weekStartsOn` uses 1 for Monday, 7 for Sunday. date-fns wants 0 for Sunday, 6 for Saturday.
@@ -43,6 +43,14 @@ export const useWeeksOfMonth = (date: Date): Week[] => {
       days,
     }),
   )
+}
+
+export const getWeekDayNames = (weekStartsOn: 1 | 2 | 3 | 4 | 5 | 6 | 7): readonly string[] => {
+  const firstDayIndex = weekStartsOn % 7
+  return [
+    ...DEFAULT_WEEK_DAY_NAMES.slice(firstDayIndex),
+    ...DEFAULT_WEEK_DAY_NAMES.slice(0, firstDayIndex),
+  ]
 }
 
 export const formatTime = (hours: number, minutes: number): string =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The Releases and Scheduled Publishing calendars arranged dates using the locale week start while retaining Sunday-first headers, offsetting every label for Monday-first locales. This uses the same locale setting for both the grid and header order. Resolves [SAPP-4420](https://linear.app/sanity/issue/SAPP-4420/align-calendar-weekday-headers-with-locale-week-start).

### What to review

Review weekday rotation in the shared date calendar utilities and its use by the DateFilters calendar consumed by Releases and Scheduled Publishing.

### Testing

- Added utility coverage for Monday-, Saturday-, and Sunday-start locales.
- Added DateFilters calendar render coverage that asserts Monday-first headers and dates share the first column.
- `pnpm vitest run --project=sanity packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/utils.test.ts packages/sanity/src/core/components/inputs/DateFilters/calendar/__tests__/CalendarMonth.test.tsx` — 2 files and 4 tests passed, with no type errors.
- `pnpm check:format` — passed.
- `pnpm check:oxlint` — passed.
- `pnpm build` — passed.

Before (`nb-NO`, Monday-first grid under Sunday-first headers):

[Misaligned Releases calendar before the fix](https://cursor.com/agents/bc-9d5b6363-eca7-4d1b-8be1-6eaaa6b15576/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar-weekday-before.png)

After (`nb-NO`, Monday-first headers aligned with the grid):

[Aligned Releases calendar after the fix](https://cursor.com/agents/bc-9d5b6363-eca7-4d1b-8be1-6eaaa6b15576/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar-weekday-after.png)

Desktop verification:

[calendar-weekday-alignment-proof.mp4](https://cursor.com/agents/bc-9d5b6363-eca7-4d1b-8be1-6eaaa6b15576/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar-weekday-alignment-proof.mp4)

### Notes for release

Fixed weekday headers appearing one day out of alignment in Releases and Scheduled Publishing calendars for locales whose weeks do not start on Sunday.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d5b6363-eca7-4d1b-8be1-6eaaa6b15576?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d5b6363-eca7-4d1b-8be1-6eaaa6b15576&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

