### PR TITLE
feat(cli): expose asset source view definition

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.cli.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.cli.test-d.ts
@@ -8,6 +8,7 @@ import type {
   createCliConfig,
   DefineAppInput,
   defineApplication,
+  defineAssetSourceView,
   defineCliConfig,
   DefineMediaLibraryInput,
   definePanelView,
@@ -37,6 +38,9 @@ describe('sanity/cli', () => {
   })
   test('defineApplication', () => {
     expectTypeOf<typeof defineApplication>().toBeFunction()
+  })
+  test('defineAssetSourceView', () => {
+    expectTypeOf<typeof defineAssetSourceView>().toBeFunction()
   })
   test('defineCliConfig', () => {
     expectTypeOf<typeof defineCliConfig>().toBeFunction()

--- a/packages/sanity/src/_exports/cli.ts
+++ b/packages/sanity/src/_exports/cli.ts
@@ -4,6 +4,7 @@ export {
   createCliConfig,
   type DefineAppInput,
   defineApplication,
+  defineAssetSourceView,
   defineCliConfig,
   type DefineMediaLibraryInput,
   definePanelView,

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -913,6 +913,7 @@ exports[`exports snapshot 1`] = `
   "./cli": {
     "createCliConfig": "function",
     "defineApplication": "function",
+    "defineAssetSourceView": "function",
     "defineCliConfig": "function",
     "definePanelView": "function",
     "defineTileView": "function",


### PR DESCRIPTION
### Description

In #14373 I forgot to export `defineAssetSourceView` from the `sanity/cli` entrypoint.

### Notes for release

The `sanity/cli` entrypoint now exports `defineAssetSourceView`.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive public API surface only; no runtime or behavioral changes beyond making an existing helper importable from `sanity/cli`.
> 
> **Overview**
> **Adds `defineAssetSourceView` to the `sanity/cli` public entrypoint** so apps and plugins can import it the same way as `definePanelView`, `defineWindowView`, and other CLI view helpers.
> 
> The change is a re-export from `@sanity/cli` in `packages/sanity/src/_exports/cli.ts`, fixing a gap from the earlier work that introduced asset source views but did not surface this helper on the main `sanity/cli` bundle. Auto-generated DTS export tests and the package exports snapshot are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784cc2e2e1f13f75d2488d05d914f3a43167de75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->