### PR TITLE
fix(deps): remove duplicated ui snapshot key from lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20112,20 +20112,6 @@ snapshots:
       styled-components: 6.5.3(react-dom@19.2.8)(react@19.2.8)
       use-effect-event: 2.0.4(react@19.2.8)
 
-  '@sanity/ui@4.0.7(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8)(react@19.2.8)
-      '@sanity/color': 3.0.8
-      '@sanity/icons': 5.2.1(react@19.2.8)
-      csstype: 3.2.3
-      motion: 13.1.1(react-dom@19.2.8)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-is: 19.2.8
-      react-refractor: 4.0.0(react@19.2.8)
-      styled-components: 6.5.3(react-dom@19.2.8)(react@19.2.8)
-      use-effect-event: 2.0.4(react@19.2.8)
-
   '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`pnpm-lock.yaml` on `main` contains the snapshot key `'@sanity/ui@4.0.7(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)'` twice (lines 20101 and 20115), with byte-identical bodies. The duplicate arrived when [#14405](https://github.com/sanity-io/sanity/pull/14405) and [#14409](https://github.com/sanity-io/sanity/pull/14409) merged a minute apart, both rewriting the lockfile.

The duplicated YAML mapping key makes CI's fresh installs reject the lockfile — `[WARN] Ignoring broken lockfile ... duplicated mapping key (20115:3)` — and re-resolve every range from scratch. That resolution picks up `@sanity/client@8.4.0` (the lockfile pins `8.3.0`; the bump PR [#14417](https://github.com/sanity-io/sanity/pull/14417) is still open), whose `DatasetsResponse` requires `description`, so the `oxlint` type check fails in `packages/@sanity/vision/src/hooks/useDatasets.test.ts` on every PR whose CI has run since ~09:52 UTC — files those PRs never touch. `bundle-stats` fails the same way.

This removes the second copy of the block. Nothing else changes: no versions move, and the lockfile parses strictly again.

### What to review

The diff is a pure 14-line deletion of the second, identical snapshot block.

### Testing

- `pnpm install --frozen-lockfile` on the fixed lockfile: `Lockfile is up to date, resolution step is skipped`, no broken-lockfile warning
- `rg -c` confirms exactly one `@sanity/ui@4.0.7(...)` snapshot key remains
- `pnpm check:oxlint` passes on `main` with locked versions (the vision errors only reproduce through the re-resolution path)

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65ba64e0-6c22-4ce7-90f2-d8abd344d8d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65ba64e0-6c22-4ce7-90f2-d8abd344d8d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

