### PR TITLE
feat(structure): add see draft banner for published documents

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -193,6 +193,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.permission-check-banner.request-permission-button.sent': 'Editor request sent',
   /** The text for the request permission button that appears for viewer roles */
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
+  /** Action that switches from the published perspective to drafts */
+  'banners.published.see-draft.action': 'See draft',
+  /** Banner shown for published-only, non-live-edit documents in the published perspective */
+  'banners.published.see-draft.text': 'This is a published document. Switch to drafts to edit it.',
   /** Description for the archived release banner, rendered when viewing the history of a version document from the published view */
   'banners.published-release.description':
     "You are viewing a read-only document that was published as part of <VersionBadge>{{title}}</VersionBadge>. It can't be edited",

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -195,7 +195,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.permission-check-banner.request-permission-button.text': 'Ask to edit',
   /** Action that switches from the published perspective to drafts */
   'banners.published.see-draft.action': 'See draft',
-  /** Banner shown for published-only, non-live-edit documents in the published perspective */
+  /** Banner shown for non-live-edit documents with a published sibling in the published perspective */
   'banners.published.see-draft.text': 'This is a published document. Switch to drafts to edit it.',
   /** Description for the archived release banner, rendered when viewing the history of a version document from the published view */
   'banners.published-release.description':

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -50,6 +50,7 @@ import {ReferenceChangedBanner} from './banners/ReferenceChangedBanner'
 import {RevisionNotFoundBanner} from './banners/RevisionNotFoundBanner'
 import {ScheduledDraftOverrideBanner} from './banners/ScheduledDraftOverrideBanner'
 import {ScheduledReleaseBanner} from './banners/ScheduledReleaseBanner'
+import {SeeDraftBanner} from './banners/SeeDraftBanner'
 import {UnpublishedDocumentBanner} from './banners/UnpublishedDocumentBanner'
 import {VariantDefinitionNotFoundBanner} from './banners/VariantDefinitionNotFoundBanner'
 import {FormView} from './documentViews/FormView'
@@ -381,6 +382,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
         <CanvasLinkedBanner />
         <DeletedDocumentBanners />
         <UnpublishedDocumentBanner />
+        <SeeDraftBanner />
         <OpenReleaseToEditBanner
           documentId={displayed?._id ?? documentId}
           isPinnedDraftOrPublished={isPinnedDraftOrPublish}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/SeeDraftBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/SeeDraftBanner.tsx
@@ -1,6 +1,12 @@
 import {Text} from '@sanity/ui'
 import {useCallback} from 'react'
-import {usePerspective, useSetPerspective, useTranslation, useWorkspace} from 'sanity'
+import {
+  getTargetSiblings,
+  usePerspective,
+  useSetPerspective,
+  useTranslation,
+  useWorkspace,
+} from 'sanity'
 
 import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
 import {structureLocaleNamespace} from '../../../../i18n'
@@ -10,11 +16,12 @@ import {Banner} from './Banner'
 
 export function SeeDraftBanner() {
   const {t} = useTranslation(structureLocaleNamespace)
-  const {editState, schemaType} = useDocumentPane()
+  const {schemaType, targetDocumentState} = useDocumentPane()
   const {selectedPerspective} = usePerspective()
   const setPerspective = useSetPerspective()
   const workspace = useWorkspace()
   const {params} = usePaneRouter()
+  const siblings = getTargetSiblings(targetDocumentState)
 
   const handleSeeDraft = useCallback(() => {
     setPerspective('drafts')
@@ -25,7 +32,7 @@ export function SeeDraftBanner() {
       selectedPerspective,
       schemaType,
       workspace,
-      editState,
+      siblings,
       isHistoryRevision: Boolean(params?.rev),
     })
   ) {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/SeeDraftBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/SeeDraftBanner.tsx
@@ -1,0 +1,48 @@
+import {Text} from '@sanity/ui'
+import {useCallback} from 'react'
+import {usePerspective, useSetPerspective, useTranslation, useWorkspace} from 'sanity'
+
+import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
+import {structureLocaleNamespace} from '../../../../i18n'
+import {shouldShowSeeDraftBanner} from '../../../../shouldShowSeeDraftBanner'
+import {useDocumentPane} from '../../useDocumentPane'
+import {Banner} from './Banner'
+
+export function SeeDraftBanner() {
+  const {t} = useTranslation(structureLocaleNamespace)
+  const {editState, schemaType} = useDocumentPane()
+  const {selectedPerspective} = usePerspective()
+  const setPerspective = useSetPerspective()
+  const workspace = useWorkspace()
+  const {params} = usePaneRouter()
+
+  const handleSeeDraft = useCallback(() => {
+    setPerspective('drafts')
+  }, [setPerspective])
+
+  if (
+    !shouldShowSeeDraftBanner({
+      selectedPerspective,
+      schemaType,
+      workspace,
+      editState,
+      isHistoryRevision: Boolean(params?.rev),
+    })
+  ) {
+    return null
+  }
+
+  return (
+    <Banner
+      tone="suggest"
+      data-testid="see-draft-banner"
+      content={<Text size={1}>{t('banners.published.see-draft.text')}</Text>}
+      action={{
+        text: t('banners.published.see-draft.action'),
+        tone: 'suggest',
+        onClick: handleSeeDraft,
+        mode: 'default',
+      }}
+    />
+  )
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/SeeDraftBanner.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/SeeDraftBanner.test.tsx
@@ -1,7 +1,7 @@
-import {type ObjectSchemaType, type SanityDocument} from '@sanity/types'
+import {type ObjectSchemaType} from '@sanity/types'
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {usePerspective, useSetPerspective} from 'sanity'
+import {type TargetDocumentState, usePerspective, useSetPerspective} from 'sanity'
 import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
@@ -38,12 +38,40 @@ const mockUsePerspective = usePerspective as Mock<typeof usePerspective>
 const mockUseSetPerspective = useSetPerspective as Mock<typeof useSetPerspective>
 const setPerspective = vi.fn()
 
-const publishedDocument: SanityDocument = {
+const publishedSibling = {
   _id: 'author-1',
   _rev: 'rev-1',
   _type: 'author',
   _createdAt: '2025-06-23T00:00:00Z',
   _updatedAt: '2025-06-23T00:00:00Z',
+  _system: {
+    bundleId: 'published',
+    group: {_ref: 'author-1', _weak: true},
+  },
+} as const
+
+const draftSibling = {
+  _id: 'drafts.author-1',
+  _rev: 'rev-2',
+  _type: 'author',
+  _createdAt: '2025-06-23T00:00:00Z',
+  _updatedAt: '2025-06-24T00:00:00Z',
+  _system: {
+    bundleId: 'drafts',
+    group: {_ref: 'author-1', _weak: true},
+  },
+} as const
+
+function readyState(
+  siblings: Extract<TargetDocumentState, {status: 'ready'}>['siblings'],
+): Extract<TargetDocumentState, {status: 'ready'}> {
+  return {
+    status: 'ready',
+    targetDocument: siblings.published,
+    scopeId: undefined,
+    variant: undefined,
+    siblings,
+  }
 }
 
 function publishedPerspective() {
@@ -72,14 +100,19 @@ function draftsPerspective() {
   }
 }
 
-function mockPublishedOnlyDocument({liveEdit = false}: {liveEdit?: boolean} = {}) {
+function mockDocumentPane({
+  liveEdit = false,
+  targetDocumentState = readyState({
+    published: publishedSibling,
+    draft: undefined,
+    version: undefined,
+  }),
+}: {
+  liveEdit?: boolean
+  targetDocumentState?: TargetDocumentState
+} = {}) {
   mockUseDocumentPane.mockReturnValue({
-    editState: {
-      ready: true,
-      draft: null,
-      published: publishedDocument,
-      version: null,
-    },
+    targetDocumentState,
     schemaType: {name: 'author', liveEdit} as ObjectSchemaType,
   } as unknown as ReturnType<typeof useDocumentPane>)
 }
@@ -97,14 +130,14 @@ describe('SeeDraftBanner', () => {
     vi.clearAllMocks()
     mockUseSetPerspective.mockReturnValue(setPerspective)
     mockUsePerspective.mockReturnValue(publishedPerspective())
-    mockPublishedOnlyDocument()
+    mockDocumentPane()
     usePaneRouter.mockReturnValue({
       params: {},
       setParams: vi.fn(),
     } as unknown as ReturnType<typeof usePaneRouter>)
   })
 
-  it('renders the see-draft banner for a published-only document in the published perspective', async () => {
+  it('renders the see-draft banner when a published sibling exists in the published perspective', async () => {
     await renderBanner()
 
     await waitFor(() => {
@@ -113,6 +146,23 @@ describe('SeeDraftBanner', () => {
     expect(
       screen.getByText('This is a published document. Switch to drafts to edit it.'),
     ).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'See draft'})).toBeInTheDocument()
+  })
+
+  it('renders when a draft already exists so the user can switch into it', async () => {
+    mockDocumentPane({
+      targetDocumentState: readyState({
+        published: publishedSibling,
+        draft: draftSibling,
+        version: undefined,
+      }),
+    })
+
+    await renderBanner()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('see-draft-banner')).toBeInTheDocument()
+    })
     expect(screen.getByRole('button', {name: 'See draft'})).toBeInTheDocument()
   })
 
@@ -129,7 +179,7 @@ describe('SeeDraftBanner', () => {
   })
 
   it('does not render for live-edit documents', async () => {
-    mockPublishedOnlyDocument({liveEdit: true})
+    mockDocumentPane({liveEdit: true})
 
     await renderBanner()
 
@@ -145,16 +195,24 @@ describe('SeeDraftBanner', () => {
     expect(screen.queryByTestId('see-draft-banner')).not.toBeInTheDocument()
   })
 
-  it('does not render when a draft already exists', async () => {
-    mockUseDocumentPane.mockReturnValue({
-      editState: {
-        ready: true,
-        draft: {...publishedDocument, _id: 'drafts.author-1'},
-        published: publishedDocument,
-        version: null,
-      },
-      schemaType: {name: 'author', liveEdit: false} as ObjectSchemaType,
-    } as unknown as ReturnType<typeof useDocumentPane>)
+  it('does not render when there is no published sibling', async () => {
+    mockDocumentPane({
+      targetDocumentState: readyState({
+        published: undefined,
+        draft: draftSibling,
+        version: undefined,
+      }),
+    })
+
+    await renderBanner()
+
+    expect(screen.queryByTestId('see-draft-banner')).not.toBeInTheDocument()
+  })
+
+  it('does not render while the target is still resolving', async () => {
+    mockDocumentPane({
+      targetDocumentState: {status: 'resolving'},
+    })
 
     await renderBanner()
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/SeeDraftBanner.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/SeeDraftBanner.test.tsx
@@ -1,0 +1,174 @@
+import {type ObjectSchemaType, type SanityDocument} from '@sanity/types'
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {usePerspective, useSetPerspective} from 'sanity'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
+import {useDocumentPane} from '../../../useDocumentPane'
+import {SeeDraftBanner} from '../SeeDraftBanner'
+
+vi.mock('../../../useDocumentPane', () => ({
+  useDocumentPane: vi.fn(),
+}))
+
+vi.mock('../../../../../components/paneRouter/usePaneRouter', () => ({
+  usePaneRouter: vi.fn(() => ({
+    params: {},
+    setParams: vi.fn(),
+  })),
+}))
+
+vi.mock('sanity', async () => {
+  const sanity = await vi.importActual('sanity')
+  return {
+    ...sanity,
+    usePerspective: vi.fn(),
+    useSetPerspective: vi.fn(),
+  }
+})
+
+const {usePaneRouter} = vi.mocked(
+  await import('../../../../../components/paneRouter/usePaneRouter'),
+)
+
+const mockUseDocumentPane = useDocumentPane as Mock<typeof useDocumentPane>
+const mockUsePerspective = usePerspective as Mock<typeof usePerspective>
+const mockUseSetPerspective = useSetPerspective as Mock<typeof useSetPerspective>
+const setPerspective = vi.fn()
+
+const publishedDocument: SanityDocument = {
+  _id: 'author-1',
+  _rev: 'rev-1',
+  _type: 'author',
+  _createdAt: '2025-06-23T00:00:00Z',
+  _updatedAt: '2025-06-23T00:00:00Z',
+}
+
+function publishedPerspective() {
+  return {
+    selectedPerspective: 'published' as const,
+    selectedPerspectiveName: 'published' as const,
+    selectedReleaseId: undefined,
+    perspectiveStack: ['published'] as ['published'],
+    excludedPerspectives: [],
+    selectedVariantName: undefined,
+    selectedVariant: undefined,
+    bundle: 'published' as const,
+  }
+}
+
+function draftsPerspective() {
+  return {
+    selectedPerspective: 'drafts' as const,
+    selectedPerspectiveName: undefined,
+    selectedReleaseId: undefined,
+    perspectiveStack: ['drafts'] as ['drafts'],
+    excludedPerspectives: [],
+    selectedVariantName: undefined,
+    selectedVariant: undefined,
+    bundle: 'drafts' as const,
+  }
+}
+
+function mockPublishedOnlyDocument({liveEdit = false}: {liveEdit?: boolean} = {}) {
+  mockUseDocumentPane.mockReturnValue({
+    editState: {
+      ready: true,
+      draft: null,
+      published: publishedDocument,
+      version: null,
+    },
+    schemaType: {name: 'author', liveEdit} as ObjectSchemaType,
+  } as unknown as ReturnType<typeof useDocumentPane>)
+}
+
+async function renderBanner() {
+  const wrapper = await createTestProvider({
+    resources: [structureUsEnglishLocaleBundle],
+  })
+
+  return render(<SeeDraftBanner />, {wrapper})
+}
+
+describe('SeeDraftBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSetPerspective.mockReturnValue(setPerspective)
+    mockUsePerspective.mockReturnValue(publishedPerspective())
+    mockPublishedOnlyDocument()
+    usePaneRouter.mockReturnValue({
+      params: {},
+      setParams: vi.fn(),
+    } as unknown as ReturnType<typeof usePaneRouter>)
+  })
+
+  it('renders the see-draft banner for a published-only document in the published perspective', async () => {
+    await renderBanner()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('see-draft-banner')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('This is a published document. Switch to drafts to edit it.'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'See draft'})).toBeInTheDocument()
+  })
+
+  it('switches to the drafts perspective without creating a document', async () => {
+    await renderBanner()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: 'See draft'})).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByRole('button', {name: 'See draft'}))
+
+    expect(setPerspective).toHaveBeenCalledTimes(1)
+    expect(setPerspective).toHaveBeenCalledWith('drafts')
+  })
+
+  it('does not render for live-edit documents', async () => {
+    mockPublishedOnlyDocument({liveEdit: true})
+
+    await renderBanner()
+
+    expect(screen.queryByTestId('see-draft-banner')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: 'See draft'})).not.toBeInTheDocument()
+  })
+
+  it('does not render in the drafts perspective', async () => {
+    mockUsePerspective.mockReturnValue(draftsPerspective())
+
+    await renderBanner()
+
+    expect(screen.queryByTestId('see-draft-banner')).not.toBeInTheDocument()
+  })
+
+  it('does not render when a draft already exists', async () => {
+    mockUseDocumentPane.mockReturnValue({
+      editState: {
+        ready: true,
+        draft: {...publishedDocument, _id: 'drafts.author-1'},
+        published: publishedDocument,
+        version: null,
+      },
+      schemaType: {name: 'author', liveEdit: false} as ObjectSchemaType,
+    } as unknown as ReturnType<typeof useDocumentPane>)
+
+    await renderBanner()
+
+    expect(screen.queryByTestId('see-draft-banner')).not.toBeInTheDocument()
+  })
+
+  it('does not render when viewing a history revision', async () => {
+    usePaneRouter.mockReturnValue({
+      params: {rev: 'rev-old'},
+      setParams: vi.fn(),
+    } as unknown as ReturnType<typeof usePaneRouter>)
+
+    await renderBanner()
+
+    expect(screen.queryByTestId('see-draft-banner')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/structure/shouldShowSeeDraftBanner.test.ts
+++ b/packages/sanity/src/structure/shouldShowSeeDraftBanner.test.ts
@@ -1,4 +1,4 @@
-import {type SanityDocument} from '@sanity/types'
+import {type VersionInfoDocumentStub} from 'sanity'
 import {expect, it} from 'vitest'
 
 import {
@@ -6,12 +6,16 @@ import {
   shouldShowSeeDraftBanner,
 } from './shouldShowSeeDraftBanner'
 
-const stubDocument: SanityDocument = {
+const publishedSibling: VersionInfoDocumentStub = {
   _id: 'author-1',
   _rev: 'rev-1',
+  _createdAt: '2025-06-23T00:00:00Z',
+  _updatedAt: '2025-06-23T00:00:00Z',
   _type: 'author',
-  _createdAt: '2025-06-23',
-  _updatedAt: '2025-06-23',
+  _system: {
+    bundleId: 'published',
+    group: {_ref: 'author-1', _weak: true},
+  },
 }
 
 const workspaceWithDraftsEnabled: ShouldShowSeeDraftBannerContext['workspace'] = {
@@ -30,19 +34,40 @@ const workspaceWithDraftsDisabled: ShouldShowSeeDraftBannerContext['workspace'] 
   },
 }
 
-const publishedOnlyEditState: ShouldShowSeeDraftBannerContext['editState'] = {
-  ready: true,
-  draft: null,
-  published: stubDocument,
+const publishedSiblings: ShouldShowSeeDraftBannerContext['siblings'] = {
+  published: publishedSibling,
 }
 
-it('shows the banner for a published-only non-live-edit document in the published perspective', () => {
+const publishedAndDraftSiblings = {
+  published: publishedSibling,
+  draft: {
+    ...publishedSibling,
+    _id: 'drafts.author-1',
+    _system: {
+      bundleId: 'drafts',
+      group: {_ref: 'author-1', _weak: true},
+    },
+  } satisfies VersionInfoDocumentStub,
+}
+
+it('shows the banner when a published sibling exists in the published perspective', () => {
   expect(
     shouldShowSeeDraftBanner({
       selectedPerspective: 'published',
       schemaType: {liveEdit: false},
       workspace: workspaceWithDraftsEnabled,
-      editState: publishedOnlyEditState,
+      siblings: publishedSiblings,
+    }),
+  ).toBe(true)
+})
+
+it('shows the banner when a draft already exists if a published sibling is present', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsEnabled,
+      siblings: publishedAndDraftSiblings,
     }),
   ).toBe(true)
 })
@@ -53,37 +78,29 @@ it('does not show the banner for live-edit documents', () => {
       selectedPerspective: 'published',
       schemaType: {liveEdit: true},
       workspace: workspaceWithDraftsEnabled,
-      editState: publishedOnlyEditState,
+      siblings: publishedSiblings,
     }),
   ).toBe(false)
 })
 
-it('does not show the banner when a draft already exists', () => {
+it('does not show the banner when there is no published sibling', () => {
   expect(
     shouldShowSeeDraftBanner({
       selectedPerspective: 'published',
       schemaType: {liveEdit: false},
       workspace: workspaceWithDraftsEnabled,
-      editState: {
-        ready: true,
-        draft: stubDocument,
-        published: stubDocument,
-      },
+      siblings: {published: undefined},
     }),
   ).toBe(false)
 })
 
-it('does not show the banner when there is no published document', () => {
+it('does not show the banner while siblings are unresolved', () => {
   expect(
     shouldShowSeeDraftBanner({
       selectedPerspective: 'published',
       schemaType: {liveEdit: false},
       workspace: workspaceWithDraftsEnabled,
-      editState: {
-        ready: true,
-        draft: null,
-        published: null,
-      },
+      siblings: undefined,
     }),
   ).toBe(false)
 })
@@ -94,7 +111,7 @@ it('does not show the banner outside the published perspective', () => {
       selectedPerspective: 'drafts',
       schemaType: {liveEdit: false},
       workspace: workspaceWithDraftsEnabled,
-      editState: publishedOnlyEditState,
+      siblings: publishedSiblings,
     }),
   ).toBe(false)
 })
@@ -105,22 +122,7 @@ it('does not show the banner when drafts are disabled', () => {
       selectedPerspective: 'published',
       schemaType: {liveEdit: false},
       workspace: workspaceWithDraftsDisabled,
-      editState: publishedOnlyEditState,
-    }),
-  ).toBe(false)
-})
-
-it('does not show the banner while edit state is not ready', () => {
-  expect(
-    shouldShowSeeDraftBanner({
-      selectedPerspective: 'published',
-      schemaType: {liveEdit: false},
-      workspace: workspaceWithDraftsEnabled,
-      editState: {
-        ready: false,
-        draft: null,
-        published: stubDocument,
-      },
+      siblings: publishedSiblings,
     }),
   ).toBe(false)
 })
@@ -131,7 +133,7 @@ it('does not show the banner when viewing a history revision', () => {
       selectedPerspective: 'published',
       schemaType: {liveEdit: false},
       workspace: workspaceWithDraftsEnabled,
-      editState: publishedOnlyEditState,
+      siblings: publishedSiblings,
       isHistoryRevision: true,
     }),
   ).toBe(false)
@@ -142,7 +144,7 @@ it('does not show the banner when schema type is missing', () => {
     shouldShowSeeDraftBanner({
       selectedPerspective: 'published',
       workspace: workspaceWithDraftsEnabled,
-      editState: publishedOnlyEditState,
+      siblings: publishedSiblings,
     }),
   ).toBe(false)
 })

--- a/packages/sanity/src/structure/shouldShowSeeDraftBanner.test.ts
+++ b/packages/sanity/src/structure/shouldShowSeeDraftBanner.test.ts
@@ -1,0 +1,148 @@
+import {type SanityDocument} from '@sanity/types'
+import {expect, it} from 'vitest'
+
+import {
+  type ShouldShowSeeDraftBannerContext,
+  shouldShowSeeDraftBanner,
+} from './shouldShowSeeDraftBanner'
+
+const stubDocument: SanityDocument = {
+  _id: 'author-1',
+  _rev: 'rev-1',
+  _type: 'author',
+  _createdAt: '2025-06-23',
+  _updatedAt: '2025-06-23',
+}
+
+const workspaceWithDraftsEnabled: ShouldShowSeeDraftBannerContext['workspace'] = {
+  document: {
+    drafts: {
+      enabled: true,
+    },
+  },
+}
+
+const workspaceWithDraftsDisabled: ShouldShowSeeDraftBannerContext['workspace'] = {
+  document: {
+    drafts: {
+      enabled: false,
+    },
+  },
+}
+
+const publishedOnlyEditState: ShouldShowSeeDraftBannerContext['editState'] = {
+  ready: true,
+  draft: null,
+  published: stubDocument,
+}
+
+it('shows the banner for a published-only non-live-edit document in the published perspective', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsEnabled,
+      editState: publishedOnlyEditState,
+    }),
+  ).toBe(true)
+})
+
+it('does not show the banner for live-edit documents', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: true},
+      workspace: workspaceWithDraftsEnabled,
+      editState: publishedOnlyEditState,
+    }),
+  ).toBe(false)
+})
+
+it('does not show the banner when a draft already exists', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsEnabled,
+      editState: {
+        ready: true,
+        draft: stubDocument,
+        published: stubDocument,
+      },
+    }),
+  ).toBe(false)
+})
+
+it('does not show the banner when there is no published document', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsEnabled,
+      editState: {
+        ready: true,
+        draft: null,
+        published: null,
+      },
+    }),
+  ).toBe(false)
+})
+
+it('does not show the banner outside the published perspective', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'drafts',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsEnabled,
+      editState: publishedOnlyEditState,
+    }),
+  ).toBe(false)
+})
+
+it('does not show the banner when drafts are disabled', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsDisabled,
+      editState: publishedOnlyEditState,
+    }),
+  ).toBe(false)
+})
+
+it('does not show the banner while edit state is not ready', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsEnabled,
+      editState: {
+        ready: false,
+        draft: null,
+        published: stubDocument,
+      },
+    }),
+  ).toBe(false)
+})
+
+it('does not show the banner when viewing a history revision', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      schemaType: {liveEdit: false},
+      workspace: workspaceWithDraftsEnabled,
+      editState: publishedOnlyEditState,
+      isHistoryRevision: true,
+    }),
+  ).toBe(false)
+})
+
+it('does not show the banner when schema type is missing', () => {
+  expect(
+    shouldShowSeeDraftBanner({
+      selectedPerspective: 'published',
+      workspace: workspaceWithDraftsEnabled,
+      editState: publishedOnlyEditState,
+    }),
+  ).toBe(false)
+})

--- a/packages/sanity/src/structure/shouldShowSeeDraftBanner.ts
+++ b/packages/sanity/src/structure/shouldShowSeeDraftBanner.ts
@@ -1,0 +1,50 @@
+import {type SchemaType} from '@sanity/types'
+import {type EditStateFor, type TargetPerspective, type Workspace} from 'sanity'
+
+import {isLiveEditEnabled} from './components/paneItem/helpers'
+
+export interface ShouldShowSeeDraftBannerContext {
+  selectedPerspective: TargetPerspective
+  schemaType?: Pick<SchemaType, 'liveEdit'>
+  workspace: {
+    document: {
+      drafts: Pick<Workspace['document']['drafts'], 'enabled'>
+    }
+  }
+  editState: Pick<EditStateFor, 'ready' | 'draft' | 'published'> | null
+  isHistoryRevision?: boolean
+}
+
+/**
+ * Show the "See draft" banner when a published-only, non-live-edit document is
+ * viewed in the published perspective. The banner switches to the drafts
+ * perspective; it does not create a draft document.
+ *
+ * Live-edit documents are editable in published and must never show this banner.
+ */
+export function shouldShowSeeDraftBanner({
+  selectedPerspective,
+  schemaType,
+  workspace,
+  editState,
+  isHistoryRevision = false,
+}: ShouldShowSeeDraftBannerContext): boolean {
+  if (!editState?.ready || isHistoryRevision) {
+    return false
+  }
+
+  if (selectedPerspective !== 'published') {
+    return false
+  }
+
+  if (!schemaType || isLiveEditEnabled(schemaType)) {
+    return false
+  }
+
+  if (!workspace.document.drafts.enabled) {
+    return false
+  }
+
+  // Published-only: a published document exists and there is no draft to open.
+  return Boolean(editState.published) && !editState.draft
+}

--- a/packages/sanity/src/structure/shouldShowSeeDraftBanner.ts
+++ b/packages/sanity/src/structure/shouldShowSeeDraftBanner.ts
@@ -1,5 +1,5 @@
 import {type SchemaType} from '@sanity/types'
-import {type EditStateFor, type TargetPerspective, type Workspace} from 'sanity'
+import {type TargetPerspective, type VersionInfoDocumentStub, type Workspace} from 'sanity'
 
 import {isLiveEditEnabled} from './components/paneItem/helpers'
 
@@ -11,14 +11,14 @@ export interface ShouldShowSeeDraftBannerContext {
       drafts: Pick<Workspace['document']['drafts'], 'enabled'>
     }
   }
-  editState: Pick<EditStateFor, 'ready' | 'draft' | 'published'> | null
+  siblings: {published: VersionInfoDocumentStub | undefined} | undefined
   isHistoryRevision?: boolean
 }
 
 /**
- * Show the "See draft" banner when a published-only, non-live-edit document is
- * viewed in the published perspective. The banner switches to the drafts
- * perspective; it does not create a draft document.
+ * Show the "See draft" banner when a non-live-edit document with a published sibling
+ * is viewed in the published perspective. The banner switches to the drafts
+ * perspective so the user can edit there (whether a draft already exists or not).
  *
  * Live-edit documents are editable in published and must never show this banner.
  */
@@ -26,10 +26,10 @@ export function shouldShowSeeDraftBanner({
   selectedPerspective,
   schemaType,
   workspace,
-  editState,
+  siblings,
   isHistoryRevision = false,
 }: ShouldShowSeeDraftBannerContext): boolean {
-  if (!editState?.ready || isHistoryRevision) {
+  if (!siblings || isHistoryRevision) {
     return false
   }
 
@@ -45,6 +45,5 @@ export function shouldShowSeeDraftBanner({
     return false
   }
 
-  // Published-only: a published document exists and there is no draft to open.
-  return Boolean(editState.published) && !editState.draft
+  return Boolean(siblings.published)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Published documents in the published perspective have no path into drafts. The form is disabled with no explanation, so editors cannot start or continue editing.

This adds a "See draft" banner at the top of the document form. It only switches to the drafts perspective — it does not create a draft. Visibility is driven by `targetDocumentState` siblings (`Boolean(siblings.published)`), so the banner still appears when a draft already exists and the user needs to switch into it.

Missing variant/release coordinates keep the existing create-at-this-perspective banners. Live-edit documents never get this banner.


<img width="1019" height="904" alt="Screenshot 2026-09-01 at 09 48 47" src="https://github.com/user-attachments/assets/2d381733-f4f7-44bc-bbb1-6fd39dd40a1d" />

Linear: [SAPP-4423](https://linear.app/sanity/issue/SAPP-4423/add-create-draft-and-variant-banners)

### What to review

- `shouldShowSeeDraftBanner` — published sibling, published perspective, drafts enabled, not live-edit, not history
- `SeeDraftBanner` — `setPerspective('drafts')` only; siblings from `getTargetSiblings(targetDocumentState)`
- Existing `DocumentNotInVariantBanner` / `DocumentNotInReleaseBanner` unchanged

### Testing

- Unit tests for the helper and banner, including "draft already exists" still showing the banner (17 passed)
- Studio verification on `/test`: published document that already has a draft shows **See draft**; clicking it switches to drafts and the existing draft content (no new document)

[See draft banner on a published document that already has a draft](https://cursor.com/agents/bc-f5aa1a0c-3fdd-4de7-9307-8b4141444773/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsee_draft_banner_when_draft_exists.png)
[After See draft, drafts perspective with existing draft content](https://cursor.com/agents/bc-f5aa1a0c-3fdd-4de7-9307-8b4141444773/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsee_draft_after_switch_to_existing_draft.png)
[see_draft_banner_existing_draft.mp4](https://cursor.com/agents/bc-f5aa1a0c-3fdd-4de7-9307-8b4141444773/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsee_draft_banner_existing_draft.mp4)

### Notes for release

When viewing a published, non-live-edit document in the published perspective, a banner now offers **See draft** to switch into the drafts perspective and edit there.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5aa1a0c-3fdd-4de7-9307-8b4141444773?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5aa1a0c-3fdd-4de7-9307-8b4141444773&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

