### PR TITLE
fix(structure): use published sibling in events inspector

### DIFF
--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
@@ -29,6 +29,7 @@ import {Flex, Box, Grid} from 'ui5'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {EventsTimelineMenu} from '../../timeline/events/EventsTimelineMenu'
 import {useDocumentPane} from '../../useDocumentPane'
+import {getPublishedComparisonBase, getPublishedSiblingScopeId} from './getPublishedComparisonBase'
 
 const Scroller = styled(ScrollContainer)`
   height: 100%;
@@ -49,24 +50,21 @@ const DIFF_INITIAL_VALUE = {
   error: null,
 }
 
-const CompareWithPublishedView = () => {
+function CompareWithPublishedView() {
   const {documentId, documentType, schemaType, editState, displayed, targetDocumentState} =
     useDocumentPane()
   const {selectedPerspective, selectedPerspectiveName, selectedReleaseId} = usePerspective()
   const {t} = useTranslation(structureLocaleNamespace)
 
   // "Published" means this lane's published sibling, not the group's published document.
-  // A scoped stub (variant-of-published) is checked out as a pair whose document arrives in
-  // `version`; a default published (no scope id) is `editState.published`.
   const siblings = getTargetSiblings(targetDocumentState)
-  const publishedStub = siblings?.published
-  const siblingScopeId = publishedStub?._system.scopeId
+  const siblingScopeId = getPublishedSiblingScopeId(siblings)
   const siblingEditState = useEditState(documentId, documentType, 'default', siblingScopeId)
-  const publishedComparisonBase = siblingScopeId
-    ? (siblingEditState.version ?? null)
-    : publishedStub || siblings === undefined
-      ? (editState?.published ?? null)
-      : null
+  const publishedComparisonBase = getPublishedComparisonBase({
+    siblings,
+    siblingVersion: siblingEditState.version,
+    published: editState?.published,
+  })
 
   const rootDiff = useMemo(() => {
     const diff = diffInput(
@@ -91,7 +89,7 @@ const CompareWithPublishedView = () => {
     return null
   }
   return (
-    <Stack gap={2} marginBottom={3}>
+    <Stack gap={2} marginBottom={3} data-testid="compare-with-published">
       <Card borderBottom paddingBottom={3}>
         <Stack gap={3} paddingTop={1}>
           <Text size={1} weight="medium">
@@ -128,6 +126,7 @@ const CompareWithPublishedView = () => {
     </Stack>
   )
 }
+
 export function EventsInspector({showChanges}: {showChanges: boolean}): ReactElement {
   const {documentId, schemaType, timelineError, value, formState} = useDocumentPane()
   const [scrollRef, setScrollRef] = useState<HTMLDivElement | null>(null)

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
@@ -55,18 +55,18 @@ const CompareWithPublishedView = () => {
   const {selectedPerspective, selectedPerspectiveName, selectedReleaseId} = usePerspective()
   const {t} = useTranslation(structureLocaleNamespace)
 
-  // For variant targets, "published" means the variant-of-published sibling, not the base
-  // published document. Its scope id checks out the sibling pair; the sibling document arrives
-  // in the `version` slot of that edit state.
-  const isVariantTarget =
-    targetDocumentState.status === 'ready' && targetDocumentState.variant !== undefined
-  const siblingScopeId = isVariantTarget
-    ? getTargetSiblings(targetDocumentState)?.published?._system.scopeId
-    : undefined
+  // "Published" means this lane's published sibling, not the group's published document.
+  // A scoped stub (variant-of-published) is checked out as a pair whose document arrives in
+  // `version`; a default published (no scope id) is `editState.published`.
+  const siblings = getTargetSiblings(targetDocumentState)
+  const publishedStub = siblings?.published
+  const siblingScopeId = publishedStub?._system.scopeId
   const siblingEditState = useEditState(documentId, documentType, 'default', siblingScopeId)
-  const publishedComparisonBase = isVariantTarget
-    ? (siblingScopeId && siblingEditState.version) || null
-    : editState?.published
+  const publishedComparisonBase = siblingScopeId
+    ? (siblingEditState.version ?? null)
+    : publishedStub || siblings === undefined
+      ? (editState?.published ?? null)
+      : null
 
   const rootDiff = useMemo(() => {
     const diff = diffInput(
@@ -77,8 +77,8 @@ const CompareWithPublishedView = () => {
     return diff
   }, [publishedComparisonBase, displayed])
 
-  if (isVariantTarget && !publishedComparisonBase) {
-    // The variant has never been published — there is nothing to compare against.
+  if (!publishedComparisonBase) {
+    // This lane has never been published — there is nothing to compare against.
     return null
   }
   if (selectedReleaseId && !editState?.version) {

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/getPublishedComparisonBase.test.ts
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/getPublishedComparisonBase.test.ts
@@ -1,0 +1,124 @@
+import {type SanityDocument} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {
+  getPublishedComparisonBase,
+  getPublishedSiblingScopeId,
+  type PublishedComparisonSiblings,
+} from './getPublishedComparisonBase'
+
+const publishedDoc: SanityDocument = {
+  _id: 'article-1',
+  _type: 'article',
+  _rev: 'pub-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-02T00:00:00Z',
+  title: 'Base published',
+}
+
+const variantPublishedDoc: SanityDocument = {
+  _id: 'versions.varscopePub.article-1',
+  _type: 'article',
+  _rev: 'var-pub-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-03T00:00:00Z',
+  title: 'Variant published',
+}
+
+const baseSiblings: PublishedComparisonSiblings = {
+  published: {_system: {}},
+}
+
+const variantSiblings: PublishedComparisonSiblings = {
+  published: {_system: {scopeId: 'varscopePub'}},
+}
+
+const unpublishedSiblings: PublishedComparisonSiblings = {
+  published: undefined,
+}
+
+describe('getPublishedSiblingScopeId', () => {
+  it('returns the published sibling scope id when present', () => {
+    expect(getPublishedSiblingScopeId(variantSiblings)).toBe('varscopePub')
+  })
+
+  it('returns undefined for the base pair and while siblings are resolving', () => {
+    expect(getPublishedSiblingScopeId(baseSiblings)).toBeUndefined()
+    expect(getPublishedSiblingScopeId(undefined)).toBeUndefined()
+    expect(getPublishedSiblingScopeId(unpublishedSiblings)).toBeUndefined()
+  })
+})
+
+describe('getPublishedComparisonBase', () => {
+  it('uses editState.published for the base pair when a published sibling exists', () => {
+    expect(
+      getPublishedComparisonBase({
+        siblings: baseSiblings,
+        siblingVersion: variantPublishedDoc,
+        published: publishedDoc,
+      }),
+    ).toBe(publishedDoc)
+  })
+
+  it('falls back to editState.published while siblings are still resolving', () => {
+    expect(
+      getPublishedComparisonBase({
+        siblings: undefined,
+        siblingVersion: undefined,
+        published: publishedDoc,
+      }),
+    ).toBe(publishedDoc)
+  })
+
+  it('returns null when the lane has no published sibling', () => {
+    expect(
+      getPublishedComparisonBase({
+        siblings: unpublishedSiblings,
+        siblingVersion: variantPublishedDoc,
+        published: publishedDoc,
+      }),
+    ).toBeNull()
+  })
+
+  it('uses the sibling version document for a scoped published variant', () => {
+    // Covers both a ready variant target and variant-missing (siblings.published is
+    // still the variant-of-published stub). Must not use the group's published document.
+    expect(
+      getPublishedComparisonBase({
+        siblings: variantSiblings,
+        siblingVersion: variantPublishedDoc,
+        published: publishedDoc,
+      }),
+    ).toBe(variantPublishedDoc)
+  })
+
+  it('does not fall back to the group published document for a scoped variant', () => {
+    expect(
+      getPublishedComparisonBase({
+        siblings: variantSiblings,
+        siblingVersion: null,
+        published: publishedDoc,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null while the scoped published sibling pair is still loading', () => {
+    expect(
+      getPublishedComparisonBase({
+        siblings: variantSiblings,
+        siblingVersion: undefined,
+        published: publishedDoc,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when resolving and the default published document has not loaded', () => {
+    expect(
+      getPublishedComparisonBase({
+        siblings: undefined,
+        siblingVersion: undefined,
+        published: null,
+      }),
+    ).toBeNull()
+  })
+})

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/getPublishedComparisonBase.ts
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/getPublishedComparisonBase.ts
@@ -1,0 +1,59 @@
+import {type SanityDocument} from '@sanity/types'
+
+/**
+ * The current lane's stubs, narrowed to the published sibling the events inspector
+ * needs. Same shape as the `siblings` field on a resolved target document state.
+ */
+export interface PublishedComparisonSiblings {
+  published?: {_system?: {scopeId?: string}}
+}
+
+/**
+ * Scope id of this lane's published sibling, used to check out the sibling pair
+ * so a variant-of-published document arrives in `editState.version`. `undefined`
+ * for the base published document (no scope id) and when siblings are unresolved.
+ *
+ * @internal
+ */
+export function getPublishedSiblingScopeId(
+  siblings: PublishedComparisonSiblings | undefined,
+): string | undefined {
+  return siblings?.published?._system?.scopeId
+}
+
+/**
+ * Resolves the published document this lane should compare against in the events
+ * inspector fallback ("Comparing with published").
+ *
+ * "Published" means this lane's published sibling, not the group's published document.
+ * A scoped stub (variant-of-published) is checked out as a pair whose document arrives
+ * in `version`; a default published (no scope id) is `editState.published`.
+ *
+ * Returns `null` when this lane has never been published, or the sibling pair has not
+ * loaded yet. While siblings are still resolving (`undefined`), falls back to
+ * `published` so the default pair does not wait on version stubs.
+ *
+ * @internal
+ */
+export function getPublishedComparisonBase({
+  siblings,
+  siblingVersion,
+  published,
+}: {
+  siblings: PublishedComparisonSiblings | undefined
+  siblingVersion: SanityDocument | null | undefined
+  published: SanityDocument | null | undefined
+}): SanityDocument | null {
+  const publishedStub = siblings?.published
+  const siblingScopeId = getPublishedSiblingScopeId(siblings)
+
+  if (siblingScopeId) {
+    return siblingVersion ?? null
+  }
+
+  if (publishedStub || siblings === undefined) {
+    return published ?? null
+  }
+
+  return null
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

When document history is truncated, Review changes falls back to “Comparing with published.” That comparison has to use this lane’s published sibling — including `variant-missing` — not the group’s published document. Unpublished lanes should not diff against `{}`.

The original nested ternary was hard to test, so the sibling vs base published resolution is extracted for unit coverage. While siblings are still resolving, it still falls back to `editState.published`, which can briefly be the wrong document on a variant lane.

### What to review

- `CompareWithPublishedView` uses `getTargetSiblings()` and scoped `useEditState` (scoped documents arrive in `version`)
- `getPublishedComparisonBase` / `getPublishedSiblingScopeId` match that sibling vs base published behavior

### Testing

Unit tests in `getPublishedComparisonBase.test.ts` cover:

- base pair uses `editState.published`
- scoped published variant uses the sibling `version` document, never the group published document
- unpublished lanes return null
- siblings still resolving fall back to `editState.published`

Studio (test workspace `/test`):

- On `grrm` (published + draft, history truncated by retention), Review changes shows **Comparing with published** against the base published document
- On an unpublished draft, Review changes shows **Same revision selected** and does not invent a published comparison
- With the **Loyal customers** variant selected (no variant document exists), **Comparing with published** is hidden — this lane was never published

[Review changes comparing with published after retention policy](https://cursor.com/agents/bc-442ff270-f857-43c5-b955-5c3fb14317ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freview_changes_comparing_with_published.webp)
[Review changes with Loyal customers variant selected](https://cursor.com/agents/bc-442ff270-f857-43c5-b955-5c3fb14317ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freview_changes_loyal_customers_variant.webp)
[review_changes_published_then_unpublished_variant.mp4](https://cursor.com/agents/bc-442ff270-f857-43c5-b955-5c3fb14317ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freview_changes_published_then_unpublished_variant.mp4)

### Notes for release

When history is unavailable, Review changes compares against this document’s published version for the current lane (including variants), not the group’s published document. Lanes that have never been published no longer show an empty published comparison.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-442ff270-f857-43c5-b955-5c3fb14317ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-442ff270-f857-43c5-b955-5c3fb14317ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

