### PR TITLE
chore(comments-v2): migrate layout and text primitives to ui5

### DIFF
--- a/packages/sanity/src/core/comments-v2/components/CommentBreadcrumbs.tsx
+++ b/packages/sanity/src/core/comments-v2/components/CommentBreadcrumbs.tsx
@@ -1,7 +1,6 @@
 import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
-import {Stack, Text} from '@sanity/ui'
 import {Fragment, useMemo} from 'react'
-import {Box, Flex} from 'ui5'
+import {Text, Box, Flex, Icon} from 'ui5'
 
 import {Tooltip} from '../../../ui-components/tooltip/Tooltip'
 
@@ -12,16 +11,12 @@ export interface CommentBreadcrumbsProps {
 
 type Item = string | string[]
 
-const separator = (
-  <Text muted>
-    <ChevronRightIcon />
-  </Text>
-)
+const separator = <Icon muted icon={ChevronRightIcon} style={{margin: '-0.4375rem'}} />
 
 const renderItem = (item: string, index: number) => {
   return (
     <Box key={`${item}-${index}`} as="li">
-      <Text textOverflow="ellipsis" size={1} weight="medium">
+      <Text truncate={1} size={1} weight="medium" as="div" trim={true}>
         {item}
       </Text>
     </Box>
@@ -57,9 +52,9 @@ export function CommentBreadcrumbs(props: CommentBreadcrumbsProps) {
           <Fragment key={key}>
             <Tooltip
               content={
-                <Stack gap={2} padding={2}>
+                <Flex gap={2} padding={2} flexDirection="column">
                   {item.map(renderItem)}
-                </Stack>
+                </Flex>
               }
             >
               <Box>{renderItem('...', index)}</Box>

--- a/packages/sanity/src/core/comments-v2/components/CommentDeleteDialog.tsx
+++ b/packages/sanity/src/core/comments-v2/components/CommentDeleteDialog.tsx
@@ -1,5 +1,5 @@
-import {Stack, Text} from '@sanity/ui'
 import {useCallback} from 'react'
+import {Text, VStack} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {TextWithTone} from '../../components/textWithTone/TextWithTone'
@@ -69,11 +69,13 @@ export function CommentDeleteDialog(props: CommentDeleteDialogProps) {
       onClose={onClose}
       width={0}
     >
-      <Stack gap={4}>
-        <Text size={1}>{body}</Text>
+      <VStack gap={4}>
+        <Text size={1} as="div" trim={true}>
+          {body}
+        </Text>
 
         {error && <TextWithTone tone="critical">{t('delete-dialog.error')}</TextWithTone>}
-      </Stack>
+      </VStack>
     </Dialog>
   )
 }

--- a/packages/sanity/src/core/comments-v2/components/__tests__/CommentBreadcrumbsStory.tsx
+++ b/packages/sanity/src/core/comments-v2/components/__tests__/CommentBreadcrumbsStory.tsx
@@ -1,4 +1,5 @@
-import {Card, Stack, Text} from '@sanity/ui'
+import {Card} from '@sanity/ui'
+import {Text, VStack} from 'ui5'
 
 import {CommentBreadcrumbs} from '../CommentBreadcrumbs'
 
@@ -13,23 +14,23 @@ export function CommentBreadcrumbsStory({
 }: CommentBreadcrumbsStoryProps) {
   return (
     <Card padding={4}>
-      <Stack gap={5}>
-        <Stack gap={2}>
-          <Text muted size={1}>
+      <VStack gap={5}>
+        <VStack gap={2}>
+          <Text muted size={1} as="div" trim={true}>
             short path
           </Text>
           <CommentBreadcrumbs maxLength={maxLength} titlePath={titlePath} />
-        </Stack>
-        <Stack gap={2}>
-          <Text muted size={1}>
+        </VStack>
+        <VStack gap={2}>
+          <Text muted size={1} as="div" trim={true}>
             truncated
           </Text>
           <CommentBreadcrumbs
             maxLength={maxLength}
             titlePath={['Article', 'Body', 'Content', 'Block', 'Image', 'Alt text']}
           />
-        </Stack>
-      </Stack>
+        </VStack>
+      </VStack>
     </Card>
   )
 }

--- a/packages/sanity/src/core/comments-v2/components/list/CommentOriginBadge.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentOriginBadge.tsx
@@ -1,0 +1,63 @@
+import {Card, Text as SanityUIText} from '@sanity/ui'
+import {styled} from 'styled-components'
+import {Text, Flex} from 'ui5'
+
+import {CircleSmallIcon} from '../../../components/temporary-icons/CircleSmall'
+import {RingIcon} from '../../../components/temporary-icons/Ring'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {commentsLocaleNamespace} from '../../i18n'
+
+export type CommentOrigin = 'draft' | 'published'
+
+/**
+ * Same slot as `DocumentVersionsStatusIndicator`: `@sanity/ui` Text sizes the
+ * 1em glyphs and applies `--card-icon-color`. ui5 `Icon` paints
+ * `--foreground-high` and drops the draft orange / published green.
+ */
+const IconSlotRoot = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  &[data-status='published'] {
+    --card-icon-color: var(--card-badge-positive-dot-color);
+  }
+  &[data-status='draft'] {
+    --card-icon-color: var(--card-badge-caution-dot-color);
+  }
+`
+
+function getOriginI18nKey(origin: CommentOrigin) {
+  switch (origin) {
+    case 'draft':
+      return 'list-item.origin.draft'
+    case 'published':
+      return 'list-item.origin.published'
+    default:
+      origin satisfies never
+      return origin
+  }
+}
+
+export function CommentOriginBadge({origin}: {origin: CommentOrigin}) {
+  const {t} = useTranslation(commentsLocaleNamespace)
+
+  return (
+    <Flex marginBottom={2}>
+      <Card border padding={1} radius={3}>
+        <Flex alignItems="center" gap={1} paddingRight={1}>
+          <IconSlotRoot data-status={origin}>
+            <SanityUIText size={2}>
+              {origin === 'draft' ? <RingIcon /> : <CircleSmallIcon />}
+            </SanityUIText>
+          </IconSlotRoot>
+
+          <Text size={0} muted weight="medium" as="div" trim={true}>
+            {t(getOriginI18nKey(origin))}
+          </Text>
+        </Flex>
+      </Card>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/comments-v2/components/list/CommentOriginBadge.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentOriginBadge.tsx
@@ -1,6 +1,6 @@
-import {Card, Text as SanityUIText} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
 import {styled} from 'styled-components'
-import {Text, Flex} from 'ui5'
+import {Flex} from 'ui5'
 
 import {CircleSmallIcon} from '../../../components/temporary-icons/CircleSmall'
 import {RingIcon} from '../../../components/temporary-icons/Ring'
@@ -48,12 +48,10 @@ export function CommentOriginBadge({origin}: {origin: CommentOrigin}) {
       <Card border padding={1} radius={3}>
         <Flex alignItems="center" gap={1} paddingRight={1}>
           <IconSlotRoot data-status={origin}>
-            <SanityUIText size={2}>
-              {origin === 'draft' ? <RingIcon /> : <CircleSmallIcon />}
-            </SanityUIText>
+            <Text size={2}>{origin === 'draft' ? <RingIcon /> : <CircleSmallIcon />}</Text>
           </IconSlotRoot>
 
-          <Text size={0} muted weight="medium" as="div" trim={true}>
+          <Text size={0} muted weight="medium">
             {t(getOriginI18nKey(origin))}
           </Text>
         </Flex>

--- a/packages/sanity/src/core/comments-v2/components/list/CommentThreadLayout.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentThreadLayout.tsx
@@ -2,12 +2,11 @@ import {type CurrentUser} from '@sanity/types'
 import {
   // oxlint-disable-next-line no-restricted-imports
   Button, // Button with specific styling and children behavior.
-  Stack,
 } from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import {type MouseEvent, type ReactNode, useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
-import {Flex} from 'ui5'
+import {Flex, VStack} from 'ui5'
 
 import {type UserListWithPermissionsHookValue} from '../../../hooks/useUserListWithPermissions'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -125,9 +124,9 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
   const lastCrumb = crumbsTitlePath[crumbsTitlePath.length - 1]
 
   return (
-    <Stack gap={2}>
+    <VStack gap={2}>
       <HeaderFlex alignItems="center" gap={2} paddingRight={1}>
-        <Stack flex={1}>
+        <Flex flexBasis="0%" flexGrow={1} flexDirection="column">
           <Flex alignItems="center">
             <BreadcrumbsButton
               aria-label={t('list-item.breadcrumb-button-go-to-field-aria-label', {
@@ -141,7 +140,7 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
               <CommentBreadcrumbs maxLength={3} titlePath={crumbsTitlePath} />
             </BreadcrumbsButton>
           </Flex>
-        </Stack>
+        </Flex>
       </HeaderFlex>
 
       {canCreateNewThread && (
@@ -157,7 +156,7 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
         </ThreadCard>
       )}
 
-      <Stack gap={2}>{children}</Stack>
-    </Stack>
+      <VStack gap={2}>{children}</VStack>
+    </VStack>
   )
 }

--- a/packages/sanity/src/core/comments-v2/components/list/CommentsList.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentsList.tsx
@@ -1,5 +1,5 @@
 import {type CurrentUser} from '@sanity/types'
-import {BoundaryElementProvider, Stack} from '@sanity/ui'
+import {BoundaryElementProvider} from '@sanity/ui'
 import {memo, useMemo, useState, type RefAttributes} from 'react'
 import {Flex} from 'ui5'
 
@@ -125,16 +125,17 @@ function CommentsListInner(props: CommentsListProps & RefAttributes<HTMLUListEle
       )}
 
       {(showComments || beforeListNode) && (
-        <Stack
+        <Flex
           as="ul"
-          flex={1}
+          flexBasis="0%"
+          flexGrow={1}
           overflow="auto"
           padding={3}
           paddingTop={1}
           paddingBottom={6}
-          sizing="border"
           gap={1}
           ref={ref}
+          flexDirection="column"
         >
           {beforeListNode}
 
@@ -155,11 +156,13 @@ function CommentsListInner(props: CommentsListProps & RefAttributes<HTMLUListEle
                 selectedPath?.fieldPath === fieldPath && !selectedPath.threadId
 
               return (
-                <Stack
+                <Flex
                   key={fieldPath}
                   as="li"
                   paddingTop={3}
                   {...applyCommentsGroupAttr(firstThreadId)}
+                  flexDirection="column"
+                  flexShrink={0}
                 >
                   <CommentThreadLayout
                     key={fieldPath}
@@ -216,11 +219,11 @@ function CommentsListInner(props: CommentsListProps & RefAttributes<HTMLUListEle
                       )
                     })}
                   </CommentThreadLayout>
-                </Stack>
+                </Flex>
               )
             })}
           </BoundaryElementProvider>
-        </Stack>
+        </Flex>
       )}
     </Flex>
   )

--- a/packages/sanity/src/core/comments-v2/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentsListItem.tsx
@@ -1,6 +1,6 @@
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {type CurrentUser} from '@sanity/types'
-import {type AvatarSize, Stack, type StackProps, useLayer} from '@sanity/ui'
+import {type AvatarSize, useLayer} from '@sanity/ui'
 import {
   type KeyboardEvent,
   memo,
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react'
 import {css, styled} from 'styled-components'
-import {Flex} from 'ui5'
+import {type PaddingProps, Flex, VStack} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {type UserListWithPermissionsHookValue} from '../../../hooks/useUserListWithPermissions'
@@ -102,7 +102,7 @@ export interface CommentsListItemProps {
   canReply?: boolean
   currentUser: CurrentUser
   hasReferencedValue?: boolean
-  innerPadding?: StackProps['padding']
+  innerPadding?: PaddingProps['padding']
   isSelected: boolean
   mentionOptions: UserListWithPermissionsHookValue
   mode: CommentsUIMode
@@ -262,15 +262,16 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
         aria-label={t('list-item.go-to-field-button.aria-label')}
       />
 
-      <Stack
+      <Flex
         as="ul"
         padding={innerPadding}
         // Add some extra padding to the bottom if there is no reply input.
         // This is to make the UI look more balanced.
         paddingBottom={canReply ? undefined : 1}
         gap={4}
+        flexDirection="column"
       >
-        <Stack as="li" {...applyCommentIdAttr(parentComment._id)}>
+        <VStack as="li" {...applyCommentIdAttr(parentComment._id)}>
           <CommentsListItemLayout
             avatarSize={avatarConfig.avatarSize}
             canDelete={parentComment._system.createdBy === currentUser.sanityUserId}
@@ -294,7 +295,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             readOnly={readOnly}
             withAvatar={avatarConfig.parentCommentAvatar}
           />
-        </Stack>
+        </VStack>
 
         {showCollapseButton && collapsed && (
           <Flex gap={1} paddingY={1}>
@@ -310,7 +311,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
         )}
 
         {splicedReplies.map((reply) => (
-          <Stack key={reply._id} as="li" {...applyCommentIdAttr(reply._id)}>
+          <VStack key={reply._id} as="li" {...applyCommentIdAttr(reply._id)}>
             <CommentsListItemLayout
               avatarSize={avatarConfig.avatarSize}
               canDelete={reply._system.createdBy === currentUser.sanityUserId}
@@ -331,7 +332,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
               readOnly={readOnly}
               withAvatar={avatarConfig.threadCommentsAvatar}
             />
-          </Stack>
+          </VStack>
         ))}
 
         {canReply && (
@@ -356,7 +357,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             withAvatar={avatarConfig.replyAvatar}
           />
         )}
-      </Stack>
+      </Flex>
     </StyledThreadCard>
   )
 })

--- a/packages/sanity/src/core/comments-v2/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentsListItemLayout.tsx
@@ -5,10 +5,8 @@ import {getTheme_v2} from '@sanity/ui/theme'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {css, styled} from 'styled-components'
-import {Text, Box, Flex, VStack, Icon} from 'ui5'
+import {Text, Box, Flex, VStack} from 'ui5'
 
-import {CircleSmallIcon} from '../../../components/temporary-icons/CircleSmall'
-import {RingIcon} from '../../../components/temporary-icons/Ring'
 import {useDidUpdate} from '../../../form/hooks/useDidUpdate'
 import {useDateTimeFormat} from '../../../hooks/useDateTimeFormat'
 import {type RelativeTimeOptions, useRelativeTime} from '../../../hooks/useRelativeTime'
@@ -35,6 +33,7 @@ import {FLEX_GAP} from '../constants'
 import {CommentInput, type CommentInputHandle} from '../pte/comment-input/CommentInput'
 import {CommentMessageSerializer} from '../pte/CommentMessageSerializer'
 import {CommentReactionsBar} from '../reactions/CommentReactionsBar'
+import {type CommentOrigin, CommentOriginBadge} from './CommentOriginBadge'
 import {CommentsListItemContextMenu} from './CommentsListItemContextMenu'
 import {CommentsListItemReferencedValue} from './CommentsListItemReferencedValue'
 
@@ -155,20 +154,6 @@ const RootStack = styled(VStack)(({theme}) => {
   `
 })
 
-const IconSlotRoot = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-
-  &[data-status='published'] {
-    --card-icon-color: var(--card-badge-positive-dot-color);
-  }
-  &[data-status='draft'] {
-    --card-icon-color: var(--card-badge-caution-dot-color);
-  }
-`
-
 interface CommentsListItemLayoutProps {
   avatarSize?: AvatarSize
   canDelete?: boolean
@@ -193,8 +178,6 @@ interface CommentsListItemLayoutProps {
   withAvatar?: boolean
 }
 
-type CommentOrigin = 'draft' | 'published'
-
 /**
  * The document a comment was made on, when that isn't the document being viewed.
  * Only draft vs published: versions and other ids return `null`.
@@ -208,15 +191,6 @@ export function getForeignCommentOrigin(
   if (!(isDraftId(source) || isPublishedId(source))) return null
   if (!(isDraftId(versionId) || isPublishedId(versionId))) return null
   return isDraftId(source) ? 'draft' : 'published'
-}
-
-function getOriginI18nKey(origin: CommentOrigin) {
-  switch (origin) {
-    case 'draft':
-      return 'list-item.origin.draft'
-    case 'published':
-      return 'list-item.origin.published'
-  }
 }
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {useTemporalPhrase: true}
@@ -402,25 +376,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
       gap={4}
     >
       <InnerStack gap={1} data-muted={displayError}>
-        {foreignOrigin && (
-          <Flex marginBottom={2}>
-            <Card border padding={1} radius={3}>
-              <Flex alignItems="center" gap={1} paddingRight={1}>
-                <IconSlotRoot data-status={foreignOrigin}>
-                  <Icon
-                    size={2}
-                    icon={foreignOrigin === 'draft' ? RingIcon : CircleSmallIcon}
-                    style={{margin: '-0.375rem'}}
-                  />
-                </IconSlotRoot>
-
-                <Text size={0} muted weight="medium" as="div" trim={true}>
-                  {t(getOriginI18nKey(foreignOrigin))}
-                </Text>
-              </Flex>
-            </Card>
-          </Flex>
-        )}
+        {foreignOrigin && <CommentOriginBadge origin={foreignOrigin} />}
 
         <HeaderFlex
           alignItems="center"

--- a/packages/sanity/src/core/comments-v2/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentsListItemLayout.tsx
@@ -1,11 +1,11 @@
 import {hues} from '@sanity/color'
 import {type CurrentUser} from '@sanity/types'
-import {type AvatarSize, Card, Stack, Text, TextSkeleton, useClickOutsideEvent} from '@sanity/ui'
+import {type AvatarSize, Card, TextSkeleton, useClickOutsideEvent} from '@sanity/ui'
 import {getTheme_v2} from '@sanity/ui/theme'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {css, styled} from 'styled-components'
-import {Box, Flex} from 'ui5'
+import {Text, Box, Flex, VStack, Icon} from 'ui5'
 
 import {CircleSmallIcon} from '../../../components/temporary-icons/CircleSmall'
 import {RingIcon} from '../../../components/temporary-icons/Ring'
@@ -92,7 +92,7 @@ const IntentText = styled(Text)(({theme}) => {
   `
 })
 
-const InnerStack = styled(Stack)`
+const InnerStack = styled(VStack)`
   transition: opacity 200ms ease;
 
   &[data-muted='true'] {
@@ -116,7 +116,7 @@ const RetryCardButton = styled(Card)`
   }
 `
 
-const RootStack = styled(Stack)(({theme}) => {
+const RootStack = styled(VStack)(({theme}) => {
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const {space} = theme.sanity
 
@@ -386,7 +386,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
   useClickOutsideEvent(!hasChanges && cancelEdit, () => [rootElementRef.current])
 
   const name = user?.displayName ? (
-    <Text size={1} weight="medium" textOverflow="ellipsis" title={user.displayName}>
+    <Text size={1} weight="medium" truncate={1} title={user.displayName} as="div" trim={true}>
       {user.displayName}
     </Text>
   ) : (
@@ -407,12 +407,14 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
             <Card border padding={1} radius={3}>
               <Flex alignItems="center" gap={1} paddingRight={1}>
                 <IconSlotRoot data-status={foreignOrigin}>
-                  <Text size={2}>
-                    {foreignOrigin === 'draft' ? <RingIcon /> : <CircleSmallIcon />}
-                  </Text>
+                  <Icon
+                    size={2}
+                    icon={foreignOrigin === 'draft' ? RingIcon : CircleSmallIcon}
+                    style={{margin: '-0.375rem'}}
+                  />
                 </IconSlotRoot>
 
-                <Text size={0} muted weight="medium">
+                <Text size={0} muted weight="medium" as="div" trim={true}>
                   {t(getOriginI18nKey(foreignOrigin))}
                 </Text>
               </Flex>
@@ -443,14 +445,20 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
                 {!displayError && (
                   <Flex alignItems="center" gap={1}>
-                    <TimeText muted size={0}>
+                    <TimeText muted size={0} forwardedAs="div" trim={true}>
                       <time dateTime={createdDate.toISOString()} title={formattedCreatedAt}>
                         {createdTimeAgo}
                       </time>
                     </TimeText>
 
                     {formattedLastEditAt && editedDate && (
-                      <TimeText muted size={0} title={formattedLastEditAt}>
+                      <TimeText
+                        muted
+                        size={0}
+                        title={formattedLastEditAt}
+                        forwardedAs="div"
+                        trim={true}
+                      >
                         <time dateTime={editedDate.toISOString()} title={formattedLastEditAt}>
                           ({t('list-item.layout-edited')})
                         </time>
@@ -463,7 +471,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
             {intent && (
               <Box flexBasis="0%" flexGrow={1}>
-                <IntentText muted size={0} textOverflow="ellipsis">
+                <IntentText muted size={0} truncate={1} forwardedAs="div" trim={true}>
                   <Translate
                     t={t}
                     i18nKey="list-item.layout-context"
@@ -512,7 +520,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
           <Flex alignItems="flex-start" gap={2}>
             {withAvatar && <SpacerAvatar $size={avatarSize} />}
 
-            <Stack flex={1}>
+            <Flex flexBasis="0%" flexGrow={1} flexDirection="column">
               <CommentInput
                 currentUser={currentUser}
                 focusOnMount
@@ -527,7 +535,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
                 value={value}
                 withAvatar={false}
               />
-            </Stack>
+            </Flex>
           </Flex>
         )}
 
@@ -561,7 +569,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
           {withAvatar && <SpacerAvatar $size={avatarSize} />}
 
           <Flex alignItems="center" gap={1} flexBasis="0%" flexGrow={1}>
-            <Text muted size={1}>
+            <Text muted size={1} as="div" trim={true}>
               {hasError && t('list-item.layout-failed-sent')}
               {isRetrying && t('list-item.layout-posting')}
             </Text>
@@ -576,7 +584,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
                 radius={2}
                 tone="primary"
               >
-                <Text size={1} muted>
+                <Text size={1} muted as="div" trim={true}>
                   {t('list-item.layout-retry')}
                 </Text>
               </RetryCardButton>

--- a/packages/sanity/src/core/comments-v2/components/list/CommentsListItemReferencedValue.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentsListItemReferencedValue.tsx
@@ -2,10 +2,10 @@ import {toPlainText} from '@portabletext/react'
 import {hues} from '@sanity/color'
 import {LinkRemovedIcon} from '@sanity/icons/LinkRemoved'
 import {isPortableTextTextBlock} from '@sanity/types'
-import {Stack, Text, type Theme} from '@sanity/ui'
+import {type Theme} from '@sanity/ui'
 import {useMemo} from 'react'
 import {css, styled} from 'styled-components'
-import {Box, Flex} from 'ui5'
+import {Text, Box, Flex, Icon} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -30,7 +30,7 @@ const InlineBox = styled(Box).attrs({marginLeft: 1, marginRight: 2})`
   }
 `
 
-const BlockQuoteStack = styled(Stack)<BlockQuoteStackProps>(({theme, $hasReferencedValue}) => {
+const BlockQuoteStack = styled(Flex)<BlockQuoteStackProps>(({theme, $hasReferencedValue}) => {
   const isDark = theme.sanity.v2?.color._dark
 
   const hue = $hasReferencedValue ? COMMENTS_HIGHLIGHT_HUE_KEY : 'gray'
@@ -70,18 +70,19 @@ export function CommentsListItemReferencedValue(props: CommentsListItemReference
     <BlockQuoteStack
       $hasReferencedValue={Boolean(hasReferencedValue)}
       data-testid="comments-list-item-referenced-value"
-      flex={1}
+      flexBasis="0%"
+      flexGrow={1}
+      flexDirection="column"
       forwardedAs="blockquote"
       padding={1}
       paddingLeft={2}
-      sizing="border"
     >
       <Flex alignItems="flex-start">
-        <Text size={1} muted>
+        <Text size={1} muted as="div" trim={true}>
           {!hasReferencedValue && (
             <Tooltip content={tooltipText}>
               <InlineBox>
-                <LinkRemovedIcon />
+                <Icon size={1} icon={LinkRemovedIcon} style={{margin: '-0.375rem'}} />
               </InlineBox>
             </Tooltip>
           )}

--- a/packages/sanity/src/core/comments-v2/components/list/CommentsListStatus.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/CommentsListStatus.tsx
@@ -1,5 +1,4 @@
-import {Container, Stack, Text} from '@sanity/ui'
-import {Flex} from 'ui5'
+import {Text, Container, Flex, VStack} from 'ui5'
 
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -41,7 +40,7 @@ export function CommentsListStatus(props: CommentsListStatusProps) {
     return (
       <Flex alignItems="center" justifyContent="center" flexBasis="0%" flexGrow={1} padding={4}>
         <Flex alignItems="center">
-          <Text size={1} muted>
+          <Text size={1} muted as="div" trim={true}>
             {t('list-status.error')}
           </Text>
         </Flex>
@@ -56,16 +55,16 @@ export function CommentsListStatus(props: CommentsListStatusProps) {
   if (hasNoComments) {
     return (
       <Flex alignItems="center" justifyContent="center" flexBasis="0%" flexGrow={1}>
-        <Container width={0} padding={4}>
-          <Stack gap={3}>
-            <Text align="center" size={1} muted weight="medium">
+        <Container size={0} padding={4}>
+          <VStack gap={3}>
+            <Text align="center" size={1} muted weight="medium" as="div" trim={true}>
               {emptyStateMessages[status].title}
             </Text>
 
-            <Text align="center" size={1} muted>
+            <Text align="center" size={1} muted as="div" trim={true}>
               {emptyStateMessages[status].message}
             </Text>
-          </Stack>
+          </VStack>
         </Container>
       </Flex>
     )

--- a/packages/sanity/src/core/comments-v2/components/list/__tests__/CommentOriginBadge.stories.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/__tests__/CommentOriginBadge.stories.tsx
@@ -1,0 +1,47 @@
+import {Card} from '@sanity/ui'
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {Text, VStack} from 'ui5'
+
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+import {CommentOriginBadge} from '../CommentOriginBadge'
+
+/**
+ * Draft vs published origin pills on comments-v2 list items. Chromatic
+ * sentinel for `--card-icon-color` on the ring / dot (ui5 `Icon` greys them).
+ */
+const meta = {
+  title: 'Comments (v2)/Origin Badge',
+  component: CommentOriginBadge,
+  decorators: [
+    (Story) => (
+      <TestWrapper schemaTypes={[]}>
+        <Story />
+      </TestWrapper>
+    ),
+  ],
+} satisfies Meta<typeof CommentOriginBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const States: Story = {
+  args: {origin: 'draft'},
+  render: () => (
+    <Card padding={4} style={{maxWidth: 420}}>
+      <VStack gap={5}>
+        <VStack gap={2}>
+          <Text muted size={1} weight="medium" as="div" trim={true}>
+            from draft
+          </Text>
+          <CommentOriginBadge origin="draft" />
+        </VStack>
+        <VStack gap={2}>
+          <Text muted size={1} weight="medium" as="div" trim={true}>
+            from published
+          </Text>
+          <CommentOriginBadge origin="published" />
+        </VStack>
+      </VStack>
+    </Card>
+  ),
+}

--- a/packages/sanity/src/core/comments-v2/components/list/__tests__/CommentOriginBadge.stories.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/__tests__/CommentOriginBadge.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   component: CommentOriginBadge,
   decorators: [
     (Story) => (
-      <TestWrapper schemaTypes={[]}>
+      <TestWrapper betaFeatures={{comments: {v2: true}}} schemaTypes={[]}>
         <Story />
       </TestWrapper>
     ),

--- a/packages/sanity/src/core/comments-v2/components/list/__tests__/CommentsListItemReferencedValue.stories.tsx
+++ b/packages/sanity/src/core/comments-v2/components/list/__tests__/CommentsListItemReferencedValue.stories.tsx
@@ -1,6 +1,7 @@
 import {type PortableTextBlock} from '@sanity/types'
-import {Card, Stack, Text} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {Text, VStack} from 'ui5'
 
 import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
 import {CommentsListItemReferencedValue} from '../CommentsListItemReferencedValue'
@@ -38,20 +39,20 @@ export const States: Story = {
   args: {hasReferencedValue: true, value: QUOTE},
   render: () => (
     <Card padding={4} style={{maxWidth: 420}}>
-      <Stack gap={5}>
-        <Stack gap={2}>
-          <Text muted size={1} weight="medium">
+      <VStack gap={5}>
+        <VStack gap={2}>
+          <Text muted size={1} weight="medium" as="div" trim={true}>
             referenced
           </Text>
           <CommentsListItemReferencedValue hasReferencedValue value={QUOTE} />
-        </Stack>
-        <Stack gap={2}>
-          <Text muted size={1} weight="medium">
+        </VStack>
+        <VStack gap={2}>
+          <Text muted size={1} weight="medium" as="div" trim={true}>
             missing referenced value
           </Text>
           <CommentsListItemReferencedValue hasReferencedValue={false} value={QUOTE} />
-        </Stack>
-      </Stack>
+        </VStack>
+      </VStack>
     </Card>
   ),
 }

--- a/packages/sanity/src/core/comments-v2/components/mentions/MentionsMenu.tsx
+++ b/packages/sanity/src/core/comments-v2/components/mentions/MentionsMenu.tsx
@@ -1,4 +1,3 @@
-import {Stack, Text} from '@sanity/ui'
 import deburr from 'lodash-es/deburr.js'
 import {
   type Ref,
@@ -10,7 +9,7 @@ import {
   type RefAttributes,
 } from 'react'
 import {styled} from 'styled-components'
-import {Box, Flex} from 'ui5'
+import {Text, Box, Flex, VStack} from 'ui5'
 
 import {CommandList} from '../../../components/commandList/CommandList'
 import {type CommandListHandle} from '../../../components/commandList/types'
@@ -22,7 +21,7 @@ import {MentionsMenuItem} from './MentionsMenuItem'
 
 const EMPTY_ARRAY: UserWithPermission[] = []
 
-const Root = styled(Stack)({
+const Root = styled(VStack)({
   maxWidth: '220px', // todo: improve
 })
 
@@ -118,7 +117,7 @@ export function MentionsMenu(props: MentionsMenuProps & RefAttributes<MentionsMe
     <Flex flexDirection="column" height="100%" data-testid="comments-mentions-menu">
       {filteredOptions.length === 0 && (
         <Box padding={5}>
-          <Text align="center" size={1} muted>
+          <Text align="center" size={1} muted as="div" trim={true}>
             {t('mentions.no-users-found')}
           </Text>
         </Box>

--- a/packages/sanity/src/core/comments-v2/components/mentions/MentionsMenuItem.tsx
+++ b/packages/sanity/src/core/comments-v2/components/mentions/MentionsMenuItem.tsx
@@ -1,7 +1,7 @@
-import {Badge, Card, Text, TextSkeleton} from '@sanity/ui'
+import {Badge, Card, TextSkeleton} from '@sanity/ui'
 import {type CSSProperties, useCallback} from 'react'
 import {styled} from 'styled-components'
-import {Box, Flex} from 'ui5'
+import {Text, Box, Flex} from 'ui5'
 
 import {type UserWithPermission} from '../../../hooks/useUserListWithPermissions'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -26,7 +26,7 @@ export function MentionsMenuItem(props: MentionsItemProps) {
   const avatar = <CommentsAvatar user={loadedUser} status={user.granted ? undefined : 'inactive'} />
 
   const text = loadedUser ? (
-    <Text size={1} textOverflow="ellipsis" title={loadedUser.displayName}>
+    <Text size={1} truncate={1} title={loadedUser.displayName} as="div" trim={true}>
       {loadedUser.displayName}
     </Text>
   ) : (

--- a/packages/sanity/src/core/comments-v2/components/onboarding/CommentsOnboardingPopover.tsx
+++ b/packages/sanity/src/core/comments-v2/components/onboarding/CommentsOnboardingPopover.tsx
@@ -1,6 +1,5 @@
-import {Stack, Text} from '@sanity/ui'
 import {keyframes, styled} from 'styled-components'
-import {Box, Flex} from 'ui5'
+import {Text, Box, Flex, VStack} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Popover, type PopoverProps} from '../../../../ui-components/popover/Popover'
@@ -39,17 +38,19 @@ export function CommentsOnboardingPopover(props: CommentsOnboardingPopoverProps)
     <StyledPopover
       content={
         <Root padding={4}>
-          <Stack gap={3}>
-            <Text weight="medium" size={1}>
+          <VStack gap={3}>
+            <Text weight="medium" size={1} as="div" trim={true}>
               {t('onboarding.header')}
             </Text>
 
-            <Text size={1}>{t('onboarding.body')}</Text>
+            <Text size={1} as="div" trim={true}>
+              {t('onboarding.body')}
+            </Text>
 
             <Flex justifyContent="flex-end" marginTop={2}>
               <Button text={t('onboarding.dismiss')} tone="primary" onClick={onDismiss} />
             </Flex>
-          </Stack>
+          </VStack>
         </Root>
       }
       open

--- a/packages/sanity/src/core/comments-v2/components/pte/CommentMessageSerializer.tsx
+++ b/packages/sanity/src/core/comments-v2/components/pte/CommentMessageSerializer.tsx
@@ -1,20 +1,20 @@
 import {PortableText, type PortableTextComponents} from '@portabletext/react'
-import {Stack} from '@sanity/ui'
 import {Fragment, type PropsWithChildren, useMemo} from 'react'
 import {css, styled} from 'styled-components'
+import {VStack} from 'ui5'
 
 import {type CommentMessage} from '../../types'
 import {transformChildren} from '../../utils/transform-children'
 import {MentionInlineBlock} from './blocks/MentionInlineBlock'
 import {NormalBlock} from './blocks/NormalBlock'
 
-const PortableTextWrap = styled(Stack)(() => {
+const PortableTextWrap = styled(VStack)(() => {
   return css`
     & > [data-ui='Text']:not(:first-child) {
       margin-top: 1em; // todo: improve
     }
 
-    & > [data-ui='Text']:has(> span:empty) {
+    & > [data-ui='Text']:empty {
       display: none;
     }
   `

--- a/packages/sanity/src/core/comments-v2/components/pte/blocks/MentionInlineBlock.tsx
+++ b/packages/sanity/src/core/comments-v2/components/pte/blocks/MentionInlineBlock.tsx
@@ -1,6 +1,6 @@
-import {Text, TextSkeleton} from '@sanity/ui'
+import {TextSkeleton} from '@sanity/ui'
 import {css, styled} from 'styled-components'
-import {Flex} from 'ui5'
+import {Text, Flex} from 'ui5'
 
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {useCurrentUser, useUser} from '../../../../store/user/hooks'
@@ -59,7 +59,9 @@ export function MentionInlineBlock(props: MentionInlineBlockProps) {
             <CommentsAvatar user={user} />
           </Flex>
 
-          <Text size={1}>{user.displayName}</Text>
+          <Text size={1} as="div" trim={true}>
+            {user.displayName}
+          </Text>
         </Flex>
       }
     >

--- a/packages/sanity/src/core/comments-v2/components/pte/blocks/NormalBlock.tsx
+++ b/packages/sanity/src/core/comments-v2/components/pte/blocks/NormalBlock.tsx
@@ -1,6 +1,6 @@
-import {Text} from '@sanity/ui'
 import {type ReactNode} from 'react'
 import {styled} from 'styled-components'
+import {Text} from 'ui5'
 
 const NormalText = styled(Text)`
   word-break: break-word;
@@ -13,5 +13,9 @@ interface NormalBlockProps {
 export function NormalBlock(props: NormalBlockProps): React.JSX.Element {
   const {children} = props
 
-  return <NormalText size={1}>{children}</NormalText>
+  return (
+    <NormalText size={1} forwardedAs="div" trim={true}>
+      {children}
+    </NormalText>
+  )
 }

--- a/packages/sanity/src/core/comments-v2/components/pte/comment-input/CommentInput.tsx
+++ b/packages/sanity/src/core/comments-v2/components/pte/comment-input/CommentInput.tsx
@@ -10,7 +10,7 @@ import {getValue} from '@portabletext/editor/selectors'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {sanitySchemaToPortableTextSchema} from '@portabletext/sanity-bridge'
 import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
-import {type AvatarSize, focusFirstDescendant, focusLastDescendant, Stack} from '@sanity/ui'
+import {type AvatarSize, focusFirstDescendant, focusLastDescendant} from '@sanity/ui'
 import {
   type FocusEvent,
   type FormEvent,
@@ -24,6 +24,7 @@ import {
   useState,
   type RefAttributes,
 } from 'react'
+import {VStack} from 'ui5'
 
 import {type UserListWithPermissionsHookValue} from '../../../../hooks/useUserListWithPermissions'
 import {NormalBlock} from '../blocks/NormalBlock'
@@ -258,7 +259,7 @@ export function CommentInput(props: CommentInputProps & RefAttributes<CommentInp
         <CommentInputDiscardDialog onClose={onDiscardCancel} onConfirm={handleDiscardConfirm} />
       )}
 
-      <Stack ref={editorContainerRef} data-testid="comment-input" onFocus={handleFocus}>
+      <VStack ref={editorContainerRef} data-testid="comment-input" onFocus={handleFocus}>
         <EditorProvider
           key={editorInstanceKey}
           initialConfig={{
@@ -283,7 +284,7 @@ export function CommentInput(props: CommentInputProps & RefAttributes<CommentInp
           >
             {focusLock && <div ref={preDivRef} tabIndex={0} />}
 
-            <Stack ref={innerRef}>
+            <VStack ref={innerRef}>
               <CommentInputInner
                 avatarSize={avatarSize}
                 currentUser={currentUser}
@@ -296,12 +297,12 @@ export function CommentInput(props: CommentInputProps & RefAttributes<CommentInp
                 renderBlock={renderBlock}
                 withAvatar={withAvatar}
               />
-            </Stack>
+            </VStack>
 
             {focusLock && <div ref={postDivRef} tabIndex={0} />}
           </CommentInputProvider>
         </EditorProvider>
-      </Stack>
+      </VStack>
     </>
   )
 }

--- a/packages/sanity/src/core/comments-v2/components/pte/comment-input/CommentInputDiscardDialog.tsx
+++ b/packages/sanity/src/core/comments-v2/components/pte/comment-input/CommentInputDiscardDialog.tsx
@@ -1,5 +1,6 @@
-import {DialogProvider, Text, ThemeColorProvider} from '@sanity/ui'
+import {DialogProvider, ThemeColorProvider} from '@sanity/ui'
 import {type MouseEvent, useCallback} from 'react'
+import {Text} from 'ui5'
 
 import {Dialog} from '../../../../../ui-components/dialog/Dialog'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
@@ -64,7 +65,9 @@ export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps)
             },
           }}
         >
-          <Text size={1}>{t('discard.text')}</Text>
+          <Text size={1} as="div" trim={true}>
+            {t('discard.text')}
+          </Text>
         </Dialog>
       </DialogProvider>
     </ThemeColorProvider>

--- a/packages/sanity/src/core/comments-v2/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/core/comments-v2/components/pte/comment-input/CommentInputInner.tsx
@@ -1,10 +1,10 @@
 import {type CurrentUser} from '@sanity/types'
-import {type AvatarSize, Card, Stack} from '@sanity/ui'
+import {type AvatarSize, Card} from '@sanity/ui'
 import {MenuDivider} from '@sanity/ui/menu'
 import {getTheme_v2} from '@sanity/ui/theme'
 import {useCallback} from 'react'
 import {css, styled} from 'styled-components'
-import {Box, Flex} from 'ui5'
+import {Box, Flex, VStack} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {TooltipDelayGroupProvider} from '../../../../../ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider'
@@ -172,7 +172,7 @@ export function CommentInputInner(props: CommentInputInnerProps) {
         sizing="border"
         tone={readOnly ? 'transparent' : 'default'}
       >
-        <Stack>
+        <VStack>
           <EditableWrap data-ui="CommentInputEditableWrap" paddingX={1} paddingY={2}>
             <Editable
               focusLock={focusLock}
@@ -223,7 +223,7 @@ export function CommentInputInner(props: CommentInputInnerProps) {
               )}
             </TooltipDelayGroupProvider>
           </Flex>
-        </Stack>
+        </VStack>
       </RootCard>
     </Flex>
   )

--- a/packages/sanity/src/core/comments-v2/components/reactions/CommentReactionsBar.tsx
+++ b/packages/sanity/src/core/comments-v2/components/reactions/CommentReactionsBar.tsx
@@ -1,11 +1,8 @@
 import {type CurrentUser} from '@sanity/types'
-import {
-  // oxlint-disable-next-line no-restricted-imports
-  Button as UIButton,
-  Text,
-} from '@sanity/ui'
+// oxlint-disable-next-line no-restricted-imports
+import {Button as UIButton} from '@sanity/ui'
 import {memo, useCallback, useMemo, useState} from 'react'
-import {Flex} from 'ui5'
+import {Text, Flex, Icon} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {TooltipDelayGroupProvider} from '../../../../ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider'
@@ -66,9 +63,7 @@ const renderMenuButton = ({open, tooltipContent}: {open: boolean; tooltipContent
     <UIButton fontSize={1} mode="ghost" padding={0} radius="full" selected={open}>
       <Flex paddingX={3} paddingY={2}>
         <Tooltip animate content={tooltipContent} disabled={open}>
-          <Text size={1}>
-            <ReactionIcon />
-          </Text>
+          <Icon size={1} icon={ReactionIcon} style={{margin: '-0.375rem'}} />
         </Tooltip>
       </Flex>
     </UIButton>
@@ -172,9 +167,11 @@ export const CommentReactionsBar = memo(function CommentReactionsBar(
                   tone={hasReacted ? 'primary' : 'default'}
                 >
                   <Flex alignItems="center" gap={1}>
-                    <EmojiText size={1}>{emoji}</EmojiText>
+                    <EmojiText size={1} forwardedAs="div" trim={true}>
+                      {emoji}
+                    </EmojiText>
 
-                    <Text size={0} weight={hasReacted ? 'semibold' : 'medium'}>
+                    <Text size={0} weight={hasReacted ? 'semibold' : 'medium'} as="div" trim={true}>
                       {reactionsList?.length}
                     </Text>
                   </Flex>

--- a/packages/sanity/src/core/comments-v2/components/reactions/CommentReactionsMenu.tsx
+++ b/packages/sanity/src/core/comments-v2/components/reactions/CommentReactionsMenu.tsx
@@ -1,14 +1,13 @@
 // oxlint-disable-next-line no-restricted-imports
-import {Button as UIButton, Grid} from '@sanity/ui'
+import {Button as UIButton} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
+import {Grid} from 'ui5'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {COMMENT_REACTION_EMOJIS} from '../../constants'
 import {commentsLocaleNamespace} from '../../i18n'
 import {type CommentReactionOption} from '../../types'
 import {EmojiText} from './EmojiText.styled'
-
-const GRID_COLUMNS = 6
 
 interface CommentReactionsMenuProps {
   options: CommentReactionOption[]
@@ -63,7 +62,7 @@ export function CommentReactionsMenu(props: CommentReactionsMenuProps) {
 
   return (
     <Grid
-      gridTemplateColumns={GRID_COLUMNS}
+      gridTemplateColumns="repeat(6, minmax(0,1fr))"
       gap={1}
       onKeyDown={handleRootKeyDown}
       ref={setRootElement}
@@ -84,7 +83,7 @@ export function CommentReactionsMenu(props: CommentReactionsMenuProps) {
             role="menuitem"
             tabIndex={-1}
           >
-            <EmojiText align="center" size={2}>
+            <EmojiText align="center" size={2} forwardedAs="div" trim={true}>
               {emoji}
             </EmojiText>
           </UIButton>

--- a/packages/sanity/src/core/comments-v2/components/reactions/CommentReactionsUsersTooltip.tsx
+++ b/packages/sanity/src/core/comments-v2/components/reactions/CommentReactionsUsersTooltip.tsx
@@ -1,7 +1,6 @@
 import {type CurrentUser} from '@sanity/types'
-import {Stack, Text} from '@sanity/ui'
 import {styled} from 'styled-components'
-import {Box, Flex} from 'ui5'
+import {type TextProps, Text, Box, Flex} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {useListFormat} from '../../../hooks/useListFormat'
@@ -13,9 +12,9 @@ import {commentsLocaleNamespace} from '../../i18n'
 import {type CommentReactionShortNames} from '../../types'
 import {EmojiText} from './EmojiText.styled'
 
-const TEXT_SIZE: number | number[] = 1
+const TEXT_SIZE: TextProps['size'] = 1
 
-const ContentStack = styled(Stack)`
+const ContentStack = styled(Flex)`
   max-width: 180px;
 `
 
@@ -25,10 +24,7 @@ const TextGroup = styled.div`
 
 const InlineText = styled(Text).attrs({size: TEXT_SIZE})`
   display: inline-block !important;
-
-  & > span {
-    white-space: break-spaces;
-  }
+  white-space: break-spaces;
 `
 
 const TextBox = styled(Box)`
@@ -102,7 +98,11 @@ function FormattedUserList({
 
     if (item.type === 'literal') {
       // Add literals as-is - the next case will rewrite literals to exclude leading non-whitespace
-      elements.push(<InlineText key={`literal-${i}`}>{item.value}</InlineText>)
+      elements.push(
+        <InlineText key={`literal-${i}`} forwardedAs="div" trim={true}>
+          {item.value}
+        </InlineText>,
+      )
       continue
     }
 
@@ -117,10 +117,12 @@ function FormattedUserList({
       elements.push(
         // Key (value) is user ID, thus unique
         <TextGroup key={item.value}>
-          <InlineText weight="medium">
+          <InlineText weight="medium" forwardedAs="div" trim={true}>
             <UserDisplayName currentUserId={currentUserId} isFirst={i === 0} userId={item.value} />
           </InlineText>
-          <InlineText>{nonWhitespace}</InlineText>
+          <InlineText forwardedAs="div" trim={true}>
+            {nonWhitespace}
+          </InlineText>
         </TextGroup>,
       )
 
@@ -133,7 +135,7 @@ function FormattedUserList({
     // in an element that does _not_ have a leading non-whitespace literal following it.
     elements.push(
       // Key (value) is user ID, thus unique
-      <InlineText key={item.value} weight="medium">
+      <InlineText key={item.value} weight="medium" forwardedAs="div" trim={true}>
         <UserDisplayName currentUserId={currentUserId} isFirst={i === 0} userId={item.value} />
       </InlineText>,
     )
@@ -154,13 +156,20 @@ function UserList({currentUserId, userIds}: ReactionTooltipComponentProps) {
 }
 
 function ReactionName({reactionName}: ReactionTooltipComponentProps) {
-  return <InlineText muted>{reactionName}</InlineText>
+  return (
+    <InlineText muted forwardedAs="div" trim={true}>
+      {reactionName}
+    </InlineText>
+  )
 }
 
 function ReactionText({children}: ReactionTooltipComponentProps) {
   return (
     <>
-      <InlineText muted>{children}</InlineText> <wbr />{' '}
+      <InlineText muted forwardedAs="div" trim={true}>
+        {children}
+      </InlineText>{' '}
+      <wbr />{' '}
     </>
   )
 }
@@ -172,9 +181,11 @@ function CommentReactionsUsersTooltipContent(
   const {t} = useTranslation(commentsLocaleNamespace)
 
   return (
-    <ContentStack padding={1}>
+    <ContentStack padding={1} flexDirection="column">
       <Flex justifyContent="center" paddingBottom={2} paddingTop={1}>
-        <EmojiText size={4}>{COMMENT_REACTION_EMOJIS[reactionName]}</EmojiText>
+        <EmojiText size={4} forwardedAs="div" trim={true}>
+          {COMMENT_REACTION_EMOJIS[reactionName]}
+        </EmojiText>
       </Flex>
 
       <TextBox>

--- a/packages/sanity/src/core/comments-v2/components/reactions/EmojiText.styled.ts
+++ b/packages/sanity/src/core/comments-v2/components/reactions/EmojiText.styled.ts
@@ -1,5 +1,5 @@
-import {Text} from '@sanity/ui'
 import {styled} from 'styled-components'
+import {Text} from 'ui5'
 
 export const EmojiText = styled(Text)`
   font-family:

--- a/packages/sanity/src/core/comments-v2/components/upsell/CommentsUpsellPanel.tsx
+++ b/packages/sanity/src/core/comments-v2/components/upsell/CommentsUpsellPanel.tsx
@@ -1,5 +1,4 @@
-import {Container} from '@sanity/ui'
-import {Box} from 'ui5'
+import {Container, Box} from 'ui5'
 
 import {type UpsellData} from '../../../studio/upsell/types'
 import {UpsellPanel} from '../../../studio/upsell/UpsellPanel'
@@ -13,7 +12,7 @@ interface CommentsUpsellPanelProps {
 export function CommentsUpsellPanel(props: CommentsUpsellPanelProps) {
   const {data, onPrimaryClick, onSecondaryClick} = props
   return (
-    <Container width={1}>
+    <Container size={1}>
       <Box marginBottom={6}>
         <UpsellPanel
           data={data}

--- a/packages/sanity/src/core/comments-v2/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/core/comments-v2/plugin/field/CommentsField.tsx
@@ -1,11 +1,12 @@
 import {hues} from '@sanity/color'
 import {type Path, type PortableTextBlock} from '@sanity/types'
-import {Stack, useBoundaryElement} from '@sanity/ui'
+import {useBoundaryElement} from '@sanity/ui'
 import * as PathUtils from '@sanity/util/paths'
 import {uuid} from '@sanity/uuid'
 import {AnimatePresence, motion, type Variants} from 'motion/react'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {css, styled} from 'styled-components'
+import {VStack} from 'ui5'
 
 import {type FieldProps} from '../../../form/types/fieldProps'
 import {getSchemaTypeTitle} from '../../../schema/helpers'
@@ -72,7 +73,7 @@ const HighlightDiv = styled(motion.div)(({theme}) => {
   `
 })
 
-const FieldStack = styled(Stack)`
+const FieldStack = styled(VStack)`
   position: relative;
 
   // Hide when the field component renders nothing (e.g. a custom

--- a/packages/sanity/src/core/comments-v2/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/core/comments-v2/plugin/field/CommentsFieldButton.tsx
@@ -4,13 +4,11 @@ import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
 import {
   // oxlint-disable-next-line no-restricted-imports
   Button as SanityUIButton,
-  Stack,
-  Text,
   useClickOutsideEvent,
 } from '@sanity/ui'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {styled} from 'styled-components'
-import {Flex} from 'ui5'
+import {Text, Flex, Icon} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Popover} from '../../../../ui-components/popover/Popover'
@@ -26,7 +24,7 @@ import {hasCommentMessageValue} from '../../helpers'
 import {commentsLocaleNamespace} from '../../i18n'
 import {type CommentMessage} from '../../types'
 
-const ContentStack = styled(Stack)`
+const ContentStack = styled(Flex)`
   width: 320px;
 `
 
@@ -141,7 +139,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     )
 
     const content = (
-      <ContentStack padding={2} gap={4}>
+      <ContentStack padding={2} gap={4} flexDirection="column">
         <CommentInput
           currentUser={currentUser}
           focusLock
@@ -200,10 +198,10 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
         gap={2}
       >
         <Flex alignItems="center" gap={2}>
-          <Text size={1}>
-            <CommentIcon />
+          <Icon muted size={1} icon={CommentIcon} style={{margin: '-0.375rem'}} />
+          <Text size={0} as="div" trim={true}>
+            {count > 9 ? '9+' : count}
           </Text>
-          <Text size={0}>{count > 9 ? '9+' : count}</Text>
         </Flex>
       </SanityUIButton>
     </Tooltip>

--- a/packages/sanity/src/core/comments-v2/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments-v2/plugin/input/components/CommentsPortableTextInput.tsx
@@ -6,7 +6,7 @@ import {
   type RangeDecorationOnMovedDetails,
 } from '@portabletext/editor'
 import {isPortableTextTextBlock, type Path} from '@sanity/types'
-import {BoundaryElementProvider, Stack, usePortal} from '@sanity/ui'
+import {BoundaryElementProvider, usePortal} from '@sanity/ui'
 import * as PathUtils from '@sanity/util/paths'
 import {uuid} from '@sanity/uuid'
 import {dequal as isEqual} from 'dequal/lite'
@@ -22,6 +22,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import {VStack} from 'ui5'
 
 import {useFormValue} from '../../../../form/contexts/FormValue'
 import {useFieldActions} from '../../../../form/field/actions/useFieldActions'
@@ -703,7 +704,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
         </AnimatePresence>
       </BoundaryElementProvider>
 
-      <Stack ref={setRootElement} onMouseDown={handleMouseDown} onMouseUp={handleMouseUp}>
+      <VStack ref={setRootElement} onMouseDown={handleMouseDown} onMouseUp={handleMouseUp}>
         <RenderDefaultCommentsPortableTextInputInner
           {...props}
           onEditorChange={onEditorChange}
@@ -713,7 +714,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
           rangeDecorations={rangeDecorations}
           onFullScreenChange={setIsFullScreen}
         />
-      </Stack>
+      </VStack>
     </>
   )
 })

--- a/packages/sanity/src/core/comments-v2/plugin/input/components/InlineCommentInputPopover.tsx
+++ b/packages/sanity/src/core/comments-v2/plugin/input/components/InlineCommentInputPopover.tsx
@@ -1,7 +1,8 @@
 import {type CurrentUser} from '@sanity/types'
-import {BoundaryElementProvider, Stack, useClickOutsideEvent, usePortal} from '@sanity/ui'
+import {BoundaryElementProvider, useClickOutsideEvent, usePortal} from '@sanity/ui'
 import {useCallback, useRef} from 'react'
 import {styled} from 'styled-components'
+import {Flex} from 'ui5'
 
 import {Popover, type PopoverProps} from '../../../../../ui-components/popover/Popover'
 import {
@@ -13,7 +14,7 @@ import {hasCommentMessageValue} from '../../../helpers'
 
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['bottom', 'top']
 
-const RootStack = styled(Stack)`
+const RootStack = styled(Flex)`
   width: 250px;
 `
 
@@ -76,7 +77,7 @@ export function InlineCommentInputPopover(props: InlineCommentInputPopoverProps)
 
   const content = (
     <BoundaryElementProvider element={boundaryElement}>
-      <RootStack padding={2} ref={contentElementRef}>
+      <RootStack padding={2} ref={contentElementRef} flexDirection="column">
         <CommentInput
           currentUser={currentUser}
           focusLock

--- a/packages/sanity/src/core/comments-v2/plugin/inspector/CommentsInspectorHeader.tsx
+++ b/packages/sanity/src/core/comments-v2/plugin/inspector/CommentsInspectorHeader.tsx
@@ -1,11 +1,11 @@
 import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {CloseIcon} from '@sanity/icons/Close'
-import {Card, Text} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {Menu} from '@sanity/ui/menu'
 import {useCallback, type RefAttributes} from 'react'
 import {styled} from 'styled-components'
-import {Flex} from 'ui5'
+import {Text, Flex} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
@@ -40,7 +40,7 @@ export function CommentsInspectorHeader(
     <Root ref={ref}>
       <Flex padding={2}>
         <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={2} paddingY={2} padding={3}>
-          <Text as="h1" size={1} weight="medium">
+          <Text as="h1" size={1} weight="medium" trim={true}>
             {t('feature-name')}
           </Text>
         </Flex>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

[#14459](https://github.com/sanity-io/sanity/pull/14459) migrates `Grid`/`Container`/`Stack`/`Text` in `core/comments` to ui5. `comments-v2` was copied from that tree after that work started, so the same surfaces were still on `@sanity/ui` v4.

This applies the same prop and import patterns there (`VStack`/column `Flex`, `Container` `width` → `size`, `Text` `as="div" trim`, `truncate={1}`, nested icons via `Icon` where they were nested in `Text`). v2-only bits (author ids, field `readOnly`) are left as-is except where they used the same layout/typography primitives.

Why not wait for #14459 and replay that patch: several v2 files already diverge (`createdBy`/`sanityUserId`, origin badge, field `readOnly`), so a path-rewritten apply would miss or overwrite those. Doing the same mechanical swap on this copy keeps both plugins aligned before the comments plugin rewrite.

The foreign-origin badge (v2-only) is **not** switched to ui5 `Icon`. Those glyphs get their draft orange / published green from `--card-icon-color`, which `@sanity/ui` `Text` applies and ui5 `Icon` does not (`--foreground-high`). The pill keeps `@sanity/ui` `Text` for both the glyph and the label, same as before the swap and the same pattern as `DocumentVersionsStatusIndicator`.

### What to review

Same mapping as #14459, under `packages/sanity/src/core/comments-v2`. There is no `CommentsInspectorError` in v2, so that file is skipped.

Origin pills: `CommentOriginBadge` — confirm the ring stays caution (orange) and the published dot stays positive (green). Chromatic story: Comments (v2)/Origin Badge.

[Origin badge draft orange ring and published green dot](https://cursor.com/agents/bc-9588a1aa-6b8c-4ad3-a95c-4b56fa2b955d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forigin_badge_states_light.png)

### Testing

- comments-v2 jsdom: 83 tests passed (the existing `CommentsListItemLayout.test.ts` import of the component file still fails without a full package build, same as on main)
- CommentInput + InlineComposerMentions browser tests: 10 passed
- Storybook stories for Comments (v2) breadcrumbs, referenced value, comment input, and origin badge
- Manual Storybook check of the origin badge after restoring `--card-icon-color` (draft ring orange, published dot green)

### Notes for release

N/A – Internal only (ui5 migration of the opt-in comments-v2 plugin)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9588a1aa-6b8c-4ad3-a95c-4b56fa2b955d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9588a1aa-6b8c-4ad3-a95c-4b56fa2b955d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

