### PR TITLE
fix: show diagnostics panel regardless of being in dashboard

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -101,13 +101,11 @@ export function ResourcesButton() {
         id="menu-button-resources"
         menu={
           <StyledMenu data-testid="menu-button-resources">
-            {!isInDashboard && (
-              <>
-                {feedbackAvailable && <FeedbackMenuItem onClick={handleOpenFeedback} />}
-                <DiagnosticsMenuItem onClick={handleOpenDiagnostics} />
-                <MenuDivider />
-              </>
+            {!isInDashboard && feedbackAvailable && (
+              <FeedbackMenuItem onClick={handleOpenFeedback} />
             )}
+            <DiagnosticsMenuItem onClick={handleOpenDiagnostics} />
+            <MenuDivider />
             <ResourcesMenuItems
               currentVersion={currentVersion}
               latestTaggedVersion={latestTaggedVersion}


### PR DESCRIPTION
Missed this in the original PR; I copied the logic of the "Give feedback" item, not realizing there was a dashboard condition in there. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small help-menu visibility change with no auth, data, or API impact.
> 
> **Overview**
> **Diagnostics** in the studio help/resources menu is no longer hidden when the studio runs in the **dashboard** (`coreUi`) rendering context.
> 
> Previously **Give feedback**, **Diagnostics**, and the following divider were all wrapped in `!isInDashboard`. That matched feedback (skipped in dashboard via `useFeedbackAvailable`) but incorrectly hid diagnostics too. **Give feedback** stays dashboard-gated and still requires `feedbackAvailable`; **Diagnostics** and the **MenuDivider** before the version/resources block now render in every context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b44a36f9d7864b29780056701fa821fb7aec55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->