### PR TITLE
chore(deps): follow @sanity/ui alpha dist-tag for the ui5 pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -115,6 +115,11 @@
       "schedule": ["every weekday"]
     },
     {
+      "description": "ui5 is the exact-pinned npm alias for the @sanity/ui v5 prerelease (pnpm catalog): strictly follow the alpha dist-tag so the pin is bumped whenever a new alpha is published, bypassing the default ignoreUnstable logic that would skip a rebased prerelease (e.g. a beta) and tracking tag rollbacks",
+      "matchDepNames": ["ui5"],
+      "followTag": "alpha"
+    },
+    {
       "description": "Upgrade @portabletext/* packages together, majors included: the editor monorepo versions its packages independently but releases them in lockstep (plugins peer-depend on the editor), so a new major line must land as one PR instead of one per major number",
       "matchPackageNames": ["@portabletext/*"],
       "dependencyDashboardApproval": false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to #14462, which pinned the `ui5` catalog entry to an exact `@sanity/ui` version. This makes sure renovate bumps that pin whenever needed.

Most of it already works out of the box, verified against the current config and history:

- Renovate updates pnpm catalog entries in this repo (e.g. #12425 bumped the `@sanity/ui` catalog entry), and the shared `sanity-io/renovate-config:semantic-commit-type` preset explicitly gives `pnpm.catalog.default` deps `fix(deps)` commits.
- The alias resolves to package name `@sanity/ui`, so the existing rules match it: 0-day `minimumReleaseAge` (`/^@sanity\//` rule), no dashboard approval + weekday schedule (important-packages rule), automerge (prerelease-number bumps classify as `patch`).
- Same-base bumps (`5.0.0-alpha.8` → `5.0.0-alpha.9`) pass renovate's default `ignoreUnstable` logic — the exact-pinned `@sanity/workbench` proves this end to end (`0.1.0-alpha.29` → `.45` all landed via renovate).

The gap: `ignoreUnstable` only offers prereleases with the same `major.minor.patch` base, so a rebased prerelease under the `alpha` tag (say `5.0.0-beta.1` or `5.1.0-alpha.1`) would silently stop updates, and renovate never follows a dist-tag rollback after a bad release. `followTag: "alpha"` closes both: renovate strictly mirrors whatever the `alpha` tag points to, which is the documented use case for the option (pre-release channels). Scoped via `matchDepNames: ["ui5"]` so the stable `@sanity/ui` v4 catalog entry keeps its normal semver behavior.

Alternative considered: `ignoreUnstable: false` for the alias — rejected because it would offer any newer prerelease ever published (even ones never tagged `alpha`) and still wouldn't track rollbacks.

### What to review

- The single rule added to `.github/renovate.json` — placement after the important-packages rule, and that the `matchDepNames` scoping looks right.

### Testing

`pnpm dlx --package renovate renovate-config-validator .github/renovate.json` passes ("Config validated successfully"). `pnpm check:format` passes. Behavior itself is exercised by renovate once a new `@sanity/ui` alpha is published.

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b66f150d-f137-4d9c-9263-f25dda9c5ad0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b66f150d-f137-4d9c-9263-f25dda9c5ad0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

