### PR TITLE
test(storybook): add ui5 flex sentinels for form field chrome

### DIFF
--- a/packages/sanity/src/core/form/components/formField/__tests__/FormFieldChrome.stories.tsx
+++ b/packages/sanity/src/core/form/components/formField/__tests__/FormFieldChrome.stories.tsx
@@ -1,0 +1,19 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+
+import {FormFieldChromeStory} from './FormFieldChromeStory'
+
+/**
+ * Reuses the in-package harness: form field chrome (FormFieldHeaderText,
+ * FormFieldSetLegend, FormFieldValidationStatus, FormFieldSet,
+ * FormFieldBaseHeader) ahead of the ui5 Flex migration.
+ */
+const meta = {
+  title: 'Form/Field Chrome',
+  component: FormFieldChromeStory,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof FormFieldChromeStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const States: Story = {}

--- a/packages/sanity/src/core/form/components/formField/__tests__/FormFieldChromeStory.tsx
+++ b/packages/sanity/src/core/form/components/formField/__tests__/FormFieldChromeStory.tsx
@@ -1,0 +1,168 @@
+import {CopyIcon} from '@sanity/icons/Copy'
+import {ResetIcon} from '@sanity/icons/Reset'
+import {type FormNodeValidation} from '@sanity/types'
+import {Card, Stack, Text} from '@sanity/ui'
+import noop from 'lodash-es/noop.js'
+
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+import {type DocumentFieldActionNode} from '../../../../config/document/fieldActions/types'
+import {FormFieldBaseHeader} from '../FormFieldBaseHeader'
+import {FormFieldHeaderText} from '../FormFieldHeaderText'
+import {FormFieldSet} from '../FormFieldSet'
+import {FormFieldSetLegend} from '../FormFieldSetLegend'
+import {FormFieldValidationStatus} from '../FormFieldValidationStatus'
+
+const LONG_TITLE =
+  'Canonical page title shown in search results, social cards and the browser tab whenever no override is set'
+
+const ERRORS: FormNodeValidation[] = [
+  {level: 'error', message: 'Title is required.', path: ['title']},
+]
+const WARNINGS: FormNodeValidation[] = [
+  {level: 'warning', message: 'Keep the title under 60 characters.', path: ['title']},
+]
+const MIXED: FormNodeValidation[] = [...ERRORS, ...WARNINGS]
+
+const DEPRECATED = {reason: 'Use the excerpt field instead.'}
+
+const FIELD_ACTIONS: DocumentFieldActionNode[] = [
+  {type: 'action', title: 'Copy field', icon: CopyIcon, onAction: noop},
+  {type: 'action', title: 'Clear field', icon: ResetIcon, onAction: noop, renderAsButton: true},
+]
+
+/**
+ * Chromatic sentinel for the form field chrome ahead of the ui5 Flex
+ * migration: header text with description, deprecated badge and validation
+ * status, a long title that has to wrap next to its badges, collapsed and
+ * expanded fieldset legends and fieldsets, validation status icons, and the
+ * base header row with and without visible field actions. Fixture copy only;
+ * shared with Storybook via a thin CSF wrapper.
+ */
+export function FormFieldChromeStory() {
+  return (
+    <TestWrapper schemaTypes={[]}>
+      <Card padding={4} style={{maxWidth: 480}}>
+        <Stack gap={5}>
+          <Stack gap={2}>
+            <Text muted size={1} weight="medium">
+              header text
+            </Text>
+            <Stack gap={4}>
+              <FormFieldHeaderText inputId="header-plain" title="Title" />
+              <FormFieldHeaderText
+                description="Used to build the canonical URL."
+                inputId="header-description"
+                title="Slug"
+              />
+              <FormFieldHeaderText
+                deprecated={DEPRECATED}
+                inputId="header-deprecated"
+                title="Summary"
+              />
+              <FormFieldHeaderText inputId="header-error" title="Email" validation={ERRORS} />
+              <FormFieldHeaderText inputId="header-warning" title="Tags" validation={WARNINGS} />
+              <FormFieldHeaderText
+                deprecated={DEPRECATED}
+                description="Wraps onto several lines while the badge and status stay centered."
+                inputId="header-long"
+                title={LONG_TITLE}
+                validation={MIXED}
+              />
+            </Stack>
+          </Stack>
+          <Stack gap={2}>
+            <Text muted size={1} weight="medium">
+              fieldset legend
+            </Text>
+            <Stack gap={4}>
+              <FormFieldSetLegend collapsed collapsible onClick={noop} title="Collapsed fieldset" />
+              <FormFieldSetLegend
+                collapsed={false}
+                collapsible
+                onClick={noop}
+                title="Expanded fieldset"
+              />
+            </Stack>
+          </Stack>
+          <Stack gap={2}>
+            <Text muted size={1} weight="medium">
+              validation status
+            </Text>
+            <Stack gap={4}>
+              <FormFieldValidationStatus fontSize={1} placement="top" validation={ERRORS} />
+              <FormFieldValidationStatus fontSize={1} placement="top" validation={WARNINGS} />
+              <FormFieldValidationStatus fontSize={1} placement="top" validation={MIXED} />
+            </Stack>
+          </Stack>
+          <Stack gap={2}>
+            <Text muted size={1} weight="medium">
+              fieldset
+            </Text>
+            <Stack gap={4}>
+              <FormFieldSet
+                collapsed
+                collapsible
+                description="Shipping and billing details for the order."
+                inputId="fieldset-collapsed"
+                onCollapse={noop}
+                onExpand={noop}
+                path={['address']}
+                title={LONG_TITLE}
+              >
+                <Text size={1}>Hidden while collapsed</Text>
+              </FormFieldSet>
+              <FormFieldSet
+                collapsed={false}
+                collapsible
+                description="Where the order ships."
+                inputId="fieldset-expanded"
+                onCollapse={noop}
+                onExpand={noop}
+                path={['address']}
+                title="Address"
+                validation={WARNINGS}
+              >
+                <Card border padding={3} radius={2}>
+                  <Text muted size={1}>
+                    Street
+                  </Text>
+                </Card>
+                <Card border padding={3} radius={2}>
+                  <Text muted size={1}>
+                    Postal code
+                  </Text>
+                </Card>
+              </FormFieldSet>
+            </Stack>
+          </Stack>
+          <Stack gap={2}>
+            <Text muted size={1} weight="medium">
+              base header
+            </Text>
+            <Stack gap={4}>
+              <FormFieldBaseHeader
+                content={
+                  <FormFieldHeaderText
+                    description="Shown above the input."
+                    inputId="base-header"
+                    title="Title"
+                  />
+                }
+                fieldFocused={false}
+                fieldHovered={false}
+                inputId="base-header"
+              />
+              <FormFieldBaseHeader
+                actions={FIELD_ACTIONS}
+                content={<FormFieldHeaderText inputId="base-header-actions" title={LONG_TITLE} />}
+                fieldFocused={false}
+                fieldHovered
+                inputId="base-header-actions"
+              />
+            </Stack>
+          </Stack>
+        </Stack>
+      </Card>
+    </TestWrapper>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

[#14366](https://github.com/sanity-io/sanity/pull/14366) swaps `@sanity/ui` `Flex` for `ui5` `Flex` across `core/form`, rewriting `align`/`justify`/`direction`/`flex` to `alignItems`/`justifyContent`/`flexDirection`/`flexBasis`+`flexGrow`. Its `FormBuilder.test.tsx.snap` update shows ui5 `Flex` emitting `--min-height: 0; --min-width: 0`, i.e. a `min-width: 0` default, so wrapping and shrink behaviour in the field chrome can drift in ways the type checker cannot see. On current `main` none of the five `formField/*.tsx` files that PR touches is rendered by any story, so Chromatic would have no baseline to diff against when it lands.

This adds one Chromatic sentinel for that chrome, on `main`, as a harness + thin CSF pair (`packages/sanity/src/core/form/components/formField/__tests__/`), following `FieldDiffChromeStory.tsx` / `FieldDiffChrome.stories.tsx`. It is separate coverage only: it does not modify `chore/ui-v5-flex-form-misc` or `chore/ui-v5-flex-form-inputs`, and touches no component. Story is `Form/Field Chrome › States`, tagged `['!dev', '!autodocs', 'vrt-only']` (pure regression fixture, out of the sidebar, still snapshotted).

Now snapshotted (all directly imported by the harness, inside `TestWrapper`, fixture copy only, 480px `Card` so long titles actually wrap):

- `FormFieldHeaderText`: plain, with description, deprecated badge, validation error, validation warning, and a long title that wraps next to a badge + mixed validation status.
- `FormFieldSetLegend`: collapsed and expanded.
- `FormFieldValidationStatus`: error, warning, mixed.
- `FormFieldSet`: collapsed (long title + description) and expanded (description + warning, two simple children).
- `FormFieldBaseHeader`: default `align="flex-end"` / `justify="space-between"` row with a content slot, and the same row with two fake `DocumentFieldActionNode`s and `fieldHovered` so the floating actions card is visible next to a wrapped title. Presence and comments are left out (they need user/comment stores).

Why not a `play` story opening the validation tooltip: `FormFieldValidationStatus`'s only `Flex` lives in the tooltip body, but a hover `play` is timing-dependent and the brief asked for deterministic-by-construction states; noted below as a follow-up.

One thing the baseline captures on purpose: in the long-title header row the ui5 `Box` wrapper around the `deprecated` badge already has `min-width: 0` and shrinks (measured 40px wrapper for a 77px badge), so the badge overflows into the status icon when the label wraps in a narrow column. That is pre-existing `main` behaviour, not a fixture artifact, and it is precisely the kind of shrink drift the sentinel is there to catch once the surrounding `Flex` changes too. Not fixed here (component changes are out of scope).

### What to review

- `FormFieldChromeStory.tsx`: the set of states, and that everything is deterministic (no timestamps, ids, network; `noop` handlers; fixed fixture copy).
- `FormFieldChrome.stories.tsx`: title `Form/Field Chrome`, `vrt-only` tags.
- Only `packages/sanity` is affected, and only with test/story files; no snapshot files updated, no `takeSnapshot()` calls, no existing harness forked.

Coverage script, `pnpm visual-coverage --prs <five formField files>`, before (on `main`):

```
uncovered  packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
uncovered  packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
uncovered  packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
uncovered  packages/sanity/src/core/form/components/formField/FormFieldSetLegend.tsx
uncovered  packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
5 UI files: 0 covered, 0 pending, 5 uncovered.
```

After (this branch):

```
covered  packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
  story  packages/sanity/src/core/form/components/formField/__tests__/FormFieldChrome.stories.tsx
covered  packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
  story  packages/sanity/src/core/form/components/formField/__tests__/FormFieldChrome.stories.tsx
covered  packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
  story  packages/sanity/src/core/form/components/formField/__tests__/FormFieldChrome.stories.tsx
covered  packages/sanity/src/core/form/components/formField/FormFieldSetLegend.tsx
  story  packages/sanity/src/core/form/components/formField/__tests__/FormFieldChrome.stories.tsx
covered  packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
  story  packages/sanity/src/core/form/components/formField/__tests__/FormFieldChrome.stories.tsx
5 UI files: 5 covered, 0 pending, 0 uncovered.
```

`pnpm visual-coverage --changed --prs` on this branch (expected for a test-only PR: story/harness files are not part of the UI universe):

```
skipped 2 non-UI or missing files
0 changed UI files: 0 covered, 0 pending, 0 uncovered.
```

`0 pending` in the `--prs` runs (re-run right before opening this PR) confirms no open PR claims any of these files.

Out of scope, left as follow-ups from #14366's remaining uncovered files: `ActivateOnFocus` (+ `ActivateOnFocus.styles.tsx`), `breadcrumbs/DialogBreadcrumbs`, `tagInput/tagInput`, `members/array/IncompatibleItemType` (the existing `inputs/arrays/__tests__/IncompatibleItemType.stories.tsx` covers the `ArrayOfObjectsInput/List` component, not this one), and the `studio/assetSourceDataset` / `studio/assetSourceMediaLibrary` files (`AssetRow`, `FileListView`, `ImageListView`, `AssetUsageList`, `ConfirmMessage`, both `SelectAssetsDialog`s, `OpenInSourceDialog`). `MediaLibraryProvider` and `EnsureMediaLibrary` are provider-shaped and mostly not worth snapshotting. A hover `play` story for the open `FormFieldValidationStatus` tooltip is another candidate.

### Testing

Ran in the Cloud VM (Node 22.22, Playwright Chromium installed for the storybook project):

- `pnpm exec oxfmt --check` on the new directory: clean.
- `pnpm exec oxlint --disable-nested-config` on both files: exit 0 (oxlint's `typeCheck` is active here; a deliberate `inputId={1}` probe in the same directory was reported as TS2322 against the real `FormFieldSet` props, then removed).
- `pnpm --filter sanity-storybook exec vitest run FormFieldChrome --reporter=verbose`: `FormFieldChrome.stories.tsx > States` passed.
- `pnpm --filter sanity-storybook test` (full suite, single process): in this 4-CPU sandbox the run aborts with `[vitest] Browser connection was closed while running tests` after 23–60 story files, each time on a different unrelated file (a PortableText story, `CommentsInspectorError`, `ToolbarApplicableSchema`), twice before the new story was even loaded; every story that did run passed, and the same happens with `--no-file-parallelism`. So I ran the same suite as 8 shards (`vitest run --shard=i/8`, fresh browser per shard): all 8 passed on the first attempt, 95/95 story files, 108/108 stories, with `FormFieldChrome.stories.tsx > States` in shard 2. I am not claiming a green single-process full run in the sandbox.
- Visual check: `pnpm dev:storybook`, then a Playwright script opened `iframe.html?id=form-field-chrome--states`, waited for content from every section (description, deprecated badge and message, both legends, fieldset child, field-actions flex and trigger) to be visible, logged no console errors, and captured the screenshot below.

[Form/Field Chrome › States rendered in Storybook (1280×900 viewport, full page)](https://cursor.com/agents/bc-46402431-14d8-4714-b4b1-1985b198f7e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fform_field_chrome_story_states.png)

### Notes for release

N/A – Internal only (test coverage)

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46402431-14d8-4714-b4b1-1985b198f7e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46402431-14d8-4714-b4b1-1985b198f7e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

