### PR TITLE
perf(bench): add scenario path/readySelector and shared navigation helper

### DIFF
--- a/perf/bench/runner/__tests__/navigation.test.ts
+++ b/perf/bench/runner/__tests__/navigation.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from 'vitest'
+
+import {type BenchScenario} from '../../scenarios/types'
+import {DEFAULT_READY_SELECTOR, readySelector, scenarioUrl} from '../session/navigation'
+
+const STUDIO_URL = 'https://localhost:3411'
+
+function scenario(overrides: Partial<BenchScenario> = {}): BenchScenario {
+  return {
+    name: 'singleString',
+    sourceFile: 'perf/bench/scenarios/singleString.ts',
+    documentType: 'singleString',
+    documentId: 'bench-single-string',
+    fixture: () => [],
+    interactions: [],
+    ...overrides,
+  }
+}
+
+describe('scenarioUrl', () => {
+  it('builds the edit-intent URL with encoded id and type', () => {
+    expect(scenarioUrl(STUDIO_URL, scenario({documentId: 'a;b/c', documentType: 'my type'}))).toBe(
+      `${STUDIO_URL}/singleString/intent/edit/id=a%3Bb%2Fc;type=my%20type`,
+    )
+  })
+
+  it('uses the workspace field over the scenario name when set', () => {
+    expect(scenarioUrl(STUDIO_URL, scenario({workspace: 'shared'}))).toBe(
+      `${STUDIO_URL}/shared/intent/edit/id=bench-single-string;type=singleString`,
+    )
+  })
+
+  it('opens the workspace-relative path instead of the intent when set', () => {
+    expect(scenarioUrl(STUDIO_URL, scenario({path: 'structure/bench-pane'}))).toBe(
+      `${STUDIO_URL}/singleString/structure/bench-pane`,
+    )
+  })
+})
+
+describe('readySelector', () => {
+  it('defaults to the editable document form', () => {
+    expect(readySelector(scenario())).toBe(DEFAULT_READY_SELECTOR)
+    expect(DEFAULT_READY_SELECTOR).toBe('[data-testid="form-view"]:not([data-read-only="true"])')
+  })
+
+  it('honors a scenario override', () => {
+    expect(readySelector(scenario({readySelector: '[data-testid="bench-custom-pane"]'}))).toBe(
+      '[data-testid="bench-custom-pane"]',
+    )
+  })
+})

--- a/perf/bench/runner/session/errors.ts
+++ b/perf/bench/runner/session/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Session failure taxonomy, in its own leaf module so both the session
+ * implementations (interaction/pageLoad/inp/soak) and the shared navigation
+ * helper can throw typed failures without an import cycle.
+ */
+
+export type SessionFailureReason =
+  | 'readiness-timeout'
+  | 'probe-timeout'
+  | 'page-error'
+  | 'console-error'
+  | 'hermeticity-violation'
+  | 'sample-count-mismatch'
+  | 'readback-mismatch'
+  | 'unexpected-endpoint'
+
+export class SessionError extends Error {
+  constructor(
+    public reason: SessionFailureReason,
+    message: string,
+    public diagnostics: string[] = [],
+  ) {
+    super(`[${reason}] ${message}`)
+    this.name = 'SessionError'
+  }
+}

--- a/perf/bench/runner/session/inp.ts
+++ b/perf/bench/runner/session/inp.ts
@@ -5,6 +5,7 @@ import {type BenchScenario} from '../../scenarios/types'
 import {computeInp, INP_MIN_INTERACTIONS, type InpResult} from '../../stats/inp'
 import {createSessionContext} from '../browser'
 import {type RunningSide} from '../servers'
+import {SessionError} from './errors'
 import {
   DEFAULT_SESSION_CONFIG,
   drainEntries,
@@ -13,9 +14,9 @@ import {
   interactionMaxDurations,
   type ReadOnlyInterruptions,
   type SessionConfig,
-  SessionError,
   typeBurst,
 } from './interaction'
+import {awaitReadiness, gotoScenario} from './navigation'
 
 export interface InpSessionResult extends InpResult {
   /**
@@ -77,19 +78,11 @@ export async function runInpSession(options: {
 
   try {
     await page.addInitScript(instrumentation)
-    await page.goto(
-      `${running.studioUrl}/${scenario.workspace ?? scenario.name}/intent/edit/id=${encodeURIComponent(scenario.documentId)};type=${encodeURIComponent(scenario.documentType)}`,
-      {waitUntil: 'domcontentloaded', timeout: DEFAULT_SESSION_CONFIG.readinessTimeoutMs},
-    )
-    await page
-      .locator('[data-testid="form-view"]:not([data-read-only="true"])')
-      .waitFor({state: 'visible', timeout: DEFAULT_SESSION_CONFIG.readinessTimeoutMs})
-      .catch(() => {
-        throw new SessionError('readiness-timeout', 'form-view never became editable', [
-          ...session.consoleErrors,
-          ...session.pageErrors,
-        ])
-      })
+    await gotoScenario(page, running.studioUrl, scenario, DEFAULT_SESSION_CONFIG.readinessTimeoutMs)
+    await awaitReadiness(page, scenario, {
+      timeoutMs: DEFAULT_SESSION_CONFIG.readinessTimeoutMs,
+      diagnostics: () => [...session.consoleErrors, ...session.pageErrors],
+    })
 
     // Discard everything from boot — INP measures interactions, not load.
     await focusField(page, scenario.interactions[0], DEFAULT_SESSION_CONFIG.readinessTimeoutMs)

--- a/perf/bench/runner/session/interaction.ts
+++ b/perf/bench/runner/session/interaction.ts
@@ -7,6 +7,8 @@ import {type BenchScenario, type InteractionTarget} from '../../scenarios/types'
 import {median} from '../../stats/quantiles'
 import {createSessionContext, type SessionContext} from '../browser'
 import {type RunningSide} from '../servers'
+import {SessionError} from './errors'
+import {awaitReadiness, gotoScenario} from './navigation'
 
 /** Characters cycled through while typing (letters + digits only). */
 export const CHARACTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
@@ -102,26 +104,7 @@ export interface InteractionSessionResult {
   memory: SessionMemory | null
 }
 
-export type SessionFailureReason =
-  | 'readiness-timeout'
-  | 'probe-timeout'
-  | 'page-error'
-  | 'console-error'
-  | 'hermeticity-violation'
-  | 'sample-count-mismatch'
-  | 'readback-mismatch'
-  | 'unexpected-endpoint'
-
-export class SessionError extends Error {
-  constructor(
-    public reason: SessionFailureReason,
-    message: string,
-    public diagnostics: string[] = [],
-  ) {
-    super(`[${reason}] ${message}`)
-    this.name = 'SessionError'
-  }
-}
+export {SessionError, type SessionFailureReason} from './errors'
 
 /**
  * How-to-resolve instructions attached as diagnostics to the two failure
@@ -416,21 +399,13 @@ export async function runInteractionSession(options: {
   try {
     await page.addInitScript(instrumentation)
 
-    await page.goto(
-      `${running.studioUrl}/${scenario.workspace ?? scenario.name}/intent/edit/id=${encodeURIComponent(scenario.documentId)};type=${encodeURIComponent(scenario.documentType)}`,
-      {waitUntil: 'domcontentloaded', timeout: config.readinessTimeoutMs},
-    )
+    await gotoScenario(page, running.studioUrl, scenario, config.readinessTimeoutMs)
 
     // Readiness: the form claims to be editable…
-    await page
-      .locator('[data-testid="form-view"]:not([data-read-only="true"])')
-      .waitFor({state: 'visible', timeout: config.readinessTimeoutMs})
-      .catch(() => {
-        throw new SessionError('readiness-timeout', 'form-view never became editable', [
-          ...session.consoleErrors,
-          ...session.pageErrors,
-        ])
-      })
+    await awaitReadiness(page, scenario, {
+      timeoutMs: config.readinessTimeoutMs,
+      diagnostics: () => [...session.consoleErrors, ...session.pageErrors],
+    })
 
     // …and a probe keystroke actually lands (the editability oracle). The
     // time-to-editable measure is emitted from inside the page on the input event, so
@@ -732,13 +707,11 @@ export async function runSoakSession(options: {
 
   try {
     await page.addInitScript(instrumentation)
-    await page.goto(
-      `${running.studioUrl}/${scenario.workspace ?? scenario.name}/intent/edit/id=${encodeURIComponent(scenario.documentId)};type=${encodeURIComponent(scenario.documentType)}`,
-      {waitUntil: 'domcontentloaded', timeout: config.readinessTimeoutMs},
-    )
-    await page
-      .locator('[data-testid="form-view"]:not([data-read-only="true"])')
-      .waitFor({state: 'visible', timeout: config.readinessTimeoutMs})
+    await gotoScenario(page, running.studioUrl, scenario, config.readinessTimeoutMs)
+    await awaitReadiness(page, scenario, {
+      timeoutMs: config.readinessTimeoutMs,
+      diagnostics: () => [...session.consoleErrors, ...session.pageErrors],
+    })
 
     const target = scenario.interactions[0]
     await focusField(page, target, config.readinessTimeoutMs)

--- a/perf/bench/runner/session/navigation.ts
+++ b/perf/bench/runner/session/navigation.ts
@@ -1,0 +1,72 @@
+import {type Page} from 'playwright'
+
+import {type BenchScenario} from '../../scenarios/types'
+import {SessionError} from './errors'
+
+/**
+ * Shared scenario navigation: every session mode boots the same way — open
+ * the scenario's route and wait for its readiness selector. Centralized here
+ * so scenario-level routing options (`path`, `readySelector`) apply to all
+ * modes identically instead of living in four hardcoded copies.
+ */
+
+/** The default readiness oracle: the document form claims to be editable. */
+export const DEFAULT_READY_SELECTOR = '[data-testid="form-view"]:not([data-read-only="true"])'
+
+/**
+ * The studio route a scenario opens: its `path` (workspace-relative, e.g. a
+ * structure pane like `structure/<itemId>`) when set, otherwise the edit
+ * intent for the document under test.
+ */
+export function scenarioUrl(studioUrl: string, scenario: BenchScenario): string {
+  const workspace = scenario.workspace ?? scenario.name
+  if (scenario.path) {
+    return `${studioUrl}/${workspace}/${scenario.path}`
+  }
+  return `${studioUrl}/${workspace}/intent/edit/id=${encodeURIComponent(scenario.documentId)};type=${encodeURIComponent(scenario.documentType)}`
+}
+
+export function readySelector(scenario: BenchScenario): string {
+  return scenario.readySelector ?? DEFAULT_READY_SELECTOR
+}
+
+export async function gotoScenario(
+  page: Page,
+  studioUrl: string,
+  scenario: BenchScenario,
+  timeoutMs: number,
+): Promise<void> {
+  await page.goto(scenarioUrl(studioUrl, scenario), {
+    waitUntil: 'domcontentloaded',
+    timeout: timeoutMs,
+  })
+}
+
+/**
+ * Wait for the scenario's readiness selector; a timeout throws a typed
+ * `readiness-timeout` SessionError naming the selector that never matched
+ * and carrying the caller's diagnostics (console/page/http errors gathered
+ * so far — the usual cause).
+ */
+export async function awaitReadiness(
+  page: Page,
+  scenario: BenchScenario,
+  options: {
+    timeoutMs: number
+    /** Appended to the failure message in parens, e.g. a load condition. */
+    context?: string
+    diagnostics?: () => string[]
+  },
+): Promise<void> {
+  const {timeoutMs, context, diagnostics} = options
+  await page
+    .locator(readySelector(scenario))
+    .waitFor({state: 'visible', timeout: timeoutMs})
+    .catch(() => {
+      throw new SessionError(
+        'readiness-timeout',
+        `${readySelector(scenario)} never became ready${context ? ` (${context})` : ''}`,
+        diagnostics?.() ?? [],
+      )
+    })
+}

--- a/perf/bench/runner/session/pageLoad.ts
+++ b/perf/bench/runner/session/pageLoad.ts
@@ -1,9 +1,11 @@
-import {type Browser, type Page} from 'playwright'
+import {type Browser} from 'playwright'
 
 import {type BenchScenario} from '../../scenarios/types'
 import {type AttachedPage, attachPage, createSessionContext} from '../browser'
 import {type RunningSide} from '../servers'
-import {HERMETICITY_HINT, SessionError} from './interaction'
+import {SessionError} from './errors'
+import {HERMETICITY_HINT} from './interaction'
+import {awaitReadiness, scenarioUrl} from './navigation'
 
 export type LoadCondition = 'boot-cold' | 'open-doc-warm'
 
@@ -198,15 +200,11 @@ async function measureLoad(options: {
   await page.addInitScript(instrumentation)
   await page.goto(url, {waitUntil: 'domcontentloaded', timeout: config.readinessTimeoutMs})
 
-  await page
-    .locator('[data-testid="form-view"]:not([data-read-only="true"])')
-    .waitFor({state: 'visible', timeout: config.readinessTimeoutMs})
-    .catch(() => {
-      throw new SessionError('readiness-timeout', `form never became editable (${condition})`, [
-        ...attached.consoleErrors,
-        ...attached.httpErrors,
-      ])
-    })
+  await awaitReadiness(page, scenario, {
+    timeoutMs: config.readinessTimeoutMs,
+    context: condition,
+    diagnostics: () => [...attached.consoleErrors, ...attached.httpErrors],
+  })
 
   const firstField = scenario.interactions[0]
   const input = page
@@ -302,7 +300,7 @@ export async function runPageLoadSample(options: {
   })
   const {context} = session
 
-  const url = `${running.studioUrl}/${scenario.workspace ?? scenario.name}/intent/edit/id=${encodeURIComponent(scenario.documentId)};type=${encodeURIComponent(scenario.documentType)}`
+  const url = scenarioUrl(running.studioUrl, scenario)
 
   try {
     await applyNetworkEmulation(session, config.network)

--- a/perf/bench/scenarios/types.ts
+++ b/perf/bench/scenarios/types.ts
@@ -31,6 +31,19 @@ export interface BenchScenario {
    * when several scenarios share one workspace (e.g. syntheticLarge).
    */
   workspace?: string
+  /**
+   * Workspace-relative route to open instead of the edit intent for the
+   * document under test — e.g. a custom structure pane (`structure/<itemId>`).
+   * The document fixture is still seeded; `documentId`/`documentType` keep
+   * identifying it.
+   */
+  path?: string
+  /**
+   * Readiness selector to wait for after navigation. Defaults to the editable
+   * document form (`DEFAULT_READY_SELECTOR` in runner/session/navigation.ts);
+   * set it for routes that don't render a document form, e.g. custom panes.
+   */
+  readySelector?: string
   documentType: string
   /** Published id of the document under test (draft is `drafts.<id>`). */
   documentId: string


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Internal perf-bench runner refactor with unit tests; no product runtime or auth/data paths affected.
> 
> **Overview**
> Bench scenarios can now open **custom studio routes** and wait on **custom readiness UI**, not only the default document edit intent and editable form.
> 
> `BenchScenario` gains optional `path` (workspace-relative URL, e.g. `structure/<itemId>`) and `readySelector` (Playwright wait target). URL building and post-navigation readiness are centralized in `runner/session/navigation.ts` (`scenarioUrl`, `gotoScenario`, `awaitReadiness`), so interaction, INP, soak, and page-load sessions all boot the same way instead of four duplicated `goto` + form-view waits.
> 
> `SessionError` / `SessionFailureReason` move to a leaf `errors.ts` so navigation can throw typed failures without import cycles; `interaction.ts` re-exports them for existing callers. Readiness timeouts now mention the selector (and optional load `context` on page-load). Vitest covers URL encoding, `workspace` vs `name`, `path` override, and default vs custom `readySelector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd77d330a1d48f294bde6f24f94f3bfd27558849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->