### PR TITLE
perf(sanity): fix idle and typing re-renders found via react devtools profiling

### DIFF
--- a/.agents/skills/react-devtools/SKILL.md
+++ b/.agents/skills/react-devtools/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: react-devtools
+description: React DevTools CLI for AI agents. Use when the user asks you to debug a React or React Native app at runtime, inspect component props/state/hooks, diagnose render performance, profile re-renders, find slow components, or understand why something re-renders. Triggers include "why does this re-render", "inspect the component", "what props does X have", "profile the app", "find slow components", "debug the UI", "check component state", "the app feels slow", or any React runtime debugging task.
+allowed-tools: Bash(agent-react-devtools:*)
+---
+
+# agent-react-devtools
+
+CLI that connects to a running React or React Native app via the React DevTools protocol and exposes the component tree, props, state, hooks, and profiling data in a token-efficient format.
+
+## Core Workflow
+
+1. **Ensure connection** — check `agent-react-devtools status`. If the daemon is not running, start it with `agent-react-devtools start`. Use `agent-react-devtools wait --connected` to block until a React app connects.
+2. **Inspect** — get the component tree, search for components, inspect props/state/hooks.
+3. **Profile** — start profiling, trigger the interaction (or ask the user to), stop profiling, analyze results.
+4. **Act** — use the data to fix the bug, optimize performance, or explain what's happening.
+
+## Essential Commands
+
+### Daemon
+
+```bash
+agent-react-devtools start              # Start daemon (auto-starts on first command)
+agent-react-devtools stop               # Stop daemon
+agent-react-devtools status             # Check connection, component count, last event
+agent-react-devtools wait --connected   # Block until a React app connects
+agent-react-devtools wait --component App # Block until a component appears
+```
+
+### Component Inspection
+
+```bash
+agent-react-devtools get tree           # Full component hierarchy (labels: @c1, @c2, ...)
+agent-react-devtools get tree --depth 3 # Limit depth
+agent-react-devtools get component @c5  # Props, state, hooks for a specific component
+agent-react-devtools find Button        # Search by display name (fuzzy)
+agent-react-devtools find Button --exact # Exact match
+agent-react-devtools count              # Count by type: fn, cls, host, memo, ...
+agent-react-devtools errors             # List components with errors or warnings
+```
+
+### Performance Profiling
+
+```bash
+agent-react-devtools profile start              # Start recording
+agent-react-devtools profile stop               # Stop and collect data
+agent-react-devtools profile slow               # Slowest components by avg render time
+agent-react-devtools profile slow --limit 10    # Top 10
+agent-react-devtools profile rerenders          # Most re-rendered components
+agent-react-devtools profile report @c5         # Detailed report for one component
+agent-react-devtools profile timeline --limit 10                        # First 10 commits (use --limit; uncapped can dump 300+ lines)
+agent-react-devtools profile timeline --limit 10 --offset 10           # Next 10 (pagination)
+agent-react-devtools profile timeline --sort duration --limit 5        # Top 5 most expensive commits
+agent-react-devtools profile timeline --sort timeline --limit 5        # Explicit chronological order (same as default)
+agent-react-devtools profile commit 3           # Detail for commit #3
+agent-react-devtools profile export profile.json # Export as React DevTools Profiler JSON
+agent-react-devtools profile diff before.json after.json  # Compare two exports
+```
+
+## Understanding the Output
+
+### Component Labels
+
+Every component gets a stable label like `@c1`, `@c2`. Use these to reference components in follow-up commands:
+
+```
+@c1 [fn] App
+├─ @c2 [fn] Header
+├─ @c3 [fn] TodoList
+│  ├─ @c4 [fn] TodoItem key=1
+│  └─ @c5 [fn] TodoItem key=2
+└─ @c6 [host] div
+```
+
+Type abbreviations: `fn` = function, `cls` = class, `host` = DOM element, `memo` = React.memo, `fRef` = forwardRef, `susp` = Suspense, `ctx` = context.
+
+Components with errors or warnings show annotations: `⚠2` = 2 warnings, `✗1` = 1 error. Use `agent-react-devtools errors` to list only affected components.
+
+### Inspected Component
+
+```
+@c3 [fn] TodoList
+props:
+  items: [{"id":1,"text":"Buy milk"},{"id":2,"text":"Walk dog"}]
+  onDelete: ƒ
+state:
+  filter: "all"
+hooks:
+  useState: "all"
+  useMemo: [...]
+  useCallback: ƒ
+```
+
+`ƒ` = function value. Values over 60 chars are truncated.
+
+### Profiling Output
+
+```
+Slowest (by avg render time):
+  @c3 [fn] ExpensiveList  avg:12.3ms  max:18.1ms  renders:47  causes:props-changed  changed: props: items, filter
+  @c4 [fn] TodoItem  avg:2.1ms  max:5.0ms  renders:94  causes:parent-rendered, props-changed  changed: props: onToggle
+```
+
+Render causes: `props-changed`, `state-changed`, `hooks-changed`, `parent-rendered`, `force-update`, `first-mount`.
+
+When specific changed keys are available, a `changed:` suffix shows exactly which props, state keys, or hooks triggered the render (e.g. `changed: props: onClick, className  state: count  hooks: #0`).
+
+## Common Patterns
+
+### Wait for the app to connect after a reload
+
+```bash
+agent-react-devtools wait --connected --timeout 10
+agent-react-devtools get tree
+```
+
+Use this after triggering a page reload or HMR update to avoid querying empty state.
+
+### Diagnose slow interactions
+
+```bash
+agent-react-devtools profile start
+# User interacts with the app (or use agent-browser to drive the UI)
+agent-react-devtools profile stop
+agent-react-devtools profile slow --limit 5
+agent-react-devtools profile rerenders --limit 5
+```
+
+Then inspect the worst offenders with `get component @cN` and `profile report @cN`.
+
+### Browse a long timeline in chunks
+
+```bash
+agent-react-devtools profile timeline --limit 20               # commits 0–19
+agent-react-devtools profile timeline --limit 20 --offset 20   # commits 20–39
+agent-react-devtools profile timeline --offset 30 --limit 10   # skip warm-up, show 30–39
+```
+
+Use `profile commit <N>` to drill into a specific commit once you spot a spike.
+
+### Find a component and check its state
+
+```bash
+agent-react-devtools find SearchBar
+agent-react-devtools get component @c12
+```
+
+### Verify a fix worked
+
+```bash
+agent-react-devtools profile start
+# Repeat the interaction
+agent-react-devtools profile stop
+agent-react-devtools profile slow --limit 5
+# Compare render counts and durations to the previous run
+```
+
+## Using with agent-browser
+
+When using `agent-browser` to drive the app while profiling or debugging, you **must use headed mode** (`--headed`). Headless Chromium does not execute ES module scripts the same way as a real browser, which prevents the devtools connect script from running properly.
+
+```bash
+agent-browser --session devtools --headed open http://localhost:5173/
+agent-react-devtools status  # Should show 1 connected app
+```
+
+## Important Rules
+
+- **Labels reset** when the app reloads or components unmount/remount. After a reload, use `wait --connected` then re-check with `get tree` or `find`.
+- **`status` first** — if status shows 0 connected apps, the React app is not connected. The user may need to run `npx agent-react-devtools init` in their project first.
+- **Headed browser required** — if using `agent-browser`, always use `--headed` mode. Headless Chromium does not properly load the devtools connect script.
+- **Profile while interacting** — profiling only captures renders that happen between `profile start` and `profile stop`. Make sure the relevant interaction happens during that window.
+- **Use `--depth`** on large trees — a deep tree can produce a lot of output. Start with `--depth 3` or `--depth 4` and go deeper only on the subtree you care about.
+
+## References
+
+| File                                                | When to read                                                   |
+| --------------------------------------------------- | -------------------------------------------------------------- |
+| [commands.md](references/commands.md)               | Full command reference with all flags and edge cases           |
+| [profiling-guide.md](references/profiling-guide.md) | Step-by-step profiling workflows and interpreting results      |
+| [setup.md](references/setup.md)                     | How to connect different frameworks (Vite, Next.js, Expo, CRA) |

--- a/.agents/skills/react-devtools/references/commands.md
+++ b/.agents/skills/react-devtools/references/commands.md
@@ -1,0 +1,148 @@
+# Command Reference
+
+## Daemon Management
+
+### `agent-react-devtools start [--port N]`
+
+Start the background daemon. Default port: 8097. The daemon listens for WebSocket connections from React apps and IPC connections from the CLI. Auto-starts when you run any other command, so you rarely need this explicitly.
+
+### `agent-react-devtools stop`
+
+Stop the daemon process. All connection state is lost.
+
+### `agent-react-devtools status`
+
+Show daemon status: port, connected apps, component count, profiling state, uptime, and last connection event.
+
+Output:
+
+```
+Daemon: running (port 8097)
+Apps: 1 connected, 42 components
+Last event: app connected 3s ago
+Uptime: 120s
+```
+
+If profiling is active, shows `Profiling: active`.
+
+### `agent-react-devtools wait --connected [--timeout S]`
+
+Block until at least one React app connects via WebSocket. Resolves immediately if already connected. Default timeout: 30s. Exits non-zero on timeout.
+
+### `agent-react-devtools wait --component <name> [--timeout S]`
+
+Block until a component with the given display name appears in the tree. Uses exact name matching. Useful after a reload to wait for a specific part of the UI to render. Default timeout: 30s. Exits non-zero on timeout.
+
+## Component Inspection
+
+### `agent-react-devtools get tree [--depth N]`
+
+Print the component hierarchy as an indented tree. Each node shows:
+
+- Label (`@c1`, `@c2`, ...) — stable within a session, resets on app reload
+- Type tag (`fn`, `cls`, `host`, `memo`, `fRef`, `susp`, `ctx`)
+- Display name
+- Key (if present)
+
+Use `--depth N` to limit tree depth. Recommended for large apps.
+
+### `agent-react-devtools get component <@cN | id>`
+
+Inspect a single component. Shows:
+
+- **props** — all prop values (functions shown as `ƒ`, long values truncated at 60 chars)
+- **state** — state values (class components and useState)
+- **hooks** — all hooks with current values and sub-hooks
+
+Accepts a label (`@c5`) or numeric React fiber ID.
+
+### `agent-react-devtools find <name> [--exact]`
+
+Search components by display name. Default is case-insensitive substring match. Use `--exact` for exact match.
+
+Returns a flat list of matching components with labels, types, and keys.
+
+### `agent-react-devtools count`
+
+Count components by type. Output: `42 components (fn:25 host:12 memo:3 cls:2)`.
+
+### `agent-react-devtools errors`
+
+List all components that have non-zero error or warning counts. React tracks console errors and warnings per component; this command surfaces them.
+
+Output example:
+
+```
+@c5 [fn] Form ⚠2 ✗1
+@c8 [fn] Input ✗3
+```
+
+`⚠N` = N warnings, `✗N` = N errors. Returns "No components with errors or warnings" when everything is clean.
+
+Error/warning annotations also appear in `get tree`, `get component`, and `find` output when counts are non-zero.
+
+## Profiling
+
+### `agent-react-devtools profile start [name]`
+
+Start a profiling session. Optional name for identification. Only one session can be active at a time.
+
+### `agent-react-devtools profile stop`
+
+Stop profiling and collect data from React. Shows a summary with duration, commit count, and top rendered components.
+
+### `agent-react-devtools profile slow [--limit N]`
+
+Rank components by average render duration (slowest first). Default limit: 10.
+
+Output columns: label, type tag, component name, avg duration, max duration, render count, all causes, changed keys.
+
+### `agent-react-devtools profile rerenders [--limit N]`
+
+Rank components by render count (most re-renders first). Default limit: 10.
+
+Output columns: label, type tag, component name, render count, all causes, changed keys.
+
+### `agent-react-devtools profile report <@cN | id>`
+
+Detailed render report for a single component: render count, avg/max/total duration, all render causes, changed keys.
+
+### `agent-react-devtools profile timeline [--limit N] [--offset N] [--sort duration|timeline]`
+
+Chronological list of React commits during the profiling session. Each entry: index, duration, component count. Default limit: 20.
+
+The header shows how many commits were returned and the total: `Commit timeline (showing 1–20 of 87):`. When all commits fit, it shows `Commit timeline (42 commits):`.
+
+Default order is chronological (timeline order). `--sort duration` re-orders entries by duration descending (most expensive first) before applying `--limit` — use this to find the heaviest commits. `--sort timeline` explicitly requests chronological order (same as the default).
+
+`--offset N` skips the first N entries (after sorting). Use with `--limit` to page through commits or skip a known-good warm-up region.
+
+### `agent-react-devtools profile commit <N | #N> [--limit N]`
+
+Detail for a specific commit by index. Shows per-component self/total duration, render causes, and changed keys.
+
+### `agent-react-devtools profile export <file>`
+
+Export profiling data as a JSON file importable in the React DevTools Profiler tab. The file can also be used as input to `profile diff`. Requires an active or recently stopped profiling session.
+
+### `agent-react-devtools profile diff <before.json> <after.json> [--limit N] [--threshold N]`
+
+Compare two exported profiling sessions and show regressed, improved, new, and removed components. Default threshold: 5% — changes below this percentage are not reported. Use `--limit N` to cap the number of components shown per category. Does **not** require the daemon to be running.
+
+### Changed Keys
+
+When React DevTools reports which specific props, state keys, or hooks triggered a re-render, profiling commands append a `changed:` suffix:
+
+```
+changed: props: onClick, className  state: count  hooks: #0
+```
+
+Categories with no changes are omitted. Keys are deduplicated across commits in aggregate reports (`profile slow`, `profile rerenders`, `profile report`).
+
+## Setup
+
+### `agent-react-devtools init [--dry-run]`
+
+Auto-detect the framework in the current directory and configure the devtools connection. Supports Vite, Next.js, CRA, and Expo/React Native.
+
+Use `--dry-run` to preview changes without writing files.

--- a/.agents/skills/react-devtools/references/profiling-guide.md
+++ b/.agents/skills/react-devtools/references/profiling-guide.md
@@ -1,0 +1,152 @@
+# Profiling Guide
+
+## Quick Start
+
+```bash
+agent-react-devtools profile start
+# Trigger the slow interaction (type, click, navigate)
+agent-react-devtools profile stop
+agent-react-devtools profile slow --limit 5
+```
+
+## Step-by-Step Workflow
+
+### 1. Establish a Baseline
+
+Before profiling, check the current state:
+
+```bash
+agent-react-devtools status          # Confirm app is connected
+agent-react-devtools count           # How many components are mounted
+agent-react-devtools get tree --depth 3  # Understand the structure
+```
+
+### 2. Profile the Interaction
+
+Start profiling, then trigger the specific interaction the user reports as slow:
+
+```bash
+agent-react-devtools profile start "typing in search"
+```
+
+The user should perform the interaction now. If using agent-browser, you can drive the interaction programmatically.
+
+```bash
+agent-react-devtools profile stop
+```
+
+### 3. Identify Bottlenecks
+
+**Slowest components** — which components take the most time per render:
+
+```bash
+agent-react-devtools profile slow --limit 5
+```
+
+**Most re-rendered** — which components render too often:
+
+```bash
+agent-react-devtools profile rerenders --limit 5
+```
+
+These two views complement each other:
+
+- A component that renders 100 times at 0.1ms each = 10ms total (re-render problem)
+- A component that renders 2 times at 50ms each = 100ms total (slow render problem)
+
+### 4. Drill Into Specific Components
+
+Once you identify a suspect, get its full render report:
+
+```bash
+agent-react-devtools profile report @c12
+```
+
+This shows all render causes and the specific changed keys (e.g. `changed: props: onClick, className  state: count`). Use the changed keys to pinpoint exactly what to stabilize or investigate. Common patterns:
+
+| Cause             | Changed keys example    | Meaning                                  | Typical Fix                                                       |
+| ----------------- | ----------------------- | ---------------------------------------- | ----------------------------------------------------------------- |
+| `parent-rendered` | _(none)_                | Parent re-rendered, child has no bailout | Wrap child in `React.memo()`                                      |
+| `props-changed`   | `props: onClick, style` | Received new prop references             | Stabilize the listed props with `useMemo`/`useCallback` in parent |
+| `state-changed`   | `state: count, filter`  | Component's own state changed            | Check if the listed state updates are necessary                   |
+| `hooks-changed`   | `hooks: #0, #2`         | A hook dependency changed                | Review deps of the listed hooks (by index)                        |
+| `first-mount`     | _(none)_                | Initial render                           | Normal — not a problem                                            |
+
+### 5. Inspect the Component
+
+Read the component's current props and hooks to understand what's changing:
+
+```bash
+agent-react-devtools get component @c12
+```
+
+Look for:
+
+- Function props (`ƒ`) — likely unstable references if not wrapped in `useCallback`
+- Object/array props — likely new references if not wrapped in `useMemo`
+- State that updates too frequently
+
+### 6. Fix and Verify
+
+After applying the fix, re-profile with the same interaction:
+
+```bash
+agent-react-devtools profile start "after fix"
+# Same interaction
+agent-react-devtools profile stop
+agent-react-devtools profile slow --limit 5
+```
+
+Compare render counts and durations to confirm improvement.
+
+## Export and Diff Workflow
+
+### Export Profiling Data
+
+After stopping a profiling session, export the data to a JSON file. This file can be imported into the React DevTools Profiler tab for visual analysis, or used as input to `profile diff`.
+
+```bash
+agent-react-devtools profile stop
+agent-react-devtools profile export baseline.json
+```
+
+### Compare Two Profiling Sessions
+
+To identify regressions or verify improvements, export profiles before and after a change, then diff them:
+
+```bash
+# Before the change
+agent-react-devtools profile start "before"
+# ... interact with the app ...
+agent-react-devtools profile stop
+agent-react-devtools profile export before.json
+
+# After the change
+agent-react-devtools profile start "after"
+# ... same interaction ...
+agent-react-devtools profile stop
+agent-react-devtools profile export after.json
+
+# Compare
+agent-react-devtools profile diff before.json after.json
+```
+
+The diff shows regressed, improved, new, and removed components. Use `--threshold` to adjust sensitivity (default: 5%) and `--limit` to cap the number of components per category.
+
+## Common Performance Issues
+
+### Cascading re-renders from context or lifted state
+
+A parent component re-renders (e.g., from a timer or context change) and all children re-render because none use `React.memo`. Look for high re-render counts with `parent-rendered` cause.
+
+### Unstable prop references
+
+Parent passes `onClick={() => ...}` or `style={{...}}` inline — creates new references every render, defeating `memo()`. The child shows `props-changed` as the cause even though the values are semantically identical. The `changed:` output tells you exactly which props are the culprits (e.g. `changed: props: onClick, style`).
+
+### Expensive computations without memoization
+
+A component does heavy work (filtering, sorting, formatting) on every render. Shows up as high avg render time. Fix with `useMemo`.
+
+### State updates in effects causing render loops
+
+An effect updates state on every render, causing unnecessary commit cycles. Look for unusually high commit counts in `profile timeline`.

--- a/.agents/skills/react-devtools/references/setup.md
+++ b/.agents/skills/react-devtools/references/setup.md
@@ -1,0 +1,120 @@
+# Setup Guide
+
+agent-react-devtools works with any React or React Native app. The `init` command auto-detects your framework and configures everything.
+
+## Auto Setup (Recommended)
+
+```bash
+cd your-react-app
+npx agent-react-devtools init
+```
+
+This detects the framework and applies the minimal configuration needed.
+
+Use `--dry-run` to preview changes without modifying files:
+
+```bash
+npx agent-react-devtools init --dry-run
+```
+
+## Framework-Specific Details
+
+### Vite
+
+`init` adds the Vite plugin to your config:
+
+```ts
+// vite.config.ts
+import {reactDevtools} from 'agent-react-devtools/vite'
+
+export default defineConfig({
+  plugins: [reactDevtools(), react()],
+})
+```
+
+The plugin only runs in dev mode (`vite dev`). It injects the connect script before your app code loads. Zero app code changes needed.
+
+### Next.js (App Router)
+
+`init` creates a client component that imports the connect script and adds it to your root layout:
+
+```tsx
+// app/devtools.tsx
+'use client'
+import 'agent-react-devtools/connect'
+export default function DevTools() {
+  return null
+}
+```
+
+Then imports it in `app/layout.tsx`.
+
+### Create React App
+
+`init` prepends the import to `src/index.tsx`:
+
+```ts
+import 'agent-react-devtools/connect'
+```
+
+### React Native / Expo
+
+React Native apps auto-connect to the devtools WebSocket on port 8097 — no code changes needed.
+
+```bash
+agent-react-devtools start
+npx react-native start
+# or: npx expo start
+```
+
+For physical devices, reverse the port:
+
+```bash
+adb reverse tcp:8097 tcp:8097
+```
+
+## Manual Setup
+
+If `init` doesn't cover your setup, add this as the first import in your entry point:
+
+```ts
+import 'agent-react-devtools/connect'
+```
+
+The connect script is:
+
+- **SSR-safe** — no-ops on the server
+- **Production-safe** — tree-shaken in production builds
+- Connects via WebSocket with a 2-second timeout
+
+## Verifying the Connection
+
+```bash
+agent-react-devtools status
+```
+
+Expected output when connected:
+
+```
+Daemon: running (port 8097)
+Apps: 1 connected, 42 components
+```
+
+If `Apps: 0 connected`:
+
+1. Check the app is running in dev mode
+2. Check the console for WebSocket connection errors
+3. Ensure no other DevTools instance is using port 8097
+4. If using `agent-browser`, make sure you're using **headed mode** (`--headed`) — headless Chromium does not properly execute the devtools connect script
+
+## Using with agent-browser
+
+When automating the browser with `agent-browser`, you must use headed mode. Headless Chromium handles ES module script execution differently, which prevents the connect script from installing the devtools hook before React loads.
+
+```bash
+# Headed mode is required for devtools to connect
+agent-browser --session devtools --headed open http://localhost:5173/
+
+# Verify connection
+agent-react-devtools status
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ pnpm --filter sanity-test-studio exec agent-react-devtools profile rerenders --l
 How it works and gotchas:
 
 - `ENABLE_REACT_DEVTOOLS=true` makes `dev/test-studio/sanity.cli.ts` add the `reactDevtools()` Vite plugin, which injects an `agent-react-devtools/connect` script that wires `react-devtools-core` to the daemon's WebSocket. Dev-server only (`apply: 'serve'`) — it can never reach `sanity build` output.
-- The flag also disables `unstable_bundledDev` so the connect script runs before the app bundle in a plain module graph. Expect one or two "Outdated Optimize Dep" reloads on first navigation after a restart (the classic dev-mode waterfall).
+- The flag currently also disables `unstable_bundledDev`, which crashes on load in this setup (being fixed separately). Expect one or two "Outdated Optimize Dep" reloads on first navigation after a restart (the classic dev-mode waterfall).
 - **The browser must be headed.** Headless Chromium does not execute the injected module script properly, so the app never registers with the daemon. On the Cloud VM, drive system Chrome via Playwright with `headless: false` (a display is available), and authenticate by appending `#token=$STUDIO_AUTH_TOKEN` to the URL from inside the script (keeps the secret out of logs).
 - Profile with StrictMode off (`SANITY_STUDIO_REACT_STRICT_MODE=false`) so dev double-rendering doesn't inflate durations — production studios don't run StrictMode.
 - Do not run `pnpm check:oxlint` while the dev studio and daemon are running (same memory constraint as noted in the Cursor Cloud gotchas).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,35 @@ How it works:
 - The flag is declared in `dev/test-studio/turbo.json` so turbo-cached builds are invalidated when it changes
 - Enabling devtools makes `sanity build` noticeably slower; that's why it's opt-in via the env flag
 
+### Profiling studio re-renders with React DevTools (agent-react-devtools)
+
+The test studio can register with a local [agent-react-devtools](https://github.com/callstackincubator/agent-react-devtools) daemon, which exposes the React component tree and render profiling over a CLI — made for AI agents to inspect props/state/hooks and hunt unnecessary re-renders. The `react-devtools` skill (`.agents/skills/react-devtools/SKILL.md`) documents the CLI; read it before profiling.
+
+```bash
+# 1. Start the daemon (port 8097)
+pnpm --filter sanity-test-studio exec agent-react-devtools start
+
+# 2. Start the studio with the connect script injected (implies ENABLE_REACT_DEVTOOLS=true)
+pnpm react-devtools:test-studio
+
+# 3. Open http://localhost:3333 in a browser, then verify the app registered
+pnpm --filter sanity-test-studio exec agent-react-devtools status
+
+# 4. Profile an interaction
+pnpm --filter sanity-test-studio exec agent-react-devtools profile start
+# ... interact with the studio ...
+pnpm --filter sanity-test-studio exec agent-react-devtools profile stop
+pnpm --filter sanity-test-studio exec agent-react-devtools profile rerenders --limit 10
+```
+
+How it works and gotchas:
+
+- `ENABLE_REACT_DEVTOOLS=true` makes `dev/test-studio/sanity.cli.ts` add the `reactDevtools()` Vite plugin, which injects an `agent-react-devtools/connect` script that wires `react-devtools-core` to the daemon's WebSocket. Dev-server only (`apply: 'serve'`) — it can never reach `sanity build` output.
+- The flag also disables `unstable_bundledDev` so the connect script runs before the app bundle in a plain module graph. Expect one or two "Outdated Optimize Dep" reloads on first navigation after a restart (the classic dev-mode waterfall).
+- **The browser must be headed.** Headless Chromium does not execute the injected module script properly, so the app never registers with the daemon. On the Cloud VM, drive system Chrome via Playwright with `headless: false` (a display is available), and authenticate by appending `#token=$STUDIO_AUTH_TOKEN` to the URL from inside the script (keeps the secret out of logs).
+- Profile with StrictMode off (`SANITY_STUDIO_REACT_STRICT_MODE=false`) so dev double-rendering doesn't inflate durations — production studios don't run StrictMode.
+- Do not run `pnpm check:oxlint` while the dev studio and daemon are running (same memory constraint as noted in the Cursor Cloud gotchas).
+
 ### Analyzing the `sanity` package bundle
 
 The `sanity` package tsdown build can emit a Rolldown [bundle analyzer](https://rolldown.rs/builtin-plugins/bundle-analyzer) markdown report (module/chunk breakdown for humans and coding agents) when `ENABLE_BUNDLE_ANALYZER=true`:

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -69,8 +69,10 @@
     "@vitejs/devtools-oxc": "^0.6.2",
     "@vitejs/devtools-rolldown": "^0.6.2",
     "@vitejs/devtools-vite": "^0.6.2",
+    "agent-react-devtools": "^0.4.0",
     "chokidar": "^5.0.0",
     "oxc-transform-react": "catalog:",
+    "react-devtools-core": "^7.0.1",
     "rimraf": "catalog:",
     "tsx": "^4.23.13",
     "vite": "catalog:"

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -8,6 +8,12 @@ const isStaging = process.env.SANITY_INTERNAL_ENV == 'staging'
 // the DevTools dock in a running `sanity dev` server without restarting it.
 // Usage: `pnpm devtools:test-studio` from the repo root (see AGENTS.md).
 const isViteDevToolsEnabled = process.env.ENABLE_VITE_DEVTOOLS === 'true'
+// Injects the agent-react-devtools connect script so the studio registers with a local
+// React DevTools daemon (`agent-react-devtools start`) for component inspection and render
+// profiling — used by AI agents via the react-devtools skill (.agents/skills/react-devtools).
+// Dev-server only (the plugin is `apply: 'serve'`), so it can never leak into builds.
+// Usage: `pnpm react-devtools:test-studio` from the repo root (see AGENTS.md).
+const isReactDevtoolsEnabled = process.env.ENABLE_REACT_DEVTOOLS === 'true'
 
 export default defineCliConfig({
   api: isStaging
@@ -28,7 +34,10 @@ export default defineCliConfig({
   // trigger the monorepo "waterfall of reload doom", which previously required
   // server.warmup.clientFiles workarounds.
   // {@link https://vite.dev/guide/rolldown#full-bundle-mode}
-  unstable_bundledDev: true,
+  // Disabled while profiling with agent-react-devtools: the injected connect script must run
+  // before the app bundle, and classic dev mode keeps the module graph closer to what the
+  // React DevTools hook expects.
+  unstable_bundledDev: process.env.ENABLE_REACT_DEVTOOLS !== 'true',
   reactCompiler: {
     // `transform: 'oxc'` runs React Compiler through `oxc-transform-react` (the native Rust
     // port): one native pass handles React Compiler, TypeScript/JSX and Fast Refresh — no babel
@@ -59,6 +68,12 @@ export default defineCliConfig({
         // `devtools: {}` makes `sanity build` emit a Rolldown build session that the DevTools dock can inspect
         build: {rolldownOptions: {devtools: {}}},
       })
+    }
+
+    if (isReactDevtoolsEnabled) {
+      // Lazy import so the devtools package is only loaded when the flag is enabled
+      const {reactDevtools} = await import('agent-react-devtools/vite')
+      nextConfig = mergeConfig(nextConfig, {plugins: [reactDevtools()]})
     }
 
     // Support React Production Profiling on deployed studios

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -8,11 +8,7 @@ const isStaging = process.env.SANITY_INTERNAL_ENV == 'staging'
 // the DevTools dock in a running `sanity dev` server without restarting it.
 // Usage: `pnpm devtools:test-studio` from the repo root (see AGENTS.md).
 const isViteDevToolsEnabled = process.env.ENABLE_VITE_DEVTOOLS === 'true'
-// Injects the agent-react-devtools connect script so the studio registers with a local
-// React DevTools daemon (`agent-react-devtools start`) for component inspection and render
-// profiling — used by AI agents via the react-devtools skill (.agents/skills/react-devtools).
-// Dev-server only (the plugin is `apply: 'serve'`), so it can never leak into builds.
-// Usage: `pnpm react-devtools:test-studio` from the repo root (see AGENTS.md).
+// React DevTools profiling via agent-react-devtools. Usage: `pnpm react-devtools:test-studio` (see AGENTS.md).
 const isReactDevtoolsEnabled = process.env.ENABLE_REACT_DEVTOOLS === 'true'
 
 export default defineCliConfig({
@@ -34,9 +30,7 @@ export default defineCliConfig({
   // trigger the monorepo "waterfall of reload doom", which previously required
   // server.warmup.clientFiles workarounds.
   // {@link https://vite.dev/guide/rolldown#full-bundle-mode}
-  // Disabled while profiling with agent-react-devtools: the injected connect script must run
-  // before the app bundle, and classic dev mode keeps the module graph closer to what the
-  // React DevTools hook expects.
+  // TODO(bundledDev): re-enable while profiling once bundledDev stops crashing on load.
   unstable_bundledDev: process.env.ENABLE_REACT_DEVTOOLS !== 'true',
   reactCompiler: {
     // `transform: 'oxc'` runs React Compiler through `oxc-transform-react` (the native Rust
@@ -71,7 +65,6 @@ export default defineCliConfig({
     }
 
     if (isReactDevtoolsEnabled) {
-      // Lazy import so the devtools package is only loaded when the flag is enabled
       const {reactDevtools} = await import('agent-react-devtools/vite')
       nextConfig = mergeConfig(nextConfig, {plugins: [reactDevtools()]})
     }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "prepublishOnly": "pnpm build",
     "publish:tarball": "tsx scripts/publish/tarball.ts",
     "radar": "pnpm --filter radar dev",
+    "react-devtools:test-studio": "ENABLE_REACT_DEVTOOLS=true pnpm dev:test-studio:studio",
     "start": "pnpm dev",
     "test": "pnpm test:vitest",
     "test:changed": "vitest --changed",

--- a/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
+++ b/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
@@ -78,16 +78,24 @@ const DivergencesProviderEnabled: ComponentType<PropsEnabled> = ({
     ? editState.published
     : (editState.version ?? editState.draft)
 
-  const collatedDivergences =
-    !hasUpstreamVersion || typeof upstreamId === 'undefined' || typeof subjectId === 'undefined'
-      ? {
-          context: new Subject<FindDivergencesContext>(),
-          observable: of(collateDocumentDivergencesInitialState),
-        }
-      : collateDocumentDivergences({
-          subjectId: subjectId,
-          upstreamId: upstreamId,
-        })
+  // Memoized because the no-upstream branch constructs a fresh Subject/observable pair, which
+  // React Compiler cannot memoize (constructor call). Without this, every render — e.g. each
+  // keystroke updating `editState`/`formState` — hands `useDivergenceNavigator` a new
+  // `divergences` observable, rebuilding and resubscribing its whole state pipeline (including
+  // a `transposeSchema` pass) and pushing a new context value to every divergence consumer.
+  const collatedDivergences = useMemo(
+    () =>
+      !hasUpstreamVersion || typeof upstreamId === 'undefined' || typeof subjectId === 'undefined'
+        ? {
+            context: new Subject<FindDivergencesContext>(),
+            observable: of(collateDocumentDivergencesInitialState),
+          }
+        : collateDocumentDivergences({
+            subjectId: subjectId,
+            upstreamId: upstreamId,
+          }),
+    [hasUpstreamVersion, upstreamId, subjectId],
+  )
 
   useCollateDivergencesContext({
     upstreamHead,

--- a/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
+++ b/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
@@ -78,11 +78,6 @@ const DivergencesProviderEnabled: ComponentType<PropsEnabled> = ({
     ? editState.published
     : (editState.version ?? editState.draft)
 
-  // Memoized because the no-upstream branch constructs a fresh Subject/observable pair, which
-  // React Compiler cannot memoize (constructor call). Without this, every render — e.g. each
-  // keystroke updating `editState`/`formState` — hands `useDivergenceNavigator` a new
-  // `divergences` observable, rebuilding and resubscribing its whole state pipeline (including
-  // a `transposeSchema` pass) and pushing a new context value to every divergence consumer.
   const collatedDivergences = useMemo(
     () =>
       !hasUpstreamVersion || typeof upstreamId === 'undefined' || typeof subjectId === 'undefined'

--- a/packages/sanity/src/core/store/presence/useGlobalPresence.tsx
+++ b/packages/sanity/src/core/store/presence/useGlobalPresence.tsx
@@ -1,12 +1,25 @@
+import {dequal} from 'dequal/lite'
+import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
+import {distinctUntilChanged, map} from 'rxjs'
 
 import {usePresenceStore} from '../datastores'
 import {type GlobalPresence} from './types'
 
-const initial: GlobalPresence[] = []
+type GlobalPresenceEntry = Pick<GlobalPresence, 'user' | 'locations'>
+
+const initial: GlobalPresenceEntry[] = []
 
 /** @internal */
-export function useGlobalPresence(): GlobalPresence[] {
+export function useGlobalPresence(): GlobalPresenceEntry[] {
   const presenceStore = usePresenceStore()
-  return useObservable(presenceStore.globalPresence$, initial)
+  const presence$ = useMemo(
+    () =>
+      presenceStore.globalPresence$.pipe(
+        map((presence) => presence.map(({user, locations}) => ({user, locations}))),
+        distinctUntilChanged<GlobalPresenceEntry[]>(dequal),
+      ),
+    [presenceStore],
+  )
+  return useObservable(presence$, initial)
 }

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -2,7 +2,10 @@ import {AddUserIcon} from '@sanity/icons/AddUser'
 import {UsersIcon} from '@sanity/icons/Users'
 import {Stack, Text} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
+import isEqual from 'lodash-es/isEqual.js'
 import {useCallback, useMemo, useState} from 'react'
+import {useObservable} from 'react-rx'
+import {distinctUntilChanged, map} from 'rxjs'
 import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
@@ -10,7 +13,8 @@ import {MenuButton, type MenuButtonProps} from '../../../../../ui-components/men
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {StatusButton} from '../../../../components/StatusButton'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
-import {useGlobalPresence} from '../../../../store/presence/useGlobalPresence'
+import {usePresenceStore} from '../../../../store/datastores'
+import {type GlobalPresence} from '../../../../store/presence/types'
 import {useColorSchemeValue} from '../../../colorScheme'
 import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {useWorkspace} from '../../../workspace'
@@ -27,8 +31,27 @@ const FooterStack = styled(Stack)`
   background-color: var(--card-bg-color);
 `
 
+type PresenceMenuEntry = Pick<GlobalPresence, 'user' | 'locations'>
+
+const EMPTY_PRESENCE: PresenceMenuEntry[] = []
+
 export function PresenceMenu() {
-  const presence = useGlobalPresence()
+  const presenceStore = usePresenceStore()
+  // `globalPresence$` re-emits — with only a fresh session-level `lastActiveAt` — for every
+  // presence heartbeat any other studio session sends (every few seconds on busy projects).
+  // Project the stream down to the fields this menu renders and drop identical emissions so
+  // heartbeats don't re-render the menu and its (mounted-while-closed) popover subtree.
+  const presence$ = useMemo(
+    () =>
+      presenceStore.globalPresence$.pipe(
+        map((presenceList) =>
+          presenceList.map(({user, locations}): PresenceMenuEntry => ({user, locations})),
+        ),
+        distinctUntilChanged<PresenceMenuEntry[]>(isEqual),
+      ),
+    [presenceStore],
+  )
+  const presence = useObservable(presence$, EMPTY_PRESENCE)
   const {projectId} = useWorkspace()
   const scheme = useColorSchemeValue()
   const {t} = useTranslation()

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -2,10 +2,7 @@ import {AddUserIcon} from '@sanity/icons/AddUser'
 import {UsersIcon} from '@sanity/icons/Users'
 import {Stack, Text} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
-import isEqual from 'lodash-es/isEqual.js'
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
-import {distinctUntilChanged, map} from 'rxjs'
 import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
@@ -13,8 +10,7 @@ import {MenuButton, type MenuButtonProps} from '../../../../../ui-components/men
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {StatusButton} from '../../../../components/StatusButton'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
-import {usePresenceStore} from '../../../../store/datastores'
-import {type GlobalPresence} from '../../../../store/presence/types'
+import {useGlobalPresence} from '../../../../store/presence/useGlobalPresence'
 import {useColorSchemeValue} from '../../../colorScheme'
 import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {useWorkspace} from '../../../workspace'
@@ -31,27 +27,8 @@ const FooterStack = styled(Stack)`
   background-color: var(--card-bg-color);
 `
 
-type PresenceMenuEntry = Pick<GlobalPresence, 'user' | 'locations'>
-
-const EMPTY_PRESENCE: PresenceMenuEntry[] = []
-
 export function PresenceMenu() {
-  const presenceStore = usePresenceStore()
-  // `globalPresence$` re-emits — with only a fresh session-level `lastActiveAt` — for every
-  // presence heartbeat any other studio session sends (every few seconds on busy projects).
-  // Project the stream down to the fields this menu renders and drop identical emissions so
-  // heartbeats don't re-render the menu and its (mounted-while-closed) popover subtree.
-  const presence$ = useMemo(
-    () =>
-      presenceStore.globalPresence$.pipe(
-        map((presenceList) =>
-          presenceList.map(({user, locations}): PresenceMenuEntry => ({user, locations})),
-        ),
-        distinctUntilChanged<PresenceMenuEntry[]>(isEqual),
-      ),
-    [presenceStore],
-  )
-  const presence = useObservable(presence$, EMPTY_PRESENCE)
+  const presence = useGlobalPresence()
   const {projectId} = useWorkspace()
   const scheme = useColorSchemeValue()
   const {t} = useTranslation()

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
@@ -1,5 +1,5 @@
 import {type ClientError, type SanityClient} from '@sanity/client'
-import isEqual from 'lodash-es/isEqual.js'
+import {dequal} from 'dequal/lite'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {combineLatest, concat, EMPTY, fromEvent, type Observable, of, timer} from 'rxjs'
@@ -157,10 +157,7 @@ export function fetchCrossDatasetReferences(
           }),
         )
     }),
-    // Every poll tick produces a fresh response object even when the references are unchanged.
-    // Drop identical results so consumers (e.g. the incoming-reference decorations, which turn
-    // each emission into a new promise and re-render their subtree) only update on real changes.
-    distinctUntilChanged(isEqual),
+    distinctUntilChanged(dequal),
   )
 }
 

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
@@ -1,4 +1,5 @@
 import {type ClientError, type SanityClient} from '@sanity/client'
+import isEqual from 'lodash-es/isEqual.js'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {combineLatest, concat, EMPTY, fromEvent, type Observable, of, timer} from 'rxjs'
@@ -156,6 +157,10 @@ export function fetchCrossDatasetReferences(
           }),
         )
     }),
+    // Every poll tick produces a fresh response object even when the references are unchanged.
+    // Drop identical results so consumers (e.g. the incoming-reference decorations, which turn
+    // each emission into a new promise and re-render their subtree) only update on real changes.
+    distinctUntilChanged(isEqual),
   )
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -914,9 +914,15 @@ importers:
       '@vitejs/devtools-vite':
         specifier: ^0.6.2
         version: 0.6.2(cac@7.0.0)(crossws@0.4.12)(srvx@0.12.7)(vite@8.2.2)
+      agent-react-devtools:
+        specifier: ^0.4.0
+        version: 0.4.0(react-devtools-core@7.0.1)(supports-color@8.1.1)(vite@8.2.2)
       oxc-transform-react:
         specifier: 'catalog:'
         version: 0.148.0
+      react-devtools-core:
+        specifier: ^7.0.1
+        version: 7.0.1
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -967,7 +973,7 @@ importers:
         version: link:../tsconfig
       '@sanity/ailf':
         specifier: ^7.36.0
-        version: 7.36.0(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(socks@2.8.9)(supports-color@8.1.1)
+        version: 7.36.0(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(react-devtools-core@7.0.1)(socks@2.8.9)(supports-color@8.1.1)
       sanity:
         specifier: workspace:*
         version: link:../../sanity
@@ -8925,6 +8931,18 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agent-react-devtools@0.4.0:
+    resolution: {integrity: sha512-nq5VgJH/lRJOGd1kCQW3+hjzNLfv4vYrhZtpC5k554MthTGJnZ9PqVZf6tx5N++YVJsWUsyuDG/S2nOfUlHi0Q==}
+    hasBin: true
+    peerDependencies:
+      react-devtools-core: '>=5.0.0'
+      vite: '>=5.0.0'
+    peerDependenciesMeta:
+      react-devtools-core:
+        optional: true
+      vite:
+        optional: true
+
   ai@6.0.272:
     resolution: {integrity: sha512-GSyvGAKp3U1hl6sGMLbdKiLQLPCzewCZGZtY1SmjPUcPbmwn2IjWQgoT+2c3DRLcsvfY0ifuw+8Dy5N/QFd7Ew==}
     engines: {node: '>=18'}
@@ -13021,6 +13039,9 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
 
+  react-devtools-core@7.0.1:
+    resolution: {integrity: sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==}
+
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
@@ -14728,6 +14749,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -17815,6 +17848,28 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.5)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.7.0(express@5.2.1)(supports-color@8.1.1)
+      hono: 4.13.5
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.5.4)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.5)
@@ -19266,7 +19321,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.14.0
 
-  '@sanity/ailf@7.36.0(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(socks@2.8.9)(supports-color@8.1.1)':
+  '@sanity/ailf@7.36.0(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(react-devtools-core@7.0.1)(socks@2.8.9)(supports-color@8.1.1)':
     dependencies:
       '@google-cloud/bigquery': 8.3.1(supports-color@8.1.1)
       '@google-cloud/storage': 7.22.0(supports-color@8.1.1)
@@ -19284,7 +19339,7 @@ snapshots:
       jiti: 2.7.0
       js-yaml: 4.3.2
       oxc-parser: 0.129.0
-      promptfoo: 0.120.27(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(socks@2.8.9)(supports-color@8.1.1)
+      promptfoo: 0.120.27(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(react-devtools-core@7.0.1)(socks@2.8.9)(supports-color@8.1.1)
       zod: 4.5.4
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -21916,6 +21971,20 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agent-react-devtools@0.4.0(react-devtools-core@7.0.1)(supports-color@8.1.1)(vite@8.2.2):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@8.1.1)(zod@3.25.76)
+      ws: 8.21.3
+      zod: 3.25.76
+    optionalDependencies:
+      react-devtools-core: 7.0.1
+      vite: 8.2.2(@types/node@24.13.3)(@vitejs/devtools@0.6.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   ai@6.0.272(zod@4.5.4):
     dependencies:
       '@ai-sdk/gateway': 3.0.185(zod@4.5.4)
@@ -24242,7 +24311,7 @@ snapshots:
 
   ini@5.0.0: {}
 
-  ink@6.8.0(@types/react@19.2.18)(react@19.2.8):
+  ink@6.8.0(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.2.5
       ansi-escapes: 7.3.0
@@ -24272,6 +24341,7 @@ snapshots:
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.18
+      react-devtools-core: 7.0.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -26005,7 +26075,7 @@ snapshots:
 
   promisepipe@3.0.0: {}
 
-  promptfoo@0.120.27(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(socks@2.8.9)(supports-color@8.1.1):
+  promptfoo@0.120.27(@aws-sdk/credential-provider-node@3.972.81)(@noble/hashes@2.4.0)(@smithy/signature-v4@5.7.3)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.18)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.23.0)(playwright-core@1.62.1)(react-devtools-core@7.0.1)(socks@2.8.9)(supports-color@8.1.1):
     dependencies:
       '@anthropic-ai/sdk': 0.78.0(zod@4.5.4)
       '@apidevtools/json-schema-ref-parser': 15.5.2(@types/json-schema@7.0.15)
@@ -26057,7 +26127,7 @@ snapshots:
       gcp-metadata: 8.1.4(supports-color@8.1.1)
       glob: 13.0.6
       http-z: 8.1.1
-      ink: 6.8.0(@types/react@19.2.18)(react@19.2.8)
+      ink: 6.8.0(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
       istextorbinary: 9.5.0
       jks-js: 1.1.7
       js-rouge: 3.2.1
@@ -26383,6 +26453,14 @@ snapshots:
   react-compiler-runtime@1.0.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  react-devtools-core@7.0.1:
+    dependencies:
+      shell-quote: 1.10.0
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   react-docgen-typescript@2.4.0(typescript@7.0.2):
     dependencies:
@@ -28229,6 +28307,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@7.5.13: {}
+
   ws@8.21.0: {}
 
   ws@8.21.3: {}
@@ -28368,6 +28448,10 @@ snapshots:
       '@yuku-parser/binding-win32-x64': 0.9.3
 
   zigpty@0.2.1: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-to-json-schema@3.25.2(zod@4.5.4):
     dependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -42,6 +42,12 @@
       "sourceType": "git",
       "computedHash": "b05fe3315ddf338551a759618f7f682ab6baf33184f97bbd65ef31826b0eab5a"
     },
+    "react-devtools": {
+      "source": "callstackincubator/agent-react-devtools",
+      "sourceType": "github",
+      "skillPath": "packages/agent-react-devtools/skills/react-devtools/SKILL.md",
+      "computedHash": "f914845954227725e3a2e8504e10779e79c1adde046b43c9046bf49e7ef262d1"
+    },
     "rxjs-like-a-pro": {
       "source": "bjoerge/rxjs-skills",
       "sourceType": "github",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Sets up agent-driven React DevTools profiling for the test studio and fixes the three sources of useless re-renders it surfaced. The studio re-rendered constantly while fully idle: every presence heartbeat from any other session (~every 2s on busy projects) re-rendered the navbar presence menu and its popover subtree, and the 5-second cross-dataset reference poll re-rendered a ~22-component card subtree to display identical results. While typing, the unmemoized `collatedDivergences` in `DivergencesProviderEnabled` handed `useDivergenceNavigator` a new observable every render, which rebuilt and resubscribed the divergence-navigator pipeline (including a `transposeSchema` pass) on every keystroke.

Profiling setup follows the existing `ENABLE_VITE_DEVTOOLS` pattern: an env-gated Vite plugin in `dev/test-studio/sanity.cli.ts` (dev-server only), a `pnpm react-devtools:test-studio` root script, the `react-devtools` skill vendored via the skills CLI, and an AGENTS.md section documenting the workflow. Equality checks use `dequal/lite`, following #14501.

Alternatives considered:

- Deduping `globalPresence$` with a full deep-equal in the store: the session-level `lastActiveAt` changes on every heartbeat, so nothing would be dropped. Instead `useGlobalPresence` (whose only consumer is the navbar menu) projects to `{user, locations}`, which is all the menu renders, and dedupes that.
- Deduping cross-dataset results at the end of `getCrossDatasetIncomingReferences`: the final objects embed JSX (`media` icons), where deep equality is unsafe; deduping the raw JSON poll results in `fetchCrossDatasetReferences` catches it for all consumers.

Measured before/after (agent-react-devtools, dev mode, StrictMode off):

| Case | Before | After |
| --- | --- | --- |
| Structure list, 15s idle | 25 commits | 7 commits (real presence changes only) |
| Author document, 30s idle | 35 commits | 6 commits |
| `transposeSchema` runs per 10 keystrokes | 13 | 0 |

Two follow-ups are tracked separately: the document-actions pipeline still re-resolves ~4–8 times per keystroke (`PaneHeaderActionButton` rendered 286 times in an 8s typing burst; `PublishAction` 155; the rest of the action row 121 each, all `args`/`states`/`node` identity churn), and `unstable_bundledDev` currently crashes on load (`ViteDevRuntime.loadExports` TypeError on a lazy chunk) even without the profiling plugin, which is why the profiling flag temporarily switches to classic dev mode.

### What to review

- `packages/sanity/src/core/store/presence/useGlobalPresence.tsx` — the hook now returns `Pick<GlobalPresence, 'user' | 'locations'>[]` (it is `@internal`; `PresenceMenu` is its only consumer). `locations[].lastActiveAt` only changes on real focus moves, so real changes still propagate.
- `packages/sanity/src/core/form/contexts/DivergencesProvider.tsx` — the `useMemo` dependency set (`hasUpstreamVersion`, `upstreamId`, `subjectId`); `collateDocumentDivergences` is LRU-cached per id pair, so the has-upstream branch was already stable.
- `packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts` — dedupe sits after the request `switchMap`s, so polling freshness is unchanged; only identical emissions are dropped. Also feeds the delete-confirm dialog.
- `dev/test-studio/sanity.cli.ts` — the `unstable_bundledDev` toggle under the profiling flag is temporary (see follow-up above).

Packages affected: `sanity` (runtime fixes), `sanity-test-studio` + root (profiling tooling, dev-only).

### Testing

- Profiled all three scenarios before/after with agent-react-devtools against the local dev studio (headed Chrome, authenticated, shared `ppsg7ml5/test` dataset); commit counts above.
- Verified the divergence fix mechanically with a temporary `transposeSchema` probe: 13 invocations per 10 keystrokes before, 0 after (instrumentation removed).
- `pnpm check:format` and `pnpm check:oxlint` (includes the type check) pass on the rebased tree; targeted suites pass after rebuild: presence, divergence, `confirmDeleteDialog`, navbar (38 files, 268 tests).

### Notes for release

Sanity Studio no longer re-renders parts of the UI while idle: presence heartbeats from other collaborators and the periodic cross-dataset reference check previously caused continuous unnecessary re-renders in every open studio tab. Typing in documents with advanced version control enabled no longer recomputes divergence navigation state on every keystroke. No API changes.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d4ba886-6c16-417c-a953-810427167c8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d4ba886-6c16-417c-a953-810427167c8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

