### PR TITLE
fix(core): enforce uniqueness validation in variant definition dialogs

### DIFF
--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -341,18 +341,22 @@ test.describe('Variants create flow', () => {
   }) => {
     const runId = createRunId('duplicate')
     const title = `${createVariantTitlePrefix()} Duplicate Keys ${runId}`
+    // Run-unique values so a leaked definition from an earlier attempt can never
+    // trip the duplicate-condition-set validation on submit.
+    const firstValue = `us-${runId}`
+    const secondValue = `fr-${runId}`
 
     await openVariantsTool(page)
     const dialog = await openCreateVariantDialog(page)
 
     await dialog.getByTestId('variant-form-title').fill(title)
-    await fillConditionRow(dialog, 0, 'audience', 'us')
+    await fillConditionRow(dialog, 0, 'audience', firstValue)
     await dialog.getByRole('button', {name: 'Add condition'}).click()
 
     const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
 
     await secondKeyInput.fill('audience')
-    await getConditionValueInputs(dialog).nth(1).fill('fr')
+    await getConditionValueInputs(dialog).nth(1).fill(secondValue)
     await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
       'Condition keys must be unique',
     )
@@ -368,8 +372,8 @@ test.describe('Variants create flow', () => {
     const document = await submitCreateVariantDialog(page, sanityClient, title)
 
     expect(document.conditions).toEqual({
-      audience: 'us',
-      audience2: 'fr',
+      audience: firstValue,
+      audience2: secondValue,
     })
   })
 
@@ -379,12 +383,16 @@ test.describe('Variants create flow', () => {
   }) => {
     const runId = createRunId('partial')
     const title = `${createVariantTitlePrefix()} Partial Key ${runId}`
+    // Run-unique values so a leaked definition from an earlier attempt can never
+    // trip the duplicate-condition-set validation on submit.
+    const firstValue = `us-${runId}`
+    const secondValue = `gb-${runId}`
 
     await openVariantsTool(page)
     const dialog = await openCreateVariantDialog(page)
 
     await dialog.getByTestId('variant-form-title').fill(title)
-    await fillConditionRow(dialog, 0, 'new', 'us')
+    await fillConditionRow(dialog, 0, 'new', firstValue)
     await dialog.getByRole('button', {name: 'Add condition'}).click()
 
     const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
@@ -401,14 +409,14 @@ test.describe('Variants create flow', () => {
     await expect(secondKeyInput).toHaveValue('newton')
     await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeHidden()
 
-    await getConditionValueInputs(dialog).nth(1).fill('gb')
+    await getConditionValueInputs(dialog).nth(1).fill(secondValue)
     await expect(dialog.getByTestId('submit-variant-button')).toBeEnabled()
 
     const document = await submitCreateVariantDialog(page, sanityClient, title)
 
     expect(document.conditions).toEqual({
-      new: 'us',
-      newton: 'gb',
+      new: firstValue,
+      newton: secondValue,
     })
   })
 
@@ -422,6 +430,7 @@ test.describe('Variants create flow', () => {
     const title = `${createVariantTitlePrefix()} Autocomplete Created ${runId}`
     const audienceValue = `returning-${runId}`
     const languageValue = `en-${runId}`
+    const sessionValue = `session-${runId}`
 
     await createVariantDefinition(sanityClient, {
       variantId: `${runId}-audience`,
@@ -451,9 +460,68 @@ test.describe('Variants create flow', () => {
     await expect(page.getByRole('option', {name: languageValue, exact: true})).toBeHidden()
     await page.getByRole('option', {name: audienceValue, exact: true}).click()
 
+    // The picked suggestion replicates the audience seed's entire condition set, and duplicate
+    // condition sets can no longer be submitted. Add a run-unique second condition so the
+    // created definition is a superset of the seed rather than a duplicate.
+    await dialog.getByRole('button', {name: 'Add condition'}).click()
+    await fillConditionRow(dialog, 1, 'session', sessionValue)
+
     const document = await submitCreateVariantDialog(page, sanityClient, title)
 
-    expect(document.conditions).toEqual({audience: audienceValue})
+    expect(document.conditions).toEqual({audience: audienceValue, session: sessionValue})
+  })
+
+  test('blocks duplicate titles and condition sets and links to the existing definition', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('uniqueness')
+    const seedVariantId = `${runId}-seed`
+    const seedTitle = `${createVariantTitlePrefix()} Uniqueness Seed ${runId}`
+    const seedValue = `loyal-${runId}`
+
+    await createVariantDefinition(sanityClient, {
+      variantId: seedVariantId,
+      conditions: {audience: seedValue},
+      metadata: {title: seedTitle},
+    })
+
+    await openVariantsTool(page)
+    await expect(getVariantRow(page, seedTitle)).toBeVisible()
+
+    const dialog = await openCreateVariantDialog(page)
+
+    // Duplicate title (title matching is case-insensitive) and the seed's exact condition set.
+    await dialog.getByTestId('variant-form-title').fill(seedTitle.toUpperCase())
+    await fillConditionRow(dialog, 0, 'audience', seedValue)
+
+    await dialog.getByTestId('submit-variant-button').click()
+
+    // Submission is blocked: the dialog stays open, no navigation happens, and both
+    // errors name the seeded definition.
+    await expect(dialog).toBeVisible()
+    expect(new URL(page.url()).pathname).toMatch(/\/variants$/)
+
+    const titleError = dialog.getByTestId('variant-form-title-error')
+    const conditionsError = dialog.getByTestId('variant-form-conditions-duplicate-error')
+
+    await expect(titleError).toContainText('A variant definition with this title already exists:')
+    await expect(titleError.getByRole('link', {name: seedTitle})).toBeVisible()
+    await expect(conditionsError).toContainText(
+      'A variant definition with the same conditions already exists:',
+    )
+    await expect(conditionsError.getByRole('link', {name: seedTitle})).toBeVisible()
+
+    // Making the condition set unique clears the conditions error; the title error remains.
+    await getConditionValueInputs(dialog).first().fill(`${seedValue}-unique`)
+    await expect(conditionsError).toBeHidden()
+    await expect(titleError).toBeVisible()
+
+    // The error links to the existing definition's detail page.
+    await titleError.getByRole('link', {name: seedTitle}).click()
+    await expect(page).toHaveURL(new RegExp(`/variants/${escapeRegExp(seedVariantId)}$`))
+    await expect(page.getByRole('heading', {name: seedTitle})).toBeVisible()
+    await expect(dialog).toBeHidden()
   })
 
   test('deletes a seeded variant from the overview', async ({page, sanityClient}) => {

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -2,15 +2,17 @@ import {at, set} from '@sanity/mutate'
 import {applyPatches} from '@sanity/mutate/_unstable_apply'
 import {Card} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
-import {type FormEvent, useCallback, useState} from 'react'
+import {type FormEvent, useCallback, useMemo, useState} from 'react'
 import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
 import {type EditableSystemVariant} from '../../types'
 import {getIsVariantInvalid} from '../../util/getIsVariantInvalid'
+import {getVariantUniquenessValidation} from '../../util/uniquenessValidation'
 import {VariantForm, type VariantFormChangeHandler} from './VariantForm'
 
 interface VariantDialogProps {
@@ -44,7 +46,17 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
   const [showValidation, setShowValidation] = useState(false)
   const [conditionsInvalid, setConditionsInvalid] = useState(false)
   const [priorityInvalid, setPriorityInvalid] = useState(false)
-  const invalid = getIsVariantInvalid(variant) || conditionsInvalid || priorityInvalid
+  const {data: allVariants} = useAllVariants()
+  const {duplicateTitleOf, duplicateConditionsOf} = useMemo(
+    () => getVariantUniquenessValidation(variant, allVariants),
+    [allVariants, variant],
+  )
+  const invalid =
+    getIsVariantInvalid(variant) ||
+    conditionsInvalid ||
+    priorityInvalid ||
+    Boolean(duplicateTitleOf) ||
+    Boolean(duplicateConditionsOf)
 
   const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
     setVariant(
@@ -95,6 +107,8 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
         <form onSubmit={handleSubmit}>
           <Box paddingBottom={4}>
             <VariantForm
+              duplicateConditionsOf={duplicateConditionsOf}
+              duplicateTitleOf={duplicateTitleOf}
               onChange={handleVariantChange}
               onConditionValidityChange={setConditionsInvalid}
               onPriorityValidityChange={setPriorityInvalid}

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -6,16 +6,19 @@ import {type Path} from '@sanity/mutate'
 import {type PortableTextBlock} from '@sanity/types'
 import {Inline, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
-import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
+import {type ChangeEvent, type ReactNode, useCallback, useId, useMemo, useState} from 'react'
+import {StateLink} from 'sanity/router'
 import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {Translate} from '../../../i18n/Translate'
 import {type VariantsLocaleResourceKeys, variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
-import {type EditableSystemVariant} from '../../types'
+import {getVariantId, getVariantTitle} from '../../tool/util'
+import {type EditableSystemVariant, type SystemVariant} from '../../types'
 import {
   getConditionKeyValidationError,
   getConditionValueValidationError,
@@ -127,9 +130,25 @@ function getPortableTextDescriptionValue(description?: PortableTextBlock[]): str
   return toPlainText(description)
 }
 
+function DuplicateVariantLink(props: {children?: ReactNode; variantId?: string}) {
+  return <StateLink state={{variantId: props.variantId}}>{props.children}</StateLink>
+}
+
+const DUPLICATE_MESSAGE_COMPONENTS = {VariantLink: DuplicateVariantLink}
+
+/**
+ * The duplicate messages embed a `<VariantLink>` tag for the rich inline error; the native
+ * `customValidity` message must be plain text, so the tags are stripped there.
+ */
+function stripVariantLinkTags(message: string): string {
+  return message.replace(/<\/?VariantLink>/g, '')
+}
+
 export type VariantFormChangeHandler = (path: Path, value: unknown) => void
 
 export function VariantForm(props: {
+  duplicateConditionsOf?: SystemVariant
+  duplicateTitleOf?: SystemVariant
   onChange: VariantFormChangeHandler
   onConditionValidityChange: (invalid: boolean) => void
   onPriorityValidityChange: (invalid: boolean) => void
@@ -137,6 +156,8 @@ export function VariantForm(props: {
   value: EditableSystemVariant
 }) {
   const {
+    duplicateConditionsOf,
+    duplicateTitleOf,
     onChange,
     onConditionValidityChange,
     onPriorityValidityChange,
@@ -160,7 +181,19 @@ export function VariantForm(props: {
   )
 
   const hasTitle = Boolean(getVariantTitleValue(value))
-  const showTitleError = showValidation && !hasTitle
+  const showTitleRequiredError = showValidation && !hasTitle
+  const duplicateTitleVariant = showValidation && hasTitle ? duplicateTitleOf : undefined
+  const showTitleError = showTitleRequiredError || Boolean(duplicateTitleVariant)
+  const titleCustomValidity = showTitleRequiredError
+    ? t('dialog.create.variant-title.required')
+    : duplicateTitleVariant
+      ? stripVariantLinkTags(
+          t('dialog.create.variant-title.duplicate', {
+            title: getVariantTitle(duplicateTitleVariant),
+          }),
+        )
+      : undefined
+  const duplicateConditionsVariant = showValidation ? duplicateConditionsOf : undefined
   const priorityValidationError = getPriorityInputValidationError(priorityInput)
   const showPriorityError = showValidation && priorityValidationError
 
@@ -256,7 +289,7 @@ export function VariantForm(props: {
         <TextInput
           autoFocus
           aria-invalid={showTitleError ? 'true' : undefined}
-          customValidity={showTitleError ? t('dialog.create.variant-title.required') : undefined}
+          customValidity={titleCustomValidity}
           data-testid="variant-form-title"
           fontSize={2}
           id={titleId}
@@ -266,7 +299,17 @@ export function VariantForm(props: {
         />
         {showTitleError && (
           <TextWithTone data-testid="variant-form-title-error" size={1} tone="critical">
-            {t('dialog.create.variant-title.required')}
+            {duplicateTitleVariant ? (
+              <Translate
+                t={t}
+                i18nKey="dialog.create.variant-title.duplicate"
+                components={DUPLICATE_MESSAGE_COMPONENTS}
+                componentProps={{variantId: getVariantId(duplicateTitleVariant._id)}}
+                values={{title: getVariantTitle(duplicateTitleVariant)}}
+              />
+            ) : (
+              t('dialog.create.variant-title.required')
+            )}
           </TextWithTone>
         )}
       </Stack>
@@ -388,6 +431,22 @@ export function VariantForm(props: {
             )
           })}
         </Stack>
+
+        {duplicateConditionsVariant && (
+          <TextWithTone
+            data-testid="variant-form-conditions-duplicate-error"
+            size={1}
+            tone="critical"
+          >
+            <Translate
+              t={t}
+              i18nKey="dialog.create.conditions.duplicate"
+              components={DUPLICATE_MESSAGE_COMPONENTS}
+              componentProps={{variantId: getVariantId(duplicateConditionsVariant._id)}}
+              values={{title: getVariantTitle(duplicateConditionsVariant)}}
+            />
+          </TextWithTone>
+        )}
 
         <Flex>
           <Button

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -1,5 +1,6 @@
-import {render, screen, waitFor} from '@testing-library/react'
+import {render, screen, waitFor, within} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
+import {type HTMLProps, type Ref} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
@@ -28,6 +29,25 @@ const variantsMock = vi.hoisted(() => ({
 vi.mock('@sanity/ui/toast', async (importOriginal) => ({
   ...(await importOriginal()),
   useToast: vi.fn(() => toastMock),
+}))
+
+// The test router has no `variantId` route, so resolve duplicate-error links to plain anchors.
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  StateLink: function MockStateLink({
+    ref,
+    state,
+    ...rest
+  }: {state?: {variantId?: string}} & HTMLProps<HTMLAnchorElement>) {
+    return (
+      // oxlint-disable-next-line jsx_a11y/anchor-has-content
+      <a
+        {...rest}
+        ref={ref as Ref<HTMLAnchorElement>}
+        href={state?.variantId ? `/variants/${state.variantId}` : '/variants'}
+      />
+    )
+  },
 }))
 
 vi.mock('../../../store/useVariantOperations', () => ({
@@ -355,6 +375,93 @@ describe('CreateVariantDialog', () => {
 
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalledWith(createdVariant._id)
+  })
+
+  it('blocks submit and links to the duplicate when the title matches an existing variant', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'alpha audience')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'beta')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+
+    const titleError = screen.getByTestId('variant-form-title-error')
+
+    expect(titleError).toHaveTextContent(
+      'A variant definition with this title already exists: Alpha audience',
+    )
+    expect(within(titleError).getByRole('link', {name: 'Alpha audience'})).toHaveAttribute(
+      'href',
+      '/variants/alpha-audience',
+    )
+
+    await user.type(screen.getByTestId('variant-form-title'), ' expanded')
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('variant-form-title-error')).not.toBeInTheDocument()
+    })
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('blocks submit and links to the duplicate when the conditions match an existing variant', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Copy of alpha')
+    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('combobox', {name: 'Value'}), 'alpha')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
+    })
+
+    await user.click(screen.getByRole('button', {name: 'Add condition'}))
+
+    const conditionKeys = screen.getAllByTestId('variant-form-condition-key')
+    const conditionValues = screen.getAllByTestId('variant-form-condition-value')
+
+    await user.type(conditionKeys[1]!, 'locale')
+    await user.type(conditionValues[1]!, 'en-US')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+
+    const conditionsError = screen.getByTestId('variant-form-conditions-duplicate-error')
+
+    expect(conditionsError).toHaveTextContent(
+      'A variant definition with the same conditions already exists: Alpha audience',
+    )
+    expect(within(conditionsError).getByRole('link', {name: 'Alpha audience'})).toHaveAttribute(
+      'href',
+      '/variants/alpha-audience',
+    )
+  })
+
+  it('allows a condition set that is a subset of an existing variant', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Alpha only')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'alpha')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+
+    expect(screen.queryByTestId('variant-form-conditions-duplicate-error')).not.toBeInTheDocument()
   })
 
   it('keeps the dialog open when creation fails', async () => {

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
@@ -3,8 +3,9 @@ import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience} from '../../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
-import {type EditableSystemVariant} from '../../../types'
+import {type EditableSystemVariant, type SystemVariant} from '../../../types'
 import {getVariantDefaults} from '../../../util/variantDefaults'
 import {VariantDialog} from '../VariantDialog'
 
@@ -12,9 +13,20 @@ const toastMock = vi.hoisted(() => ({
   push: vi.fn(),
 }))
 
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
 vi.mock('@sanity/ui/toast', async (importOriginal) => ({
   ...(await importOriginal()),
   useToast: vi.fn(() => toastMock),
+}))
+
+vi.mock('../../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => variantsMock),
 }))
 
 describe('VariantDialog', () => {
@@ -24,6 +36,10 @@ describe('VariantDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     onSubmit.mockResolvedValue(undefined)
+    variantsMock.data = []
+    variantsMock.byId = new Map()
+    variantsMock.loading = false
+    variantsMock.error = undefined
   })
 
   const renderDialog = async (props?: {
@@ -118,6 +134,31 @@ describe('VariantDialog', () => {
       'Priority must be a number',
     )
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits an unchanged variant without flagging it as its own duplicate', async () => {
+    const user = userEvent.setup()
+    variantsMock.data = [variantAlphaAudience]
+    variantsMock.byId = new Map([[variantAlphaAudience._id, variantAlphaAudience]])
+
+    await renderDialog({
+      initialValue: {
+        _id: variantAlphaAudience._id,
+        _type: variantAlphaAudience._type,
+        conditions: variantAlphaAudience.conditions,
+        priority: variantAlphaAudience.priority,
+        metadata: variantAlphaAudience.metadata,
+      },
+      renderCancelButton: true,
+    })
+
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.queryByTestId('variant-form-title-error')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('variant-form-conditions-duplicate-error')).not.toBeInTheDocument()
   })
 
   it('shows an error toast and keeps the dialog open when submit fails', async () => {

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -143,6 +143,9 @@ const variantsLocaleStrings = {
   'dialog.create.variant-title.placeholder': 'e.g. Loyal customers',
   /** Validation message when the variant title is missing. */
   'dialog.create.variant-title.required': 'Title is required',
+  /** Validation message when the variant title matches an existing variant definition. */
+  'dialog.create.variant-title.duplicate':
+    'A variant definition with this title already exists: <VariantLink>{{title}}</VariantLink>',
   /** Label for the description field in the create variant dialog. */
   'dialog.create.description.label': 'Description',
   /** Placeholder for the description field in the create variant dialog. */
@@ -159,6 +162,9 @@ const variantsLocaleStrings = {
   /** Description for the conditions section in the create variant dialog. */
   'dialog.create.conditions.description':
     'Add key/value pairs that define when this variant definition applies.',
+  /** Validation message when the conditions match an existing variant definition. */
+  'dialog.create.conditions.duplicate':
+    'A variant definition with the same conditions already exists: <VariantLink>{{title}}</VariantLink>',
   /** Label for the condition key field in the create variant dialog. */
   'dialog.create.condition-key.label': 'Key',
   /** Validation message when a condition key is repeated. */

--- a/packages/sanity/src/core/variants/util/__tests__/uniquenessValidation.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/uniquenessValidation.test.ts
@@ -1,0 +1,151 @@
+import {describe, expect, it} from 'vitest'
+
+import {VARIANT_DOCUMENTS_PATH} from '../../store/constants'
+import {type EditableSystemVariant} from '../../types'
+import {getVariantUniquenessValidation} from '../uniquenessValidation'
+
+function createVariant(
+  id: string,
+  overrides: Partial<Omit<EditableSystemVariant, '_id'>> = {},
+): EditableSystemVariant {
+  return {
+    _id: `${VARIANT_DOCUMENTS_PATH}.${id}`,
+    _type: 'system.variant',
+    conditions: {},
+    priority: 0,
+    metadata: {title: '', description: []},
+    ...overrides,
+  }
+}
+
+describe('getVariantUniquenessValidation', () => {
+  it('matches another variant with the same title', () => {
+    const existing = createVariant('existing', {
+      metadata: {title: 'Loyal customers', description: []},
+    })
+    const candidate = createVariant('candidate', {
+      metadata: {title: 'Loyal customers', description: []},
+    })
+
+    expect(getVariantUniquenessValidation(candidate, [existing]).duplicateTitleOf).toBe(existing)
+  })
+
+  it('matches titles case-insensitively and ignores surrounding whitespace', () => {
+    const existing = createVariant('existing', {
+      metadata: {title: 'Loyal Customers', description: []},
+    })
+    const candidate = createVariant('candidate', {
+      metadata: {title: '  loyal customers  ', description: []},
+    })
+
+    expect(getVariantUniquenessValidation(candidate, [existing]).duplicateTitleOf).toBe(existing)
+  })
+
+  it('does not match different titles', () => {
+    const existing = createVariant('existing', {
+      metadata: {title: 'Loyal customers', description: []},
+    })
+    const candidate = createVariant('candidate', {
+      metadata: {title: 'New customers', description: []},
+    })
+
+    expect(getVariantUniquenessValidation(candidate, [existing]).duplicateTitleOf).toBeUndefined()
+  })
+
+  it('never matches empty titles', () => {
+    const existing = createVariant('existing', {metadata: {title: '   ', description: []}})
+    const candidate = createVariant('candidate', {metadata: {title: '', description: []}})
+
+    expect(getVariantUniquenessValidation(candidate, [existing]).duplicateTitleOf).toBeUndefined()
+  })
+
+  it('matches another variant with an identical condition set', () => {
+    const existing = createVariant('existing', {conditions: {audience: 'loyal'}})
+    const candidate = createVariant('candidate', {conditions: {audience: 'loyal'}})
+
+    expect(getVariantUniquenessValidation(candidate, [existing]).duplicateConditionsOf).toBe(
+      existing,
+    )
+  })
+
+  it('does not match when the candidate has an extra condition', () => {
+    const existing = createVariant('existing', {conditions: {audience: 'loyal'}})
+    const candidate = createVariant('candidate', {conditions: {audience: 'loyal', country: 'us'}})
+
+    expect(
+      getVariantUniquenessValidation(candidate, [existing]).duplicateConditionsOf,
+    ).toBeUndefined()
+  })
+
+  it('does not match when the existing variant has an extra condition', () => {
+    const existing = createVariant('existing', {conditions: {audience: 'loyal', country: 'us'}})
+    const candidate = createVariant('candidate', {conditions: {audience: 'loyal'}})
+
+    expect(
+      getVariantUniquenessValidation(candidate, [existing]).duplicateConditionsOf,
+    ).toBeUndefined()
+  })
+
+  it('does not match when a condition value differs', () => {
+    const existing = createVariant('existing', {conditions: {audience: 'loyal', country: 'us'}})
+    const candidate = createVariant('candidate', {conditions: {audience: 'loyal', country: 'no'}})
+
+    expect(
+      getVariantUniquenessValidation(candidate, [existing]).duplicateConditionsOf,
+    ).toBeUndefined()
+  })
+
+  it('matches regardless of condition key order', () => {
+    const existing = createVariant('existing', {conditions: {audience: 'loyal', country: 'us'}})
+    const candidate = createVariant('candidate', {conditions: {country: 'us', audience: 'loyal'}})
+
+    expect(getVariantUniquenessValidation(candidate, [existing]).duplicateConditionsOf).toBe(
+      existing,
+    )
+  })
+
+  it('never matches empty condition sets', () => {
+    const existing = createVariant('existing', {conditions: {}})
+    const candidate = createVariant('candidate', {conditions: {}})
+
+    expect(
+      getVariantUniquenessValidation(candidate, [existing]).duplicateConditionsOf,
+    ).toBeUndefined()
+  })
+
+  it('excludes the candidate itself so editing an unchanged variant never matches', () => {
+    const stored = createVariant('stored', {
+      conditions: {audience: 'loyal'},
+      metadata: {title: 'Loyal customers', description: []},
+    })
+    const edited = createVariant('stored', {
+      conditions: {audience: 'loyal'},
+      metadata: {title: 'Loyal customers', description: []},
+    })
+
+    expect(getVariantUniquenessValidation(edited, [stored])).toEqual({
+      duplicateTitleOf: undefined,
+      duplicateConditionsOf: undefined,
+    })
+  })
+
+  it('reports title and condition duplicates from different variants independently', () => {
+    const sameTitle = createVariant('same-title', {
+      conditions: {audience: 'vip'},
+      metadata: {title: 'Loyal customers', description: []},
+    })
+    const sameConditions = createVariant('same-conditions', {
+      conditions: {audience: 'loyal'},
+      metadata: {title: 'Another title', description: []},
+    })
+    const candidate = createVariant('candidate', {
+      conditions: {audience: 'loyal'},
+      metadata: {title: 'Loyal customers', description: []},
+    })
+
+    expect(getVariantUniquenessValidation(candidate, [sameTitle, sameConditions])).toEqual({
+      duplicateTitleOf: sameTitle,
+      duplicateConditionsOf: sameConditions,
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/util/uniquenessValidation.ts
+++ b/packages/sanity/src/core/variants/util/uniquenessValidation.ts
@@ -1,0 +1,81 @@
+import {type EditableSystemVariant} from '../types'
+import {getVariantTitleValue} from './getIsVariantInvalid'
+
+/**
+ * The existing variants that a candidate variant would duplicate, per uniqueness check.
+ *
+ * @internal
+ */
+export interface VariantUniquenessValidation<T extends EditableSystemVariant> {
+  /** The first other variant whose title matches the candidate's (trimmed, case-insensitive). */
+  duplicateTitleOf: T | undefined
+  /** The first other variant whose condition set exactly matches the candidate's. */
+  duplicateConditionsOf: T | undefined
+}
+
+function getNormalizedConditions(
+  conditions: EditableSystemVariant['conditions'],
+): Map<string, string> {
+  const normalized = new Map<string, string>()
+
+  for (const [key, value] of Object.entries(conditions)) {
+    const trimmedKey = key.trim()
+    // Conditions come from stored documents, so guard against non-string values.
+    const trimmedValue = typeof value === 'string' ? value.trim() : ''
+
+    if (trimmedKey && trimmedValue) {
+      normalized.set(trimmedKey, trimmedValue)
+    }
+  }
+
+  return normalized
+}
+
+function conditionsAreEqual(a: Map<string, string>, b: Map<string, string>): boolean {
+  if (a.size !== b.size) {
+    return false
+  }
+
+  for (const [key, value] of a) {
+    if (b.get(key) !== value) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Finds existing variants that the candidate would duplicate: one with the same title (trimmed,
+ * case-insensitive) and one with exactly the same condition set (same number of conditions, same
+ * keys, same trimmed values — key order is irrelevant). A variant whose conditions are a subset or
+ * superset of the candidate's is not a duplicate.
+ *
+ * The candidate itself is excluded by `_id`, so an unchanged variant never matches itself when
+ * editing. Empty titles and empty condition sets never match — those are covered by the
+ * required-field validation.
+ *
+ * @internal
+ */
+export function getVariantUniquenessValidation<T extends EditableSystemVariant>(
+  variant: EditableSystemVariant,
+  allVariants: readonly T[],
+): VariantUniquenessValidation<T> {
+  const otherVariants = allVariants.filter((other) => other._id !== variant._id)
+
+  const title = getVariantTitleValue(variant).toLowerCase()
+  const conditions = getNormalizedConditions(variant.conditions)
+
+  const duplicateTitleOf = title
+    ? otherVariants.find((other) => getVariantTitleValue(other).toLowerCase() === title)
+    : undefined
+
+  const duplicateConditionsOf =
+    conditions.size > 0
+      ? otherVariants.find((other) =>
+          conditionsAreEqual(conditions, getNormalizedConditions(other.conditions)),
+        )
+      : undefined
+
+  return {duplicateTitleOf, duplicateConditionsOf}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

It is currently possible to create several variant definitions with the same title or the exact same condition set ([SAPP-4103](https://linear.app/sanity/issue/SAPP-4103/enforce-uniqueness-validation-for-variant-definition-creation)). This adds the studio-side guard: submitting the create/edit dialog is blocked when the trimmed, case-insensitive title or the full condition set (same keys and values, order-independent — a subset/superset is not a duplicate) matches another definition, and each error links to the duplicated definition's detail page. Checks only surface after a submit attempt, following the dialog's existing `showValidation` pattern, and the variant being edited is excluded by `_id` so re-saving an unchanged definition is never flagged.

API enforcement is still required and remains out of scope here — this validation only sees definitions loaded in the local store, so concurrent sessions can still race.
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/68cc9f0c-845f-4e7f-93f9-62a5aec0e064" />

### What to review

- `packages/sanity/src/core/variants/util/uniquenessValidation.ts` — the pure matching rules (title normalization, exact condition-set equality, self-exclusion).
- `packages/sanity/src/core/variants/components/dialog/VariantForm.tsx` — the duplicate errors render the matched definition's title as a `StateLink` to its detail page via `<Translate>`; the native `customValidity` message reuses the same resource with the link tags stripped, so the title input keeps its `:invalid` styling without leaking markup into the browser's validation bubble.
- `e2e/tests/variants/variantTool.spec.ts` — the autocomplete spec used to submit the exact condition set of its own seed, which the new validation now blocks; it now adds a run-unique second condition, and the previously fixed condition values in the duplicate-keys/partial-key specs are run-unique too so leaked docs from failed attempts can never collide.
- Affected packages: `sanity`, plus the `e2e` workspace.

### Testing

- New unit tests for `getVariantUniquenessValidation` (12 cases: case/whitespace title matching, subset vs superset condition sets in both directions, key order, self-exclusion).
- New dialog tests: duplicate title and duplicate conditions block `createVariant` and render the link (`/variants/alpha-audience`), fixing the field clears the error and submits, a subset condition set submits fine, and editing an unchanged variant is not flagged as its own duplicate.
- New e2e test (`blocks duplicate titles and condition sets and links to the existing definition`): seeds a definition via the API, submits a duplicate (uppercased title + same condition set), asserts both errors with links, that a unique value clears the conditions error, and that the error link navigates to the seeded definition's detail page.
- Full variants spec run locally against a fresh `ittbm412` dataset: 8/8 passed on chromium and 8/8 on firefox (`--retries=0`), plus a 3x `--repeat-each` stress run of the autocomplete and uniqueness tests (6/6).
- `pnpm check:format`, `pnpm check:oxlint`, and the full variants unit suite (40 files, 257 tests) pass.
- Manually verified in the test studio against the `/test` workspace: submitting a duplicate shows both linked errors, editing the condition value clears the conditions error live, and clicking the link navigates to the existing definition's detail page (the seeded demo definition was deleted afterwards).

[Create variant definition dialog showing both duplicate errors with links](https://cursor.com/agents/bc-48e43008-72f0-4f02-8351-c69925af2087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_duplicate_errors_with_links.webp)

[variant_duplicate_validation_demo.mp4](https://cursor.com/agents/bc-48e43008-72f0-4f02-8351-c69925af2087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariant_duplicate_validation_demo.mp4)

### Notes for release

N/A – Part of the Variants open beta; studio-side validation for duplicate variant definitions.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48e43008-72f0-4f02-8351-c69925af2087?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48e43008-72f0-4f02-8351-c69925af2087&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

