### PR TITLE
fix(deps): pin ui5 to exact @sanity/ui version

### DIFF
--- a/dev/storybook/package.json
+++ b/dev/storybook/package.json
@@ -20,7 +20,7 @@
     "react-dom": "catalog:",
     "sanity": "workspace:*",
     "styled-components": "catalog:",
-    "ui5": "npm:@sanity/ui@alpha"
+    "ui5": "catalog:"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ catalogs:
       specifier: ^7.0.2
       version: 7.0.2
     ui5:
-      specifier: npm:@sanity/ui@alpha
+      specifier: npm:@sanity/ui@5.0.0-alpha.8
       version: 5.0.0-alpha.8
     vite:
       specifier: ^8.2.2
@@ -586,7 +586,7 @@ importers:
         specifier: 'catalog:'
         version: 6.5.3(react-dom@19.2.8)(react@19.2.8)
       ui5:
-        specifier: npm:@sanity/ui@alpha
+        specifier: 'catalog:'
         version: '@sanity/ui@5.0.0-alpha.8(react-dom@19.2.8)(react@19.2.8)'
     devDependencies:
       '@chromatic-com/storybook':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,7 +48,9 @@ catalog:
   react-rx: ^6.0.0
   rimraf: ^6.1.3
   styled-components: ^6.5.3
-  ui5: npm:@sanity/ui@alpha
+  # Exact version on purpose (like @sanity/workbench): bumps are explicit so published
+  # packages ship the version we validated instead of whatever the alpha dist-tag points to
+  ui5: npm:@sanity/ui@5.0.0-alpha.8
   tsdown: ^0.22.14
   typescript: ^7.0.2
   vite: ^8.2.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The `ui5` catalog entry pointed at the floating `alpha` dist-tag, and pnpm copies the catalog specifier verbatim into published manifests — `sanity@latest` on npm currently ships `"ui5": "npm:@sanity/ui@alpha"`. Userland installs therefore resolve whatever the dist-tag points to at their install time, so a freshly published alpha (and any regression in it) reaches users before we've validated it, and users can end up on a newer version than the monorepo lockfile. Pinning the catalog to the exact version makes bumps explicit, the same model as `@sanity/workbench`: renovate opens a bump PR (the `@sanity/ui` package rules already match the alias via its package name), we validate, userland gets exactly that version.

`dev/storybook` carried its own `npm:@sanity/ui@alpha` specifier instead of `catalog:`; it now uses the catalog so there is a single place to bump and the visual tests can't drift onto a different version than the packages.

### What to review

- `pnpm-workspace.yaml` — the pin (`npm:@sanity/ui@5.0.0-alpha.8`, which is what `alpha` points to today and what the lockfile already resolved) and the comment explaining it
- `dev/storybook/package.json` — switched to `catalog:`
- `pnpm-lock.yaml` — specifier-only diff; the resolved version is unchanged, so the installed tree is identical

Affected published packages: `sanity`, `@sanity/vision`, `@sanity/access-ui` (all declare `"ui5": "catalog:"`).

### Testing

No code change — the resolved dependency tree is byte-identical, so build/unit tests exercise the same code as `main`. Verified what matters for this change:

- `pnpm pack` on `sanity` and `@sanity/vision`: tarball manifests now carry `"ui5": "npm:@sanity/ui@5.0.0-alpha.8"` (previously the floating `npm:@sanity/ui@alpha`)
- `pnpm install --frozen-lockfile` and `pnpm check:format` pass
- `pnpm depcheck` reports the same pre-existing failures as a clean `main` checkout (unused `lefthook` root devDependency + a knip config hint), unrelated to this change

### Notes for release

N/A – dependency management change: `sanity` now resolves a pinned `@sanity/ui` v5 alpha for the `ui5` alias instead of the floating `alpha` dist-tag.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b66f150d-f137-4d9c-9263-f25dda9c5ad0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b66f150d-f137-4d9c-9263-f25dda9c5ad0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

