### PR TITLE
fix(structure): use a publish variant label on variant documents

### DIFF
--- a/packages/sanity/src/core/variants/USER_GUIDE.md
+++ b/packages/sanity/src/core/variants/USER_GUIDE.md
@@ -62,7 +62,7 @@ If the selected variant name doesn't match any existing variant definition (for 
 
 ### Publishing
 
-**Publish** on a variant draft publishes it as the **published variant** — the content the API serves for matching conditions. The base published document is not touched.
+**Publish variant** on a variant draft publishes it as the **published variant** — the content the API serves for matching conditions. The base published document is not touched.
 
 - If the variant has been published before, the new publish replaces the published variant's content.
 - Variant documents in a **release** are not published individually: they're disabled with _"This version is published as part of its release"_ and go live when the release is published, like any other release content.

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -31,6 +31,7 @@ import {
   PublishButtonDisabledStart,
   PublishButtonClicked,
 } from './__telemetry__/documentActions.telemetry'
+import {getPublishActionLabel} from './getPublishActionLabel'
 import {PUBLISH_DISABLED_REASON} from './operationDisabledReasons'
 
 const PUBLISHED_STATE = {status: 'published'} as const
@@ -245,11 +246,18 @@ export const usePublishAction: DocumentActionComponent = (props) => {
      * Skipped when a variant is selected: the base published document says nothing about the
      * variant's publish state (the store-level disabled reasons and target guards apply instead).
      */
+    // `selectedVariantName` is the sticky param — available before the target document loads.
+    const label = getPublishActionLabel(t, {
+      isVariant: Boolean(selectedVariantName),
+      publishScheduled,
+      publishState,
+    })
+
     if (published && !draft && !version && !selectedVariantName) {
       return {
         tone: 'default',
         icon: PublishIcon,
-        label: t('action.publish.label'),
+        label,
         title: getDisabledReason('ALREADY_PUBLISHED', published?._updatedAt, t),
         disabled: true,
       }
@@ -259,7 +267,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
       return {
         tone: 'default',
         icon: PublishIcon,
-        label: t('action.publish.label'),
+        label,
         title: (
           <InsufficientPermissionsMessage context="publish-document" currentUser={currentUser} />
         ),
@@ -280,14 +288,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
     return {
       disabled: disabled || isPermissionsLoading,
       tone: 'default',
-      label:
-        publishState?.status === 'published'
-          ? t('action.publish.published.label')
-          : publishScheduled
-            ? t('action.publish.validation-in-progress.label')
-            : publishState?.status === 'publishing'
-              ? t('action.publish.running.label')
-              : t('action.publish.draft.label'),
+      label,
       // @todo: Implement loading state, to show a `<Button loading />` state
       // loading: publishScheduled || publishState === 'publishing',
       icon: PublishIcon,

--- a/packages/sanity/src/structure/documentActions/getPublishActionLabel.test.ts
+++ b/packages/sanity/src/structure/documentActions/getPublishActionLabel.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it} from 'vitest'
+
+import {getPublishActionLabel} from './getPublishActionLabel'
+
+const LABELS = {
+  'action.publish.draft.label': 'Publish',
+  'action.publish.published.label': 'Published',
+  'action.publish.running.label': 'Publishing…',
+  'action.publish.validation-in-progress.label': 'Validating document…',
+  'action.publish.variant.label': 'Publish variant',
+} as const
+
+function t(key: string) {
+  return LABELS[key as keyof typeof LABELS]
+}
+
+describe('getPublishActionLabel', () => {
+  it('uses Publish for a base draft', () => {
+    expect(
+      getPublishActionLabel(t, {
+        isVariant: false,
+        publishScheduled: false,
+        publishState: null,
+      }),
+    ).toBe('Publish')
+  })
+
+  it('uses Publish variant when publishing a content variant', () => {
+    expect(
+      getPublishActionLabel(t, {
+        isVariant: true,
+        publishScheduled: false,
+        publishState: null,
+      }),
+    ).toBe('Publish variant')
+  })
+
+  it('keeps in-progress labels regardless of variant', () => {
+    expect(
+      getPublishActionLabel(t, {
+        isVariant: true,
+        publishScheduled: true,
+        publishState: null,
+      }),
+    ).toBe('Validating document…')
+
+    expect(
+      getPublishActionLabel(t, {
+        isVariant: true,
+        publishScheduled: false,
+        publishState: {status: 'publishing', publishRevision: 'rev-1'},
+      }),
+    ).toBe('Publishing…')
+
+    expect(
+      getPublishActionLabel(t, {
+        isVariant: true,
+        publishScheduled: false,
+        publishState: {status: 'published'},
+      }),
+    ).toBe('Published')
+  })
+})

--- a/packages/sanity/src/structure/documentActions/getPublishActionLabel.ts
+++ b/packages/sanity/src/structure/documentActions/getPublishActionLabel.ts
@@ -1,0 +1,35 @@
+type PublishState =
+  | {status: 'publishing'; publishRevision: string | undefined}
+  | {status: 'published'}
+  | null
+
+/**
+ * Idle, in-progress, and completed labels for the publish document action.
+ * Variant documents use a distinct idle label so editors can tell they are
+ * publishing the variant, not the base document.
+ *
+ * @internal
+ */
+export function getPublishActionLabel(
+  t: (key: string) => string,
+  {
+    isVariant,
+    publishScheduled,
+    publishState,
+  }: {
+    isVariant: boolean
+    publishScheduled: boolean
+    publishState: PublishState
+  },
+) {
+  if (publishState?.status === 'published') {
+    return t('action.publish.published.label')
+  }
+  if (publishScheduled) {
+    return t('action.publish.validation-in-progress.label')
+  }
+  if (publishState?.status === 'publishing') {
+    return t('action.publish.running.label')
+  }
+  return t(isVariant ? 'action.publish.variant.label' : 'action.publish.draft.label')
+}

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -104,6 +104,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Tooltip when the "Publish" document action is disabled due to validation issues */
   'action.publish.validation-issues.tooltip':
     'There are validation errors that need to be fixed before this document can be published',
+  /** Label for the "Publish" document action when publishing a content variant */
+  'action.publish.variant.label': 'Publish variant',
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Waiting for tasks to finish before publishing',
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

When a content variant is selected, the idle publish action still said **Publish**, the same as the base document. That made it easy to think the button would publish the base document.

Use **Publish variant** whenever `selectedVariantName` is set. In-progress labels (`Validating document…`, `Publishing…`, `Published`) stay the same. Release-scoped variants are unchanged: this action still does not appear there.

<img width="1216" height="901" alt="Screenshot 2026-09-03 at 11 26 54" src="https://github.com/user-attachments/assets/9732c347-f103-49db-a7fe-0a8587782ae4" />

[SAPP-4090](https://linear.app/sanity/issue/SAPP-4090/use-a-publish-variant-label-for-the-publish-action-on-variant)

### What to review

- Idle label in `PublishAction` when a variant is selected vs a base draft
- New `action.publish.variant.label` string (sort-keys placement)
- Footer test id becomes `action-publishvariant` for the variant idle label

### Testing

- Unit tests for `getPublishActionLabel` (base idle, variant idle, in-progress labels)
- Manual in `/test`: Author draft footer is **Publish** (`action-publish`) on All users (Default); after selecting Loyal customers and creating the variant document, the footer is **Publish variant** (`action-publishvariant`). Returning to default restores **Publish**.

### Notes for release

N/A – Part of content variants

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06467145-e971-4185-bf56-de992bd1732b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06467145-e971-4185-bf56-de992bd1732b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

