### PR TITLE
test(e2e): harden reference publish gate and search results waits

### DIFF
--- a/e2e/tests/inputs/reference.spec.ts
+++ b/e2e/tests/inputs/reference.spec.ts
@@ -73,8 +73,9 @@ async function publishPaneDocument(page: Page, paneIndex: number) {
 
   // Only click once the button is actionable: a click that lands while the
   // document is still syncing/validating is queued behind validation, which
-  // can take tens of seconds on a slow backend.
-  await expect(publishButton).toBeEnabled()
+  // can take tens of seconds on a slow backend — give this wait the same
+  // budget as the completion gate below.
+  await expect(publishButton).toBeEnabled({timeout: 60_000})
   await publishButton.click()
 
   await expect(

--- a/e2e/tests/inputs/reference.spec.ts
+++ b/e2e/tests/inputs/reference.spec.ts
@@ -51,6 +51,37 @@ async function searchAndSelectReference(
   await option.click({force: true})
 }
 
+/**
+ * Click publish in the given document pane (0-based index) and wait for the
+ * publish to complete.
+ *
+ * Completion is asserted on the publish button settling into its disabled
+ * state with the plain "Publish" accessible name — the published,
+ * no-pending-changes state, derived from document state. While the document is
+ * still syncing or validating the button carries a different accessible name
+ * ("Syncing document…" / "Validating document…"), so this cannot match early.
+ *
+ * The pane-footer status text is deliberately not used as the completion
+ * signal: it renders the latest entry of the events API feed, which on a
+ * loaded backend can lag far behind the publish itself — CI traces show the
+ * footer still on "Draft created … ago" 15+ seconds after the publish landed
+ * (the button already showed "Published x seconds ago" at that point).
+ */
+async function publishPaneDocument(page: Page, paneIndex: number) {
+  const pane = page.getByTestId('document-pane').nth(paneIndex)
+  const publishButton = pane.getByTestId('action-publish')
+
+  // Only click once the button is actionable: a click that lands while the
+  // document is still syncing/validating is queued behind validation, which
+  // can take tens of seconds on a slow backend.
+  await expect(publishButton).toBeEnabled()
+  await publishButton.click()
+
+  await expect(
+    pane.getByRole('button', {name: 'Publish', exact: true, disabled: true}),
+  ).toBeVisible({timeout: 60_000})
+}
+
 withDefaultClient((context) => {
   test(`value can be changed after the document has been published`, async ({
     page,
@@ -279,7 +310,6 @@ withDefaultClient((context) => {
 
     test.slow()
     const originalTitle = 'Initial Doc'
-    const documentStatus = page.getByTestId('pane-footer-document-status')
 
     await createDraftDocument('/content/input-debug;simpleReferences')
     await expect(page.getByTestId('string-input')).toBeVisible()
@@ -303,15 +333,12 @@ withDefaultClient((context) => {
     await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText(
       'Reference test',
     )
-    await page.getByTestId('action-publish').nth(1).click() // publish reference
-    await expectPublishedStatus(documentStatus.nth(1))
+    await publishPaneDocument(page, 1) // publish reference
 
     /** --- IN ORIGINAL DOC --- */
     await page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
 
-    await page.getByTestId('action-publish').first().click() // publish reference
-
-    await expectPublishedStatus(documentStatus.first())
+    await publishPaneDocument(page, 0) // publish original document
 
     // open the context menu
     const documentPane = page.getByTestId('document-pane')

--- a/e2e/tests/navbar/search.spec.ts
+++ b/e2e/tests/navbar/search.spec.ts
@@ -37,6 +37,11 @@ function queriesOf(recentSearches: StoredSearchItem[]): string[] {
 }
 
 test('searching creates unique saved searches', async ({page, sanityClient, _testContext}) => {
+  // Three search → open-result → persisted-write round trips against the live
+  // API: on a loaded CI runner two healthy rounds alone have taken ~35s, so
+  // the default 60s budget leaves no room for a single slow round.
+  test.slow()
+
   const dataset = sanityClient.config().dataset
   const storedSearchKey = `${SEARCH_KEY}.${dataset}`
 
@@ -110,12 +115,19 @@ test('searching creates unique saved searches', async ({page, sanityClient, _tes
     // re-runs a search when the terms change, so a response that comes back
     // without it is never retried on its own. Opening is part of the retry
     // because a studio that is still settling can drop the popover again.
+    //
+    // Each attempt gets a generous visibility window: on a starved CI runner
+    // the studio can take well over five seconds to *render* results it has
+    // already received (a CI trace shows the matching response arriving within
+    // an attempt's window while the option only painted ~20s later), and every
+    // retype cancels the in-flight search and starts that work over — with a
+    // short window the retries livelock the very rendering they wait for.
     await expect(async () => {
       await openSearchIfClosed()
       await searchInput.fill('')
       await searchInput.fill(query)
-      await expect(seededResult).toBeVisible({timeout: 5_000})
-    }).toPass({intervals: [1_000, 2_000], timeout: 30_000})
+      await expect(seededResult).toBeVisible({timeout: 15_000})
+    }).toPass({intervals: [1_000, 2_000], timeout: 45_000})
 
     // Wait for the write itself rather than reading the value back afterwards:
     // the studio rebuilds recent searches from the value it last saw, so the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Hardens the two hard e2e failures (each failed 3/3 attempts) from [this agent report](https://e2e-studio-cti332zed.sanity.dev/agent-report.md) ([workflow run](https://github.com/sanity-io/sanity/actions/runs/33728450769), commit ec12aff on an unrelated PR — the same run had 49 other flaky-but-passed tests, i.e. a heavily degraded runner/backend window). Test-only changes; no production code touched.

**1. chromium `inputs/reference.spec.ts` › "when reference is set to weak: true, it shouldn't strength on publish"**

Root cause (from the CI video and trace): the test clicked publish on the second pane immediately after filling the title, while the footer still showed "Saving…". The click was accepted but queued behind validation — the button flipped to a disabled "Validating document…" for ~25s before the publish executed. The test then waited on `pane-footer-document-status` to read "Published …". That footer text renders the newest entry of the **events API feed** (`useEvents()` in `DocumentStatusLine`), which on the degraded backend lagged behind reality and even **regressed** — the assertion's own call log shows the footer moving from "Edited just now" back to "Draft created 21/31/41 sec. ago". The final video frame proves the mismatch: the publish button is disabled with tooltip "Published 15 seconds ago" while the footer still says "Draft created 41 sec. ago". The publish succeeded; the gate was watching the wrong signal.

Reproduced deterministically: stalling `/data/history/*/events/documents/*` responses via `page.route` makes the old footer gate fail exactly like CI (publish succeeds regardless), while the new document-state gate passes in ~13s under the same stall.

Fix: a `publishPaneDocument` helper that (a) waits for the publish button to be actionable before clicking, and (b) gates completion on the button settling into its disabled state with the plain "Publish" accessible name — the published-no-pending-changes state, derived from document state, unambiguous because the syncing/validating states carry different accessible names ("Syncing document…" / "Validating document…"). The test's actual subject — inspecting that the weak reference keeps `_weak: true` and gains no `_strengthenOnPublish` — is unchanged. The sibling `_strengthenOnPublish and _weak properties are removed…` test has the same pattern but is `test.skip`ed on both CI browsers (it never runs), so it was left alone.

**2. firefox `navbar/search.spec.ts` › "searching creates unique saved searches"**

Root cause (from the retry trace): this was **not** search-index lag — every completed search request returned the seeded document in ~4ms (response bodies in the trace confirm it). The failure is a client-side render livelock on a starved runner: the retry loop gives each attempt 5s of visibility wait, but the studio took longer than that to paint results it had already received (the trace shows a hit response landing inside an attempt's window with the option only present in the DOM ~20s later, after the test had failed), and every retry's `fill('')` + refill cancels the in-flight search and restarts the rendering work it is waiting for. Three such searches also don't reliably fit the 60s test budget — the healthy portion of the failing attempt already spent ~35s on two rounds.

Also documented for the record: the report's final-attempt page snapshot showing the seeded book as "This document has been deleted / Discarded draft just now" is post-mortem capture noise, not a cause — the trace shows `Attach "error-context"` running *after* the `_testContext` fixture teardown that deletes the seeded draft.

Fix: keep the retype-retry loop (it still covers genuinely failed/aborted requests), but give each attempt a 15s visibility window inside a 45s `toPass` budget, and mark the test `test.slow()` so three search → open-result → persisted-write round trips have headroom on a loaded runner.

Rejected alternative for both: blanket timeout increases on the existing waits — for the reference spec the events feed demonstrably regresses rather than merely lags, so no budget reliably fixes a gate on it; for the search spec a longer outer budget without a longer per-attempt window keeps the livelock.

### What to review

Two test files, no production changes:

- `e2e/tests/inputs/reference.spec.ts` — new `publishPaneDocument` helper + the `weak: true` test using it
- `e2e/tests/navbar/search.spec.ts` — `test.slow()` and widened per-attempt visibility window

### Testing

Local runs against a fresh `cursor_ci_*` dataset on staging project `ittbm412` per AGENTS.md, all with `--retries=0`:

- Deterministic repro of failure 1: with the events feed stalled via `page.route`, the old footer gate fails identically to CI in ~40s while the new document-state gate passes in ~13s.
- Hardened `weak: true` test: `--repeat-each=3` green on chromium and firefox (also ~3× faster than the old gate, since the doc-state signal settles before the events feed).
- Hardened search test: `--repeat-each=3` green on firefox and chromium.
- Full `reference.spec.ts` + `search.spec.ts` green on both browsers.
- `pnpm check:format` and `pnpm check:oxlint` pass.

### Notes for release

N/A – Internal only (test changes)

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21636ac7-1292-41fe-a276-e443f2fef26f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21636ac7-1292-41fe-a276-e443f2fef26f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

