### PR TITLE
feat(storybook): add visual coverage checker and skill

### DIFF
--- a/.agents/skills/sanity-visual-coverage/SKILL.md
+++ b/.agents/skills/sanity-visual-coverage/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: sanity-visual-coverage
+description: Check whether Studio UI is covered by Chromatic visual regression, for a PR's changed files or for the whole tree, and decide between "already covered", "a story is pending in an open PR", and "needs a story". Use when reviewing a PR that touches packages/**/src/**/*.tsx or *.css.ts, when asked "is this covered by Chromatic", when planning ui5 or vanilla-extract migration work, or before opening a PR that adds stories.
+---
+
+# Visual regression coverage
+
+The question this skill answers is "if this file's rendering changes, does a Chromatic snapshot
+catch it?". The answer is a static fact about the repo, so a script computes it. Do not answer it
+by reading the Chromatic check, and do not answer it from memory.
+
+## Run the check
+
+```bash
+pnpm visual-coverage --changed                # files changed vs origin/main, including uncommitted
+pnpm visual-coverage --changed --prs          # also mark files that an open PR is about to cover
+pnpm visual-coverage <path> [<path>...]       # specific files
+pnpm visual-coverage                          # whole tree, one row per area
+pnpm visual-coverage --uncovered              # whole tree plus every uncovered file
+pnpm visual-coverage --format json ...        # machine-readable, same modes
+pnpm visual-coverage --help
+```
+
+For a PR you are not on: `gh pr checkout <number> && pnpm visual-coverage --changed --prs`. Every
+same-repo PR that touches `packages/**/src/**/*.tsx` or `*.css.ts` also gets a sticky
+"Visual regression coverage" comment from `.github/workflows/visual-coverage.yml`, produced by the
+same script with `--format markdown --prs`. Read that comment first when reviewing.
+
+The script is `scripts/visualCoverage.ts`. It has no dependencies and runs under `tsx` or plain
+Node 22.18+ (`node scripts/visualCoverage.ts`).
+
+## What counts as covered
+
+Chromatic snapshots stories, not components. A component is covered when a story renders it. The
+script models that as direct imports:
+
+| Evidence       | Files                                           | Chromatic project | Status in the report                                                        |
+| -------------- | ----------------------------------------------- | ----------------- | --------------------------------------------------------------------------- |
+| `story`        | `packages/**/src/**/*.stories.tsx`              | Storybook, active | `covered`                                                                   |
+| `browser-test` | `packages/**/src/**/*.browser.test.tsx`         | Vitest, dormant   | `covered`, flagged "no Chromatic snapshot yet" until the Vitest token lands |
+| `pending`      | a `*.stories.tsx` added by an open PR (`--prs`) | none yet          | `pending`, claimed by that PR                                               |
+
+A file is covered when a story or browser test imports it directly, or imports a `*Story.tsx`
+harness that imports it. A `.css.ts` file inherits the coverage of the `.tsx` files that import
+it. Nothing deeper than that counts. `TestWrapper` imports the whole `sanity` package, so a
+transitive graph would mark everything covered, and Chromatic's TurboSnap has the same blind
+spot. That is why the green Chromatic check on a PR says only "the affected stories still
+match", never "your component is rendered by a story".
+
+## How stories map to Studio UI
+
+- `dev/storybook` is the host. Its `stories` glob in `dev/storybook/.storybook/main.ts` finds
+  `*.stories.tsx` under every workspace package's `src`. Stories live next to the component in
+  its `__tests__` directory. Nothing lives under `dev/storybook/stories`.
+- Two story shapes. Plain variant grids for `packages/sanity/src/ui-components` wrappers
+  (`Button.stories.tsx` imports `../Button`). Harness stories for anything that needs a
+  workspace, i18n, or layers. The harness is `<Name>Story.tsx`, wraps `TestWrapper`, and is shared
+  with the `<Name>.browser.test.tsx` when one exists. `<Name>.stories.tsx` is then a thin CSF file
+  whose `component` is the harness.
+- "ui5 sentinel" and "box sentinel" are the same thing. A story added so the `@sanity/ui` to
+  `ui5` Box/Flex/Card migration gets a snapshot before the swap lands. The harness renders the
+  states most likely to drift (tones, spacing, truncation, empty states) with fixture copy only.
+  Naming follows the harness pattern above. `title` is `Area/Component`. Pure regression
+  fixtures carry `tags: ['!dev', '!autodocs', 'vrt-only']` so they stay out of the sidebar but in
+  the snapshot set. Read `FieldDiffChromeStory.tsx` and `FieldDiffChrome.stories.tsx` under
+  `packages/sanity/src/core/field/diff/components/__tests__` as the reference pair.
+- A story covers exactly the components its harness imports. A `DocumentLayout` story also
+  paints buttons and cards, but only the `Button` story is the sentinel for `Button`.
+
+## Decision procedure
+
+Run `pnpm visual-coverage --changed --prs` on the branch, then per file:
+
+1. `covered`. Done. If the change adds a state the story does not render (a new tone, an empty
+   state, a truncation case), extend the existing story or harness. Do not add a second story
+   for the same component.
+2. `pending`. Do not add a story. The PR number is in the report. Review that PR, or comment on
+   it if the variant you need is missing.
+3. `uncovered`, and the file paints something (layout, tone, spacing, text). Add coverage per
+   `.agents/skills/sanity-visual-regression/SKILL.md`. Reuse an existing `*Story.tsx` harness
+   in the same directory before creating one.
+4. `uncovered`, and the file is a provider, hook wrapper, context, or renders only children.
+   Nothing to snapshot. Say so in the PR instead of adding a story.
+
+For migration planning, `pnpm visual-coverage --uncovered --prs` lists the gap. Pick from it, do
+not survey by hand.
+
+## Avoiding duplicate coverage PRs
+
+Sentinel coverage for the ui5 migration is being added in a stack of PRs titled
+`test(storybook): add ui5 ... sentinels ...`, on branches named
+`cursor/ui5-visual-regression-coverage-*` (base of the stack is
+[#14056](https://github.com/sanity-io/sanity/pull/14056), tip at the time of writing is
+[#14511](https://github.com/sanity-io/sanity/pull/14511)). The migration itself lands on
+`chore/ui-v5-*` branches.
+
+- `--prs` already accounts for every open PR that adds a `*.stories.tsx`. A file reported as
+  `pending` is claimed.
+- To see the stack: `gh pr list --state open --search "test(storybook) in:title" --json number,title,headRefName,baseRefName`.
+- Do not rebase, rewrite, or push to those branches. A new coverage PR goes on top of the stack
+  tip when it depends on a harness added there, or off `main` when its files are disjoint from
+  every open PR.
+- Before opening a coverage PR, run the check with `--prs` one more time. If anything you added
+  is now `pending` elsewhere, drop it.

--- a/.agents/skills/sanity-visual-regression/SKILL.md
+++ b/.agents/skills/sanity-visual-regression/SKILL.md
@@ -20,6 +20,10 @@ baselines. Review diffs on the Chromatic build linked from the PR check.
 
 ## Quick start: add visual coverage for a component
 
+Before writing anything, run `pnpm visual-coverage <path> --prs` and follow
+[sanity-visual-coverage](../sanity-visual-coverage/SKILL.md). It reports whether a story already
+renders the component or an open PR is about to, so you only add what is missing.
+
 1. Add a co-located `*.stories.tsx` file to the owning package's `src` tree, usually in the same
    `__tests__` directory as the component or harness. Storybook discovers story files in workspace
    package `src` trees — do not add CSF under `dev/storybook/stories/`. Two patterns:

--- a/.claude/skills/sanity-visual-coverage
+++ b/.claude/skills/sanity-visual-coverage
@@ -1,0 +1,1 @@
+../../.agents/skills/sanity-visual-coverage

--- a/.cursor/skills/sanity-visual-coverage
+++ b/.cursor/skills/sanity-visual-coverage
@@ -1,0 +1,1 @@
+../../.agents/skills/sanity-visual-coverage

--- a/.github/workflows/visual-coverage.yml
+++ b/.github/workflows/visual-coverage.yml
@@ -42,7 +42,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          pnpm --silent visual-coverage --format markdown --prs --changed "origin/$BASE_REF" \
+          pnpm --silent visual-coverage --format markdown --prs --changed --base "origin/$BASE_REF" \
             > /tmp/visual-coverage.md
           cat /tmp/visual-coverage.md >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/visual-coverage.yml
+++ b/.github/workflows/visual-coverage.yml
@@ -1,0 +1,53 @@
+name: Visual coverage
+permissions: {}
+
+# Posts a sticky "Visual regression coverage" comment on PRs that touch Studio
+# UI files: for each changed component, which story or browser test renders it,
+# or which open PR is about to. Static import analysis, no Storybook build;
+# see scripts/visualCoverage.ts and .agents/skills/sanity-visual-coverage.
+# Informational only, like the Chromatic burn-in checks.
+
+on:
+  pull_request:
+    paths:
+      - "packages/**/src/**/*.tsx"
+      - "packages/**/src/**/*.css.ts"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Coverage report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # On fork PRs GITHUB_TOKEN is read-only regardless of the permissions
+    # block, so the comment step would 403 (same guard as bench.yml).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write # for the sticky PR comment
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The script diffs against the merge-base with the base branch.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Write report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          pnpm --silent visual-coverage --format markdown --prs --changed "origin/$BASE_REF" \
+            > /tmp/visual-coverage.md
+          cat /tmp/visual-coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: PR comment with report
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        with:
+          comment-tag: "visual-coverage"
+          file-path: /tmp/visual-coverage.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,7 +474,13 @@ pnpm dev:storybook                    # Storybook dev server at http://localhost
 pnpm build:storybook                  # Static build via turbo (dev/storybook/storybook-static)
 pnpm --filter sanity-storybook test   # Run every story as a vitest browser-mode test
 CHROMATIC=1 pnpm --filter sanity test:browser   # Chromatic archive capture run (chromium only)
+pnpm visual-coverage --changed --prs  # Which changed UI files a story renders (PR comment runs the same)
+pnpm visual-coverage --uncovered      # Whole-tree coverage by area, plus the uncovered files
 ```
+
+Before adding a story, run `pnpm visual-coverage` and follow the `sanity-visual-coverage` skill
+(`.agents/skills/sanity-visual-coverage/SKILL.md`): it tells covered from pending (claimed by an
+open PR) from uncovered, so coverage PRs do not duplicate the open `test(storybook)` stack.
 
 Repo secrets: `CHROMATIC_PROJECT_TOKEN_STORYBOOK` (active), `CHROMATIC_PROJECT_TOKEN_E2E`
 (active, used by e2e), `CHROMATIC_PROJECT_TOKEN_VITEST` (dormant until Chromatic's Vitest early

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "test:vitest": "vitest --run",
     "test:vitest:watch": "vitest --watch",
     "tsdoc:dev": "sanity-tsdoc dev",
+    "visual-coverage": "tsx scripts/visualCoverage.ts",
     "watch": "pnpm --filter @sanity/* --filter sanity watch"
   },
   "devDependencies": {

--- a/scripts/visualCoverage.ts
+++ b/scripts/visualCoverage.ts
@@ -1,0 +1,484 @@
+import {execFileSync} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import {isAbsolute, join, posix, relative, sep} from 'node:path'
+import process from 'node:process'
+import {parseArgs} from 'node:util'
+
+type EvidenceKind = 'story' | 'browser-test'
+interface Evidence {
+  file: string
+  kind: EvidenceKind
+}
+interface PendingEvidence {
+  pr: number
+  file: string
+}
+interface Coverage {
+  file: string
+  coveredBy: Evidence[]
+  pendingIn: PendingEvidence[]
+}
+type Status = 'covered' | 'pending' | 'uncovered'
+type Format = 'text' | 'markdown' | 'json'
+interface PullRequest {
+  number: number
+  headRefName: string
+  files: {path: string}[]
+}
+interface AreaRow {
+  area: string
+  covered: number
+  pending: number
+  total: number
+}
+
+const FORMATS: readonly Format[] = ['text', 'markdown', 'json']
+const UI_FILE = /^packages\/.+\/src\/.+\.(?:tsx|css\.ts)$/
+const EXCLUDED_SEGMENT = /\/(?:__tests__|__fixtures__|__mocks__|__workshop__|test)\//
+const EXCLUDED_SUFFIXES = [
+  '.test.tsx',
+  '.test.ts',
+  '.stories.tsx',
+  '.stories.ts',
+  'Story.tsx',
+  '.d.ts',
+]
+const RELATIVE_IMPORT = /\b(?:from|import)\s*\(?\s*['"](\.[^'"\n]*)['"]/g
+const MARKDOWN_EVIDENCE_LIMIT = 3
+const MAX_BUFFER = 64 * 1024 * 1024
+
+const USAGE = `Usage: pnpm visual-coverage [options] [file ...]
+       node scripts/visualCoverage.ts [options] [file ...]
+
+Reports whether Studio UI files (packages/**/src/**/*.tsx, *.css.ts) are rendered by a
+committed Storybook story (*.stories.tsx) or vitest browser test (*.browser.test.tsx),
+directly or through a colocated *Story.tsx harness.
+
+Modes
+  file ...             Report the given files (repo-relative or absolute paths)
+  --changed            Report files changed since the merge base with --base (default:
+                       origin/main, or main when origin/main does not exist)
+  (no files/--changed) Whole tree: coverage table per area
+
+Options
+  --base <ref>         Base ref for --changed
+  --prs                Mark files as pending when an open PR adds a story for them (uses gh)
+  --uncovered          Tree mode: also list every uncovered file
+  --format <fmt>       text (default), markdown (PR comment), json (Coverage[])
+  --help               Show this help`
+
+function statusOf(coverage: Coverage): Status {
+  if (coverage.coveredBy.length > 0) return 'covered'
+  return coverage.pendingIn.length > 0 ? 'pending' : 'uncovered'
+}
+
+function isUiFile(file: string): boolean {
+  if (!UI_FILE.test(file) || EXCLUDED_SEGMENT.test(file)) return false
+  return !EXCLUDED_SUFFIXES.some((suffix) => file.endsWith(suffix))
+}
+
+function isStory(file: string): boolean {
+  return file.endsWith('.stories.tsx') || file.endsWith('.stories.ts')
+}
+
+function isHarness(file: string): boolean {
+  return file.endsWith('Story.tsx')
+}
+
+function isStyleModule(file: string): boolean {
+  return file.endsWith('.css.ts') || file.endsWith('.styled.tsx')
+}
+
+function coveringKind(file: string): EvidenceKind | undefined {
+  if (!file.startsWith('packages/')) return undefined
+  if (isStory(file)) return 'story'
+  return file.endsWith('.browser.test.tsx') ? 'browser-test' : undefined
+}
+
+function run(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: MAX_BUFFER,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+}
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.trim().replace(/\s*\n\s*/g, '; ')
+}
+
+function readSource(root: string, file: string): string {
+  try {
+    return readFileSync(join(root, file), 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function parseImports(source: string): string[] {
+  return Array.from(source.matchAll(RELATIVE_IMPORT), (match) => match[1])
+}
+
+function resolveImport(importer: string, spec: string, files: ReadonlySet<string>) {
+  const base = posix.join(posix.dirname(importer), spec).replace(/\.(?:jsx?|tsx?)$/, '')
+  const candidates = [`${base}.tsx`, `${base}.ts`, `${base}/index.tsx`, `${base}/index.ts`, base]
+  return candidates.find((candidate) => files.has(candidate))
+}
+
+function resolveImports(importer: string, source: string, files: ReadonlySet<string>): string[] {
+  const targets: string[] = []
+  for (const spec of parseImports(source)) {
+    const target = resolveImport(importer, spec, files)
+    if (target) targets.push(target)
+  }
+  return targets
+}
+
+type ImportReader = (file: string) => string[]
+
+function createImportReader(root: string, files: ReadonlySet<string>): ImportReader {
+  const cache = new Map<string, string[]>()
+  return (file) => {
+    let targets = cache.get(file)
+    if (!targets) {
+      targets = resolveImports(file, readSource(root, file), files)
+      cache.set(file, targets)
+    }
+    return targets
+  }
+}
+
+function targetsWithHarness(file: string, importsOf: ImportReader): Set<string> {
+  const direct = importsOf(file)
+  const targets = new Set(direct)
+  for (const target of direct) {
+    if (!isHarness(target)) continue
+    for (const harnessTarget of importsOf(target)) targets.add(harnessTarget)
+  }
+  return targets
+}
+
+function uniqueSorted<T>(items: T[], key: (item: T) => string): T[] {
+  const byKey = new Map(items.map((item) => [key(item), item]))
+  return [...byKey.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([, item]) => item)
+}
+
+function buildCoverage(
+  root: string,
+  files: ReadonlySet<string>,
+  universe: string[],
+  pending: ReadonlyMap<string, PendingEvidence[]>,
+): Map<string, Coverage> {
+  const importsOf = createImportReader(root, files)
+  const coverage = new Map<string, Coverage>()
+  for (const file of universe) {
+    coverage.set(file, {file, coveredBy: [], pendingIn: [...(pending.get(file) ?? [])]})
+  }
+
+  for (const covering of files) {
+    const kind = coveringKind(covering)
+    if (!kind) continue
+    for (const target of targetsWithHarness(covering, importsOf)) {
+      coverage.get(target)?.coveredBy.push({file: covering, kind})
+    }
+  }
+
+  // Styles are only visible through the component that applies them, so a style module
+  // inherits the coverage of every file importing it. Repeat until stable because a
+  // `.styled.tsx` module often sits between the component and its `.css.ts`.
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const [file, importer] of coverage) {
+      for (const target of importsOf(file)) {
+        const styles = isStyleModule(target) ? coverage.get(target) : undefined
+        if (!styles) continue
+        const before = styles.coveredBy.length + styles.pendingIn.length
+        styles.coveredBy = uniqueSorted([...styles.coveredBy, ...importer.coveredBy], evidenceKey)
+        styles.pendingIn = uniqueSorted([...styles.pendingIn, ...importer.pendingIn], pendingKey)
+        if (styles.coveredBy.length + styles.pendingIn.length !== before) changed = true
+      }
+    }
+  }
+
+  for (const entry of coverage.values()) {
+    entry.coveredBy = uniqueSorted(entry.coveredBy, evidenceKey).sort(nearestSentinelFirst(entry))
+    entry.pendingIn = uniqueSorted(entry.pendingIn, pendingKey)
+  }
+  return coverage
+}
+
+const evidenceKey = (e: Evidence): string => e.file
+const pendingKey = (e: PendingEvidence): string => `${String(e.pr).padStart(8, '0')} ${e.file}`
+
+// A component's own story sits next to it; a story that merely imports it lives elsewhere. Show
+// stories before browser tests, then the evidence sharing the longest directory prefix.
+function nearestSentinelFirst(coverage: Coverage): (a: Evidence, b: Evidence) => number {
+  const dir = `${posix.dirname(coverage.file)}/`
+  const sharedPrefix = (e: Evidence): number => {
+    let i = 0
+    while (i < dir.length && dir[i] === e.file[i]) i += 1
+    return i
+  }
+  return (a, b) =>
+    Number(b.kind === 'story') - Number(a.kind === 'story') ||
+    sharedPrefix(b) - sharedPrefix(a) ||
+    a.file.localeCompare(b.file)
+}
+
+function parseAddedLines(diff: string): Map<string, string[]> {
+  const added = new Map<string, string[]>()
+  let current: string[] | undefined
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++ ')) {
+      current = line.startsWith('+++ b/') ? [] : undefined
+      if (current) added.set(line.slice('+++ b/'.length).trimEnd(), current)
+    } else if (current && line.startsWith('+')) {
+      current.push(line.slice(1))
+    }
+  }
+  return added
+}
+
+function loadPendingFromPrs(
+  root: string,
+  files: ReadonlySet<string>,
+  universe: ReadonlySet<string>,
+  currentBranch: string,
+): Map<string, PendingEvidence[]> {
+  const pending = new Map<string, PendingEvidence[]>()
+  let prs: PullRequest[]
+  try {
+    const fields = 'number,title,headRefName,files'
+    const args = ['pr', 'list', '--state', 'open', '--limit', '100', '--json', fields]
+    prs = JSON.parse(run('gh', args, root)) as PullRequest[]
+  } catch (error) {
+    console.warn(`warning: gh pr list failed (${errorMessage(error)}); pending coverage omitted`)
+    return pending
+  }
+
+  for (const pr of prs) {
+    // The current branch's own PR is the report subject, not pending work elsewhere.
+    if (pr.headRefName === currentBranch) continue
+    const paths = pr.files.map((file) => file.path)
+    if (!paths.some((path) => isStory(path) || isHarness(path))) continue
+
+    let diff: string
+    try {
+      diff = run('gh', ['pr', 'diff', String(pr.number)], root)
+    } catch (error) {
+      console.warn(`warning: gh pr diff ${pr.number} failed (${errorMessage(error)}); skipped`)
+      continue
+    }
+
+    const added = parseAddedLines(diff)
+    const known = new Set([...files, ...paths])
+    const importsOf: ImportReader = (file) => {
+      const local = files.has(file) ? readSource(root, file) : ''
+      return resolveImports(file, [...(added.get(file) ?? []), local].join('\n'), known)
+    }
+    for (const story of added.keys()) {
+      // Edits to a committed story are already counted as coverage; only new stories are pending.
+      if (!isStory(story) || files.has(story)) continue
+      for (const target of targetsWithHarness(story, importsOf)) {
+        if (!universe.has(target)) continue
+        const list = pending.get(target) ?? []
+        list.push({pr: pr.number, file: story})
+        pending.set(target, list)
+      }
+    }
+  }
+  return pending
+}
+
+function summaryLine(items: Coverage[], noun: string): string {
+  const counts: Record<Status, number> = {covered: 0, pending: 0, uncovered: 0}
+  for (const item of items) counts[statusOf(item)] += 1
+  return `${items.length} ${noun}: ${counts.covered} covered, ${counts.pending} pending, ${counts.uncovered} uncovered.`
+}
+
+function formatText(items: Coverage[], noun: string): string {
+  const lines: string[] = []
+  for (const item of items) {
+    lines.push(`${statusOf(item)}  ${item.file}`)
+    for (const e of item.coveredBy) lines.push(`  ${e.kind}  ${e.file}`)
+    for (const e of item.pendingIn) lines.push(`  pending  #${e.pr} ${e.file}`)
+  }
+  lines.push(summaryLine(items, noun))
+  return lines.join('\n')
+}
+
+function markdownEvidence(item: Coverage): string {
+  const cells = item.coveredBy.map((e) =>
+    e.kind === 'story'
+      ? `\`${e.file}\``
+      : `\`${e.file}\` (browser test, no Chromatic snapshot yet)`,
+  )
+  for (const e of item.pendingIn) cells.push(`#${e.pr} \`${e.file}\``)
+  const shown = cells.slice(0, MARKDOWN_EVIDENCE_LIMIT)
+  if (cells.length > shown.length) shown.push(`+${cells.length - shown.length} more`)
+  return shown.join('<br>')
+}
+
+function formatMarkdown(items: Coverage[], noun: string): string {
+  const heading = '### Visual regression coverage'
+  if (items.length === 0) {
+    return `${heading}\n\nNo changed UI files (\`packages/**/src/**/*.tsx\`, \`*.css.ts\`).`
+  }
+  const rows = items.map((item) => [`\`${item.file}\``, statusOf(item), markdownEvidence(item)])
+  const table = renderTable(['File', 'Status', 'Evidence'], rows, 'markdown')
+  const legend =
+    'covered: a committed `*.stories.tsx` (Chromatic snapshots it) or `*.browser.test.tsx` imports the file, directly or through its `*Story.tsx` harness. ' +
+    'pending: an open PR adds such a story; do not open a duplicate. uncovered: no story renders this file. ' +
+    'How to add one: `.agents/skills/sanity-visual-coverage/SKILL.md`.'
+  return [heading, '', summaryLine(items, noun), '', table, '', legend].join('\n')
+}
+
+function renderTable(headers: string[], rows: string[][], format: Format): string {
+  if (format === 'markdown') {
+    const separator = headers.map((header) => '-'.repeat(header.length))
+    return [headers, separator, ...rows].map((cells) => `| ${cells.join(' | ')} |`).join('\n')
+  }
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i].length)))
+  const line = (cells: string[]) =>
+    cells.map((cell, i) => (i === 0 ? cell.padEnd(widths[i]) : cell.padStart(widths[i]))).join('  ')
+  return [line(headers), ...rows.map(line)].join('\n')
+}
+
+function areaOf(file: string): string {
+  const match = /^(packages\/(?:@[^/]+\/)?[^/]+\/src)\/(.+)$/.exec(file)
+  if (!match) return posix.dirname(file)
+  const [, packageSrc, rest] = match
+  if (packageSrc !== 'packages/sanity/src') return packageSrc
+  return [packageSrc, ...rest.split('/').slice(0, -1).slice(0, 2)].join('/')
+}
+
+function summarizeAreas(items: Coverage[]): AreaRow[] {
+  const areas = new Map<string, AreaRow>()
+  const totals: AreaRow = {area: 'total', covered: 0, pending: 0, total: 0}
+  for (const item of items) {
+    const area = areaOf(item.file)
+    const row = areas.get(area) ?? {area, covered: 0, pending: 0, total: 0}
+    areas.set(area, row)
+    const status = statusOf(item)
+    for (const target of [row, totals]) {
+      if (status === 'covered') target.covered += 1
+      if (status === 'pending') target.pending += 1
+      target.total += 1
+    }
+  }
+  return [...[...areas.values()].sort((a, b) => a.area.localeCompare(b.area)), totals]
+}
+
+function formatTree(items: Coverage[], prs: boolean, uncovered: boolean, format: Format): string {
+  const headers = ['area', 'covered', ...(prs ? ['pending'] : []), 'total', '%']
+  const rows = summarizeAreas(items).map((row) => [
+    row.area,
+    String(row.covered),
+    ...(prs ? [String(row.pending)] : []),
+    String(row.total),
+    `${row.total ? Math.round((row.covered / row.total) * 100) : 0}%`,
+  ])
+  const output = [renderTable(headers, rows, format)]
+  if (uncovered) {
+    const missing = items.filter((item) => statusOf(item) === 'uncovered')
+    output.push('', `${missing.length} uncovered files:`)
+    for (const item of missing)
+      output.push(format === 'markdown' ? `- \`${item.file}\`` : item.file)
+  }
+  return output.join('\n')
+}
+
+function refExists(root: string, ref: string): boolean {
+  try {
+    run('git', ['rev-parse', '--verify', '--quiet', ref], root)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function changedFiles(root: string, base: string | undefined): string[] {
+  const ref = base ?? (refExists(root, 'origin/main') ? 'origin/main' : 'main')
+  const mergeBase = run('git', ['merge-base', ref, 'HEAD'], root).trim()
+  const diff = run('git', ['diff', '--name-only', '--diff-filter=ACMR', mergeBase], root)
+  return diff.split('\n').filter(Boolean)
+}
+
+function toRepoRelative(root: string, input: string): string {
+  return isAbsolute(input) ? relative(root, input).split(sep).join('/') : posix.normalize(input)
+}
+
+function fail(message: string): never {
+  console.error(`${message}\n\n${USAGE}`)
+  process.exit(2)
+}
+
+function parseCli() {
+  return parseArgs({
+    args: process.argv.slice(2),
+    allowPositionals: true,
+    options: {
+      changed: {type: 'boolean', default: false},
+      base: {type: 'string'},
+      prs: {type: 'boolean', default: false},
+      uncovered: {type: 'boolean', default: false},
+      format: {type: 'string', default: 'text'},
+      help: {type: 'boolean', default: false},
+    },
+  })
+}
+
+function main(): void {
+  let cli: ReturnType<typeof parseCli>
+  try {
+    cli = parseCli()
+  } catch (error) {
+    fail(errorMessage(error))
+  }
+  const {values, positionals} = cli
+  if (values.help) {
+    console.log(USAGE)
+    return
+  }
+  const format = FORMATS.find((candidate) => candidate === values.format)
+  if (!format) fail(`Unknown format: ${values.format}`)
+
+  const root = run('git', ['rev-parse', '--show-toplevel'], process.cwd()).trim()
+  const files = new Set(run('git', ['ls-files', '-z'], root).split('\0').filter(Boolean))
+  const universeList = [...files].filter(isUiFile).sort()
+  const universe = new Set(universeList)
+  // On pull_request events the checkout is a detached merge commit; the workflow's env names
+  // the PR branch instead.
+  const branch =
+    process.env.GITHUB_HEAD_REF || run('git', ['rev-parse', '--abbrev-ref', 'HEAD'], root).trim()
+  const pending = values.prs
+    ? loadPendingFromPrs(root, files, universe, branch)
+    : new Map<string, PendingEvidence[]>()
+  const coverage = buildCoverage(root, files, universeList, pending)
+
+  const treeMode = positionals.length === 0 && !values.changed
+  let selected = universeList
+  if (!treeMode) {
+    const requested = values.changed
+      ? changedFiles(root, values.base)
+      : positionals.map((input) => toRepoRelative(root, input))
+    selected = [...new Set(requested.filter((file) => universe.has(file)))]
+    const skipped = requested.length - selected.length
+    if (skipped > 0) console.error(`skipped ${skipped} non-UI or missing files`)
+  }
+  const items = selected.flatMap((file) => coverage.get(file) ?? [])
+  const noun = values.changed ? 'changed UI files' : 'UI files'
+
+  if (format === 'json') {
+    console.log(JSON.stringify(items, null, 2))
+  } else if (treeMode) {
+    console.log(formatTree(items, values.prs, values.uncovered, format))
+  } else {
+    console.log(format === 'markdown' ? formatMarkdown(items, noun) : formatText(items, noun))
+  }
+}
+
+main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

There was no way to answer "is this Studio UI covered by Chromatic?" without reading story files by hand, and the open `test(storybook)` sentinel stack (#14056 through #14511, plus #14215 and #14315) made it easy to open a duplicate. The Chromatic check itself cannot answer it: `TestWrapper` imports the whole `sanity` package, so TurboSnap re-snapshots most stories on most PRs whether or not a story renders the changed component.

This adds one script and one skill, no new test framework and no new stories.

`scripts/visualCoverage.ts` (`pnpm visual-coverage`) does static import analysis over `packages/**/src`. A `.tsx` or `.css.ts` file is `covered` when a committed `*.stories.tsx` or `*.browser.test.tsx` imports it directly or through its colocated `*Story.tsx` harness. Style modules (`.css.ts`, `.styled.tsx`) inherit their importers' coverage. `pending` means an open PR adds such a story (`--prs`, via `gh pr list` and `gh pr diff`). Modes: `--changed` for a branch vs `origin/main`, explicit paths, or no arguments for the tree grouped by area. `--format markdown` is the PR comment, `--format json` is for agents. It has no dependencies and runs under `tsx` or plain Node 22.18+.

`.agents/skills/sanity-visual-coverage/SKILL.md` (symlinked into `.cursor/skills` and `.claude/skills`) says how stories map to Studio UI, what a ui5 box sentinel is, how to run the check on a PR and on the tree, and the covered / pending / uncovered decision procedure including the rule not to touch the stack branches. `sanity-visual-regression` and `AGENTS.md` point at it.

`.github/workflows/visual-coverage.yml` runs the same script with `--format markdown --prs` on same-repo PRs touching `packages/**/src/**/*.tsx` or `*.css.ts` and posts a sticky comment. Never gating, same fork guard as `bench.yml`.

### What to review

- `scripts/visualCoverage.ts`. The coverage definition lives in `buildCoverage`: one import hop, plus the harness hop and style-module propagation. Push back if you think transitive coverage should count; I chose not to because it would mark everything covered for the reason above.
- `.agents/skills/sanity-visual-coverage/SKILL.md`. Is the decision procedure the one you would want a cloud agent to follow before opening a coverage PR?
- The workflow. It reuses `./.github/actions/setup` and the `thollander/actions-comment-pull-request` pin from `bench.yml`. zizmor reports one low finding (`./.github/actions/setup` self-repository syntax), same as every other workflow here.

### Testing

Run on this branch at `d677948`:

```
pnpm visual-coverage packages/sanity/src/ui-components/button/Button.tsx        # covered, Button.stories.tsx first
pnpm visual-coverage packages/sanity/src/core/field/diff/components/ValueError.tsx   # covered via FieldDiffChromeStory harness
pnpm visual-coverage packages/sanity/src/core/changeIndicators/ElementWithChangeBar.css.ts   # covered through .styled.tsx
pnpm visual-coverage --prs packages/sanity/src/core/components/detailLayout/DetailIdentity.tsx  # pending, #14511
pnpm visual-coverage           # 63 areas, 47 of 1372 files covered, 0.13s
pnpm visual-coverage --changed # this branch: 0 changed UI files
```

`oxlint` (type-aware) and `oxfmt` pass on the script. No unit test: the script has no workspace vitest project and adding one is a bigger change than the checker; the runs above are the check a reviewer reruns.

### Notes for release

N/A: internal tooling
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fc618ab-a381-4b10-b0ea-99057634aa34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fc618ab-a381-4b10-b0ea-99057634aa34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

