### PR TITLE
chore(core): adds siblings to useTargetDocumentState

### DIFF
--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -933,6 +933,7 @@ export {
   getCreatableVariantTarget,
   getPairTarget,
   getTargetScopeId,
+  getTargetSiblings,
   type TargetDocumentState,
   useTargetDocumentState,
 } from '../core/hooks/useTargetDocumentState'

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -35,6 +35,7 @@ import {
   getCreatableVariantTarget,
   getPairTarget,
   getTargetScopeId,
+  getTargetSiblings,
   useTargetDocumentState,
 } from '../hooks/useTargetDocumentState'
 import {useValidationStatus} from '../hooks/useValidationStatus'
@@ -541,7 +542,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     }
 
     // in cases where the document has drafts but the schema is live edit, there is a risk of data loss, so we disable editing in this case
-    if (liveEdit && editState.draft?._id) {
+    if (liveEdit && getTargetSiblings(targetDocumentState)?.draft) {
       return true
     }
 

--- a/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
+++ b/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
@@ -7,6 +7,8 @@ import {
   getPairTarget,
   getTargetDocumentState,
   getTargetScopeId,
+  getTargetSiblings,
+  type TargetDocumentSiblings,
 } from '../useTargetDocumentState'
 
 const PUBLISHED_ID = 'article-1'
@@ -88,6 +90,15 @@ const variantOptions = {
   selectedVariantName: 'alpha-audience',
 }
 
+function siblings(partial: Partial<TargetDocumentSiblings> = {}): TargetDocumentSiblings {
+  return {
+    published: undefined,
+    draft: undefined,
+    version: undefined,
+    ...partial,
+  }
+}
+
 describe('getTargetDocumentState', () => {
   describe('without a requested variant', () => {
     it('resolves while version stubs are loading', () => {
@@ -102,7 +113,7 @@ describe('getTargetDocumentState', () => {
         targetDocument: draftBase,
         scopeId: undefined,
         variant: undefined,
-        publishedSibling: undefined,
+        siblings: siblings({published: publishedBase, draft: draftBase}),
       })
     })
 
@@ -112,7 +123,11 @@ describe('getTargetDocumentState', () => {
         targetDocument: releaseVersion,
         scopeId: RELEASE_ID,
         variant: undefined,
-        publishedSibling: undefined,
+        siblings: siblings({
+          published: publishedBase,
+          draft: draftBase,
+          version: releaseVersion,
+        }),
       })
     })
 
@@ -124,7 +139,7 @@ describe('getTargetDocumentState', () => {
         targetDocument: undefined,
         scopeId: undefined,
         variant: undefined,
-        publishedSibling: undefined,
+        siblings: siblings({published: publishedBase}),
       })
     })
   })
@@ -159,7 +174,7 @@ describe('getTargetDocumentState', () => {
         targetDocument: draftAlphaVariant,
         scopeId: 'varscope',
         variant: variantAlphaAudience,
-        publishedSibling: undefined,
+        siblings: siblings({draft: draftAlphaVariant}),
       })
     })
 
@@ -169,7 +184,7 @@ describe('getTargetDocumentState', () => {
         status: 'variant-missing',
         variant: variantAlphaAudience,
         bundle: 'published',
-        publishedSibling: undefined,
+        siblings: siblings({draft: draftAlphaVariant}),
       })
     })
 
@@ -182,7 +197,7 @@ describe('getTargetDocumentState', () => {
         targetDocument: draftAlphaVariant,
         scopeId: 'varscope',
         variant: variantAlphaAudience,
-        publishedSibling: publishedAlphaVariant,
+        siblings: siblings({published: publishedAlphaVariant, draft: draftAlphaVariant}),
       })
 
       // Published bundle: the target IS the sibling.
@@ -191,7 +206,38 @@ describe('getTargetDocumentState', () => {
         targetDocument: publishedAlphaVariant,
         scopeId: 'varscopePub',
         variant: variantAlphaAudience,
-        publishedSibling: publishedAlphaVariant,
+        siblings: siblings({published: publishedAlphaVariant, draft: draftAlphaVariant}),
+      })
+    })
+
+    it('reports the release-scoped variant as siblings.version', () => {
+      const releaseAlphaVariant = versionStub({
+        _id: `versions.varscopeRel.${PUBLISHED_ID}`,
+        _system: {
+          bundleId: RELEASE_ID,
+          variant: variantRef(variantAlphaAudience._id),
+          group: groupRef,
+          scopeId: 'varscopeRel',
+        },
+      })
+      const versions = [
+        publishedBase,
+        draftBase,
+        publishedAlphaVariant,
+        draftAlphaVariant,
+        releaseAlphaVariant,
+      ]
+
+      expect(getTargetDocumentState({...variantOptions, versions, bundle: RELEASE_ID})).toEqual({
+        status: 'ready',
+        targetDocument: releaseAlphaVariant,
+        scopeId: 'varscopeRel',
+        variant: variantAlphaAudience,
+        siblings: siblings({
+          published: publishedAlphaVariant,
+          draft: draftAlphaVariant,
+          version: releaseAlphaVariant,
+        }),
       })
     })
 
@@ -203,7 +249,7 @@ describe('getTargetDocumentState', () => {
         status: 'variant-missing',
         variant: variantAlphaAudience,
         bundle: 'drafts',
-        publishedSibling: publishedAlphaVariant,
+        siblings: siblings({published: publishedAlphaVariant}),
       })
     })
 
@@ -216,7 +262,7 @@ describe('getTargetDocumentState', () => {
           status: 'variant-missing',
           variant: variantAlphaAudience,
           bundle: 'drafts',
-          publishedSibling: publishedAlphaVariantAdvertisingDraft,
+          siblings: siblings({published: publishedAlphaVariantAdvertisingDraft}),
           creatableTarget: {id: DRAFT_SIBLING_ID, scopeId: 'varscopeDraft'},
         })
       })
@@ -252,7 +298,10 @@ describe('getTargetDocumentState', () => {
           targetDocument: draftAlphaVariant,
           scopeId: 'varscope',
           variant: variantAlphaAudience,
-          publishedSibling: publishedAlphaVariantAdvertisingDraft,
+          siblings: siblings({
+            published: publishedAlphaVariantAdvertisingDraft,
+            draft: draftAlphaVariant,
+          }),
         })
       })
     })
@@ -308,6 +357,29 @@ describe('getCreatableVariantTarget', () => {
           versions: [publishedBase, draftBase, publishedAlphaVariant],
         }),
       ),
+    ).toBeUndefined()
+  })
+})
+
+describe('getTargetSiblings', () => {
+  it('returns siblings for ready and variant-missing states', () => {
+    expect(getTargetSiblings(getTargetDocumentState(baseOptions))).toEqual(
+      siblings({published: publishedBase, draft: draftBase}),
+    )
+    expect(getTargetSiblings(getTargetDocumentState(variantOptions))).toEqual(
+      siblings({draft: draftAlphaVariant}),
+    )
+    expect(
+      getTargetSiblings(getTargetDocumentState({...variantOptions, bundle: 'published'})),
+    ).toEqual(siblings({draft: draftAlphaVariant}))
+  })
+
+  it('returns undefined while resolving or when the variant definition is missing', () => {
+    expect(
+      getTargetSiblings(getTargetDocumentState({...baseOptions, versionsLoading: true})),
+    ).toBeUndefined()
+    expect(
+      getTargetSiblings(getTargetDocumentState({...variantOptions, selectedVariant: undefined})),
     ).toBeUndefined()
   })
 })

--- a/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
+++ b/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, it} from 'vitest'
 
 import {type VersionInfoDocumentStub} from '../../releases/store/types'
-import {variantAlphaAudience} from '../../variants/__fixtures__/variants.fixture'
+import {
+  variantAlphaAudience,
+  variantNorwegianMarket,
+} from '../../variants/__fixtures__/variants.fixture'
 import {
   getCreatableVariantTarget,
   getPairTarget,
@@ -13,6 +16,9 @@ import {
 
 const PUBLISHED_ID = 'article-1'
 const RELEASE_ID = 'rSummer'
+const RELEASE_2_ID = 'rWinter'
+const MISSING_RELEASE_ID = 'rAutumn'
+const AGENT_BUNDLE_ID = 'agent-run-1'
 const groupRef = {_type: 'reference', _ref: PUBLISHED_ID, _weak: true} as const
 const variantRef = (variantId: string) =>
   ({_type: 'reference', _ref: variantId, _weak: true}) as const
@@ -44,6 +50,23 @@ const releaseVersion = versionStub({
     scopeId: RELEASE_ID,
   },
 })
+const release2Version = versionStub({
+  _id: `versions.${RELEASE_2_ID}.${PUBLISHED_ID}`,
+  _system: {
+    bundleId: RELEASE_2_ID,
+    release: {_ref: `_.releases.${RELEASE_2_ID}`, _weak: true},
+    group: groupRef,
+    scopeId: RELEASE_2_ID,
+  },
+})
+const agentBundleVersion = versionStub({
+  _id: `versions.${AGENT_BUNDLE_ID}.${PUBLISHED_ID}`,
+  _system: {
+    bundleId: AGENT_BUNDLE_ID,
+    group: groupRef,
+    scopeId: AGENT_BUNDLE_ID,
+  },
+})
 const draftAlphaVariant = versionStub({
   _id: `versions.varscope.${PUBLISHED_ID}`,
   _system: {
@@ -60,6 +83,14 @@ const publishedAlphaVariant = versionStub({
     variant: variantRef(variantAlphaAudience._id),
     group: groupRef,
     scopeId: 'varscopePub',
+  },
+})
+const publishedBetaVariant = versionStub({
+  _id: `versions.varscopeBetaPub.${PUBLISHED_ID}`,
+  _system: {
+    variant: variantRef(variantNorwegianMarket._id),
+    group: groupRef,
+    scopeId: 'varscopeBetaPub',
   },
 })
 // A variant-of-published sibling advertising the (stable, server-generated) id its drafts-bundle
@@ -304,6 +335,135 @@ describe('getTargetDocumentState', () => {
           }),
         })
       })
+    })
+  })
+
+  describe('sibling isolation across a mixed inventory', () => {
+    // No published default: a published variant must never occupy the default published slot.
+    // No release-scoped variant A: looking at A in release 1 must leave version empty.
+    const mixedVersions = [
+      draftBase,
+      releaseVersion,
+      release2Version,
+      agentBundleVersion,
+      publishedAlphaVariant,
+      draftAlphaVariant,
+      publishedBetaVariant,
+    ]
+    const mixedOptions = {...baseOptions, versions: mixedVersions}
+
+    it.each([
+      {
+        name: 'default / drafts reports only the default draft',
+        bundle: 'drafts' as const,
+        selectedVariant: undefined,
+        selectedVariantName: undefined,
+        expected: {
+          status: 'ready' as const,
+          targetDocument: draftBase,
+          scopeId: undefined,
+          variant: undefined,
+          siblings: siblings({draft: draftBase}),
+        },
+      },
+      {
+        name: 'default / published does not treat a published variant as the default published',
+        bundle: 'published' as const,
+        selectedVariant: undefined,
+        selectedVariantName: undefined,
+        expected: {
+          status: 'ready' as const,
+          targetDocument: undefined,
+          scopeId: undefined,
+          variant: undefined,
+          siblings: siblings({draft: draftBase}),
+        },
+      },
+      {
+        name: 'default / release 1 reports the release in version and keeps the default draft',
+        bundle: RELEASE_ID,
+        selectedVariant: undefined,
+        selectedVariantName: undefined,
+        expected: {
+          status: 'ready' as const,
+          targetDocument: releaseVersion,
+          scopeId: RELEASE_ID,
+          variant: undefined,
+          siblings: siblings({draft: draftBase, version: releaseVersion}),
+        },
+      },
+      {
+        name: 'default / release 3 leaves version empty when that release has no document',
+        bundle: MISSING_RELEASE_ID,
+        selectedVariant: undefined,
+        selectedVariantName: undefined,
+        expected: {
+          status: 'ready' as const,
+          targetDocument: undefined,
+          scopeId: undefined,
+          variant: undefined,
+          siblings: siblings({draft: draftBase}),
+        },
+      },
+      {
+        name: 'default / agent bundle reports the agent document in version',
+        bundle: AGENT_BUNDLE_ID,
+        selectedVariant: undefined,
+        selectedVariantName: undefined,
+        expected: {
+          status: 'ready' as const,
+          targetDocument: agentBundleVersion,
+          scopeId: AGENT_BUNDLE_ID,
+          variant: undefined,
+          siblings: siblings({draft: draftBase, version: agentBundleVersion}),
+        },
+      },
+      {
+        name: 'variant A / drafts reports only A published and draft, never the default draft',
+        bundle: 'drafts' as const,
+        selectedVariant: variantAlphaAudience,
+        selectedVariantName: 'alpha-audience',
+        expected: {
+          status: 'ready' as const,
+          targetDocument: draftAlphaVariant,
+          scopeId: 'varscope',
+          variant: variantAlphaAudience,
+          siblings: siblings({published: publishedAlphaVariant, draft: draftAlphaVariant}),
+        },
+      },
+      {
+        name: 'variant B / drafts reports only B published, with no draft',
+        bundle: 'drafts' as const,
+        selectedVariant: variantNorwegianMarket,
+        selectedVariantName: 'norwegian-market',
+        expected: {
+          status: 'variant-missing' as const,
+          variant: variantNorwegianMarket,
+          bundle: 'drafts' as const,
+          siblings: siblings({published: publishedBetaVariant}),
+        },
+      },
+      {
+        name: 'variant A / release 1 leaves version empty when A has no release-scoped document',
+        bundle: RELEASE_ID,
+        selectedVariant: variantAlphaAudience,
+        selectedVariantName: 'alpha-audience',
+        expected: {
+          status: 'variant-missing' as const,
+          variant: variantAlphaAudience,
+          bundle: RELEASE_ID,
+          siblings: siblings({published: publishedAlphaVariant, draft: draftAlphaVariant}),
+        },
+      },
+    ])('$name', ({bundle, selectedVariant, selectedVariantName, expected}) => {
+      expect(
+        getTargetDocumentState({
+          ...mixedOptions,
+          bundle,
+          selectedVariant,
+          selectedVariantName,
+        }),
+      ).toEqual(expected)
     })
   })
 })

--- a/packages/sanity/src/core/hooks/useTargetDocumentState.ts
+++ b/packages/sanity/src/core/hooks/useTargetDocumentState.ts
@@ -5,10 +5,11 @@ import {usePerspective} from '../perspective/usePerspective'
 import {useDocumentVersions} from '../releases/hooks/useDocumentVersions'
 import {type VersionInfoDocumentStub} from '../releases/store/types'
 import {type DocumentPairTarget} from '../store/document/types'
-import {getVersionFromId} from '../util/draftUtils'
-import {getTargetDocument, getVariantPublishedSibling} from '../util/getTargetDocument'
+import {getVersionFromId, isSystemBundle} from '../util/draftUtils'
+import {getTargetDocument} from '../util/getTargetDocument'
 import {useAllVariants} from '../variants/store/useAllVariants'
 import {type SystemVariant} from '../variants/types'
+import {useSchema} from './useSchema'
 
 /**
  * The id and scope of a missing draft variant that can be created by typing: the id is known
@@ -25,6 +26,20 @@ export interface CreatableTargetDocument {
 }
 
 /**
+ * The published, draft, and release-scoped documents in the current lane (base pair when no
+ * variant is selected, variant siblings when one is). Each field is `undefined` when that
+ * document does not exist. Present on every resolved {@link TargetDocumentState}.
+ *
+ * @internal
+ * @beta
+ */
+export interface TargetDocumentSiblings {
+  published: VersionInfoDocumentStub | undefined
+  draft: VersionInfoDocumentStub | undefined
+  version: VersionInfoDocumentStub | undefined
+}
+
+/**
  * The resolution state of the document targeted by the selected perspective (bundle) and variant.
  *
  * The union is shaped by what consumers must do, not just by what was observed:
@@ -36,12 +51,17 @@ export interface CreatableTargetDocument {
  *   selected and no stub exists for the bundle, in which case base draft/published semantics
  *   legitimately apply. `scopeId` is the bundle segment to thread into version-aware hooks
  *   (release id for release stubs, opaque scope hash for variant stubs, `undefined` for the
- *   base pair).
+ *   base pair). `siblings` always lists the published, draft, and non system bundle scoped documents in
+ *   the current lane (base pair or variant), each `undefined` when that document does not exist.
  * - `variant-missing` — a variant is selected but the document has no variant-scoped version
  *   for the current bundle. When `creatableTarget` is set (drafts bundle, published variant
  *   advertising its draft sibling id), the document is editable: typing creates the draft
- *   variant at the advertised id, seeded from the published sibling. Otherwise consumers must
- *   treat the document as read-only and offer creation. Never fall back to the base pair.
+ *   variant at the advertised id, seeded from the published sibling. **Live-edit exception:**
+ *   if a published sibling exists, the state is `ready` on that sibling instead (Drafts checks
+ *   out published); if only a leftover drafts sibling exists, that leftover is the target.
+ *   `creatableTarget` is never set. Otherwise consumers must treat the document as read-only
+ *   and offer creation. Never fall back to the base pair. `siblings` still lists whatever
+ *   published/draft/release documents exist in the selected variant's lane.
  * - `variant-definition-document-not-found` — the requested variant name matches no
  *   `system.variant` definition. An error state, never silently treated as "no variant".
  *
@@ -56,29 +76,18 @@ export type TargetDocumentState =
       scopeId: string | undefined
       /** The selected variant when the resolved target is a variant-scoped version. */
       variant: SystemVariant | undefined
-      /**
-       * The variant-of-published sibling stub (same `_system.variant`, no `_system.bundleId`).
-       * Only set for variant targets; `undefined` means the variant has never been published.
-       * Publish-state gating (already-published, unpublishable, discard copy) must read this
-       * instead of the base `published` document.
-       */
-      publishedSibling: VersionInfoDocumentStub | undefined
+      siblings: TargetDocumentSiblings
     }
   | {
       status: 'variant-missing'
       variant: SystemVariant
       bundle: PerspectiveBundle
-      /**
-       * The variant-of-published sibling, when the variant is missing in the current bundle but
-       * published. Lets consumers distinguish "never existed" from "exists published, not in
-       * this bundle".
-       */
-      publishedSibling: VersionInfoDocumentStub | undefined
+      siblings: TargetDocumentSiblings
       /**
        * Present when the missing variant document can be created by typing: the drafts-bundle
        * variant of a published variant whose `_system.draft` weak ref advertises the (stable,
        * server-generated) id the draft will occupy. The pair is checked out at this id with
-       * `allowCreate` declared to the store, and the display falls back to `publishedSibling`
+       * `allowCreate` declared to the store, and the display falls back to `siblings.published`
        * until the document exists.
        */
       creatableTarget?: CreatableTargetDocument
@@ -110,6 +119,32 @@ function getCreatableTarget(
     return undefined
   }
   return {id: draftId, scopeId}
+}
+
+function getDocumentSiblings(
+  versions: VersionInfoDocumentStub[],
+  variantId: string | undefined,
+  bundle: PerspectiveBundle,
+): TargetDocumentSiblings {
+  return {
+    published: getTargetDocument({
+      bundle: 'published',
+      variant: variantId,
+      documentVersions: versions,
+    }),
+    draft: getTargetDocument({
+      bundle: 'drafts',
+      variant: variantId,
+      documentVersions: versions,
+    }),
+    version: isSystemBundle(bundle)
+      ? undefined
+      : getTargetDocument({
+          bundle,
+          variant: variantId,
+          documentVersions: versions,
+        }),
+  }
 }
 
 /**
@@ -148,6 +183,20 @@ export function getCreatableVariantTarget(
   state: TargetDocumentState,
 ): CreatableTargetDocument | undefined {
   return state.status === 'variant-missing' ? state.creatableTarget : undefined
+}
+
+/**
+ * The published/draft/release siblings of a resolved target, or `undefined` while the target is
+ * still resolving or the selected variant definition was not found.
+ *
+ * @internal
+ * @beta
+ */
+export function getTargetSiblings(state: TargetDocumentState): TargetDocumentSiblings | undefined {
+  if (state.status === 'ready' || state.status === 'variant-missing') {
+    return state.siblings
+  }
+  return undefined
 }
 
 /**
@@ -224,7 +273,7 @@ export function getTargetDocumentState(options: {
       targetDocument,
       scopeId: targetDocument?._system.scopeId ?? undefined,
       variant: undefined,
-      publishedSibling: undefined,
+      siblings: getDocumentSiblings(versions, undefined, bundle),
     }
   }
 
@@ -249,18 +298,15 @@ export function getTargetDocumentState(options: {
     documentVersions: versions,
   })
 
-  const publishedSibling = getVariantPublishedSibling({
-    variant: selectedVariant._id,
-    documentVersions: versions,
-  })
+  const siblings = getDocumentSiblings(versions, selectedVariant._id, bundle)
 
   if (!targetDocument) {
     return {
       status: 'variant-missing',
       variant: selectedVariant,
       bundle,
-      publishedSibling,
-      creatableTarget: getCreatableTarget(bundle, publishedSibling),
+      siblings,
+      creatableTarget: getCreatableTarget(bundle, siblings.published),
     }
   }
 
@@ -269,7 +315,7 @@ export function getTargetDocumentState(options: {
     targetDocument,
     scopeId: targetDocument._system.scopeId ?? undefined,
     variant: selectedVariant,
-    publishedSibling,
+    siblings,
   }
 }
 

--- a/packages/sanity/src/core/hooks/useTargetDocumentState.ts
+++ b/packages/sanity/src/core/hooks/useTargetDocumentState.ts
@@ -9,7 +9,6 @@ import {getVersionFromId, isSystemBundle} from '../util/draftUtils'
 import {getTargetDocument} from '../util/getTargetDocument'
 import {useAllVariants} from '../variants/store/useAllVariants'
 import {type SystemVariant} from '../variants/types'
-import {useSchema} from './useSchema'
 
 /**
  * The id and scope of a missing draft variant that can be created by typing: the id is known
@@ -56,12 +55,7 @@ export interface TargetDocumentSiblings {
  * - `variant-missing` — a variant is selected but the document has no variant-scoped version
  *   for the current bundle. When `creatableTarget` is set (drafts bundle, published variant
  *   advertising its draft sibling id), the document is editable: typing creates the draft
- *   variant at the advertised id, seeded from the published sibling. **Live-edit exception:**
- *   if a published sibling exists, the state is `ready` on that sibling instead (Drafts checks
- *   out published); if only a leftover drafts sibling exists, that leftover is the target.
- *   `creatableTarget` is never set. Otherwise consumers must treat the document as read-only
- *   and offer creation. Never fall back to the base pair. `siblings` still lists whatever
- *   published/draft/release documents exist in the selected variant's lane.
+ *   variant at the advertised id, seeded from the published sibling.
  * - `variant-definition-document-not-found` — the requested variant name matches no
  *   `system.variant` definition. An error state, never silently treated as "no variant".
  *

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
@@ -46,7 +46,7 @@ const READY_BASE_TARGET = {
   targetDocument: undefined,
   scopeId: undefined,
   variant: undefined,
-  publishedSibling: undefined,
+  siblings: {published: undefined, draft: undefined, version: undefined},
 } as const
 
 const config = defineConfig({
@@ -156,7 +156,7 @@ describe('DiscardVersionDialog operation target', () => {
       targetDocument: undefined,
       scopeId: 'someVariantScope',
       variant: {_id: 'variant-doc'},
-      publishedSibling: undefined,
+      siblings: {published: undefined, draft: undefined, version: undefined},
     } as unknown as ReturnType<typeof useTargetDocumentState>)
 
     await renderDialog({versionId: 'versions.rSummer.my-doc'})

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -10,7 +10,11 @@ import {
   type DocumentActionDescription,
   type DocumentActionProps,
 } from '../../../config/document/actions'
-import {getTargetScopeId, useTargetDocumentState} from '../../../hooks/useTargetDocumentState'
+import {
+  getTargetScopeId,
+  getTargetSiblings,
+  useTargetDocumentState,
+} from '../../../hooks/useTargetDocumentState'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../store/user/hooks'
@@ -24,7 +28,7 @@ import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
 export const useUnpublishVersionAction: DocumentActionComponent = (
   props: DocumentActionProps,
 ): DocumentActionDescription | null => {
-  const {id, type, release, published, version} = props
+  const {id, type, release, version} = props
   const currentUser = useCurrentUser()
   const {t} = useTranslation(releasesLocaleNamespace)
   const isAlreadyUnpublished = version ? isGoingToUnpublish(version) : false
@@ -38,12 +42,9 @@ export const useUnpublishVersionAction: DocumentActionComponent = (
   // below instead of silently operating on the base pair.
   const isTargetReady = targetDocumentState.status === 'ready'
   const scopeId = getTargetScopeId(targetDocumentState)
-  const isVariantTarget = isTargetReady && targetDocumentState.variant !== undefined
-  // For variant release versions, "is there something published to unpublish" is answered by the
-  // variant-of-published sibling — the base `published` document says nothing about the variant.
-  const isPublished = isVariantTarget
-    ? targetDocumentState.publishedSibling !== undefined
-    : published !== null
+  // "Is there something published to unpublish"
+  const siblings = getTargetSiblings(targetDocumentState)
+  const isPublished = Boolean(siblings?.published)
 
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id,

--- a/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
@@ -134,13 +134,13 @@ describe('useCreatableVariantInitialValue', () => {
     expect(documentPreviewStoreMock.unstable_observeDocument).not.toHaveBeenCalled()
   })
 
-  it('passes the fallback through for a variant-missing state without a creatable target', async () => {
+  it('passes the fallback through for a variant-missing state without a published sibling', async () => {
     const wrapper = await createTestProvider()
     const missingState: TargetDocumentState = {
       status: 'variant-missing',
       variant: variantAlphaAudience,
       bundle: 'drafts',
-      siblings: {published: siblingStub, draft: undefined, version: undefined},
+      siblings: {published: undefined, draft: undefined, version: undefined},
     }
 
     const {result} = renderHook(() => useCreatableVariantInitialValue(missingState, fallback), {

--- a/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
@@ -60,8 +60,7 @@ const creatableState: TargetDocumentState = {
   status: 'variant-missing',
   variant: variantAlphaAudience,
   bundle: 'drafts',
-  publishedSibling: siblingStub,
-  creatableTarget: DRAFT_TARGET,
+  siblings: {published: siblingStub, draft: undefined, version: undefined},
 }
 
 const fallback: InitialValueState = {
@@ -124,7 +123,7 @@ describe('useCreatableVariantInitialValue', () => {
       targetDocument: undefined,
       scopeId: undefined,
       variant: undefined,
-      publishedSibling: undefined,
+      siblings: {published: undefined, draft: undefined, version: undefined},
     }
 
     const {result} = renderHook(() => useCreatableVariantInitialValue(readyState, fallback), {
@@ -141,7 +140,7 @@ describe('useCreatableVariantInitialValue', () => {
       status: 'variant-missing',
       variant: variantAlphaAudience,
       bundle: 'drafts',
-      publishedSibling: siblingStub,
+      siblings: {published: siblingStub, draft: undefined, version: undefined},
     }
 
     const {result} = renderHook(() => useCreatableVariantInitialValue(missingState, fallback), {

--- a/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useCreatableVariantInitialValue.test.ts
@@ -151,6 +151,23 @@ describe('useCreatableVariantInitialValue', () => {
     expect(documentPreviewStoreMock.unstable_observeDocument).not.toHaveBeenCalled()
   })
 
+  it('passes the fallback through for a missing variant on a release, even when the published sibling advertises a draft id', async () => {
+    const wrapper = await createTestProvider()
+    const missingOnRelease: TargetDocumentState = {
+      status: 'variant-missing',
+      variant: variantAlphaAudience,
+      bundle: 'rSummer',
+      siblings: {published: siblingStub, draft: undefined, version: undefined},
+    }
+
+    const {result} = renderHook(() => useCreatableVariantInitialValue(missingOnRelease, fallback), {
+      wrapper,
+    })
+
+    expect(result.current).toBe(fallback)
+    expect(documentPreviewStoreMock.unstable_observeDocument).not.toHaveBeenCalled()
+  })
+
   it('stays loading (with the draft target id) until the published sibling arrives', async () => {
     const wrapper = await createTestProvider()
 

--- a/packages/sanity/src/core/variants/hooks/useCreatableVariantInitialValue.ts
+++ b/packages/sanity/src/core/variants/hooks/useCreatableVariantInitialValue.ts
@@ -3,11 +3,7 @@ import {useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
 import {map, of} from 'rxjs'
 
-import {
-  type CreatableTargetDocument,
-  getCreatableVariantTarget,
-  type TargetDocumentState,
-} from '../../hooks/useTargetDocumentState'
+import {getTargetSiblings, type TargetDocumentState} from '../../hooks/useTargetDocumentState'
 import {useDocumentPreviewStore} from '../../store/datastores'
 import {type InitialValueState} from '../../store/document/initialValue/types'
 import {getPublishedId} from '../../util/draftUtils'
@@ -30,7 +26,7 @@ import {getPublishedId} from '../../util/draftUtils'
  */
 export function buildCreatableVariantInitialValue(options: {
   publishedSibling: SanityDocumentLike
-  target: CreatableTargetDocument
+  target: {scopeId: string; id: string}
   variantId: string
 }): SanityDocumentLike {
   const {publishedSibling, target, variantId} = options
@@ -69,14 +65,14 @@ export function useCreatableVariantInitialValue(
   fallback: InitialValueState,
 ): InitialValueState {
   const documentPreviewStore = useDocumentPreviewStore()
-  const creatableTarget = getCreatableVariantTarget(targetDocumentState)
   const isVariantMissing = targetDocumentState.status === 'variant-missing'
   const variantId = isVariantMissing ? targetDocumentState.variant._id : undefined
-  const publishedSiblingId = isVariantMissing
-    ? targetDocumentState.publishedSibling?._id
-    : undefined
-  const targetId = creatableTarget?.id
-  const targetScopeId = creatableTarget?.scopeId
+  const siblings = getTargetSiblings(targetDocumentState)
+
+  const publishedSiblingVersionStub = siblings?.published
+  const publishedSiblingId = publishedSiblingVersionStub?._id
+  const targetId = publishedSiblingVersionStub?._system.draft?._ref
+  const targetScopeId = publishedSiblingVersionStub?._system.scopeId
 
   const publishedSibling$ = useMemo(() => {
     if (!targetId || !publishedSiblingId) {

--- a/packages/sanity/src/core/variants/hooks/useCreatableVariantInitialValue.ts
+++ b/packages/sanity/src/core/variants/hooks/useCreatableVariantInitialValue.ts
@@ -6,7 +6,7 @@ import {map, of} from 'rxjs'
 import {getTargetSiblings, type TargetDocumentState} from '../../hooks/useTargetDocumentState'
 import {useDocumentPreviewStore} from '../../store/datastores'
 import {type InitialValueState} from '../../store/document/initialValue/types'
-import {getPublishedId} from '../../util/draftUtils'
+import {getPublishedId, getVersionFromId} from '../../util/draftUtils'
 
 /**
  * Builds the initial value for a creatable missing draft variant from its published sibling: the
@@ -26,7 +26,7 @@ import {getPublishedId} from '../../util/draftUtils'
  */
 export function buildCreatableVariantInitialValue(options: {
   publishedSibling: SanityDocumentLike
-  target: {scopeId: string; id: string}
+  target: {id: string}
   variantId: string
 }): SanityDocumentLike {
   const {publishedSibling, target, variantId} = options
@@ -41,7 +41,7 @@ export function buildCreatableVariantInitialValue(options: {
       },
       variant: {_ref: variantId, _weak: true as const},
       bundleId: 'drafts',
-      scopeId: target.scopeId,
+      scopeId: getVersionFromId(target.id),
     },
   }
 }
@@ -72,7 +72,6 @@ export function useCreatableVariantInitialValue(
   const publishedSiblingVersionStub = siblings?.published
   const publishedSiblingId = publishedSiblingVersionStub?._id
   const targetId = publishedSiblingVersionStub?._system.draft?._ref
-  const targetScopeId = publishedSiblingVersionStub?._system.scopeId
 
   const publishedSibling$ = useMemo(() => {
     if (!targetId || !publishedSiblingId) {
@@ -88,7 +87,7 @@ export function useCreatableVariantInitialValue(
   const publishedSibling = useSyncObservable(publishedSibling$, null)
 
   return useMemo(() => {
-    if (!targetId || !targetScopeId || !variantId) {
+    if (!targetId || !variantId) {
       return fallback
     }
     if (!publishedSibling) {
@@ -99,9 +98,9 @@ export function useCreatableVariantInitialValue(
       error: null,
       value: buildCreatableVariantInitialValue({
         publishedSibling,
-        target: {id: targetId, scopeId: targetScopeId},
+        target: {id: targetId},
         variantId,
       }),
     }
-  }, [targetId, targetScopeId, variantId, publishedSibling, fallback])
+  }, [targetId, variantId, publishedSibling, fallback])
 }

--- a/packages/sanity/src/core/variants/hooks/useCreatableVariantInitialValue.ts
+++ b/packages/sanity/src/core/variants/hooks/useCreatableVariantInitialValue.ts
@@ -67,6 +67,9 @@ export function useCreatableVariantInitialValue(
   const documentPreviewStore = useDocumentPreviewStore()
   const isVariantMissing = targetDocumentState.status === 'variant-missing'
   const variantId = isVariantMissing ? targetDocumentState.variant._id : undefined
+  const isCreatableBundle =
+    // Only drafts bundle are created while typing, releases and agents have a creation button
+    targetDocumentState.status === 'variant-missing' && targetDocumentState.bundle === 'drafts'
   const siblings = getTargetSiblings(targetDocumentState)
 
   const publishedSiblingVersionStub = siblings?.published
@@ -74,20 +77,20 @@ export function useCreatableVariantInitialValue(
   const targetId = publishedSiblingVersionStub?._system.draft?._ref
 
   const publishedSibling$ = useMemo(() => {
-    if (!targetId || !publishedSiblingId) {
+    if (!targetId || !publishedSiblingId || !isCreatableBundle) {
       return of(null)
     }
     return documentPreviewStore
       .unstable_observeDocument(publishedSiblingId)
       .pipe(map((doc) => doc ?? null))
-  }, [targetId, publishedSiblingId, documentPreviewStore])
+  }, [targetId, publishedSiblingId, documentPreviewStore, isCreatableBundle])
   // Kept synchronous: the sibling snapshot feeds the initial value used when
   // creating the variant document, so a deferred read could seed the new
   // document from a stale sibling.
   const publishedSibling = useSyncObservable(publishedSibling$, null)
 
   return useMemo(() => {
-    if (!targetId || !variantId) {
+    if (!targetId || !variantId || !isCreatableBundle) {
       return fallback
     }
     if (!publishedSibling) {
@@ -102,5 +105,5 @@ export function useCreatableVariantInitialValue(
         variantId,
       }),
     }
-  }, [targetId, variantId, publishedSibling, fallback])
+  }, [targetId, variantId, publishedSibling, fallback, isCreatableBundle])
 }

--- a/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
@@ -4,6 +4,7 @@ import {
   type DocumentActionComponent,
   getPairTarget,
   getTargetScopeId,
+  getTargetSiblings,
   InsufficientPermissionsMessage,
   isPublishedId,
   useCurrentUser,
@@ -25,27 +26,18 @@ const DISABLED_REASON_KEY = {
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
 /** @internal */
-export const useDiscardChangesAction: DocumentActionComponent = ({
-  id,
-  type,
-  published,
-  liveEdit,
-  version,
-  draft,
-}) => {
+export const useDiscardChangesAction: DocumentActionComponent = ({id, type, version, draft}) => {
   const {displayed, targetDocumentState} = useDocumentPane()
   // The scope of the document targeted by the selected perspective (undefined when the target is
   // still resolving or the draft/published pair applies). While resolving, the action is disabled
   // below instead of silently operating on the base pair.
   const isTargetReady = targetDocumentState.status === 'ready'
   const scopeId = getTargetScopeId(targetDocumentState)
-  const isVariantTarget = isTargetReady && targetDocumentState.variant !== undefined
-  // The discard confirmation copy depends on whether a published counterpart exists ("revert to
-  // published" vs "delete document"). For variant targets that counterpart is the
-  // variant-of-published sibling, not the base published document.
-  const publishedCounterpartExists = isVariantTarget
-    ? targetDocumentState.publishedSibling !== undefined
-    : Boolean(published)
+  // Confirmation copy depends on whether a published counterpart exists in the current lane
+  // ("revert to published" vs "delete document").
+  const siblings = getTargetSiblings(targetDocumentState)
+  const publishedCounterpartExists = Boolean(siblings?.published)
+
   const {discardChanges} = useDocumentOperation(id, type, getPairTarget(targetDocumentState))
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -224,6 +224,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
     validationStatus.revision,
     revision,
     doPublish,
+    setPublishScheduled,
   ])
 
   return useMemo(() => {

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -77,8 +77,8 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   const scopeId = getTargetScopeId(targetDocumentState)
   const isVariantTarget = isTargetReady && targetDocumentState.variant !== undefined
   const siblings = getTargetSiblings(targetDocumentState)
-  // Publish-state timestamps and completion tracking live on the current lane's published
-  // sibling. Fall back to the pair snapshot while the target is still resolving.
+  // Publish-state timestamps and completion tracking live on the current lane's published sibling.
+  // (While the target is resolving, the action is disabled below.)
   const publishedInfo = siblings?.published
 
   const {publish} = useDocumentOperation(id, type, getPairTarget(targetDocumentState))

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -8,6 +8,7 @@ import {
   type DocumentActionComponent,
   getPairTarget,
   getTargetScopeId,
+  getTargetSiblings,
   InsufficientPermissionsMessage,
   isPublishedPerspective,
   type TFunction,
@@ -75,15 +76,10 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   const isTargetReady = targetDocumentState.status === 'ready'
   const scopeId = getTargetScopeId(targetDocumentState)
   const isVariantTarget = isTargetReady && targetDocumentState.variant !== undefined
-  // For variant targets, publish state (already-published timestamps, publish-completion revision
-  // tracking) lives on the variant-of-published sibling — the base `published` document says
-  // nothing about whether the *variant* is published.
-  const publishedInfo = isVariantTarget ? targetDocumentState.publishedSibling : published
-  // Variant publish locks need the sibling revision (not in any pair snapshot). Base draft
-  // publish omits this and keeps using `snapshots.published._rev` inside the operation.
-  const publishedRevisionId = isVariantTarget
-    ? targetDocumentState.publishedSibling?._rev
-    : undefined
+  const siblings = getTargetSiblings(targetDocumentState)
+  // Publish-state timestamps and completion tracking live on the current lane's published
+  // sibling. Fall back to the pair snapshot while the target is still resolving.
+  const publishedInfo = siblings?.published
 
   const {publish} = useDocumentOperation(id, type, getPairTarget(targetDocumentState))
   const validationStatus = useValidationStatus(value._id, type, !release)
@@ -119,10 +115,10 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   const telemetry = useTelemetry()
 
   const doPublish = useCallback(() => {
-    publish.execute(isVariantTarget ? {publishedRevisionId} : undefined)
+    publish.execute(isVariantTarget ? {publishedRevisionId: currentPublishRevision} : undefined)
     telemetry.log(PublishButtonClicked, {documentId: id, stage: 'started'})
     setPublishState({status: 'publishing', publishRevision: currentPublishRevision})
-  }, [publish, isVariantTarget, publishedRevisionId, currentPublishRevision, telemetry, id])
+  }, [publish, isVariantTarget, currentPublishRevision, telemetry, id])
 
   useEffect(() => {
     // make sure the validation status is about the current revision and not an earlier one

--- a/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
@@ -5,6 +5,7 @@ import {
   type DocumentActionModalDialogProps,
   getPairTarget,
   getTargetScopeId,
+  getTargetSiblings,
   InsufficientPermissionsMessage,
   useCurrentUser,
   useDocumentOperation,
@@ -42,11 +43,10 @@ export const useUnpublishAction: DocumentActionComponent = ({
   const isTargetReady = targetDocumentState.status === 'ready'
   const scopeId = getTargetScopeId(targetDocumentState)
   const isVariantTarget = isTargetReady && targetDocumentState.variant !== undefined
-  // A variant is unpublishable only when its variant-of-published sibling exists — the base
-  // `published` document says nothing about the variant's publish state.
-  const isVariantUnpublishable = isVariantTarget
-    ? targetDocumentState.publishedSibling !== undefined
-    : true
+  // Unpublishable only when a published document exists in the current lane — the base published
+  // document when no variant is selected, the variant-of-published sibling when one is.
+  const siblings = getTargetSiblings(targetDocumentState)
+  const publishedExists = Boolean(siblings?.published)
   const {unpublish} = useDocumentOperation(id, type, getPairTarget(targetDocumentState))
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
@@ -118,7 +118,7 @@ export const useUnpublishAction: DocumentActionComponent = ({
       }
     }
 
-    if (!isVariantUnpublishable) {
+    if (siblings && !publishedExists) {
       return {
         tone: 'critical',
         icon: UnpublishIcon,
@@ -143,7 +143,8 @@ export const useUnpublishAction: DocumentActionComponent = ({
     liveEditSchemaType,
     isPermissionsLoading,
     isTargetReady,
-    isVariantUnpublishable,
+    publishedExists,
+    siblings,
     permissions?.granted,
     unpublish.disabled,
     t,

--- a/packages/sanity/src/structure/panes/document/comments/__tests__/CommentsWrapper.test.tsx
+++ b/packages/sanity/src/structure/panes/document/comments/__tests__/CommentsWrapper.test.tsx
@@ -49,7 +49,13 @@ vi.mock('../../useDocumentPane', () => ({
     onPathOpen: vi.fn(),
     inspector: null,
     openInspector: vi.fn(),
-    targetDocumentState: {status: 'ready', scopeId: undefined},
+    targetDocumentState: {
+      status: 'ready',
+      scopeId: undefined,
+      targetDocument: undefined,
+      variant: undefined,
+      siblings: {published: undefined, draft: undefined, version: undefined},
+    },
   })),
 }))
 
@@ -82,7 +88,13 @@ describe('CommentsWrapper', () => {
       onPathOpen: vi.fn(),
       inspector: null,
       openInspector: vi.fn(),
-      targetDocumentState: {status: 'ready', scopeId: undefined},
+      targetDocumentState: {
+        status: 'ready',
+        scopeId: undefined,
+        targetDocument: undefined,
+        variant: undefined,
+        siblings: {published: undefined, draft: undefined, version: undefined},
+      },
     })
 
     mockGetTargetScopeId.mockReturnValue(undefined)
@@ -291,7 +303,7 @@ describe('CommentsWrapper', () => {
         scopeId: 'varscope',
         targetDocument: undefined,
         variant: undefined,
-        publishedSibling: undefined,
+        siblings: {published: undefined, draft: undefined, version: undefined},
       }
 
       mockUseDocumentPane.mockReturnValue({
@@ -359,7 +371,7 @@ describe('CommentsWrapper', () => {
         scopeId: 'varscope',
         targetDocument: undefined,
         variant: {_id: 'system.variant.alpha-audience', name: 'alpha-audience'},
-        publishedSibling: undefined,
+        siblings: {published: undefined, draft: undefined, version: undefined},
       }
 
       mockUseDocumentPane.mockReturnValue({

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/__tests__/FormView.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/__tests__/FormView.test.tsx
@@ -83,7 +83,7 @@ function buildDocumentPaneValue(overrides: Partial<DocumentPaneValue> = {}): Doc
       targetDocument: undefined,
       scopeId: undefined,
       variant: undefined,
-      publishedSibling: undefined,
+      siblings: {published: undefined, draft: undefined, version: undefined},
     },
     ...overrides,
   } as unknown as DocumentPaneValue

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -30,6 +30,7 @@ const READY_TARGET_STATE = {
   targetDocument: undefined,
   scopeId: undefined,
   variant: undefined,
+  siblings: {published: undefined, draft: undefined, version: undefined},
 }
 
 const EXISTING_DOCUMENT_VERSIONS = {
@@ -386,6 +387,7 @@ describe('CopyDocumentActions', () => {
         status: 'variant-missing',
         variant: {_id: 'variant-1'},
         bundle: 'published',
+        siblings: {published: undefined, draft: undefined, version: undefined},
       })
 
       render(<CopyDocumentActions />, {wrapper})
@@ -410,6 +412,7 @@ describe('CopyDocumentActions', () => {
         targetDocument: {_id: 'versions.v1a2b3c4.doc-123'},
         scopeId: 'v1a2b3c4',
         variant: {_id: 'variant-1'},
+        siblings: {published: undefined, draft: undefined, version: undefined},
       })
 
       render(<CopyDocumentActions />, {wrapper})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/DocumentTargetBadges.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/DocumentTargetBadges.test.tsx
@@ -85,7 +85,11 @@ const readyState = (
   targetDocument,
   scopeId: targetDocument?._system.scopeId,
   variant,
-  publishedSibling: variant ? publishedVariant : undefined,
+  siblings: {
+    published: variant ? publishedVariant : undefined,
+    draft: undefined,
+    version: undefined,
+  },
 })
 
 const DEFAULT_PERSPECTIVE = {
@@ -238,7 +242,7 @@ describe('DocumentTargetBadges', () => {
         status: 'variant-missing',
         variant: variantAlphaAudience,
         bundle: 'drafts',
-        publishedSibling: publishedVariant,
+        siblings: {published: publishedVariant, draft: undefined, version: undefined},
       },
     })
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
@@ -83,7 +83,7 @@ const readyState = (
   targetDocument,
   scopeId: targetDocument?._system.scopeId,
   variant: undefined,
-  publishedSibling: undefined,
+  siblings: {published: undefined, draft: undefined, version: undefined},
 })
 
 const variantMissingState = (
@@ -93,7 +93,7 @@ const variantMissingState = (
   status: 'variant-missing',
   variant: variantAlphaAudience,
   bundle,
-  publishedSibling,
+  siblings: {published: publishedSibling, draft: undefined, version: undefined},
 })
 
 describe('getTargetBadgePerspective', () => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
@@ -31,8 +31,8 @@ export function getBadgeSystemDocument(
     return state.targetDocument
   }
 
-  if (state.status === 'variant-missing' && state.publishedSibling) {
-    return state.publishedSibling
+  if (state.status === 'variant-missing' && state.siblings.published) {
+    return state.siblings.published
   }
 
   return displayed ?? undefined
@@ -96,7 +96,7 @@ export function isTargetBadgeMissing({
     case 'variant-definition-document-not-found':
       return true
     case 'variant-missing':
-      return !(isLiveEdit && Boolean(state.publishedSibling) && isSystemBundle(bundle))
+      return !(isLiveEdit && Boolean(state.siblings.published) && isSystemBundle(bundle))
     case 'ready':
       return !state.targetDocument && !state.variant && !isSystemBundle(bundle)
     default:

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
@@ -9,6 +9,7 @@ import {
   ChangesError,
   type DocumentChangeContextInstance,
   type DocumentGroupEvent,
+  getTargetSiblings,
   isReleaseDocument,
   LoadingBlock,
   NoChanges,
@@ -60,7 +61,7 @@ const CompareWithPublishedView = () => {
   const isVariantTarget =
     targetDocumentState.status === 'ready' && targetDocumentState.variant !== undefined
   const siblingScopeId = isVariantTarget
-    ? targetDocumentState.publishedSibling?._system.scopeId
+    ? getTargetSiblings(targetDocumentState)?.published?._system.scopeId
     : undefined
   const siblingEditState = useEditState(documentId, documentType, 'default', siblingScopeId)
   const publishedComparisonBase = isVariantTarget

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -381,6 +381,7 @@ exports[`exports snapshot 1`] = `
     "getSelectedVariant": "function",
     "getTargetDocument": "function",
     "getTargetScopeId": "function",
+    "getTargetSiblings": "function",
     "getTemplatePermissions": "function",
     "getValueAtPath": "function",
     "getValueError": "function",


### PR DESCRIPTION
### Description

Variant publish/draft/unpublish checks were `isVariant ? publishedSibling : pair.published`. That fork doesn't scale (live-edit variants in #14394), and `publishedSibling` only existed for variants so the default lane still used a different source.

`useTargetDocumentState` now always reports lane-scoped `siblings` (`published` / `draft` / `version`). Each slot is the current lane (default, or that variant); missing documents stay `undefined`; a published variant never fills the default published slot. `version` is only the current release/agent bundle, not every version.

Existence checks read `getTargetSiblings(state)` instead of branching. Operation routing that is actually variant-specific (pair checkout, publish revision lock, incoming refs) is unchanged.

### What to review

- `TargetDocumentSiblings` / `getDocumentSiblings` in `useTargetDocumentState` — the lane model is the contract
- Publish / Unpublish / Discard / UnpublishVersion / live-edit leftover-draft gating that dropped the `isVariant` existence fork
- `useCreatableVariantInitialValue` still seeds only on the drafts bundle when the published sibling advertises `_system.draft._ref` (not every missing variant)

Packages: `sanity` (core + structure)

### Testing

- `useTargetDocumentState.test.ts` — mixed-inventory isolation (default vs variant A vs variant B vs release) and `getTargetSiblings` resolving / missing-definition cases
- `useCreatableVariantInitialValue.test.ts` — missing variant on a release with an advertised draft ref does not observe or seed

### Notes for release

N/A – Part of variants; internal `useTargetDocumentState` contract, not user-facing.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c35898f29d799aa121e2f27c54fad12d14c103ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->