### PR TITLE
ci(renovate): group sdk dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,14 @@
       "matchPackageNames": ["!@portabletext/*", "!@sanity/client", "!@sanity/ui"]
     },
     {
+      "description": "Upgrade @sanity/sdk and @sanity/sdk-react together across all workspaces and dependency types, bumping every manifest to keep a single version throughout the repository",
+      "matchPackageNames": ["@sanity/sdk", "@sanity/sdk-react"],
+      "dependencyDashboardApproval": false,
+      "schedule": ["every weekday"],
+      "groupName": "sanity-sdk",
+      "rangeStrategy": "bump"
+    },
+    {
       "matchDepTypes": ["dependencies"],
       "matchPackageNames": [
         "@portabletext/*",


### PR DESCRIPTION
### Description

We want to bump `@sanity/sdk` and `@sanity/sdk-react` as a unit, and also in packages + apps at the same time.

### What to review

…

### Testing

I ran it through a linter

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Renovate configuration changes; no application or runtime behavior is affected.
> 
> **Overview**
> Adds a Renovate **package rule** so `@sanity/sdk` and `@sanity/sdk-react` upgrade in **one PR** (`groupName`: `sanity-sdk`) instead of separate bumps per package or workspace.
> 
> The rule applies across all manifests and dependency types, uses **`rangeStrategy`: `bump`** to align versions repo-wide, skips dependency-dashboard approval, and runs on a **weekday** schedule—matching the pattern used for other coordinated internal packages (e.g. `@portabletext/*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58af34a0247f3fa622ecdd6c87654bf3ec648c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->