### PR TITLE
chore(agents): add sanity-ui-migration-progress skill

### DIFF
--- a/.agents/skills/sanity-ui-migration-progress/SKILL.md
+++ b/.agents/skills/sanity-ui-migration-progress/SKILL.md
@@ -50,10 +50,10 @@ bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh <di
 **Detect alias** when unsure:
 
 ```bash
-rg '"([^"]+)":\s*"npm:@sanity/ui@' package.json -r '$1'
+rg -o '"([^"]+)":\s*"npm:@sanity/ui@' package.json -r '$1'
 ```
 
-If the default `ui5` finds no imports, the script auto-detects the alias from the nearest `package.json`.
+If the default `ui5` finds no imports, the script auto-detects the alias from the nearest `package.json` at or above `<dir>`, then from any `package.json` below it.
 
 **Scope matters.** Counts depend on the directory passed — scanning a subdirectory vs repo root (`.`) can differ when ui5 imports exist in multiple packages or apps. Always state the directory used in the report.
 

--- a/.agents/skills/sanity-ui-migration-progress/SKILL.md
+++ b/.agents/skills/sanity-ui-migration-progress/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: sanity-ui-migration-progress
+description: Measures @sanity/ui v5 side-by-side migration progress — per-component import file counts (v5 alias vs @sanity/ui), JSX instance counts, and styled() instance counts with alias resolution. Use when reporting migration status or tracking progress over time.
+---
+
+# Sanity UI migration progress
+
+Reports how far an `@sanity/ui` → v5 migration has progressed in a directory tree.
+
+## Migration model
+
+This skill assumes a **side-by-side** setup:
+
+- **`@sanity/ui`** — legacy package still on v3 or v4
+- **v5 alias** (usually `ui5`) — v5 installed under a package alias, e.g. `"ui5": "npm:@sanity/ui@alpha"` in `package.json`
+- Migrated components import from the alias; unmigrated ones still import from `@sanity/ui`
+
+Both can coexist during a gradual, per-component migration.
+
+## When to use
+
+- User asks for migration progress, status, or coverage
+- After a migration batch — compare to a saved baseline
+- CI or periodic snapshots (run the script, commit or archive output)
+
+## Quick start
+
+Run the script from the repo root (paths below are relative to it).
+
+**All components in progress** (any component with a v5 import):
+
+```bash
+bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh <dir> [v5-alias] [@sanity/ui]
+```
+
+**Specific component(s)** (including before migration has started):
+
+```bash
+bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh <dir> --component Flex
+bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh <dir> --component Box --component Flex
+```
+
+| Argument           | Default      | Example                                |
+| ------------------ | ------------ | -------------------------------------- |
+| `<dir>`            | _(required)_ | `.`, `src/`, `apps/studio`             |
+| `[v5-alias]`       | `ui5`        | Side-by-side alias from `package.json` |
+| `[@sanity/ui]`     | `@sanity/ui` | Legacy import path still on v3/v4      |
+| `--component NAME` | _(none)_     | `Flex`, `Box` — repeat for several     |
+
+**Detect alias** when unsure:
+
+```bash
+rg '"([^"]+)":\s*"npm:@sanity/ui@' package.json -r '$1'
+```
+
+If the default `ui5` finds no imports, the script auto-detects the alias from the nearest `package.json`.
+
+**Scope matters.** Counts depend on the directory passed — scanning a subdirectory vs repo root (`.`) can differ when ui5 imports exist in multiple packages or apps. Always state the directory used in the report.
+
+### Choosing scope
+
+Infer the directory from what the user says — do not default to a subdirectory unless they name one.
+
+| User says                                                        | Directory                                                                  |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| "across the repo", "whole repo", "entire monorepo", "everywhere" | `.` (repo root)                                                            |
+| A specific path ("in `src/`", "the studio app")                  | That path                                                                  |
+| Nothing about scope                                              | Ask — or use `.` in monorepos where ui5 imports may span multiple packages |
+
+In monorepos, ui5 imports often live in several packages or apps — scanning only the main library undercounts repo-wide progress.
+
+## Workflow
+
+```
+- [ ] 1. Confirm directory, v5 alias, and optional component name(s)
+- [ ] 2. Run measure-progress.sh
+- [ ] 3. Present the table + call out partial components
+```
+
+### Step 1 — Confirm scope
+
+Ask or infer (see [Choosing scope](#choosing-scope) above):
+
+| Input         | Notes                                                                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Directory** | Repo-wide requests → `.`; subdirectory requests → that path                                                                          |
+| **v5 alias**  | Usually `ui5`; monorepos may resolve via `catalog:` — import path in source is still `ui5`                                           |
+| **Component** | Optional. Omit to list all components with v5 imports; provide one name to measure that component only (works even if not on v5 yet) |
+
+### Step 2 — Run the script
+
+**All in-progress components (repo-wide):**
+
+```bash
+bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh . ui5
+```
+
+**Scoped to a subdirectory:**
+
+```bash
+bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh src/ ui5
+```
+
+**One component:**
+
+```bash
+bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh <dir> ui5 --component Flex
+```
+
+If the user names a component, always pass `--component` — do not rely on discover mode.
+
+If discover mode finds **no v5 imports**, report that and stop — do not attempt to install anything:
+
+- **No alias in `package.json`** — the repo has no v5 side-by-side setup; nothing to measure
+- **Alias present, no imports** — setup exists but migration has not started (or the directory is too narrow). Suggest `--component <Name>` to measure legacy usage for a specific component.
+
+Example output columns:
+
+| Column                  | Meaning                                                       |
+| ----------------------- | ------------------------------------------------------------- |
+| **v5 imp**              | Files with a value import of this component from the v5 alias |
+| **leg imp**             | Files still importing from `@sanity/ui`                       |
+| **imp tot**             | Union of import files (both packages in one file counts once) |
+| **jsx mig / unm / tot** | `<LocalName>` instances via alias-resolved bindings           |
+| **jsx %**               | `jsx mig / jsx tot`                                           |
+| **sty mig / unm / tot** | `styled(LocalName)` at definition sites                       |
+
+The **component list** comes from v5 imports (discover mode) or from `--component` flags. Discover mode omits components not yet on v5; `--component` always reports the named component(s).
+
+### Step 3 — Present results
+
+Summarize in plain language:
+
+1. **Fully migrated** — `leg imp = 0` and `jsx unm = 0`
+2. **In progress** — v5 imports exist but legacy imports or JSX remain
+
+Discover mode only lists components with at least one v5 import — everything in the table
+has migration started. Components still entirely on `@sanity/ui` do not appear unless the
+user passed `--component`.
+
+Use this template:
+
+```markdown
+## Migration progress: `<dir>`
+
+**Scope:** `<dir>` · v5 alias `ui5` · `<date>`
+
+| Component | v5 files | legacy files | JSX migrated | JSX remaining | JSX % |
+| --------- | -------- | ------------ | ------------ | ------------- | ----- |
+| …         | …        | …            | …            | …             | …     |
+
+**Fully migrated:** …
+**In progress:** …
+```
+
+## Limitations
+
+| Gap                            | Why                                                                                           |
+| ------------------------------ | --------------------------------------------------------------------------------------------- |
+| **Element-type indirection**   | `cond ? Box : Card` — not counted; needs manual migration                                     |
+| **Cross-file styled wrappers** | Counts `styled(LocalName)` where defined; usage in importers is not re-attributed             |
+| **Re-exports / barrels**       | Binding must appear in the file that uses the component                                       |
+| **Mixed imports in one file**  | JSX split by binding source; rare double-import files may need manual review                  |
+| **Components not on ui5 yet**  | Absent from discover-mode table; use `--component` to measure legacy usage for a specific one |
+
+This skill **reports only** — it does not install dependencies or run migrations. If v5 is not
+present, say so and stop.

--- a/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
+++ b/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
@@ -87,7 +87,9 @@ has_v5_alias() {
 
 # Collect exported component names from v5 value imports (skip `type` specifiers).
 discover_components() {
-  rg -U --multiline -o "import \{([^}]+)\} from ['\"]${V5_PKG}['\"]" \
+  # --no-filename: when scanning a directory rg prefixes each match with its path, which would
+  # swallow the first specifier of every import in the sed/tr pipeline below.
+  rg -U --multiline -o --no-filename "import \{([^}]+)\} from ['\"]${V5_PKG}['\"]" \
     --glob '*.ts' --glob '*.tsx' "$SEARCH_DIR" 2>/dev/null \
     | sed 's/^import {//;s/} from.*//' \
     | tr ',' '\n' \

--- a/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
+++ b/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Measure @sanity/ui → v5 (ui5 alias) migration progress for a directory tree.
+#
+#   measure-progress.sh <dir> [v5-alias] [@sanity/ui]
+#   measure-progress.sh <dir> --component Flex
+#   measure-progress.sh <dir> ui5 @sanity/ui --component Box --component Flex
+#
+# Without --component: reports every component with at least one v5 value import.
+# With --component:    reports only the named component(s), even if not on v5 yet.
+#
+# Per component:
+#   - import file counts: v5, @sanity/ui, total (union of files)
+#   - JSX instance counts: migrated (v5 binding), unmigrated (@sanity/ui binding), total
+#   - styled() instance counts: migrated, unmigrated, total
+#
+# Instance counts resolve import aliases (`{ Box as UIBox }` → `<UIBox>`).
+#
+# Requires: ripgrep (rg), bash 4+
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: measure-progress.sh <dir> [v5-alias] [@sanity/ui] [--component NAME ...]
+
+  <dir>                 Directory tree to scan
+  v5-alias              Side-by-side v5 package name (default: ui5)
+  @sanity/ui            Legacy import path (default: @sanity/ui)
+  --component, -c NAME  Report one component only; repeat for several (PascalCase)
+
+With no --component flags, lists every component imported from the v5 alias.
+With --component, reports that component even when migration has not started.
+EOF
+}
+
+SEARCH_DIR=""
+V5_PKG="ui5"
+LEGACY_PKG="@sanity/ui"
+REQUESTED_COMPONENTS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -c | --component)
+      [ $# -lt 2 ] && { echo "error: $1 requires a component name" >&2; exit 1; }
+      REQUESTED_COMPONENTS+=("$2")
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [ -z "$SEARCH_DIR" ]; then
+        SEARCH_DIR="$1"
+      elif [ "$V5_PKG" = "ui5" ] && [ "$LEGACY_PKG" = "@sanity/ui" ] && [[ "$1" != @* ]] && [ ${#REQUESTED_COMPONENTS[@]} -eq 0 ]; then
+        V5_PKG="$1"
+      elif [ "$LEGACY_PKG" = "@sanity/ui" ] && [[ "$1" == @* ]]; then
+        LEGACY_PKG="$1"
+      else
+        echo "error: unexpected argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+SEARCH_DIR="${SEARCH_DIR:-.}"
+
+command -v rg >/dev/null || { echo "ripgrep (rg) required" >&2; exit 1; }
+
+# Discover v5 alias from nearest package.json when default is used and ui5 imports are absent.
+if [ "$V5_PKG" = "ui5" ] && ! rg -q "from ['\"]ui5['\"]" --glob '*.{ts,tsx}' "$SEARCH_DIR" 2>/dev/null; then
+  detected=$(rg '"([^"]+)":\s*"npm:@sanity/ui@' --glob 'package.json' "$SEARCH_DIR" -r '$1' 2>/dev/null | head -1)
+  [ -n "$detected" ] && V5_PKG="$detected"
+fi
+
+has_v5_alias() {
+  rg -q "\"${V5_PKG}\":" --glob 'package.json' "$SEARCH_DIR" 2>/dev/null
+}
+
+# Collect exported component names from v5 value imports (skip `type` specifiers).
+discover_components() {
+  rg -U --multiline -o "import \{([^}]+)\} from ['\"]${V5_PKG}['\"]" \
+    --glob '*.ts' --glob '*.tsx' "$SEARCH_DIR" 2>/dev/null \
+    | sed 's/^import {//;s/} from.*//' \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+    | rg -v '^type ' \
+    | sed 's/ as .*//' \
+    | rg '^[A-Z]' \
+    | sort -u
+}
+
+# Count files containing a value import of COMPONENT from PACKAGE.
+count_import_files() {
+  local component="$1" package="$2"
+  rg -lU --multiline \
+    "import \{[^}]*?\b${component}\b[^}]*?\} from ['\"]${package}['\"]" \
+    --glob '*.ts' --glob '*.tsx' "$SEARCH_DIR" 2>/dev/null \
+    | wc -l | tr -d ' '
+}
+
+# file<TAB>localName for COMPONENT imported from PACKAGE (alias-aware).
+resolve_bindings() {
+  local component="$1" package="$2"
+  local f local_name
+  while IFS= read -r f; do
+    local_name=$(rg -oU --multiline \
+      "import \{[^}]*?\b${component}\b(\s+as\s+(\w+))?[^}]*?\} from ['\"]${package}['\"]" \
+      -r '$2' "$f" 2>/dev/null | head -1)
+    [ -z "$local_name" ] && local_name="$component"
+    printf '%s\t%s\n' "$f" "$local_name"
+  done < <(rg -lU --multiline \
+    "import \{[^}]*?\b${component}\b[^}]*?\} from ['\"]${package}['\"]" \
+    --glob '*.ts' --glob '*.tsx' "$SEARCH_DIR" 2>/dev/null)
+}
+
+# Sum JSX and styled() hits for bindings from one package.
+count_instances() {
+  local component="$1" package="$2" kind="$3"
+  local jsx=0 styled=0 file local_name hits
+  while IFS=$'\t' read -r file local_name; do
+    if [ "$kind" = "jsx" ] || [ "$kind" = "both" ]; then
+      hits=$(rg "<${local_name}[\s/>]" --glob '*.tsx' --glob '*.jsx' "$file" 2>/dev/null | wc -l | tr -d ' ')
+      jsx=$((jsx + hits))
+    fi
+    if [ "$kind" = "styled" ] || [ "$kind" = "both" ]; then
+      hits=$(rg "styled\\(${local_name}\\)" --glob '*.ts' --glob '*.tsx' "$file" 2>/dev/null | wc -l | tr -d ' ')
+      styled=$((styled + hits))
+    fi
+  done < <(resolve_bindings "$component" "$package")
+  if [ "$kind" = "jsx" ]; then echo "$jsx"
+  elif [ "$kind" = "styled" ]; then echo "$styled"
+  else echo "$jsx $styled"
+  fi
+}
+
+# Union of import files for legacy + v5.
+count_total_import_files() {
+  local component="$1"
+  {
+    rg -lU --multiline \
+      "import \{[^}]*?\b${component}\b[^}]*?\} from ['\"]${V5_PKG}['\"]" \
+      --glob '*.ts' --glob '*.tsx' "$SEARCH_DIR" 2>/dev/null
+    rg -lU --multiline \
+      "import \{[^}]*?\b${component}\b[^}]*?\} from ['\"]${LEGACY_PKG}['\"]" \
+      --glob '*.ts' --glob '*.tsx' "$SEARCH_DIR" 2>/dev/null
+  } | sort -u | wc -l | tr -d ' '
+}
+
+pct() {
+  local part="$1" whole="$2"
+  if [ "$whole" -eq 0 ]; then echo "—"
+  else awk "BEGIN {printf \"%.0f%%\", ($part / $whole) * 100}"
+  fi
+}
+
+if [ ${#REQUESTED_COMPONENTS[@]} -gt 0 ]; then
+  components=$(printf '%s\n' "${REQUESTED_COMPONENTS[@]}" | sort -u)
+  mode="component"
+else
+  components=$(discover_components)
+  mode="discover"
+fi
+
+if [ -z "$components" ]; then
+  if [ "$mode" = "component" ]; then
+    echo "No component names provided." >&2
+    exit 1
+  fi
+
+  if has_v5_alias; then
+    echo "No migration progress to report under ${SEARCH_DIR}."
+    echo "The '${V5_PKG}' alias is listed in package.json but no value imports from '${V5_PKG}' were found."
+    echo "Migration may not have started yet, or the search directory may be too narrow."
+  else
+    echo "No migration progress to report under ${SEARCH_DIR}."
+    echo "No v5 side-by-side alias ('${V5_PKG}') found in package.json under this tree."
+    echo "This repo does not appear to have a v5 install — nothing to measure."
+  fi
+  echo "Pass a component to measure legacy usage before migration: measure-progress.sh <dir> --component Flex"
+  exit 0
+fi
+
+if [ "$mode" = "component" ] && ! has_v5_alias; then
+  echo "Note: no '${V5_PKG}' alias in package.json — v5 counts will be zero." >&2
+fi
+
+echo "Sanity UI migration progress"
+echo "  directory:  ${SEARCH_DIR}"
+echo "  v5 alias:     ${V5_PKG}"
+echo "  legacy pkg:   ${LEGACY_PKG}"
+if [ "$mode" = "component" ]; then
+  echo "  components:   $(echo "$components" | tr '\n' ' ' | sed 's/ $//')"
+else
+  echo "  components:   all with v5 imports"
+fi
+echo
+
+printf '%-12s %7s %7s %7s %7s %7s %7s %6s %7s %7s %7s %6s\n' \
+  "Component" \
+  "v5 imp" "leg imp" "imp tot" \
+  "jsx mig" "jsx unm" "jsx tot" "jsx%" \
+  "sty mig" "sty unm" "sty tot" "sty%"
+printf '%-12s %7s %7s %7s %7s %7s %7s %6s %7s %7s %7s %6s\n' \
+  "────────────" \
+  "───────" "───────" "───────" \
+  "───────" "───────" "───────" "────" \
+  "───────" "───────" "───────" "────"
+
+tot_v5_imp=0 tot_leg_imp=0
+tot_jsx_mig=0 tot_jsx_unm=0 tot_jsx=0
+tot_sty_mig=0 tot_sty_unm=0 tot_sty=0
+component_count=0
+
+while IFS= read -r component; do
+  [ -z "$component" ] && continue
+  component_count=$((component_count + 1))
+
+  v5_imp=$(count_import_files "$component" "$V5_PKG")
+  leg_imp=$(count_import_files "$component" "$LEGACY_PKG")
+  imp_tot=$(count_total_import_files "$component")
+
+  jsx_mig=$(count_instances "$component" "$V5_PKG" jsx)
+  jsx_unm=$(count_instances "$component" "$LEGACY_PKG" jsx)
+  jsx_tot=$((jsx_mig + jsx_unm))
+
+  sty_mig=$(count_instances "$component" "$V5_PKG" styled)
+  sty_unm=$(count_instances "$component" "$LEGACY_PKG" styled)
+  sty_tot=$((sty_mig + sty_unm))
+
+  jsx_pct=$(pct "$jsx_mig" "$jsx_tot")
+  sty_pct=$(pct "$sty_mig" "$sty_tot")
+
+  printf '%-12s %7s %7s %7s %7s %7s %7s %6s %7s %7s %7s %6s\n' \
+    "$component" "$v5_imp" "$leg_imp" "$imp_tot" \
+    "$jsx_mig" "$jsx_unm" "$jsx_tot" "$jsx_pct" \
+    "$sty_mig" "$sty_unm" "$sty_tot" "$sty_pct"
+
+  tot_v5_imp=$((tot_v5_imp + v5_imp))
+  tot_leg_imp=$((tot_leg_imp + leg_imp))
+  tot_jsx_mig=$((tot_jsx_mig + jsx_mig))
+  tot_jsx_unm=$((tot_jsx_unm + jsx_unm))
+  tot_jsx=$((tot_jsx + jsx_tot))
+  tot_sty_mig=$((tot_sty_mig + sty_mig))
+  tot_sty_unm=$((tot_sty_unm + sty_unm))
+  tot_sty=$((tot_sty + sty_tot))
+done <<< "$components"
+
+if [ "$component_count" -gt 1 ]; then
+  printf '%-12s %7s %7s %7s %7s %7s %7s %6s %7s %7s %7s %6s\n' \
+    "────────────" \
+    "───────" "───────" "───────" \
+    "───────" "───────" "───────" "────" \
+    "───────" "───────" "───────" "────"
+  printf '%-12s %7s %7s %7s %7s %7s %7s %6s %7s %7s %7s %6s\n' \
+    "TOTAL" "$tot_v5_imp" "$tot_leg_imp" "—" \
+    "$tot_jsx_mig" "$tot_jsx_unm" "$tot_jsx" "$(pct "$tot_jsx_mig" "$tot_jsx")" \
+    "$tot_sty_mig" "$tot_sty_unm" "$tot_sty" "$(pct "$tot_sty_mig" "$tot_sty")"
+fi
+
+echo
+echo "Legend:"
+echo "  v5 imp / leg imp  — files with a value import from the v5 alias / @sanity/ui"
+echo "  imp tot           — union of v5 + legacy import files for that component"
+echo "  jsx mig / unm     — <LocalName> hits via alias-resolved bindings per file"
+echo "  jsx %             — migrated JSX / total JSX instances"
+echo "  sty mig / unm     — styled(LocalName) hits via alias-resolved bindings per file"

--- a/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
+++ b/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
@@ -132,7 +132,10 @@ count_instances() {
   local jsx=0 styled=0 file local_name hits
   while IFS=$'\t' read -r file local_name; do
     if [ "$kind" = "jsx" ] || [ "$kind" = "both" ]; then
-      hits=$(rg "<${local_name}[\s/>]" --glob '*.tsx' --glob '*.jsx' "$file" 2>/dev/null | wc -l | tr -d ' ')
+      # Opening tags only (`</Name>` does not match). The tag name may be followed by a space,
+      # `/`, `>`, or end of line (`<Name` with props on the following lines), but not by more
+      # identifier characters or a `.`. -o counts every tag on a line, not just the line.
+      hits=$(rg -o "<${local_name}([^\w.]|\$)" --glob '*.tsx' --glob '*.jsx' "$file" 2>/dev/null | wc -l | tr -d ' ')
       jsx=$((jsx + hits))
     fi
     if [ "$kind" = "styled" ] || [ "$kind" = "both" ]; then

--- a/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
+++ b/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
@@ -73,6 +73,8 @@ done
 
 SEARCH_DIR="${SEARCH_DIR:-.}"
 
+[ -d "$SEARCH_DIR" ] || { echo "error: not a directory: $SEARCH_DIR" >&2; exit 1; }
+
 command -v rg >/dev/null || { echo "ripgrep (rg) required" >&2; exit 1; }
 
 # Discover v5 alias from nearest package.json when default is used and ui5 imports are absent.

--- a/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
+++ b/.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh
@@ -77,14 +77,43 @@ SEARCH_DIR="${SEARCH_DIR:-.}"
 
 command -v rg >/dev/null || { echo "ripgrep (rg) required" >&2; exit 1; }
 
-# Discover v5 alias from nearest package.json when default is used and ui5 imports are absent.
+# The nearest package.json at or above SEARCH_DIR, if any. A scanned subdirectory usually has
+# none of its own; the alias is declared by the package (or workspace root) that contains it.
+nearest_package_json() {
+  local dir
+  dir=$(cd "$SEARCH_DIR" && pwd -P) || return 1
+  while :; do
+    if [ -f "$dir/package.json" ]; then
+      echo "$dir/package.json"
+      return 0
+    fi
+    [ "$dir" = "/" ] && return 1
+    dir=$(dirname "$dir")
+  done
+}
+NEAREST_PKG_JSON=$(nearest_package_json || true)
+
+# Run rg with the given arguments over the package.json files that can declare the alias for
+# this tree: the nearest one at or above SEARCH_DIR, then any nested ones below it (monorepo
+# packages). Succeeds when either search matched.
+rg_package_json() {
+  local status=1
+  if [ -n "$NEAREST_PKG_JSON" ]; then
+    rg "$@" "$NEAREST_PKG_JSON" 2>/dev/null && status=0
+  fi
+  rg "$@" --glob 'package.json' "$SEARCH_DIR" 2>/dev/null && status=0
+  return $status
+}
+
+# Discover the v5 alias from package.json when the default is used and ui5 imports are absent.
+# -o --no-filename so only the captured alias is printed, not the path and the rest of the line.
 if [ "$V5_PKG" = "ui5" ] && ! rg -q "from ['\"]ui5['\"]" --glob '*.{ts,tsx}' "$SEARCH_DIR" 2>/dev/null; then
-  detected=$(rg '"([^"]+)":\s*"npm:@sanity/ui@' --glob 'package.json' "$SEARCH_DIR" -r '$1' 2>/dev/null | head -1)
+  detected=$(rg_package_json -o --no-filename '"([^"]+)":\s*"npm:@sanity/ui@' -r '$1' | head -1)
   [ -n "$detected" ] && V5_PKG="$detected"
 fi
 
 has_v5_alias() {
-  rg -q "\"${V5_PKG}\":" --glob 'package.json' "$SEARCH_DIR" 2>/dev/null
+  rg_package_json -q "\"${V5_PKG}\":"
 }
 
 # Collect exported component names from v5 value imports (skip `type` specifiers).
@@ -189,15 +218,15 @@ if [ -z "$components" ]; then
     echo "Migration may not have started yet, or the search directory may be too narrow."
   else
     echo "No migration progress to report under ${SEARCH_DIR}."
-    echo "No v5 side-by-side alias ('${V5_PKG}') found in package.json under this tree."
-    echo "This repo does not appear to have a v5 install — nothing to measure."
+    echo "No '${V5_PKG}' alias is declared in a package.json at or under ${SEARCH_DIR}."
+    echo "Either there is no v5 side-by-side install to measure, or the alias has another name: pass it as the second argument."
   fi
   echo "Pass a component to measure legacy usage before migration: measure-progress.sh <dir> --component Flex"
   exit 0
 fi
 
 if [ "$mode" = "component" ] && ! has_v5_alias; then
-  echo "Note: no '${V5_PKG}' alias in package.json — v5 counts will be zero." >&2
+  echo "Note: no '${V5_PKG}' alias is declared in a package.json at or under ${SEARCH_DIR}; only imports from '${V5_PKG}' count as migrated." >&2
 fi
 
 echo "Sanity UI migration progress"

--- a/.claude/skills/sanity-ui-migration-progress
+++ b/.claude/skills/sanity-ui-migration-progress
@@ -1,0 +1,1 @@
+../../.agents/skills/sanity-ui-migration-progress

--- a/.cursor/skills/sanity-ui-migration-progress
+++ b/.cursor/skills/sanity-ui-migration-progress
@@ -1,0 +1,1 @@
+../../.agents/skills/sanity-ui-migration-progress


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Lauren Ashpole wrote a skill that measures `@sanity/ui` → `ui5` migration progress (per-component import file counts, JSX instance counts, `styled()` counts, alias-aware) and shared it with the design-system studio integration group as a zip. This installs it in the repo so every agent (and human) gets it on checkout instead of installing it per machine.

It follows the in-repo skill layout: source under `.agents/skills/sanity-ui-migration-progress/`, symlinked from `.claude/skills/` and `.cursor/skills/` like `sanity-visual-coverage`. It is not added to `skills-lock.json` because it has no remote source to track. Deviations from the zip, one commit each:

- `SKILL.md` invokes the script at `.agents/skills/.../scripts/measure-progress.sh` (repo-root relative) instead of `~/.cursor/skills/...`, which does not exist on a fresh clone. Tables are oxfmt-formatted so `pnpm check:format` passes; no prose changed.
- Discover mode dropped the first specifier of every import: `rg` prefixes matches with the file path when scanning a directory, so `sed 's/^import {//'` never matched and the `^[A-Z]` filter removed it. On `packages/sanity/src/core/comments` this hid `Box` entirely (10 ui5 import files) while reporting `Flex`. Fixed with `--no-filename`; `--component` mode was never affected.
- Review follow-ups (Bugbot + Copilot):
  - Alias auto-detect ran `rg -r` without `-o --no-filename`, so `V5_PKG` became the file path plus the rest of the `package.json` line. Fixed in the script and in the `SKILL.md` snippet.
  - Alias lookup now matches what `SKILL.md` promised: the nearest `package.json` at or above `<dir>` is checked first, then any nested ones below it. Before, scanning a subdirectory of a package never found the alias, and the `--component` note wrongly claimed "v5 counts will be zero". The no-alias messages now describe what was searched instead of asserting an outcome.
  - A missing or mistyped `<dir>` now exits 1 with an error instead of printing "no migration progress" (every `rg` call silences stderr).
  - JSX counting missed formatted multi-line opening tags (`<Flex` at end of line with props below), 78 of 785 `Flex` tags in `packages/sanity/src`. The regex now also accepts end of line, excludes longer identifiers and member access (`<FlexProps`, `<Box.Item>`), and counts matches with `-o` so several tags on one line all count.

### What to review

- `.agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh`: `nearest_package_json` / `rg_package_json` (alias lookup), the JSX regex in `count_instances`, and the directory check. @laurenashpole, please sanity-check these against your local copy; the numbers your copy reports will move a little (see Testing).
- `.agents/skills/sanity-ui-migration-progress/SKILL.md`: path edits, formatting, `-o` in the detect-alias snippet, and the sentence describing auto-detect.

### Testing

No automated tests; the skill is a bash + ripgrep script. Verified manually in this repo:

- `bash .agents/skills/sanity-ui-migration-progress/scripts/measure-progress.sh packages/sanity/src/core/comments` reports `Box` 10/0 files, 9 JSX, and `Flex` 18/0 files, 35 JSX (was 31 before the multi-line fix; the 4 extra are `<Flex` at end of line). Cross-checked with an independent `rg -o` over the same files.
- Same directory before the discover-mode fix reported only `Flex`.
- `--component Box --component Flex --component Text` on that directory reports `Text` at 0/19 files, 0/27 JSX, and no longer prints the "v5 counts will be zero" note (the alias is found in `packages/sanity/package.json`).
- Repo-wide `. ui5` completes in about 60s and lists Box, Container, Flex, Grid, Icon, Text, VStack (43% of 3196 JSX instances migrated).
- Fixtures under `/tmp`: alias `myalias` declared in `package.json` is auto-detected both when scanning the package root and when scanning only its `src/` (nearest lookup); a multi-line `<Box` tag counts, two `<Flex>` on one line count as 2, `<Boxy />` and `<Box.Item />` do not count; a tree with no alias anywhere prints the reworded messages; `does/not/exist` exits 1 with `error: not a directory`.
- `pnpm oxfmt --check .agents .claude .cursor` passes; the script is committed with the executable bit.

### Notes for release

N/A – Internal only (agent skill, no package changes)

---

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C0BJFG11M7Y/p1787844892119909?thread_ts=1787844892.119909&cid=C0BJFG11M7Y)

<div><a href="https://cursor.com/agents/bc-9e8fcf03-0747-5eaa-b62f-32e85891330c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8fcf03-0747-5eaa-b62f-32e85891330c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

