### PR TITLE
fix(deps): repair duplicate sanity ui lockfile entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20112,20 +20112,6 @@ snapshots:
       styled-components: 6.5.3(react-dom@19.2.8)(react@19.2.8)
       use-effect-event: 2.0.4(react@19.2.8)
 
-  '@sanity/ui@4.0.7(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8)(react@19.2.8)
-      '@sanity/color': 3.0.8
-      '@sanity/icons': 5.2.1(react@19.2.8)
-      csstype: 3.2.3
-      motion: 13.1.1(react-dom@19.2.8)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-is: 19.2.8
-      react-refractor: 4.0.0(react@19.2.8)
-      styled-components: 6.5.3(react-dom@19.2.8)(react@19.2.8)
-      use-effect-event: 2.0.4(react@19.2.8)
-
   '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The latest `@sanity/ui` dependency update left two identical YAML mappings in `pnpm-lock.yaml`. pnpm consequently ignores the broken lockfile during the bundle-stats baseline build, normalizes the lockfile, and prevents the action from switching to the PR head. Removing the duplicate preserves the intended resolution without introducing unrelated dependency churn.

The repair PR's own non-required bundle-stats check necessarily fails because that action builds the malformed `main` SHA before checking out this fixed head. Once merged, dependency PRs such as #14428 can rerun against a valid baseline.

### What to review

Confirm the remaining `@sanity/ui@4.0.7` snapshot is identical to the removed duplicate.

### Testing

- `pnpm install --frozen-lockfile`
- `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/@sanity/*'`
- `pnpm check:oxlint`
- All merge-required PR checks pass; no unresolved review threads remain

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9e86239-8dc8-4588-82db-7badf3de5882?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9e86239-8dc8-4588-82db-7badf3de5882&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

