### PR TITLE
refactor(core): awaitable document operations and useAsyncOperation hook

### DIFF
--- a/dev/test-studio/documentActions/actions/createCustomPublishAction.ts
+++ b/dev/test-studio/documentActions/actions/createCustomPublishAction.ts
@@ -14,7 +14,7 @@ export const createCustomPublishAction = memoize(
         ...defaultPublishAction,
         label: 'Custom publish that sets publishedAt to now',
         onHandle: () => {
-          documentOperations.patch.execute([{set: {publishedAt: new Date().toISOString()}}])
+          void documentOperations.patch.execute([{set: {publishedAt: new Date().toISOString()}}])
           defaultPublishAction?.onHandle?.()
         },
       }
@@ -35,7 +35,7 @@ export const createNoopPatchPublishAction = memoize(
         ...defaultPublishAction,
         label: 'Custom publish that sets someBoolean to true',
         onHandle: () => {
-          documentOperations.patch.execute([{set: {someBoolean: true}}])
+          void documentOperations.patch.execute([{set: {someBoolean: true}}])
           defaultPublishAction?.onHandle?.()
         },
       }

--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -902,6 +902,7 @@ export {useDataset} from '../core/hooks/useDataset'
 export {useDateTimeFormat, type UseDateTimeFormatOptions} from '../core/hooks/useDateTimeFormat'
 export {useDialogStack} from '../core/hooks/useDialogStack'
 export {type DocumentIdStack, useDocumentIdStack} from '../core/hooks/useDocumentIdStack'
+export {type AsyncOperation, useAsyncOperation} from '../core/hooks/useAsyncOperation'
 export {useDocumentOperation} from '../core/hooks/useDocumentOperation'
 export {useDocumentOperationEvent} from '../core/hooks/useDocumentOperationEvent'
 export {
@@ -1259,6 +1260,7 @@ export {
   type MapDocument,
   type Operation,
   type OperationArgs,
+  type OperationCallOutcome,
   type OperationImpl,
   type OperationsAPI,
 } from '../core/store/document/document-pair/operations/types'

--- a/packages/sanity/src/core/divergence/hooks/useDivergenceController.ts
+++ b/packages/sanity/src/core/divergence/hooks/useDivergenceController.ts
@@ -194,7 +194,7 @@ export function useDivergenceController(
     )
 
     const patches = createUpsertResolutionMarkerPatches(...markers)
-    patch.execute(patches.map(SanityEncoder.encodePatch))
+    void patch.execute(patches.map(SanityEncoder.encodePatch))
   }
 
   const takeUpstreamValue = async () => {
@@ -218,7 +218,7 @@ export function useDivergenceController(
       ).pipe(toArray()),
     )
 
-    patch.execute(patches.map(SanityEncoder.encodePatch))
+    void patch.execute(patches.map(SanityEncoder.encodePatch))
   }
 
   return {

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -627,7 +627,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
           telemetry.log(CreatedDraft)
         }
 
-        patch.execute(toMutationPatches(event.patches), initialValue?.value)
+        void patch.execute(toMutationPatches(event.patches), initialValue?.value)
       }
     }
   }, [editState.draft, editState.published, initialValue, patch, telemetry, readOnly])

--- a/packages/sanity/src/core/hooks/__tests__/useAsyncOperation.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useAsyncOperation.test.tsx
@@ -1,0 +1,86 @@
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+
+import {
+  type Operation,
+  type OperationCallOutcome,
+} from '../../store/document/document-pair/operations/types'
+import {useAsyncOperation} from '../useAsyncOperation'
+
+function createControlledOperation() {
+  let settle!: (outcome: OperationCallOutcome) => void
+  const operation: Operation<[revision: string]> = {
+    disabled: false,
+    execute: () =>
+      new Promise<OperationCallOutcome>((resolve) => {
+        settle = resolve
+      }),
+  }
+  return {operation, settle: (outcome: OperationCallOutcome) => settle(outcome)}
+}
+
+describe('useAsyncOperation', () => {
+  it('tracks pending state across the call and resolves with the outcome', async () => {
+    const {operation, settle} = createControlledOperation()
+    const {result} = renderHook(() => useAsyncOperation(operation))
+
+    expect(result.current.isPending).toBe(false)
+
+    let outcome: Promise<OperationCallOutcome>
+    act(() => {
+      outcome = result.current.execute('rev-1')
+    })
+
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+
+    act(() => settle({type: 'success'}))
+
+    await expect(outcome!).resolves.toEqual({type: 'success'})
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.error).toBeNull()
+  })
+
+  it('exposes the error of a failed call and clears it on the next call', async () => {
+    const first = createControlledOperation()
+    const {result} = renderHook(() => useAsyncOperation(first.operation))
+
+    let outcome: Promise<OperationCallOutcome>
+    act(() => {
+      outcome = result.current.execute('rev-1')
+    })
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+    act(() => first.settle({type: 'error', error: new Error('restore failed')}))
+
+    await expect(outcome!).resolves.toEqual({
+      type: 'error',
+      error: new Error('restore failed'),
+    })
+    await waitFor(() => expect(result.current.error).toEqual(new Error('restore failed')))
+    expect(result.current.isPending).toBe(false)
+
+    act(() => {
+      void result.current.execute('rev-2')
+    })
+    await waitFor(() => expect(result.current.error).toBeNull())
+
+    // Settle the second call so no transition is left pending across tests.
+    act(() => first.settle({type: 'success'}))
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+  })
+
+  it('does not surface an error for cancelled calls', async () => {
+    const {operation, settle} = createControlledOperation()
+    const {result} = renderHook(() => useAsyncOperation(operation))
+
+    let outcome: Promise<OperationCallOutcome>
+    act(() => {
+      outcome = result.current.execute('rev-1')
+    })
+    await waitFor(() => expect(result.current.isPending).toBe(true))
+    act(() => settle({type: 'cancelled'}))
+
+    await expect(outcome!).resolves.toEqual({type: 'cancelled'})
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/packages/sanity/src/core/hooks/useAsyncOperation.ts
+++ b/packages/sanity/src/core/hooks/useAsyncOperation.ts
@@ -1,0 +1,80 @@
+import {useCallback, useState, useTransition} from 'react'
+
+import {
+  type Operation,
+  type OperationCallOutcome,
+} from '../store/document/document-pair/operations/types'
+
+/**
+ * An awaitable view over a document {@link Operation}, exposing React 19 action semantics:
+ * a pending flag driven by a transition and the error of the most recent call.
+ *
+ * @hidden
+ * @beta
+ */
+export interface AsyncOperation<
+  ExtraArgs extends any[] = [],
+  ErrorStrings extends string = string,
+> {
+  /** Mirrors {@link Operation.disabled} for the underlying operation. */
+  disabled: false | ErrorStrings | 'NOT_READY'
+  /**
+   * Executes the operation inside a React transition and resolves with the outcome of this
+   * specific call. The promise never rejects: failures resolve as `{type: 'error'}`, and calls
+   * superseded by a newer operation on the same document resolve as `{type: 'cancelled'}`.
+   */
+  execute: (...args: ExtraArgs) => Promise<OperationCallOutcome>
+  /** True from the moment `execute` is called until the outcome settles. */
+  isPending: boolean
+  /** The error of the most recent call, or null. Cleared when a new call starts. */
+  error: Error | null
+}
+
+/**
+ * Wraps a document operation (from `useDocumentOperation`) in an awaitable async action.
+ *
+ * Instead of firing the operation and separately watching `useDocumentOperationEvent` for a
+ * matching event, callers await the outcome of their own call:
+ *
+ * ```ts
+ * const {restore} = useDocumentOperation(id, type)
+ * const restoreAsync = useAsyncOperation(restore)
+ *
+ * const handleConfirm = async () => {
+ *   const outcome = await restoreAsync.execute(revision)
+ *   if (outcome.type === 'success') navigateIntent('edit', {id, type})
+ * }
+ * ```
+ *
+ * `isPending` stays true for the full duration of the call (React 19 async transition), and
+ * `error` holds the failure of the most recent call for inline error UI.
+ *
+ * @hidden
+ * @beta
+ */
+export function useAsyncOperation<ExtraArgs extends any[], ErrorStrings extends string>(
+  operation: Operation<ExtraArgs, ErrorStrings>,
+): AsyncOperation<ExtraArgs, ErrorStrings> {
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<Error | null>(null)
+
+  const execute = useCallback(
+    (...args: ExtraArgs) => {
+      // Cleared outside the transition: updates inside an async transition are batched until the
+      // action settles, which would leave a stale error visible for the duration of the retry.
+      setError(null)
+      return new Promise<OperationCallOutcome>((resolve) => {
+        startTransition(async () => {
+          const outcome = await operation.execute(...args)
+          if (outcome.type === 'error') {
+            setError(outcome.error)
+          }
+          resolve(outcome)
+        })
+      })
+    },
+    [operation],
+  )
+
+  return {disabled: operation.disabled, execute, isPending, error}
+}

--- a/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
@@ -142,7 +142,7 @@ function withComlinkEvent<OperationName extends keyof OperationsAPI>({
         execute: (...args: ExecuteParameters<OperationName>) => {
           const next = () => recordEvent(comlinkEventType)
           preRecordEvent(next)
-          api[operationName].execute(...args)
+          return api[operationName].execute(...args)
         },
       },
     }

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -119,7 +119,7 @@ export function DiscardVersionDialog(props: {
 
     setIsDiscarding(true)
     awaitingDiscardRef.current = true
-    discardChanges.execute()
+    void discardChanges.execute()
   }, [discardChanges])
 
   return (

--- a/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
@@ -126,7 +126,7 @@ export function UnpublishVersionDialog(props: {
 
     setIsUnpublishing(true)
     awaitingUnpublishRef.current = true
-    unpublish.execute()
+    void unpublish.execute()
   }, [canUnpublish, unpublish])
 
   return (

--- a/packages/sanity/src/core/store/document/document-pair/operationEvents.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/operationEvents.test.ts
@@ -1,8 +1,9 @@
 import {type SanityClient} from '@sanity/client'
-import {of} from 'rxjs'
+import {NEVER, of, throwError} from 'rxjs'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import {createSchema} from '../../../schema/createSchema'
+import {type HistoryStore} from '../../history/createHistoryStore'
 import {editOperations} from './editOperations'
 import {type OperationsAPI} from './operations/types'
 
@@ -83,8 +84,8 @@ describe('operationEvents', () => {
     expect(operationsA?.patch.disabled).toBe(false)
     expect(operationsB?.patch.disabled).toBe(false)
 
-    operationsA?.patch.execute([{set: {title: 'hello'}}], {_id: 'task-1', _type: 'tasks.task'})
-    operationsA?.commit.execute()
+    void operationsA?.patch.execute([{set: {title: 'hello'}}], {_id: 'task-1', _type: 'tasks.task'})
+    void operationsA?.commit.execute()
 
     await new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -94,5 +95,76 @@ describe('operationEvents', () => {
 
     subscriptionA.unsubscribe()
     subscriptionB.unsubscribe()
+  })
+
+  describe('execute() outcome promise', () => {
+    // Each test uses its own dataset so it gets its own memoized operationEvents pipeline.
+    async function setup(dataset: string, historyStore: Partial<HistoryStore>) {
+      const {client} = createDocumentClient(dataset)
+      const idPair = {publishedId: 'task-1', draftId: 'drafts.task-1'}
+
+      let operations: OperationsAPI | undefined
+      const subscription = editOperations(
+        {client, historyStore: historyStore as HistoryStore, schema},
+        idPair,
+        'tasks.task',
+      ).subscribe((value) => {
+        operations = value
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(operations?.restore.disabled).toBe(false)
+
+      return {operations: operations!, subscription}
+    }
+
+    it('resolves with a success outcome when this call completes', async () => {
+      const {operations, subscription} = await setup('outcome-success', {
+        restore: vi.fn(() => of(undefined)),
+      })
+
+      await expect(operations.restore.execute('rev-1')).resolves.toEqual({type: 'success'})
+
+      subscription.unsubscribe()
+    })
+
+    it('resolves with an error outcome when this call fails', async () => {
+      const {operations, subscription} = await setup('outcome-error', {
+        restore: vi.fn(() => throwError(() => new Error('restore failed'))),
+      })
+
+      await expect(operations.restore.execute('rev-1')).resolves.toEqual({
+        type: 'error',
+        error: new Error('restore failed'),
+      })
+
+      subscription.unsubscribe()
+    })
+
+    it('resolves with a cancelled outcome when superseded by a newer operation', async () => {
+      const {operations, subscription} = await setup('outcome-cancelled', {
+        restore: vi.fn(() => NEVER),
+      })
+
+      const inFlight = operations.restore.execute('rev-1')
+      // A newer operation on the same document drops the in-flight restore (switchMap).
+      void operations.patch.execute([{set: {title: 'hello'}}], {_id: 'task-1', _type: 'tasks.task'})
+
+      await expect(inFlight).resolves.toEqual({type: 'cancelled'})
+
+      subscription.unsubscribe()
+    })
+
+    it('resolves with a cancelled outcome when the executor is torn down mid-flight', async () => {
+      const {operations, subscription} = await setup('outcome-teardown', {
+        restore: vi.fn(() => NEVER),
+      })
+
+      const inFlight = operations.restore.execute('rev-1')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      subscription.unsubscribe()
+
+      await expect(inFlight).resolves.toEqual({type: 'cancelled'})
+    })
   })
 })

--- a/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
@@ -5,6 +5,7 @@ import {
   catchError,
   concatMap,
   filter,
+  finalize,
   groupBy,
   last,
   map,
@@ -31,7 +32,7 @@ import {duplicate} from './operations/duplicate'
 import {patch} from './operations/patch'
 import {publish} from './operations/publish'
 import {restore} from './operations/restore'
-import {type OperationArgs, type OperationsAPI} from './operations/types'
+import {type OperationArgs, type OperationCallOutcome, type OperationsAPI} from './operations/types'
 import {unpublish} from './operations/unpublish'
 import {del as serverDel} from './serverOperations/delete'
 import {discardChanges as serverDiscardChanges} from './serverOperations/discardChanges'
@@ -46,6 +47,12 @@ interface ExecuteArgs {
   typeName: string
   storeKey?: string
   extraArgs: any[]
+  /**
+   * Resolves the outcome promise handed to the caller of this specific `execute()` call.
+   * Promise resolution is idempotent, so the `finalize`-based `cancelled` fallback is a no-op
+   * when a `success`/`error` outcome has already been settled.
+   */
+  settle?: (outcome: OperationCallOutcome) => void
 }
 
 function maybeObservable(v: void | Observable<any>) {
@@ -90,15 +97,30 @@ const execute = (
 
 const operationCalls$ = new Subject<ExecuteArgs>()
 
-/** @internal */
+/**
+ * Emits an operation call into the shared executor pipeline and returns a promise for the outcome
+ * of this specific call.
+ *
+ * The promise never rejects — errors resolve as `{type: 'error', error}` — so fire-and-forget
+ * callers that ignore the return value cannot cause unhandled rejections. Callers that need to
+ * await completion (e.g. {@link useAsyncOperation}) inspect the resolved outcome instead.
+ *
+ * Note: execution requires an active subscriber to the pair's operation pipeline (which
+ * `useDocumentOperation` guarantees while mounted, via `editOperations`). If the pipeline is torn
+ * down while this call is in flight, the promise resolves `cancelled`.
+ *
+ * @internal
+ */
 export function emitOperation(
   operationName: keyof OperationsAPI,
   idPair: IdPair,
   typeName: string,
   extraArgs: any[],
   storeKey?: string,
-): void {
-  operationCalls$.next({operationName, idPair, typeName, storeKey, extraArgs})
+): Promise<OperationCallOutcome> {
+  return new Promise<OperationCallOutcome>((settle) => {
+    operationCalls$.next({operationName, idPair, typeName, storeKey, extraArgs, settle})
+  })
 }
 
 // These are the operations that cannot be performed while the document is in an inconsistent state
@@ -185,6 +207,17 @@ export const operationEvents = memoize(
               catchError((err): Observable<IntermediaryError> =>
                 of({type: 'error', args, error: err}),
               ),
+              tap((result) => {
+                args.settle?.(
+                  result.type === 'success'
+                    ? {type: 'success'}
+                    : {type: 'error', error: result.error},
+                )
+              }),
+              // Runs on completion (already settled above — no-op) and on unsubscription:
+              // a newer operation on the same document cancelled this one via `switchMap`,
+              // or the executor was torn down while the call was in flight.
+              finalize(() => args.settle?.({type: 'cancelled'})),
             ),
           ),
         ),
@@ -201,7 +234,13 @@ export const operationEvents = memoize(
         (window as any).SLOW ? timer(10000).pipe(map(() => result)) : of(result),
       ),
       tap((result) => {
-        emitOperation('commit', result.args.idPair, result.args.typeName, [], result.args.storeKey)
+        void emitOperation(
+          'commit',
+          result.args.idPair,
+          result.args.typeName,
+          [],
+          result.args.storeKey,
+        )
       }),
     )
 

--- a/packages/sanity/src/core/store/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/document/document-pair/operations/types.ts
@@ -8,6 +8,23 @@ import {type DocumentVersionSnapshots} from '../snapshotPair'
 /** @public */
 export type MapDocument = (document: SanityDocumentLike) => SanityDocumentLike
 
+/**
+ * The terminal outcome of a single `execute()` call, resolved by the promise returned from
+ * {@link Operation.execute}.
+ *
+ * - `success` / `error` mirror the corresponding operation events for this specific call.
+ * - `cancelled` means the call never produced an event: it was superseded by a newer operation on
+ *   the same document (the executor intentionally drops in-flight operations, e.g. typing after
+ *   publish cancels the publish), or the operation executor was torn down.
+ *
+ * @hidden
+ * @beta
+ */
+export type OperationCallOutcome =
+  | {type: 'success'}
+  | {type: 'error'; error: Error}
+  | {type: 'cancelled'}
+
 /** @internal */
 export interface OperationImpl<
   ExtraArgs extends any[] = [],
@@ -20,7 +37,15 @@ export interface OperationImpl<
 /** @internal */
 export interface Operation<ExtraArgs extends any[] = [], ErrorStrings extends string = string> {
   disabled: false | ErrorStrings | 'NOT_READY'
-  execute(...extra: ExtraArgs): void
+  /**
+   * Triggers the operation and returns a promise for the outcome of this specific call.
+   *
+   * The promise never rejects: failures resolve as `{type: 'error'}` and operations dropped by
+   * the executor (superseded by a newer operation on the same document) resolve as
+   * `{type: 'cancelled'}`, so existing fire-and-forget callers can keep ignoring the return
+   * value. Await it (e.g. via `useAsyncOperation`) to drive pending/error UI.
+   */
+  execute(...extra: ExtraArgs): Promise<OperationCallOutcome>
 }
 
 type GuardedOperation = Operation<any[], 'NOT_READY'>

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -96,7 +96,7 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft}) => {
         }
       })
 
-      deleteOp.execute(versions)
+      void deleteOp.execute(versions)
       setIsDeleting(false)
     },
     [deleteOp, documentStore.pair, id, telemetry, type],

--- a/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DiscardChangesAction.tsx
@@ -52,7 +52,7 @@ export const useDiscardChangesAction: DocumentActionComponent = ({id, type, vers
   const isPublished = displayed?._id && isPublishedId(displayed?._id)
 
   const handleConfirm = useCallback(() => {
-    discardChanges.execute()
+    void discardChanges.execute()
     setConfirmDialogOpen(false)
   }, [discardChanges])
 

--- a/packages/sanity/src/structure/documentActions/DuplicateAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DuplicateAction.tsx
@@ -61,7 +61,7 @@ export const useDuplicateAction: DuplicateDocumentActionComponent = ({id, type, 
         .operationEvents(id, type)
         .pipe(filter((e) => e.op === 'duplicate' && e.type === 'success')),
     )
-    duplicate.execute(dupeId, {mapDocument})
+    void duplicate.execute(dupeId, {mapDocument})
 
     // only navigate to the duplicated document when the operation is successful
     await duplicateSuccess

--- a/packages/sanity/src/structure/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/structure/documentActions/HistoryRestoreAction.tsx
@@ -1,11 +1,11 @@
 import {RevertIcon} from '@sanity/icons/Revert'
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {useCallback, useMemo, useState} from 'react'
 import {
   type DocumentActionComponent,
   type DocumentActionDialogProps,
   getPairTarget,
+  useAsyncOperation,
   useDocumentOperation,
-  useDocumentOperationEvent,
   useTranslation,
 } from 'sanity'
 import {useRouter} from 'sanity/router'
@@ -22,33 +22,25 @@ export const useHistoryRestoreAction: DocumentActionComponent = ({id, type, revi
   // below instead of silently operating on the base pair.
   const isTargetReady = targetDocumentState.status === 'ready'
   const {restore} = useDocumentOperation(id, type, getPairTarget(targetDocumentState))
-  const event = useDocumentOperationEvent(id, type)
+  const restoreAsync = useAsyncOperation(restore)
   const {navigateIntent} = useRouter()
-  const prevEvent = useRef(event)
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
   const {t} = useTranslation(structureLocaleNamespace)
 
   const handleConfirm = useCallback(() => {
-    restore.execute(revision!)
     setConfirmDialogOpen(false)
-  }, [restore, revision])
+    // Await the outcome of this specific restore call: navigate only when it succeeded
+    // (errors surface through the global operation-events toast).
+    void restoreAsync.execute(revision!).then((outcome) => {
+      if (outcome.type === 'success') {
+        navigateIntent('edit', {id, type})
+      }
+    })
+  }, [restoreAsync, revision, navigateIntent, id, type])
 
   const handleCancel = useCallback(() => {
     setConfirmDialogOpen(false)
   }, [])
-
-  /**
-   * If the restore operation is successful, navigate to the document edit view
-   */
-  useEffect(() => {
-    if (!event || event === prevEvent.current) return
-
-    if (event.type === 'success' && event.op === 'restore') {
-      navigateIntent('edit', {id, type})
-    }
-
-    prevEvent.current = event
-  }, [event, id, navigateIntent, type])
 
   const handle = useCallback(() => {
     setConfirmDialogOpen(true)
@@ -87,9 +79,18 @@ export const useHistoryRestoreAction: DocumentActionComponent = ({id, type, revi
       ),
       icon: RevertIcon,
       dialog,
-      disabled: isRevisionInitial || !isTargetReady,
+      disabled: isRevisionInitial || !isTargetReady || restoreAsync.isPending,
     }
-  }, [dialog, handle, isRevisionInitial, isRevisionLatest, isTargetReady, revisionNotFound, t])
+  }, [
+    dialog,
+    handle,
+    isRevisionInitial,
+    isRevisionLatest,
+    isTargetReady,
+    restoreAsync.isPending,
+    revisionNotFound,
+    t,
+  ])
 }
 
 useHistoryRestoreAction.action = 'restore'

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -115,7 +115,9 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   const telemetry = useTelemetry()
 
   const doPublish = useCallback(() => {
-    publish.execute(isVariantTarget ? {publishedRevisionId: currentPublishRevision} : undefined)
+    void publish.execute(
+      isVariantTarget ? {publishedRevisionId: currentPublishRevision} : undefined,
+    )
     telemetry.log(PublishButtonClicked, {documentId: id, stage: 'started'})
     setPublishState({status: 'publishing', publishRevision: currentPublishRevision})
   }, [publish, isVariantTarget, currentPublishRevision, telemetry, id])

--- a/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
@@ -67,7 +67,7 @@ export const useUnpublishAction: DocumentActionComponent = ({
 
   const handleConfirm = useCallback(() => {
     setConfirmDialogOpen(false)
-    unpublish.execute()
+    void unpublish.execute()
   }, [unpublish])
 
   const dialog: DocumentActionModalDialogProps | null = useMemo(() => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DeletedDocumentBanners.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DeletedDocumentBanners.tsx
@@ -41,7 +41,7 @@ function DeletedDocumentBanner() {
   const {navigateIntent} = useRouter()
 
   const handleRestore = useCallback(() => {
-    restore.execute('lastRevision')
+    void restore.execute('lastRevision')
     navigateIntent('edit', {id: documentId, type: documentType})
   }, [documentId, documentType, navigateIntent, restore])
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ObsoleteDraftBanner.tsx
@@ -46,13 +46,13 @@ export const ObsoleteDraftBanner: ComponentType<ObsoleteDraftBannerProps> = ({
   const {publish, discardChanges} = useDocumentOperation(documentId, displayed?._type || '')
 
   const handlePublish = useCallback(() => {
-    publish.execute()
+    void publish.execute()
     setPublishing(true)
     telemetry.log(ResolvedLiveEdit, {liveEditResolveType: 'publish'})
   }, [publish, telemetry])
 
   const handleDiscard = useCallback(() => {
-    discardChanges.execute()
+    void discardChanges.execute()
     setDiscarding(true)
     telemetry.log(ResolvedLiveEdit, {liveEditResolveType: 'discard'})
   }, [discardChanges, telemetry])

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -590,6 +590,7 @@ exports[`exports snapshot 1`] = `
     "useAllVariants": "function",
     "useAnnotationColor": "function",
     "useArchivedReleases": "function",
+    "useAsyncOperation": "function",
     "useCanvasCompanionDoc": "function",
     "useChangeIndicatorsReportedValues": "function",
     "useChangeIndicatorsReporter": "function",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Proof of concept for awaitable document operations (design exploration; see also Linear PS-486). Today `execute()` is a synchronous emit into the shared per-document executor, and completion is only observable through `operationEvents` — which carries op name + published id but no per-call correlation. That has bred four ad-hoc waiting strategies (`prevEvent` ref effects, `awaitingRef` + `versionId` filters in the version dialogs, `firstValueFrom` in DuplicateAction, `_rev`-watching in PublishAction) and blocks pending/error UI like the retry issue raised in [#14394 (comment)](https://github.com/sanity-io/sanity/pull/14394#discussion_r3893550887).

The fix is at the source: each `execute()` call now carries its own settlement function through the existing pipeline, and returns `Promise<OperationCallOutcome>` (`success` | `error` | `cancelled`). Key decisions:

- **Resolve, never reject** — fire-and-forget callers can keep ignoring the return value without unhandled rejections; awaiting callers branch on the outcome.
- **`cancelled` is a first-class outcome** — the executor intentionally drops in-flight ops when a newer op arrives for the same document (`switchMap`; typing cancels publish). An idempotent `finalize` settles superseded calls, replacing e.g. DeleteAction's 30s-timeout heuristic for detecting drops.
- **Event stream untouched** — `DocumentOperationResults` toasts and every existing `useDocumentOperationEvent` consumer keep working; migration can be incremental.
- **React 19 on top** — `useAsyncOperation(operation)` wraps `execute` in an async transition (`isPending` spans the full call, `error` holds the last failure). Since `execute` now returns a real promise, plain `startTransition(async () => …)`, `useActionState`, or even `use()` compose directly where preferred.

Alternatives considered:

- Hook-layer-only correlation (formalize DuplicateAction's `firstValueFrom` pattern): no store changes, but inherits the correlation races and hangs on cancelled ops.
- Rejecting promise on error: idiomatic but every fire-and-forget site becomes an unhandled-rejection hazard.
- A TanStack-Query-style mutation store: strictly more power (queues, retries, optimistic state) but a rewrite; this change is a compatible stepping stone.

`HistoryRestoreAction` is migrated as the demonstration: the `prevEvent` effect is gone, navigation happens on the outcome of the action's own call, and the action disables while pending.

### What to review

- `packages/sanity/src/core/store/document/document-pair/operationEvents.ts` — the settlement plumbing (`tap` + idempotent `finalize`); this is the heart of the change.
- `packages/sanity/src/core/hooks/useAsyncOperation.ts` — transition semantics; note the error state is cleared outside the transition because async-transition updates batch until the action settles.
- `packages/sanity/src/structure/documentActions/HistoryRestoreAction.tsx` — before/after of the consumer pattern.
- The `void` prefixes across call sites are mechanical (`no-floating-promises` now flags every ignored `execute()` — a useful side effect: the type system marks every site that ignores completion).
- One behavior caveat: `patch`/`commit` outcomes settle when the local buffer commit is *requested*, not when the network round-trip finishes (their impls return immediately). The server-action ops (publish, delete, unpublish, discardChanges, restore, duplicate) genuinely await the network call.

Affected package: `sanity`.

### Testing

- `operationEvents.test.ts`: four new tests covering success, error, cancellation-by-supersession, and executor-teardown settlement.
- `useAsyncOperation.test.tsx`: pending-state lifecycle, error surfacing/clearing, cancelled calls not surfacing errors.
- Full sweep green: document store suite (224 tests), structure documentActions/panes + releases dialogs + hooks (573 tests), `pnpm check:oxlint`, `pnpm check:format`, `pnpm test:exports`.

### Notes for release

N/A – Internal only (PoC for design discussion; `useAsyncOperation` is `@internal`/`@beta`).

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f1bd43a-f4c5-4bd5-9554-6f76ee2d4e25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f1bd43a-f4c5-4bd5-9554-6f76ee2d4e25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

