### PR TITLE
fix(sanity): false-positive appearance of `ReferenceChangedBanner`

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
@@ -1,155 +1,165 @@
 import {CloseIcon} from '@sanity/icons/Close'
 import {SyncIcon} from '@sanity/icons/Sync'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {type KeyedSegment, type Reference} from '@sanity/types'
+import {type Reference, type SanityDocument} from '@sanity/types'
 import {Text} from '@sanity/ui'
 import {fromString as pathFromString, get as pathGet} from '@sanity/util/paths'
-import {memo, useCallback, useMemo} from 'react'
+import {type ComponentType, memo, useCallback, useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
 import {concat, type Observable, of} from 'rxjs'
-import {debounceTime, map} from 'rxjs/operators'
+import {distinctUntilChanged, map} from 'rxjs/operators'
 import {
-  type DocumentAvailability,
+  type EditStateFor,
   getPublishedId,
-  isSystemBundle,
-  useDocumentPreviewStore,
+  isGoingToUnpublish,
+  isPublishedPerspective,
+  useDocumentStore,
   usePerspective,
+  useTargetScopeId,
   useTranslation,
 } from 'sanity'
 
 import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
 import {structureLocaleNamespace} from '../../../../i18n'
-import {type RouterPaneGroup} from '../../../../types'
+import {useResolvedPanesList} from '../../../../structureResolvers/useResolvedPanesList'
+import {isDocumentPaneNode} from '../../../../utils'
 import {Banner} from './Banner'
 
 interface ParentReferenceInfo {
   loading: boolean
   result?: {
-    availability: {
-      draft: DocumentAvailability
-      published: DocumentAvailability
-      version?: DocumentAvailability
-    }
+    available: boolean
     refValue: string | undefined
   }
 }
 
-export const ReferenceChangedBanner = memo(() => {
-  const documentPreviewStore = useDocumentPreviewStore()
+const ReferenceChangedBannerComponent: ComponentType = () => {
+  const documentStore = useDocumentStore()
   const {selectedPerspectiveName} = usePerspective()
   const {params, groupIndex, routerPanesState, replaceCurrent, BackLink} = usePaneRouter()
-  const routerReferenceId = routerPanesState[groupIndex]?.[0].id
-  const parentGroup = routerPanesState[groupIndex - 1] as RouterPaneGroup | undefined
-  const parentSibling = parentGroup?.[0]
-  const parentId = parentSibling?.id
-  const hasHistoryOpen = Boolean(parentSibling?.params?.rev)
-  const parentRefPath = (params?.parentRefPath && pathFromString(params.parentRefPath)) || null
+  const {paneDataItems} = useResolvedPanesList()
+  const routerReferenceId = routerPanesState.at(groupIndex)?.at(0)?.id
+  const parentPath = params?.parentRefPath ? pathFromString(params.parentRefPath) : null
   const {t} = useTranslation(structureLocaleNamespace)
 
+  const parentPaneData = paneDataItems.find(
+    (item) => item.groupIndex === groupIndex && item.siblingIndex === 0,
+  )
+
+  const parentPane = parentPaneData?.pane
+  const parentId = parentPaneData?.itemId
+  const parentGroupId = getPublishedId(parentId ?? '')
+
+  const parentType =
+    parentPane && isDocumentPaneNode(parentPane) ? parentPane.options.type : undefined
+
+  const hasHistoryOpen = Boolean(parentPaneData?.params?.rev)
+
+  const targetScopeId = useTargetScopeId({
+    documentId: parentGroupId,
+    selectedPerspectiveName,
+  })
+
+  // This assumes the parent pane shares the same perspective as the referenced
+  // document pane. This is true because all Structure panes share the same
+  // perspective. It will need to be refactored if panes are given the ability
+  // to control their own perspective.
+  const publishedPerspectiveSelected =
+    typeof selectedPerspectiveName !== 'undefined' &&
+    isPublishedPerspective(selectedPerspectiveName)
+
   /**
-   * Loads information regarding the reference field of the parent pane. This
-   * is only applicable to child references (aka references-in-place).
+   * Watches the reference field of the parent pane. This is only applicable to
+   * child references (aka references-in-place).
    *
    * It utilizes the pane ID of the parent pane (which is a document ID) along
    * with the `parentRefPath` router param on the current pane to find the
    * current value of the reference field on the parent document.
    *
    * This is used to compare with the current pane's document ID. If the IDs
-   * don't match then this banner should reveal itself
+   * don't match then this banner should reveal itself.
    */
-  const referenceInfoObservable = useMemo((): Observable<ParentReferenceInfo> => {
-    const parentRefPathSegment = parentRefPath?.[0] as string | undefined
-
+  const parentReferenceInfoObservable = useMemo((): Observable<ParentReferenceInfo> => {
     // short-circuit: this document pane is not a child reference pane
-    if (!parentId || !parentRefPathSegment || !parentRefPath) {
+    if (!parentId || !parentPath || !parentType) {
       return of({loading: false})
     }
-
-    const publishedId = getPublishedId(parentId)
-    const path = pathFromString(parentRefPathSegment)
-
-    // note: observePaths doesn't support keyed path segments, so we need to select the nearest parent
-    const keyedSegmentIndex = path.findIndex(
-      (p): p is KeyedSegment => typeof p == 'object' && '_key' in p,
-    )
 
     return concat(
       // emit a loading state instantly
       of({loading: true}),
-      // then emit the values from watching the published ID's path
-      documentPreviewStore
-        .unstable_observePathsDocumentPair(
-          publishedId,
-          (keyedSegmentIndex === -1 ? path : path.slice(0, keyedSegmentIndex)) as string[][],
-          {
-            version: isSystemBundle(selectedPerspectiveName) ? undefined : selectedPerspectiveName,
-          },
-        )
-        .pipe(
-          // this debounce time is needed to prevent flashing banners due to
-          // the router state updating faster than the content-lake state. we
-          // debounce to wait for more emissions because the value pulled
-          // initially could be stale.
-          debounceTime(750),
-          map(({draft, published, version}): ParentReferenceInfo => ({
+      documentStore.pair.editState(parentGroupId, parentType, targetScopeId).pipe(
+        map((editState): ParentReferenceInfo => {
+          if (!editState.ready) {
+            return {loading: true}
+          }
+
+          const parentDocument = selectDisplayedDocument(editState, publishedPerspectiveSelected)
+
+          return {
             loading: false,
             result: {
-              availability: {
-                draft: draft.availability,
-                published: published.availability,
-                ...(version?.availability
-                  ? {
-                      version: version.availability,
-                    }
-                  : {}),
-              },
-              refValue: pathGet<Reference>(
-                version?.snapshot || draft.snapshot || published.snapshot,
-                parentRefPath,
-              )?._ref,
+              available: parentDocument !== null,
+              refValue: pathGet<Reference>(parentDocument, parentPath)?._ref,
             },
-          })),
+          }
+        }),
+        distinctUntilChanged(
+          (a, b) =>
+            a.loading === b.loading &&
+            a.result?.available === b.result?.available &&
+            a.result?.refValue === b.result?.refValue,
         ),
+      ),
     )
-  }, [selectedPerspectiveName, documentPreviewStore, parentId, parentRefPath])
+  }, [
+    documentStore,
+    parentGroupId,
+    parentId,
+    parentPath,
+    parentType,
+    publishedPerspectiveSelected,
+    targetScopeId,
+  ])
+
   // Kept synchronous: `handleReloadReference` navigates to `refValue` from
   // this snapshot, so a deferred value could point the reload action at a
   // stale parent reference.
-  const referenceInfo = useSyncObservable(referenceInfoObservable, {loading: true})
+  const parentReferenceInfo = useSyncObservable(parentReferenceInfoObservable, {loading: true})
 
   const handleReloadReference = useCallback(() => {
-    if (referenceInfo.loading) return
+    if (parentReferenceInfo.loading) return
 
-    if (referenceInfo.result?.refValue) {
+    if (parentReferenceInfo.result?.refValue) {
       replaceCurrent({
-        id: referenceInfo.result.refValue,
+        id: parentReferenceInfo.result.refValue,
         params: params as Record<string, string>,
       })
     }
-  }, [referenceInfo.loading, referenceInfo.result, replaceCurrent, params])
+  }, [parentReferenceInfo.loading, parentReferenceInfo.result, replaceCurrent, params])
 
   const shouldHide =
-    // if `parentId` or `parentRefPath` is not present then this banner is n/a
+    // if `parentId` or `parentPath` is not present then this banner is n/a
     !parentId ||
-    !parentRefPath ||
+    !parentPath ||
+    !routerReferenceId ||
     // if viewing this pane via history, then hide
     hasHistoryOpen ||
     // if loading, hide
-    referenceInfo.loading ||
+    parentReferenceInfo.loading ||
     // if the parent document is not available (e.g. due to permission denied or
     // not found) we don't want to display a warning here, but instead rely on the
     // parent view to display the appropriate message
-    (!referenceInfo.result?.availability.draft.available &&
-      !referenceInfo.result?.availability.published.available) ||
+    !parentReferenceInfo.result?.available ||
     // if the references are the same, then hide the reference changed banner
-    referenceInfo.result?.refValue === routerReferenceId
+    parentReferenceInfo.result?.refValue === routerReferenceId
 
   if (shouldHide) return null
 
   return (
     <Banner
       action={
-        referenceInfo.result?.refValue
+        parentReferenceInfo.result?.refValue
           ? {
               onClick: handleReloadReference,
               icon: SyncIcon,
@@ -164,7 +174,7 @@ export const ReferenceChangedBanner = memo(() => {
       data-testid="reference-changed-banner"
       content={
         <Text size={1} weight="medium">
-          {referenceInfo.result?.refValue
+          {parentReferenceInfo.result?.refValue
             ? t('banners.reference-changed-banner.reason-changed.text')
             : t('banners.reference-changed-banner.reason-removed.text')}
         </Text>
@@ -173,4 +183,30 @@ export const ReferenceChangedBanner = memo(() => {
       tone="caution"
     />
   )
-})
+}
+
+export const ReferenceChangedBanner = memo(ReferenceChangedBannerComponent)
+
+/**
+ * Select the displayed document, mirroring the selection logic used by the
+ * document pane.
+ *
+ * This is used to infer which member of the **referencing** document group to
+ * watch for a disconnected reference.
+ *
+ * In a future iteration, this logic will be centralised.
+ */
+function selectDisplayedDocument(
+  editState: EditStateFor,
+  publishedPerspectiveSelected: boolean,
+): SanityDocument | null {
+  if (editState.version) {
+    return isGoingToUnpublish(editState.version) ? editState.published : editState.version
+  }
+
+  if (publishedPerspectiveSelected) {
+    return editState.published
+  }
+
+  return editState.draft ?? editState.published
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/ReferenceChangedBanner.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/ReferenceChangedBanner.test.tsx
@@ -1,0 +1,400 @@
+import {type SanityDocument} from '@sanity/types'
+import {act, render, screen} from '@testing-library/react'
+import {type PropsWithChildren} from 'react'
+import {BehaviorSubject} from 'rxjs'
+import {type DocumentStore, type EditStateFor, useDocumentStore, usePerspective} from 'sanity'
+import {ResolvedPanesProvider} from 'sanity/_singletons'
+import {test as baseTest, describe, expect, type Mock, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {LOADING_PANE} from '../../../../../constants'
+import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
+import {type Panes} from '../../../../../structureResolvers/useResolvedPanes'
+import {type PaneNode} from '../../../../../types'
+import {ReferenceChangedBanner} from '../ReferenceChangedBanner'
+
+vi.mock('sanity', async () => {
+  const sanity = await vi.importActual('sanity')
+  return {
+    ...sanity,
+    useDocumentStore: vi.fn(),
+    usePerspective: vi.fn(),
+  }
+})
+
+vi.mock('../../../../../components/paneRouter/usePaneRouter', () => ({
+  usePaneRouter: vi.fn(),
+}))
+
+const {usePaneRouter} = vi.mocked(
+  await import('../../../../../components/paneRouter/usePaneRouter'),
+)
+
+const mockUseDocumentStore = useDocumentStore as Mock<typeof useDocumentStore>
+const mockUsePerspective = usePerspective as Mock<typeof usePerspective>
+
+const PARENT_ID = 'parent-doc'
+const PARENT_TYPE = 'article'
+const CHILD_ID = 'child-doc'
+const OTHER_ID = 'other-doc'
+const RELEASE_ID = 'rSummer'
+const REF_FIELD = 'featured'
+
+const DRAFTS_PERSPECTIVE: ReturnType<typeof usePerspective> = {
+  selectedPerspectiveName: undefined,
+  selectedReleaseId: undefined,
+  selectedPerspective: 'drafts',
+  perspectiveStack: ['drafts'],
+  excludedPerspectives: [],
+  selectedVariantName: undefined,
+  selectedVariant: undefined,
+  bundle: 'drafts',
+}
+
+/** A release perspective, which is what scopes the parent to its version layer. */
+const RELEASE_PERSPECTIVE: ReturnType<typeof usePerspective> = {
+  ...DRAFTS_PERSPECTIVE,
+  selectedPerspectiveName: RELEASE_ID,
+  selectedReleaseId: RELEASE_ID,
+  perspectiveStack: [RELEASE_ID, 'drafts'],
+  bundle: RELEASE_ID,
+}
+
+const PUBLISHED_PERSPECTIVE: ReturnType<typeof usePerspective> = {
+  ...DRAFTS_PERSPECTIVE,
+  selectedPerspectiveName: 'published',
+  selectedPerspective: 'published',
+  perspectiveStack: ['published'],
+  bundle: 'published',
+}
+
+/** The parent pane as the structure resolver hands it over, with its type already resolved. */
+const PARENT_PANE = {
+  id: 'parent-pane',
+  type: 'document',
+  options: {id: PARENT_ID, type: PARENT_TYPE},
+} as PaneNode
+
+/** The implicit root pane the structure resolver puts in front of every router pane group. */
+const ROOT_PANE = {
+  id: 'root',
+  type: 'list',
+  title: 'Content',
+} as PaneNode
+
+/** The pane rendering the banner. */
+const CHILD_PANE = {
+  id: 'child-pane',
+  type: 'document',
+  options: {id: CHILD_ID, type: 'child-type'},
+} as PaneNode
+
+function BackLink({children}: PropsWithChildren) {
+  return <a href="/back">{children}</a>
+}
+
+function parentSnapshot(refId: string | undefined): SanityDocument {
+  return {
+    _id: PARENT_ID,
+    _type: PARENT_TYPE,
+    _rev: 'parent-rev',
+    _createdAt: '2024-01-01T00:00:00Z',
+    _updatedAt: '2024-01-02T00:00:00Z',
+    ...(refId ? {[REF_FIELD]: {_type: 'reference', _ref: refId}} : {}),
+  }
+}
+
+/**
+ * The version a release marks for unpublishing: a tombstone that carries no fields of its own, so
+ * the parent pane displays the published document instead.
+ */
+function unpublishTombstone(): SanityDocument {
+  return {
+    ...parentSnapshot(undefined),
+    _id: `versions.${RELEASE_ID}.${PARENT_ID}`,
+    _system: {delete: true},
+  }
+}
+
+function editStateFor(overrides: Partial<EditStateFor>): EditStateFor {
+  return {
+    id: PARENT_ID,
+    type: PARENT_TYPE,
+    transactionSyncLock: null,
+    draft: null,
+    published: null,
+    version: null,
+    liveEdit: false,
+    liveEditSchemaType: false,
+    ready: true,
+    release: undefined,
+    scopeId: undefined,
+    ...overrides,
+  }
+}
+
+/**
+ * The resolved pane tree the way `useResolvedPanes` builds it: the implicit root pane occupies
+ * group 0, so each router pane group sits one index further along. The parent of the pane
+ * rendering the banner is therefore at group 1, which is that pane's `usePaneRouter` `groupIndex`.
+ */
+function resolvedPanes(
+  parentPane: PaneNode | typeof LOADING_PANE,
+  parentPaneParams: Record<string, string> = {},
+): Panes {
+  const paneDataItems = [
+    {groupIndex: 0, siblingIndex: 0, itemId: 'root', params: {}, pane: ROOT_PANE},
+    {groupIndex: 1, siblingIndex: 0, itemId: PARENT_ID, params: parentPaneParams, pane: parentPane},
+    {groupIndex: 2, siblingIndex: 0, itemId: CHILD_ID, params: {}, pane: CHILD_PANE},
+  ]
+
+  return {
+    paneDataItems,
+    routerPanes: [],
+    resolvedPanes: paneDataItems.map((item) => item.pane),
+    maximizedPane: null,
+    setMaximizedPane: vi.fn(),
+  } as unknown as Panes
+}
+
+interface RenderBannerOptions {
+  perspective?: ReturnType<typeof usePerspective>
+  parentPane?: PaneNode | typeof LOADING_PANE
+  parentPaneParams?: Record<string, string>
+}
+
+interface ParentEditState {
+  /**
+   * Emits a new edit state for the parent, the way its buffered document does when the parent form
+   * is patched. Starts out ready with no snapshot in any layer, which is what a parent that cannot
+   * be read looks like.
+   */
+  emit: (overrides?: Partial<EditStateFor>) => void
+  /**
+   * The mocked `documentStore.pair.editState`, for asserting which document, type and version
+   * layer the banner subscribes to.
+   */
+  spy: Mock<DocumentStore['pair']['editState']>
+}
+
+interface ReferenceChangedBannerFixtures {
+  parentEditState: ParentEditState
+  replaceCurrentSpy: Mock<ReturnType<typeof usePaneRouter>['replaceCurrent']>
+  renderBanner: (options?: RenderBannerOptions) => Promise<void>
+}
+
+const test = baseTest.extend<ReferenceChangedBannerFixtures>({
+  // oxlint-disable-next-line no-empty-pattern
+  parentEditState: async ({}, consume) => {
+    const editState$ = new BehaviorSubject(editStateFor({}))
+
+    await consume({
+      emit: (overrides = {}) => editState$.next(editStateFor(overrides)),
+      spy: vi.fn(() => editState$),
+    })
+  },
+  // oxlint-disable-next-line no-empty-pattern
+  replaceCurrentSpy: async ({}, consume) => {
+    await consume(vi.fn())
+  },
+  renderBanner: async ({parentEditState, replaceCurrentSpy}, consume) => {
+    const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+    let unmountBanner: (() => void) | undefined
+
+    await consume(
+      async ({
+        perspective = DRAFTS_PERSPECTIVE,
+        parentPane = PARENT_PANE,
+        parentPaneParams,
+      } = {}) => {
+        mockUsePerspective.mockReturnValue(perspective)
+
+        mockUseDocumentStore.mockReturnValue({
+          pair: {editState: parentEditState.spy},
+        } as unknown as ReturnType<typeof useDocumentStore>)
+
+        usePaneRouter.mockReturnValue({
+          params: {parentRefPath: REF_FIELD},
+          groupIndex: 1,
+          routerPanesState: [[{id: PARENT_ID}], [{id: CHILD_ID}]],
+          replaceCurrent: replaceCurrentSpy,
+          BackLink,
+        } as unknown as ReturnType<typeof usePaneRouter>)
+
+        unmountBanner = render(
+          <ResolvedPanesProvider value={resolvedPanes(parentPane, parentPaneParams)}>
+            <ReferenceChangedBanner />
+          </ResolvedPanesProvider>,
+          {wrapper},
+        ).unmount
+
+        // oxlint-disable-next-line testing-library/no-unnecessary-act -- settles a store subscription, not a Testing Library call
+        await act(async () => {})
+      },
+    )
+
+    unmountBanner?.()
+    mockUsePerspective.mockReset()
+    mockUseDocumentStore.mockReset()
+    usePaneRouter.mockReset()
+  },
+})
+
+test('reveals the banner as soon as the parent form patches the reference', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  // The point of reading the parent through its edit state: the parent pane applies patches
+  // optimistically to its buffered document, so picking a reference (or creating one in place)
+  // must show up here without waiting for the mutation to be committed, round-tripped and
+  // re-fetched. The banner has to appear on the emission alone — nothing below waits for a timer,
+  // so a debounce reintroduced between the edit state and the banner would fail here.
+  parentEditState.emit({draft: parentSnapshot(CHILD_ID)})
+
+  await renderBanner()
+
+  // Pins the pane lookup to the parent document pane. `paneDataItems` and `usePaneRouter`'s
+  // `groupIndex` are offset by the implicit root pane, so reading the parent one group too far up
+  // resolves the root list pane instead, leaving the banner with no document type to watch and
+  // permanently hidden.
+  expect(parentEditState.spy).toHaveBeenCalledWith(PARENT_ID, PARENT_TYPE, undefined)
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+
+  await act(async () => {
+    parentEditState.emit({draft: parentSnapshot(OTHER_ID)})
+  })
+
+  expect(screen.getByText('This reference has changed since you opened it.')).toBeInTheDocument()
+})
+
+test('stays hidden until the parent document pair is ready', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  // An unready pair has null snapshots, which reads exactly like a removed reference. The banner
+  // used to debounce emissions to ride out that window; `ready` reports it directly.
+  parentEditState.emit({ready: false})
+
+  await renderBanner()
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+
+  await act(async () => {
+    parentEditState.emit({draft: parentSnapshot(undefined)})
+  })
+
+  expect(
+    screen.getByText('This reference has been removed since you opened it.'),
+  ).toBeInTheDocument()
+})
+
+test('reads the parent at the scope the selected perspective resolves to', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  // The reference field has to be read from the document the parent pane is actually editing. Under
+  // a release perspective that is the parent's release version, so the scope has to be threaded
+  // into the pair checkout — reading the base pair instead would compare against the draft's
+  // reference and warn (or stay silent) about a field the user is not looking at.
+  parentEditState.emit({version: parentSnapshot(OTHER_ID)})
+
+  await renderBanner({perspective: RELEASE_PERSPECTIVE})
+
+  expect(parentEditState.spy).toHaveBeenCalledWith(PARENT_ID, PARENT_TYPE, RELEASE_ID)
+
+  expect(screen.getByTestId('reference-changed-banner')).toBeInTheDocument()
+})
+
+test('reads the published document under the published perspective', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  // The published perspective pins the parent pane to its published document, so the reference has
+  // to be read from there. Falling back to the draft — which is checked out alongside the published
+  // document, and can hold a reference the user is not looking at (or linger after drafts were
+  // turned off) — would warn about a change the parent pane does not show.
+  parentEditState.emit({draft: parentSnapshot(OTHER_ID), published: parentSnapshot(CHILD_ID)})
+
+  await renderBanner({perspective: PUBLISHED_PERSPECTIVE})
+
+  expect(parentEditState.spy).toHaveBeenCalledWith(PARENT_ID, PARENT_TYPE, undefined)
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+})
+
+test('reads the published document when the parent version is marked for unpublishing', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  // The parent pane replaces an unpublish tombstone with the published document, because the
+  // tombstone holds no fields. Reading the reference off the tombstone would report every such
+  // parent as having had its reference removed.
+  parentEditState.emit({version: unpublishTombstone(), published: parentSnapshot(CHILD_ID)})
+
+  await renderBanner({perspective: RELEASE_PERSPECTIVE})
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+})
+
+test('stays hidden when no layer of the parent document can be read', async ({renderBanner}) => {
+  // The parent pane reports the permission error itself; without this guard the missing snapshot
+  // would be misread as "the reference was removed". The default edit state is exactly this:
+  // ready, with nothing in any layer.
+  await renderBanner({perspective: RELEASE_PERSPECTIVE})
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+})
+
+test('warns that the reference was removed when the parent is readable but the field is gone', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  parentEditState.emit({draft: parentSnapshot(undefined)})
+
+  await renderBanner()
+
+  expect(
+    screen.getByText('This reference has been removed since you opened it.'),
+  ).toBeInTheDocument()
+
+  expect(screen.getByRole('link', {name: 'Close reference'})).toBeInTheDocument()
+})
+
+test('stays hidden while the parent reference still points at the open document', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  parentEditState.emit({draft: parentSnapshot(CHILD_ID)})
+
+  await renderBanner()
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+})
+
+test('stays hidden while the parent pane is showing a historical revision', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  // Viewing the parent through history means its reference field is being read at an older
+  // revision, so a mismatch says nothing about the reference having changed.
+  parentEditState.emit({draft: parentSnapshot(OTHER_ID)})
+
+  await renderBanner({parentPaneParams: {rev: 'parent-rev-1'}})
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+})
+
+test('stays hidden while the parent pane is still resolving', async ({
+  parentEditState,
+  renderBanner,
+}) => {
+  // The parent's document type comes from its resolved pane, so there is nothing to read (and
+  // nothing to warn about) until the structure resolver has produced it.
+  parentEditState.emit({draft: parentSnapshot(OTHER_ID)})
+
+  await renderBanner({parentPane: LOADING_PANE})
+
+  expect(screen.queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+  expect(parentEditState.spy).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
### Description

`ReferenceChangedBanner` previously relied on `DocumentPreviewStore` to
determine whether the reference target had changed. This was
problematic when creating a reference in place, because the id of the
new reference target only propagated through Studio after a server
roundtrip.

The banner now uses the referencing document's edit state instead, which
is updated optimistically, and therefore propagates through the Studio
app immediately.

This change prevents the banner appearing erroneously while the
reference id mutation initiated by `ReferenceInput` is in flight.

It also updates the check on the availability of the referencing
document to respect the presence of a version.

### What to review

The `ReferenceChangedBanner` when creating a reference in place. It should never flicker erroneously when the reference target pane opens, even when the client's connection is slow.

### Testing

Added unit tests. Verified flickering no longer occurs with throttled connection.

### Notes for release

Fixes a bug that could cause the "This reference has changed since you opened it." banner to flicker erroneously, especially when the client's connection is slow.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes reference-in-place UX by swapping data sources and document-layer selection logic; mistakes could hide real warnings or show false ones, but scope is limited to Structure’s reference-changed banner.
> 
> **Overview**
> Fixes erroneous flicker of the **“reference changed”** banner when opening in-place reference panes, especially on slow connections.
> 
> **`ReferenceChangedBanner`** no longer watches the parent reference through **`DocumentPreviewStore`** (server-roundtrip lag). It subscribes to the parent document’s **`documentStore.pair.editState`**, so the reference field reflects optimistic parent form patches immediately. The old **750ms debounce** is removed; loading/unready states use **`editState.ready`**, and emissions are deduped with **`distinctUntilChanged`**.
> 
> Parent context comes from **`useResolvedPanesList`** (correct pane/type vs raw router groups), with **`useTargetScopeId`** and a new **`selectDisplayedDocument`** helper so the watched reference matches what the parent document pane shows (published perspective, release versions, unpublish tombstones). Availability is simplified to whether a display snapshot exists, avoiding false “removed” warnings when the parent is unreadable.
> 
> Adds a **Vitest** suite covering optimistic updates, readiness, perspectives, history, and loading panes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc68d0020091b60d4632c195097862902b125f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->