### PR TITLE
feat(comments)!: remove unstable_comments

### DIFF
--- a/dev/embedded-studio/sanity.config.ts
+++ b/dev/embedded-studio/sanity.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   dataset: 'test',
 
   document: {
-    unstable_comments: {
+    comments: {
       enabled: true,
     },
   },

--- a/packages/sanity/src/core/config/__tests__/documentCommentsEnabledReducer.test.ts
+++ b/packages/sanity/src/core/config/__tests__/documentCommentsEnabledReducer.test.ts
@@ -1,0 +1,213 @@
+import {describe, expect, it} from 'vitest'
+
+import {documentCommentsEnabledReducer} from '../configPropertyReducers'
+import {type PluginOptions} from '../types'
+
+describe('documentCommentsEnabledReducer', () => {
+  it('returns the initial value when no config is provided', () => {
+    const config: PluginOptions = {name: 'test'}
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: 'doc1', documentType: 'article'},
+      initialValue: true,
+    })
+
+    expect(result).toBe(true)
+  })
+
+  it('returns false when config sets enabled to false', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      document: {
+        comments: {
+          enabled: false,
+        },
+      },
+    }
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: 'doc1', documentType: 'article'},
+      initialValue: true,
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('returns true when config sets enabled to true', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      document: {
+        comments: {
+          enabled: true,
+        },
+      },
+    }
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: 'doc1', documentType: 'article'},
+      initialValue: false,
+    })
+
+    expect(result).toBe(true)
+  })
+
+  it('supports a function that returns true', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      document: {
+        comments: {
+          enabled: () => true,
+        },
+      },
+    }
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: 'doc1', documentType: 'article'},
+      initialValue: false,
+    })
+
+    expect(result).toBe(true)
+  })
+
+  it('supports a function that returns false', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      document: {
+        comments: {
+          enabled: () => false,
+        },
+      },
+    }
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: 'doc1', documentType: 'article'},
+      initialValue: true,
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('passes context to the function', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      document: {
+        comments: {
+          enabled: (ctx) => ctx.documentType === 'article',
+        },
+      },
+    }
+
+    expect(
+      documentCommentsEnabledReducer({
+        config,
+        context: {documentId: 'doc1', documentType: 'article'},
+        initialValue: true,
+      }),
+    ).toBe(true)
+
+    expect(
+      documentCommentsEnabledReducer({
+        config,
+        context: {documentId: 'doc1', documentType: 'page'},
+        initialValue: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('the last plugin wins when multiple plugins configure comments', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      plugins: [
+        {
+          name: 'plugin-a',
+          document: {
+            comments: {
+              enabled: true,
+            },
+          },
+        },
+        {
+          name: 'plugin-b',
+          document: {
+            comments: {
+              enabled: false,
+            },
+          },
+        },
+      ],
+    }
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: 'doc1', documentType: 'article'},
+      initialValue: true,
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('handles undefined documentId in context', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      document: {
+        comments: {
+          enabled: (ctx) => ctx.documentId === undefined,
+        },
+      },
+    }
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: undefined, documentType: 'article'},
+      initialValue: false,
+    })
+
+    expect(result).toBe(true)
+  })
+
+  it('throws when enabled is not a boolean or function', () => {
+    const config: PluginOptions = {
+      name: 'test',
+      document: {
+        comments: {
+          // @ts-expect-error -- invalid config
+          enabled: 'yes',
+        },
+      },
+    }
+
+    expect(() =>
+      documentCommentsEnabledReducer({
+        config,
+        context: {documentId: 'doc1', documentType: 'article'},
+        initialValue: true,
+      }),
+    ).toThrow(
+      'Expected `document.comments.enabled` to be a boolean or a function, but received string',
+    )
+  })
+
+  it('ignores leftover document.unstable_comments config', () => {
+    const config = {
+      name: 'test',
+      document: {
+        unstable_comments: {
+          enabled: false,
+        },
+      },
+    } as PluginOptions
+
+    const result = documentCommentsEnabledReducer({
+      config,
+      context: {documentId: 'doc1', documentType: 'article'},
+      initialValue: true,
+    })
+
+    expect(result).toBe(true)
+  })
+})

--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -697,6 +697,28 @@ describe('search strategy selection', () => {
   })
 })
 
+describe('document comments config', () => {
+  const projectId = 'ppsg7ml5'
+  const dataset = 'production'
+
+  it('resolves comments.enabled and does not expose unstable_comments', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      document: {
+        comments: {
+          enabled: false,
+        },
+      },
+    })
+
+    expect(source.document.comments.enabled({documentId: 'doc1', documentType: 'article'})).toBe(
+      false,
+    )
+    expect(source.document).not.toHaveProperty('unstable_comments')
+  })
+})
+
 function getSearchOptionsPlugin(options: PluginOptions['search']): PluginOptions {
   return definePlugin({
     name: 'sanity/search-options',

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -343,9 +343,7 @@ export const documentCommentsEnabledReducer = (opts: {
   // That is, if a plugin returns true, but the next plugin returns false, the result will be false.
   // The last plugin 'wins'.
   const result = flattenedConfig.reduce((acc, {config: innerConfig}) => {
-    const resolver =
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      innerConfig.document?.comments?.enabled ?? innerConfig.document?.unstable_comments?.enabled
+    const resolver = innerConfig.document?.comments?.enabled
 
     if (!resolver && typeof resolver !== 'boolean') return acc
     if (typeof resolver === 'function') return resolver(context)

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -814,17 +814,6 @@ function resolveSource({
           propertyName: 'document.unstable_languageFilter',
           reducer: documentLanguageFilterReducer,
         }),
-      /** @todo this is deprecated so it will eventually be removed */
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      unstable_comments: {
-        enabled: (partialContext) => {
-          return documentCommentsEnabledReducer({
-            context: partialContext,
-            config,
-            initialValue: true,
-          })
-        },
-      },
       comments: {
         enabled: (partialContext) => {
           return documentCommentsEnabledReducer({

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -334,11 +334,6 @@ export interface DocumentPluginOptions {
    */
   newDocumentOptions?: NewDocumentOptionsResolver
 
-  /** @deprecated Use `comments` instead */
-  unstable_comments?: {
-    enabled: boolean | ((context: DocumentCommentsEnabledContext) => boolean)
-  }
-
   /** @internal */
   comments?: {
     enabled: boolean | ((context: DocumentCommentsEnabledContext) => boolean)
@@ -909,11 +904,6 @@ export interface Source {
      * @beta
      */
     inspectors: (props: PartialContext<DocumentInspectorContext>) => DocumentInspector[]
-
-    /** @deprecated  Use `comments` instead */
-    unstable_comments: {
-      enabled: (props: DocumentCommentsEnabledContext) => boolean
-    }
 
     /** @internal */
     comments: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`document.unstable_comments` has been deprecated since comments GA in favor of `document.comments`. The alias has been around long enough that v7 is the right place to drop it.

This should be **merged for v7**. It is a **breaking change**.

**BREAKING CHANGE:** `document.unstable_comments` is removed from studio config and from the resolved source. Studios still using the old key must switch to `document.comments`.

```ts
// before
document: {
  unstable_comments: {enabled: true},
}

// after
document: {
  comments: {enabled: true},
}
```

Keeping the alias would leave a public deprecated path in the v7 config surface. A warning-only deprecation was already in place; remaining on it would not force the migration.

### What to review

- Config types and `prepareConfig` no longer expose `unstable_comments`
- `documentCommentsEnabledReducer` only reads `document.comments.enabled`
- Embedded studio config migrated to `document.comments`

### Testing

- Added reducer coverage for `document.comments.enabled` (boolean, function, plugin precedence, invalid values)
- Asserts leftover `document.unstable_comments` is ignored
- Asserts resolved sources expose `document.comments` and not `document.unstable_comments`

### Notes for release

**Breaking change — merge for v7.** `document.unstable_comments` is removed. Use `document.comments` instead:

```ts
export default defineConfig({
  // ...
  document: {
    comments: {
      enabled: true, // or (context) => boolean
    },
  },
})
```

Studios that still set `unstable_comments` will no longer have that config applied (comments stay enabled by default). Anyone who used the old key to *disable* comments must move that setting to `document.comments.enabled`.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9eb3bcec-f549-4541-ad0b-8234cf3439db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eb3bcec-f549-4541-ad0b-8234cf3439db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

