### PR TITLE
Revert "fix(deps): repair duplicate sanity ui lockfile entry"

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20131,6 +20131,20 @@ snapshots:
       '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.18
 
+  '@sanity/ui@4.0.7(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8)(react@19.2.8)
+      '@sanity/color': 3.0.8
+      '@sanity/icons': 5.2.1(react@19.2.8)
+      csstype: 3.2.3
+      motion: 13.1.1(react-dom@19.2.8)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      react-refractor: 4.0.0(react@19.2.8)
+      styled-components: 6.5.3(react-dom@19.2.8)(react@19.2.8)
+      use-effect-event: 2.0.4(react@19.2.8)
+
   '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4


### PR DESCRIPTION
Reverts sanity-io/sanity#14431

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only revert with no runtime code changes; main risk is possible duplicate-resolution or install-graph confusion for `@sanity/ui`.
> 
> **Overview**
> Reverts sanity-io/sanity#14431, undoing the lockfile cleanup that removed a duplicate `@sanity/ui` resolution.
> 
> The diff **re-adds** the full `pnpm-lock.yaml` snapshot for **`@sanity/ui@4.0.7`** (with its dependency tree), so **both** `@sanity/ui@4.0.7` and `@sanity/ui@5.0.0-alpha.7` are present in the lockfile again. No application source changes—only dependency lock metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe17ce61106d6cb69cebc5bb352a3ec31b64405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->