### PR TITLE
fix(core): fallback to published doc when creating a draft variant

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -266,8 +266,11 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
                       )
 
                     const targetPair = await firstValueFrom(readTargetPair)
-                    const baseVariant = targetPair[editStateSlot]
-
+                    const baseVariant =
+                      editStateSlot === 'draft'
+                        ? // in drafts fallback to published, the ui shows the published when seeing a "non existent" draft
+                          targetPair[editStateSlot] || targetPair.published
+                        : targetPair[editStateSlot]
                     // If there is no base variant, create an empty variant.
                     if (baseVariant === null) {
                       await createVariantDocument({


### PR DESCRIPTION
### Description

Fixes an issue in where creating a variant, viewing a "non existent" draft document would create an empty variant.
This is because it was checking in the `editState.draft` which is null, this adds the fallback to use the `editState.published` when the `draft` is missing

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to how the base document is chosen when creating variants from the drafts bundle; no auth or persistence contract changes beyond fixing incorrect empty variants.
> 
> **Overview**
> Fixes variant creation from the **drafts** perspective when no draft exists but the UI still shows the published document.
> 
> When resolving the base document for `createVariant`, the inventory now uses **`targetPair.published`** if `editStateSlot` is `draft` and `targetPair.draft` is missing. Previously it treated a null draft as “no base” and created an **empty** variant instead of cloning from published content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9548f08a1d2b1a0eebcf55270923eb9edebd2a1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->