### PR TITLE
fix(structure): keep document header height stable when variants is enabled

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -57,6 +57,9 @@ const TargetBadge = styled(Card)`
   display: inline-flex;
   align-items: center;
   flex: none;
+  /* Drawn as an inset shadow instead of the Card border prop so the 1px border
+     does not make the badge taller than the box-shadow-bordered VersionChip pills. */
+  box-shadow: inset 0 0 0 1px var(--card-border-color);
 `
 const BadgeContainer = styled(Flex)`
   user-select: none;
@@ -107,8 +110,10 @@ const PerspectiveBadgeLabel = memo(function PerspectiveBadgeLabel({
 
   if (isReleaseDocument(selectedPerspective)) {
     return (
-      <BadgeContainer gap={2} paddingY={1} paddingRight={2} align="center">
-        <ReleaseAvatarIcon release={selectedPerspective} />
+      <BadgeContainer gap={2} padding={2} align="center">
+        <Text size={1}>
+          <ReleaseAvatarIcon release={selectedPerspective} />
+        </Text>
 
         <ReleaseTitle
           title={selectedPerspective.metadata?.title}
@@ -168,7 +173,6 @@ export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
         <BadgeMotionWrapper animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
           <TargetBadge
             tone={getPerspectiveBadgeTone(badgePerspective)}
-            border
             radius={4}
             data-ui="DocumentTargetPerspectiveBadge"
           >
@@ -177,7 +181,7 @@ export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
         </BadgeMotionWrapper>
         {selectedVariantBadge ? (
           <BadgeMotionWrapper animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
-            <TargetBadge tone="suggest" border radius={4} data-ui="DocumentTargetVariantBadge">
+            <TargetBadge tone="suggest" radius={4} data-ui="DocumentTargetVariantBadge">
               <VariantBadgeLabel variant={selectedVariantBadge} />
             </TargetBadge>
           </BadgeMotionWrapper>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

With `beta.variants.enabled`, the document status header row is 2px taller than the regular version-chip header. The `TargetBadge` Card used the `border` prop, which in @sanity/ui v4 is a real 1px CSS border (2px of layout height), while the `VersionChip` pills draw their border as an inset box-shadow that costs no layout height. The badge now uses the same inset box-shadow technique (the idiom already used by `TasksUserAvatar`, comments `InlineObject`/`Annotation`, and @sanity/ui's own KBD). Measurement also surfaced that the release-perspective badge label rendered a bare `ReleaseAvatarIcon` (16px line box → 26px badge); it is now wrapped in `Text size={1}` — the canonical pattern from `VersionChip`/`ReleaseAvatar` — with the same `padding={2}` as its sibling labels.

Rejected alternative: hard-coding a row or badge height in `DocumentPanelHeader`, which would mask the mismatch instead of fixing the elements that create it. The truly canonical fix (Card `border` not costing layout height) belongs upstream in @sanity/ui and is out of scope here.

### What to review

Single file in the `sanity` package: `packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx`. Two deliberate visual changes to the release badge, worth a design glance: its avatar icon now renders at the 21px optical size the chips use (was 16px), and its label gains left padding where it previously had none (`paddingY={1} paddingRight={2}` → `padding={2}`), aligning it with the Drafts/Published/variant label states.

The `box-shadow` comment in `TargetBadge` is load-bearing: the unconditional inset shadow would clobber a future `shadow`/`border` prop passed by a new call site.

### Testing

Rendered heights measured in vitest browser-mode Chromium (@sanity/ui 4.0.7): before — chips 25px, drafts/variant badges 27px, release badge 26px; after — everything 25px. Confirmed in the live test studio: the variants-on header card measured 51.98px before and 49.98px after, now identical to the variants-off workspace. The existing 7 jsdom tests for `DocumentTargetBadges` pass (jsdom cannot assert on layout, per repo convention).

Deferred follow-up: a Chromatic story rendering `DocumentTargetBadges` next to a `VersionChip` would pin the height parity this PR restores against future @sanity/ui bumps or padding tweaks.

[Before/after height measurement of chips vs badges](https://cursor.com/agents/bc-c46854a6-5469-58ef-af64-7b8efc0be694/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader-height-before-after.png)

### Notes for release

N/A – Part of the variants beta (not generally available).

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C078QLWUXF1/p1787916215403449?thread_ts=1787916215.403449&cid=C078QLWUXF1)

<div><a href="https://cursor.com/agents/bc-c46854a6-5469-58ef-af64-7b8efc0be694?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c46854a6-5469-58ef-af64-7b8efc0be694&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

