### PR TITLE
fix(mutator): drop patch paths that cannot apply to the local document

### DIFF
--- a/packages/@sanity/mutator/src/jsonpath/Expression.ts
+++ b/packages/@sanity/mutator/src/jsonpath/Expression.ts
@@ -253,9 +253,9 @@ export class Expression {
     return result
   }
 
-  toFieldReferences(): number[] | string[] {
+  toFieldReferences(probe?: Probe): number[] | string[] {
     if (this.isIndexReference()) {
-      return this.toIndicies()
+      return this.toIndicies(probe)
     }
     if (this.expr.type === 'attribute') {
       return [this.expr.name]

--- a/packages/@sanity/mutator/src/jsonpath/Matcher.ts
+++ b/packages/@sanity/mutator/src/jsonpath/Matcher.ts
@@ -135,7 +135,7 @@ export class Matcher {
       if (descender.tail) {
         // Not arrived yet
         const matcher = new Matcher(descender.descend(), this)
-        descenderHead.toFieldReferences().forEach(() => {
+        descenderHead.toFieldReferences(probe).forEach(() => {
           leads.push({
             target: descenderHead,
             matcher: matcher,

--- a/packages/@sanity/mutator/src/jsonpath/Matcher.ts
+++ b/packages/@sanity/mutator/src/jsonpath/Matcher.ts
@@ -132,6 +132,12 @@ export class Matcher {
         return
       }
 
+      if (probe.containerType() === 'primitive' && descenderHead.isIndexReference()) {
+        // An index reference never matches a primitive value, and resolving
+        // it would require a length the value does not have
+        return
+      }
+
       if (descender.tail) {
         // Not arrived yet
         const matcher = new Matcher(descender.descend(), this)

--- a/packages/@sanity/mutator/src/patch/ImmutableAccessor.ts
+++ b/packages/@sanity/mutator/src/patch/ImmutableAccessor.ts
@@ -52,7 +52,7 @@ export class ImmutableAccessor implements Probe {
       return false
     }
 
-    if (i >= this.length()) {
+    if (i < 0 || i >= this.length()) {
       return null
     }
 

--- a/packages/@sanity/mutator/src/patch/InsertPatch.ts
+++ b/packages/@sanity/mutator/src/patch/InsertPatch.ts
@@ -21,10 +21,8 @@ export class InsertPatch {
   apply(targets: Expression[], accessor: ImmutableAccessor): ImmutableAccessor {
     let result = accessor
     if (accessor.containerType() !== 'array') {
-      const valueType = accessor.valueType()
-      throw new Error(
-        `Attempt to apply insert patch to value of type "${valueType}" at path "${accessor.path.join(' → ')}"`,
-      )
+      // Insert targets only exist for arrays
+      return result
     }
 
     switch (this.location) {

--- a/packages/@sanity/mutator/src/patch/InsertPatch.ts
+++ b/packages/@sanity/mutator/src/patch/InsertPatch.ts
@@ -58,7 +58,7 @@ function minIndex(targets: Expression[], accessor: ImmutableAccessor): number {
   // Ranges may be zero-length and not turn up in indices
   targets.forEach((target) => {
     if (target.isRange()) {
-      const {start} = target.expandRange()
+      const {start} = target.expandRange(accessor)
       if (start < result) {
         result = start
       }
@@ -73,7 +73,7 @@ function maxIndex(targets: Expression[], accessor: ImmutableAccessor): number {
   // Ranges may be zero-length and not turn up in indices
   targets.forEach((target) => {
     if (target.isRange()) {
-      const {end} = target.expandRange()
+      const {end} = target.expandRange(accessor)
       if (end > result) {
         result = end
       }

--- a/packages/@sanity/mutator/src/patch/Patcher.ts
+++ b/packages/@sanity/mutator/src/patch/Patcher.ts
@@ -66,17 +66,28 @@ function process(matcher: Matcher, accessor: ImmutableAccessor) {
   const {leads, delivery} = matcher.match(accessor)
   leads.forEach((lead) => {
     if (lead.target.isIndexReference()) {
-      lead.target.toIndicies().forEach((i) => {
+      if (result.containerType() !== 'array') {
+        // Don't follow lead, only arrays have indices
+        return
+      }
+
+      lead.target.toIndicies(result).forEach((i) => {
         const item = result.getIndex(i)
         if (!item) {
-          throw new Error('Index out of bounds')
+          // Don't follow lead, no such index
+          return
         }
 
         result = result.setIndexAccessor(i, process(lead.matcher, item))
       })
     } else if (lead.target.isAttributeReference()) {
-      // `set`/`setIfMissing` on a primitive value overwrites it
-      if (isSetPatch && result.containerType() === 'primitive') {
+      if (result.containerType() === 'primitive') {
+        if (!isSetPatch) {
+          // Don't follow lead, a primitive value has no attributes
+          return
+        }
+
+        // `set`/`setIfMissing` on a primitive value overwrites it
         result = result.set({})
       }
 

--- a/packages/@sanity/mutator/src/patch/SetPatch.ts
+++ b/packages/@sanity/mutator/src/patch/SetPatch.ts
@@ -18,9 +18,17 @@ export class SetPatch {
       if (target.isSelfReference()) {
         result = result.set(this.value)
       } else if (target.isIndexReference()) {
-        target.toIndicies(accessor).forEach((i) => {
-          result = result.setIndex(i, this.value)
-        })
+        if (result.containerType() === 'array') {
+          target.toIndicies(accessor).forEach((i) => {
+            // A write at exactly `length` appends contiguously; anything past that
+            // would leave `undefined` holes in the array, so those writes are dropped
+            if (i < 0 || i > result.length()) {
+              return
+            }
+
+            result = result.setIndex(i, this.value)
+          })
+        }
       } else if (target.isAttributeReference()) {
         // setting a subproperty on a primitive value overwrites it, eg
         // `{set: {'address.street': 'California St'}}` on `{address: 'Fiction St'}` will result in

--- a/packages/@sanity/mutator/src/patch/UnsetPatch.ts
+++ b/packages/@sanity/mutator/src/patch/UnsetPatch.ts
@@ -24,9 +24,8 @@ export class UnsetPatch {
         })
         break
       default:
-        throw new Error(
-          'Target value is neither indexable or an object. This error should potentially just be silently ignored?',
-        )
+        // A primitive value has nothing to unset
+        break
     }
     return result
   }

--- a/packages/@sanity/mutator/test/BufferedDocument.test.ts
+++ b/packages/@sanity/mutator/test/BufferedDocument.test.ts
@@ -288,3 +288,58 @@ test('remotely created documents has _rev', () => {
     })
     .assertHEAD('_rev', '2')
 })
+
+test('remote patch touching an out-of-range index arrives while local edits are pending', () => {
+  new BufferedDocumentTester({
+    _id: 'a',
+    _type: 't',
+    _rev: '1',
+    body: [{_key: 'a', _type: 'block', children: [{_key: 'a1', _type: 'span', text: 'hello'}]}],
+  })
+    .stage('when applying local edit')
+    .localPatch({
+      id: 'a',
+      set: {'body[0].children[0].text': 'hello world'},
+    })
+    .hasLocalEdits()
+    .stage('when remote patch touching an out-of-range index arrives')
+    .remotePatch('1', '2', {
+      id: 'a',
+      set: {'body[4].children[0].text': 'x'},
+    })
+    .assertLOCAL('body[0].children[0].text', 'hello world')
+    .assert((doc) => {
+      expect(doc?.document.HEAD?._rev).toBe('2')
+    })
+    .stage('when the next remote patch arrives')
+    .remotePatch('2', '3', {
+      id: 'a',
+      set: {title: 'still alive'},
+    })
+    .assertHEAD('title', 'still alive')
+    .assertLOCAL('title', 'still alive')
+    .assertLOCAL('body[0].children[0].text', 'hello world')
+})
+
+test('pending local patch on an array index removed by a remote patch rebases cleanly', () => {
+  new BufferedDocumentTester({
+    _id: 'a',
+    _type: 't',
+    _rev: '1',
+    items: [{title: 'one'}, {title: 'two'}, {title: 'three'}],
+  })
+    .stage('when applying local edit to the third item')
+    .localPatch({
+      id: 'a',
+      set: {'items[2].title': 'three edited'},
+    })
+    .hasLocalEdits()
+    .assertLOCAL('items[2].title', 'three edited')
+    .stage('when a remote patch removes the last two items')
+    .remotePatch('1', '2', {
+      id: 'a',
+      unset: ['items[1:3]'],
+    })
+    .didRebase()
+    .assertLOCAL('items', [{title: 'one'}])
+})

--- a/packages/@sanity/mutator/test/BufferedDocument.test.ts
+++ b/packages/@sanity/mutator/test/BufferedDocument.test.ts
@@ -308,9 +308,7 @@ test('remote patch touching an out-of-range index arrives while local edits are 
       set: {'body[4].children[0].text': 'x'},
     })
     .assertLOCAL('body[0].children[0].text', 'hello world')
-    .assert((doc) => {
-      expect(doc?.document.HEAD?._rev).toBe('2')
-    })
+    .assertHEAD('_rev', '2')
     .stage('when the next remote patch arrives')
     .remotePatch('2', '3', {
       id: 'a',

--- a/packages/@sanity/mutator/test/extract.test.ts
+++ b/packages/@sanity/mutator/test/extract.test.ts
@@ -17,4 +17,8 @@ test('resolves negative-index and open-ended-range descends against the value', 
   expect(extract('a[0:].b', {a: [{b: 1}]})).toEqual([1])
   // Out of range descends resolve to nothing rather than throwing.
   expect(extract('a[5].b', {a: [{b: 1}]})).toEqual([])
+  // Index descends into a non-array resolve to nothing, even the shapes
+  // that need the value's length to resolve.
+  expect(extract('a[-1].b', {a: 'string'})).toEqual([])
+  expect(extract('a[0:].b', {a: 'string'})).toEqual([])
 })

--- a/packages/@sanity/mutator/test/extract.test.ts
+++ b/packages/@sanity/mutator/test/extract.test.ts
@@ -9,3 +9,12 @@ test('basic extraction', () => {
   expect(extract('[@ > 7]', [10, null, 2])).toEqual([10])
   expect(extract('..kazoo', {kazoo: 'fneh', zip: null})).toEqual(['fneh'])
 })
+
+test('resolves negative-index and open-ended-range descends against the value', () => {
+  // These path shapes previously threw ("must have a probe") because the lead
+  // count was resolved without the value in scope.
+  expect(extract('a[-1].b', {a: [{b: 1}, {b: 2}]})).toEqual([2])
+  expect(extract('a[0:].b', {a: [{b: 1}]})).toEqual([1])
+  // Out of range descends resolve to nothing rather than throwing.
+  expect(extract('a[5].b', {a: [{b: 1}]})).toEqual([])
+})

--- a/packages/@sanity/mutator/test/patchExamples/diffMatchPatch.ts
+++ b/packages/@sanity/mutator/test/patchExamples/diffMatchPatch.ts
@@ -76,6 +76,21 @@ const examples: PatchExample[] = [
       a: null,
     },
   },
+  {
+    name: 'Diff match patch descending past an out-of-range index',
+    before: {
+      body: [{children: [{text: 'The rabid dog'}]}],
+    },
+    patch: {
+      id: 'a',
+      diffMatchPatch: {
+        'body[4].children[0].text': '@@ -1,13 +1,12 @@\n The \n-rabid\n+nice\n  dog\n',
+      },
+    },
+    after: {
+      body: [{children: [{text: 'The rabid dog'}]}],
+    },
+  },
 ]
 
 export default examples

--- a/packages/@sanity/mutator/test/patchExamples/insert.ts
+++ b/packages/@sanity/mutator/test/patchExamples/insert.ts
@@ -129,6 +129,38 @@ const examples: PatchExample[] = [
       a: 'string',
     },
   },
+  {
+    name: 'Insert before a negative-index range anchor',
+    before: {
+      a: [1, 2, 3],
+    },
+    patch: {
+      id: 'a',
+      insert: {
+        before: 'a[-2:-1]',
+        items: [9],
+      },
+    },
+    after: {
+      a: [1, 9, 2, 3],
+    },
+  },
+  {
+    name: 'Insert after an open-ended range anchor',
+    before: {
+      a: [1, 2, 3],
+    },
+    patch: {
+      id: 'a',
+      insert: {
+        after: 'a[1:]',
+        items: [9],
+      },
+    },
+    after: {
+      a: [1, 2, 3, 9],
+    },
+  },
 ]
 
 export default examples

--- a/packages/@sanity/mutator/test/patchExamples/insert.ts
+++ b/packages/@sanity/mutator/test/patchExamples/insert.ts
@@ -113,6 +113,22 @@ const examples: PatchExample[] = [
       scores: [{a: 1}, {a: 'hello'}, {a: 3}],
     },
   },
+  {
+    name: 'Insert anchored to an index of a non-array',
+    before: {
+      a: 'string',
+    },
+    patch: {
+      id: 'a',
+      insert: {
+        after: 'a[-1]',
+        items: [1],
+      },
+    },
+    after: {
+      a: 'string',
+    },
+  },
 ]
 
 export default examples

--- a/packages/@sanity/mutator/test/patchExamples/set.ts
+++ b/packages/@sanity/mutator/test/patchExamples/set.ts
@@ -431,6 +431,36 @@ const examples: PatchExample[] = [
       a: [{b: 9}],
     },
   },
+  {
+    name: 'Set descending through a negative index into a non-array',
+    before: {
+      a: 'string',
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[-1].b': 9,
+      },
+    },
+    after: {
+      a: 'string',
+    },
+  },
+  {
+    name: 'Set descending through an open-ended range into a non-array',
+    before: {
+      a: 'string',
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[0:].b': 9,
+      },
+    },
+    after: {
+      a: 'string',
+    },
+  },
 ]
 
 export default examples

--- a/packages/@sanity/mutator/test/patchExamples/set.ts
+++ b/packages/@sanity/mutator/test/patchExamples/set.ts
@@ -305,6 +305,102 @@ const examples: PatchExample[] = [
       a: 3,
     },
   },
+  {
+    name: 'Set descending past an out-of-range array index',
+    before: {
+      body: [{_key: 'a', _type: 'block', children: [{_key: 'a1', _type: 'span', text: 'hello'}]}],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'body[4].children[0].text': 'x',
+      },
+    },
+    after: {
+      body: [{_key: 'a', _type: 'block', children: [{_key: 'a1', _type: 'span', text: 'hello'}]}],
+    },
+  },
+  {
+    name: 'Set descending an index into a non-array',
+    before: {
+      a: 'string',
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[0].b': 1,
+      },
+    },
+    after: {
+      a: 'string',
+    },
+  },
+  {
+    name: 'Set at an out-of-range array index',
+    before: {
+      body: [
+        {_key: 'a', _type: 'block'},
+        {_key: 'b', _type: 'block'},
+      ],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'body[5]': {_key: 'z', _type: 'block'},
+      },
+    },
+    after: {
+      body: [
+        {_key: 'a', _type: 'block'},
+        {_key: 'b', _type: 'block'},
+      ],
+    },
+  },
+  {
+    name: 'Set at exactly the array length appends',
+    before: {
+      a: [1, 2],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[2]': 3,
+      },
+    },
+    after: {
+      a: [1, 2, 3],
+    },
+  },
+  {
+    name: 'Set at a negative index resolving out of range',
+    before: {
+      a: [1, 2],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[-5]': 9,
+      },
+    },
+    after: {
+      a: [1, 2],
+    },
+  },
+  {
+    name: 'Set at an index of a non-array',
+    before: {
+      a: 'string',
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[0]': 1,
+      },
+    },
+    after: {
+      a: 'string',
+    },
+  },
 ]
 
 export default examples

--- a/packages/@sanity/mutator/test/patchExamples/set.ts
+++ b/packages/@sanity/mutator/test/patchExamples/set.ts
@@ -401,6 +401,36 @@ const examples: PatchExample[] = [
       a: 'string',
     },
   },
+  {
+    name: 'Set descending through a negative index',
+    before: {
+      a: [{b: 1}],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[-1].b': 9,
+      },
+    },
+    after: {
+      a: [{b: 9}],
+    },
+  },
+  {
+    name: 'Set descending through an open-ended range',
+    before: {
+      a: [{b: 1}],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a[0:].b': 9,
+      },
+    },
+    after: {
+      a: [{b: 9}],
+    },
+  },
 ]
 
 export default examples

--- a/packages/@sanity/mutator/test/patchExamples/unset.ts
+++ b/packages/@sanity/mutator/test/patchExamples/unset.ts
@@ -147,6 +147,32 @@ const examples: PatchExample[] = [
       b: [{key: '123'}],
     },
   },
+  {
+    name: 'Unset attribute of a primitive value',
+    before: {
+      a: 'string',
+    },
+    patch: {
+      id: 'a',
+      unset: ['a.b'],
+    },
+    after: {
+      a: 'string',
+    },
+  },
+  {
+    name: 'Unset descending into a primitive value',
+    before: {
+      a: 'string',
+    },
+    patch: {
+      id: 'a',
+      unset: ['a.b.c'],
+    },
+    after: {
+      a: 'string',
+    },
+  },
 ]
 
 export default examples

--- a/packages/sanity/src/core/store/document/buffered-doc/createObservableBufferedDocument.test.ts
+++ b/packages/sanity/src/core/store/document/buffered-doc/createObservableBufferedDocument.test.ts
@@ -1,0 +1,90 @@
+import {type SanityDocument} from '@sanity/types'
+import {Subject} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {type ListenerEvent} from '../getPairListener'
+import {type MutationEvent} from '../types'
+import {createObservableBufferedDocument} from './createObservableBufferedDocument'
+
+const INITIAL: SanityDocument = {
+  _id: 'drafts.doc-1',
+  _rev: 'r0',
+  _type: 'news',
+  _createdAt: '2026-01-01T00:00:00.000Z',
+  _updatedAt: '2026-01-01T00:00:00.000Z',
+  body: [{_key: 'a', _type: 'block', children: [{_key: 'a1', _type: 'span', text: 'hello'}]}],
+}
+
+function mutationEvent(
+  previousRev: string,
+  resultRev: string,
+  mutations: MutationEvent['mutations'],
+): MutationEvent {
+  return {
+    type: 'mutation',
+    documentId: 'drafts.doc-1',
+    transactionId: resultRev,
+    mutations,
+    effects: {apply: [], revert: []},
+    previousRev,
+    resultRev,
+    transactionTotalEvents: 1,
+    transactionCurrentEvent: 1,
+    messageReceivedAt: new Date().toISOString(),
+    visibility: 'transaction',
+    transition: 'update',
+  }
+}
+
+test('a remote patch that cannot apply to the local document does not error the snapshot stream', () => {
+  const listenerEvent$ = new Subject<ListenerEvent>()
+  const buffered = createObservableBufferedDocument(listenerEvent$)
+
+  const snapshots: SanityDocument[] = []
+  let streamError: unknown = null
+  buffered.updates$.subscribe({
+    next: (event) => {
+      if (event.type === 'snapshot' && event.document) {
+        snapshots.push(event.document)
+      }
+    },
+    error: (err) => {
+      streamError = err
+    },
+  })
+
+  listenerEvent$.next({type: 'snapshot', documentId: 'drafts.doc-1', document: INITIAL})
+
+  // unsaved local edits are sitting in the buffer
+  buffered.addMutation({
+    patch: {id: 'drafts.doc-1', set: {'body[0].children[0].text': 'hello world'}},
+  })
+
+  // a client whose copy of `body` is longer than ours patches the fifth block
+  listenerEvent$.next(
+    mutationEvent('r0', 'r1', [
+      {patch: {id: 'drafts.doc-1', set: {'body[4].children[0].text': 'x'}}},
+    ]),
+  )
+
+  expect(streamError).toBeNull()
+
+  // the unapplicable sub-patch was dropped, the local edit is intact
+  const afterPoison = snapshots.at(-1)
+  expect(afterPoison?.body).toMatchObject([
+    {_key: 'a', children: [{_key: 'a1', text: 'hello world'}]},
+  ])
+
+  // subsequent remote mutations still come through
+  listenerEvent$.next(
+    mutationEvent('r1', 'r2', [{patch: {id: 'drafts.doc-1', set: {title: 'still alive'}}}]),
+  )
+
+  const afterHealthy = snapshots.at(-1)
+  expect(streamError).toBeNull()
+  expect(afterHealthy?.title).toBe('still alive')
+  expect(afterHealthy?._rev).toBe('r2')
+  expect(afterHealthy?.body).toMatchObject([
+    {_key: 'a', children: [{_key: 'a1', text: 'hello world'}]},
+  ])
+})

--- a/packages/sanity/src/core/store/document/buffered-doc/createObservableBufferedDocument.test.ts
+++ b/packages/sanity/src/core/store/document/buffered-doc/createObservableBufferedDocument.test.ts
@@ -3,7 +3,7 @@ import {Subject} from 'rxjs'
 import {expect, test} from 'vitest'
 
 import {type ListenerEvent} from '../getPairListener'
-import {type MutationEvent} from '../types'
+import {mutationEvent} from '../utils/__test__/test-utils'
 import {createObservableBufferedDocument} from './createObservableBufferedDocument'
 
 const INITIAL: SanityDocument = {
@@ -13,27 +13,6 @@ const INITIAL: SanityDocument = {
   _createdAt: '2026-01-01T00:00:00.000Z',
   _updatedAt: '2026-01-01T00:00:00.000Z',
   body: [{_key: 'a', _type: 'block', children: [{_key: 'a1', _type: 'span', text: 'hello'}]}],
-}
-
-function mutationEvent(
-  previousRev: string,
-  resultRev: string,
-  mutations: MutationEvent['mutations'],
-): MutationEvent {
-  return {
-    type: 'mutation',
-    documentId: 'drafts.doc-1',
-    transactionId: resultRev,
-    mutations,
-    effects: {apply: [], revert: []},
-    previousRev,
-    resultRev,
-    transactionTotalEvents: 1,
-    transactionCurrentEvent: 1,
-    messageReceivedAt: new Date().toISOString(),
-    visibility: 'transaction',
-    transition: 'update',
-  }
 }
 
 test('a remote patch that cannot apply to the local document does not error the snapshot stream', () => {
@@ -62,9 +41,12 @@ test('a remote patch that cannot apply to the local document does not error the 
 
   // a client whose copy of `body` is longer than ours patches the fifth block
   listenerEvent$.next(
-    mutationEvent('r0', 'r1', [
-      {patch: {id: 'drafts.doc-1', set: {'body[4].children[0].text': 'x'}}},
-    ]),
+    mutationEvent({
+      documentId: 'drafts.doc-1',
+      previousRev: 'r0',
+      resultRev: 'r1',
+      mutations: [{patch: {id: 'drafts.doc-1', set: {'body[4].children[0].text': 'x'}}}],
+    }),
   )
 
   expect(streamError).toBeNull()
@@ -77,7 +59,12 @@ test('a remote patch that cannot apply to the local document does not error the 
 
   // subsequent remote mutations still come through
   listenerEvent$.next(
-    mutationEvent('r1', 'r2', [{patch: {id: 'drafts.doc-1', set: {title: 'still alive'}}}]),
+    mutationEvent({
+      documentId: 'drafts.doc-1',
+      previousRev: 'r1',
+      resultRev: 'r2',
+      mutations: [{patch: {id: 'drafts.doc-1', set: {title: 'still alive'}}}],
+    }),
   )
 
   const afterHealthy = snapshots.at(-1)

--- a/packages/sanity/src/core/store/document/utils/__test__/test-utils.ts
+++ b/packages/sanity/src/core/store/document/utils/__test__/test-utils.ts
@@ -2,23 +2,25 @@ import {type MutationPayload} from '../../buffered-doc/types'
 import {type MutationEvent} from '../../types'
 
 export function mutationEvent({
+  documentId = 'test',
   previousRev,
   resultRev,
   mutations,
 }: {
+  documentId?: string
   previousRev: string
   resultRev: string
   mutations: MutationPayload[]
 }): MutationEvent {
-  // @ts-expect-error -- pre-existing, fix later
   return {
     type: 'mutation',
-    documentId: 'test',
+    documentId,
     transactionId: resultRev,
     effects: {revert: [], apply: []},
     mutations,
     previousRev: previousRev,
     resultRev: resultRev,
+    messageReceivedAt: new Date().toISOString(),
     transition: 'update',
     transactionCurrentEvent: 1,
     transactionTotalEvents: 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

When two clients edit one document, an incoming remote patch, or a rebase replaying pending local patches onto a changed base, can reference a path the local copy no longer has. The patch engine already tolerates this for attribute paths ("Don't follow lead, no such attribute"), for `diffMatchPatch` and `inc`/`dec` (f44a5c0dc9), and `setIfMissing` ignores index targets outright. Numeric index handling was the exception: a path descending past an out-of-range index threw `Index out of bounds`, a `set` landing on an out-of-range index wrote past the end and left `undefined` holes (no `_key`, so the array becomes uneditable with "Missing keys"), and index/attribute targets on a container of the wrong type threw from the accessor. In the studio, those throws escape `bufferedDocument.arrive()` inside an unguarded operator in `createObservableBufferedDocument`, error the document's snapshot stream, and crash the open pane. Whatever the author had not saved is gone. That is the incident in #14418, hit twice in production on a Portable Text document with a second editor active.

This fixes the engine rather than wrapping `arrive()` in `catchError`, for a reason verified at runtime: `Document.arrive()` pushes the mutation into `incoming` before applying and only removes it after a successful apply, so a caught throw leaves the poisoned mutation queued. Every later listener event re-runs it and re-throws while HEAD stops advancing. Catching would turn a visible crash into a document that silently stops syncing. A real recovery would need a resync from the server, and no such wiring exists at that layer (the `OutOfSyncError` machinery lives upstream in `getPairListener`). Skipping in the engine needs neither: `Mutation.apply` advances `_rev` regardless, so the event chain continues and content reconciles on the next snapshot, the same contract the already-guarded patch types rely on.

Two smaller calls worth flagging: a `set` at exactly `length` still appends (kept, it is contiguous and pinned by a test), and the skips are silent to match the sibling branches (the issue suggested skip-and-warn; none of the existing guards warn, and rebase replays would make a warn noisy).

### What to review

- `packages/@sanity/mutator/src/patch/` — the patch-type guards. Each mirrors an existing sibling pattern in the same file or a neighbor.
- The one judgment call: a `set` at an index past the end is dropped rather than clamped into an append. The write was positional; appending it somewhere else would silently reorder content that the server did not.
- Review-round fixes for the two throw sites the guards did not cover, both resolving index and range expressions against the value instead of a probeless call. `InsertPatch` range anchors (`a[-2:-1]`, `a[1:]`) expanded without the accessor. `Matcher.extractMatches` counted descend leads via a probeless `toFieldReferences()`, so a negative index or open-ended range descend (`a[-1].b`, `a[0:].b`) threw before any guard ran, reachable by any client since the server resolves the index against its own copy.
- `Matcher` is shared by the public `extract()`/`extractWithPath()`, so those same descend shapes now resolve (skipping missing indices) instead of throwing. Locked by an `extract` test.
- `packages/sanity` is test-only.

### Testing

Commits are staged red then green: failing repros land before each fix. On the parent of the original fix, 11 of the first 13 tests fail (including the issue's exact reproduction); the review round adds 5 more repros that throw on the current engine and pass after the two follow-up fixes.

- Mutator coverage: patch examples for the descend-past-index, non-array, out-of-range set, exactly-length append, negative index, dmp descend, range-anchored insert, and negative/open-range descend cases; two `BufferedDocument` tests (remote arrival with pending local edits; rebase over indices a remote patch removed); an `extract` test locking the resolve-instead-of-throw behavior. Full `@sanity/mutator` project green (147 tests).
- Studio: `createObservableBufferedDocument.test.ts` proves the snapshot stream survives and keeps applying later mutations. It now uses the shared `mutationEvent` helper.
- `pnpm build`, `pnpm test`, `pnpm check:format`, `pnpm check:oxlint`, `pnpm test:exports` pass locally. `isUsingLegacyHttp` and `pnpm depcheck` fail identically on `main` in this VM, unrelated to this change.
- Verified the five review repros against the built `@sanity/mutator` artifact: all throw before, apply cleanly after.

Manual end-to-end verification in the test studio. Two editors on one Portable Text document, simulated by rewriting a real listener mutation (real revisions, effects and ordering) so it descends past an array index the local copy does not have. On `main` the incoming change crashes the open pane ("The structure tool crashed / Index out of bounds"); with the fix the same change is dropped and the editor stays live and editable.

Before (on `main`), healthy editor then crash when the remote change lands:

[before_fix_healthy_editor_then_crash_on_remote_edit.mp4](https://cursor.com/agents/bc-cd45686f-6935-41c0-8ea2-20ac26dd6774/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_healthy_editor_then_crash_on_remote_edit.mp4)

[Structure tool crashed with Index out of bounds](https://cursor.com/agents/bc-cd45686f-6935-41c0-8ea2-20ac26dd6774/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_structure_tool_crashed.webp)

After (with the fix), same remote change, editor stays alive and editable:

[after_fix_editor_survives_out_of_range_remote_patch.mp4](https://cursor.com/agents/bc-cd45686f-6935-41c0-8ea2-20ac26dd6774/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_editor_survives_out_of_range_remote_patch.mp4)

[Editor still editable after the out-of-range remote patch](https://cursor.com/agents/bc-cd45686f-6935-41c0-8ea2-20ac26dd6774/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_editor_still_editable.webp)

### Follow-up (out of scope)

Range descends double-apply their payload: `inc` through `a[0:2].b` increments twice, because `Matcher.extractMatches` pushes one identical lead per resolved index and `Patcher` then iterates every index for each lead. This is pre-existing (not introduced here), and the probe threading in this PR does not fix it (it is duplicate leads, not probeless resolution). Left for a separate issue; see the inline comment on `Patcher.ts`. The clean fix (resolve leads to concrete indices in `extractMatches`) would collapse the three index-interpreting sites into one and remove this along with the throw class above.

### Notes for release

Fixes a crash that could take down an open document editor when several people edit the same document. When a collaborator's change referenced an array position that no longer existed in your copy of the document, the studio could throw `Index out of bounds`, stop syncing the document, and lose your unsaved edits. It could also insert empty array items that showed up as "Missing keys" and made the field uneditable. Such changes are now skipped and the document reconciles with the server on the next update; nothing is required from users.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd45686f-6935-41c0-8ea2-20ac26dd6774?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd45686f-6935-41c0-8ea2-20ac26dd6774&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

