### PR TITLE
test(storybook): add ui5 flex layout sentinel for the dev flex migration

### DIFF
--- a/packages/sanity/src/ui-components/__tests__/FlexLayouts.stories.tsx
+++ b/packages/sanity/src/ui-components/__tests__/FlexLayouts.stories.tsx
@@ -1,0 +1,191 @@
+import {SpinnerIcon} from '@sanity/icons/Spinner'
+import {Badge, Box, Card, Checkbox, Stack, Text} from '@sanity/ui'
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {type ReactNode} from 'react'
+import {type AlignItems, Flex} from 'ui5'
+
+import {Button} from '../button/Button'
+
+const ALIGN_ITEMS: AlignItems[] = ['flex-start', 'center', 'flex-end', 'baseline', 'stretch']
+
+function Section(props: {label: string; children: ReactNode}) {
+  const {label, children} = props
+  return (
+    <Stack gap={2}>
+      <Text muted size={1} weight="medium">
+        {label}
+      </Text>
+      {children}
+    </Stack>
+  )
+}
+
+/**
+ * Layout sentinel for the `ui5` Flex primitive, mirroring the prop mappings
+ * the dev-studio Flex migration relies on (embedded-studio, preview-iframe,
+ * radar, studio-diagnostics-viewer, the e2e studio layouts and test-studio):
+ * `flexDirection`/`alignItems`/`justifyContent`/`flexWrap` for the v4
+ * `direction`/`align`/`justify`/`wrap` props, `height="100%"` for
+ * `height="fill"`, and `flexBasis="0%" flexGrow={1}` / `flexShrink={0}` for
+ * `flex={1}` / inline flex styles. Those apps live outside the Storybook
+ * glob and render live data, so the primitive is snapshotted here together
+ * with the `@sanity/ui` v4 children they mix in (Card, Badge, Checkbox and a
+ * v4 `Box flex={1}`). Fixture copy only; no spinner animation.
+ */
+const meta = {
+  title: 'Sanity UI/Flex Layouts',
+  component: Flex,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof Flex>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Layouts: Story = {
+  render: () => (
+    <Card padding={4} style={{maxWidth: 560}}>
+      <Stack gap={5}>
+        <Section label="column shell: flexDirection=column height=100% overflow=hidden, body flexBasis=0% flexGrow=1">
+          <Card border radius={2} style={{height: 160}}>
+            <Flex flexDirection="column" height="100%" overflow="hidden">
+              <Card borderBottom>
+                <Flex gap={1} padding={2}>
+                  <Button mode="ghost" text="Layout" />
+                  <Button mode="ghost" text="Studio" />
+                </Flex>
+              </Card>
+              <Flex flexDirection="column" flexBasis="0%" flexGrow={1}>
+                <Card height="fill" padding={3} tone="primary">
+                  <Text size={1}>Body fills the remaining height</Text>
+                </Card>
+              </Flex>
+            </Flex>
+          </Card>
+        </Section>
+
+        <Section label="centered loading state: alignItems=center justifyContent=center height=100%">
+          <Card border radius={2} style={{height: 120}}>
+            <Flex
+              alignItems="center"
+              flexDirection="column"
+              gap={3}
+              height="100%"
+              justifyContent="center"
+            >
+              <Text muted size={2}>
+                <SpinnerIcon />
+              </Text>
+              <Text align="center" muted size={1}>
+                Loading document
+              </Text>
+            </Flex>
+          </Card>
+        </Section>
+
+        <Section label="wrapping row: alignItems=center gap=3 flexWrap=wrap with a v4 Box flex=1">
+          <Card border padding={3} radius={2} style={{maxWidth: 360}}>
+            <Flex alignItems="center" gap={3} flexWrap="wrap">
+              <Box flex={1} style={{minWidth: 220}}>
+                <Stack gap={2}>
+                  <Text size={1} weight="medium">
+                    Document pane render time regressed
+                  </Text>
+                  <Flex alignItems="center" gap={2}>
+                    <Text muted size={0}>
+                      2 days ago
+                    </Text>
+                    <Text muted size={0}>
+                      · cursor[bot]
+                    </Text>
+                  </Flex>
+                </Stack>
+              </Box>
+              <Badge fontSize={0} tone="critical">
+                first bad commit
+              </Badge>
+              <Badge fontSize={0}>a1b2c3d</Badge>
+              <Badge fontSize={0}>v4.12.0</Badge>
+              <Button mode="ghost" text="Open" />
+            </Flex>
+          </Card>
+        </Section>
+
+        <Section label="space-between header: flexBasis=0% flexGrow=1 title, flexShrink=0 actions">
+          <Card border padding={3} radius={2} style={{maxWidth: 320}}>
+            <Flex alignItems="center" gap={3} justifyContent="space-between">
+              <Flex flexBasis="0%" flexDirection="column" flexGrow={1} gap={1}>
+                <Text size={1} weight="medium">
+                  Largest Contentful Paint on the document pane after a cold reload
+                </Text>
+                <Text muted size={0}>
+                  median of 5 runs
+                </Text>
+              </Flex>
+              <Flex alignItems="center" flexShrink={0} gap={2}>
+                <Badge fontSize={0} tone="positive">
+                  ↓ -22%
+                </Badge>
+                <Button mode="bleed" text="Details" />
+              </Flex>
+            </Flex>
+          </Card>
+        </Section>
+
+        <Section label="dialog footer: gap=2 justifyContent=flex-end">
+          <Card border padding={3} radius={2}>
+            <Flex gap={2} justifyContent="flex-end">
+              <Button mode="ghost" text="Cancel" />
+              <Button text="Start bisect" tone="primary" />
+            </Flex>
+          </Card>
+        </Section>
+
+        <Section label="alignItems variants against a taller sibling">
+          <Stack gap={3}>
+            {ALIGN_ITEMS.map((alignItems) => (
+              <Flex key={alignItems} alignItems={alignItems} gap={3}>
+                <Card border padding={2} radius={2} tone="transparent">
+                  <Text size={0}>alignItems="{alignItems}"</Text>
+                </Card>
+                <Card border padding={3} radius={2} style={{height: 56}}>
+                  <Text size={1}>taller sibling</Text>
+                </Card>
+              </Flex>
+            ))}
+          </Stack>
+        </Section>
+
+        <Section label="tool menu: flexDirection=row (topbar) vs column (sidebar)">
+          <Flex alignItems="flex-start" gap={5}>
+            <Flex flexDirection="row" gap={3}>
+              <Button mode="bleed" text="Structure" />
+              <Button mode="bleed" text="Vision" />
+              <Button mode="bleed" text="Releases" />
+            </Flex>
+            <Flex flexDirection="column" gap={3}>
+              <Button mode="bleed" text="Structure" />
+              <Button mode="bleed" text="Vision" />
+              <Button mode="bleed" text="Releases" />
+            </Flex>
+          </Flex>
+        </Section>
+
+        <Section label="checkbox row: as=label alignItems=center gap=2">
+          <Card border padding={3} radius={2}>
+            <Flex alignItems="center" as="label" gap={2}>
+              <Checkbox defaultChecked />
+              <Flex flexBasis="0%" flexGrow={1}>
+                <Text size={1} weight="semibold">
+                  All languages
+                </Text>
+              </Flex>
+              <Text muted size={1}>
+                3 of 3
+              </Text>
+            </Flex>
+          </Card>
+        </Section>
+      </Stack>
+    </Card>
+  ),
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Companion coverage for #14523 (`chore: migrate flex in dev`, 45 files, `@sanity/ui` v4 `Flex` → `ui5` `Flex`). That PR touches only `dev/**`, so no existing Chromatic snapshot exercises the prop mappings it introduces — and none of the changed surfaces can be brought into the package Storybook:

- **Out of scope for the VRT model by design.** The Storybook `stories` glob is `packages/{sanity,groq,@repo/*,@sanity/*}/src/**` (`dev/storybook/.storybook/main.ts`), `scripts/visualCoverage.ts` only treats `packages/**/src/**` as UI files, and the `Visual coverage` workflow does not even trigger for #14523 (its `paths` filter is `packages/**/src/**`). `pnpm visual-coverage --prs <all 45 files>` reports `skipped 45 non-UI or missing files`.
- **Not importable from a `packages/sanity` story.** `dev/storybook/README.md` requires package-local imports ("use package-local imports instead of reaching across workspace boundaries"); the dev apps also pull deps the `sanity` package does not have (`@visx/*`, `@sanity/visual-editing`, `@sanity/preview-url-secret`).
- **Not deterministic.** Every meaningful visual surface in the PR renders live data or real Studio context: the Radar tools (`bisect/*`, `ComparisonsTool`, `ReleasesTool`, `AddRegressionDialog`, `trends/*`) read `useDocumentStore`/`useClient`/`useCurrentUser`; the preview-iframe screens (`FieldGroups`, `InitialValues`, `InternationalizedArrayTest`, `LongList`, `SimpleBlockPortableText`, `main`) run live GROQ via `useQuery`; the e2e `StudioLayout`/`DocumentLayout`, test-studio `studioComponents`, `ToolMenu`, `CustomInspector`, `CustomNavigator`, form-components-api, `PageBlockAnchor`, `SideBySideObjectInput`, `referenceCreateButtonRepro`, PT previews and `JsonDocumentDump` wrap `renderDefault`/`usePaneRouter`/`useFormValue`/`useDocumentPane` inside a real workspace; `embedded-studio/App` mounts `StudioProvider` with a real config; `studio-diagnostics-viewer/App` and `DiagnosticsTool` are paste-JSON screens whose only Flex change is a `justifyContent="flex-end"` footer. The e2e layouts are already exercised by the Playwright suite on #14523 itself; the rest is covered by that PR's manual Presentation/custom-pane testing.

What *is* importable and shared is the primitive itself: every one of those 45 files now depends on `ui5` `Flex` emitting the same CSS as the v4 props did. This PR adds one `vrt-only` primitive sentinel, `Sanity UI/Flex Layouts`, next to the existing `Card Tones` / `Badge Tones` sentinels in `packages/sanity/src/ui-components/__tests__/`. It renders the exact mappings #14523 relies on, with the same `@sanity/ui` v4 children the dev code mixes in (`Card`, `Badge`, `Checkbox`, a v4 `Box flex={1}`):

- fill-height column shell — `flexDirection="column" height="100%" overflow="hidden"` with a `flexBasis="0%" flexGrow={1}` body (`embedded-studio/App`, e2e `StudioLayout`/`DocumentLayout`, `CustomInspector`, `CustomNavigator`)
- centered loading state — `alignItems="center" justifyContent="center" height="100%"` (preview-iframe loaders, `JsonDocumentDump`, `TrendsTool`)
- wrapping row — `alignItems="center" gap flexWrap="wrap"` around a v4 `Box flex={1}` (Radar session/release/drift rows, `CustomNavbar`, `DemoRow`)
- space-between header — `flexBasis="0%" flexGrow={1}` title next to `flexShrink={0}` actions (`TrendsTool` `SeriesCard`, `RunDetailPopover`)
- dialog footer — `gap={2} justifyContent="flex-end"` (`NewSessionDialog`, `AddRegressionDialog`, `SessionView`, `DiagnosticsTool`, diagnostics viewer, `createAnonymousVersion`)
- all five `alignItems` values against a taller sibling (`flex-start` in `InitialValues`/`LongList`/`CalloutPreview`, `baseline` in `TrendsTool`, `stretch` in `ResultCard`, `flex-end` in `referenceCreateButtonRepro`)
- `flexDirection` row vs column (`ToolMenu` topbar/sidebar)
- `as="label"` checkbox row (`NewSessionDialog`, `LanguageFilterMenuButton`)

Alternatives rejected:

- Adding `dev/**` to the Storybook glob or a `dev/storybook/stories` folder: a config change to the VRT host, against the README convention, and it would only snapshot live-data screens that cannot hold a stable baseline.
- Importing the dev components from a `packages/sanity` story: crosses workspace boundaries and drags dev-only dependencies into the `sanity` story graph.
- One `*Story.tsx` harness per dev surface: none needs `TestWrapper`, and there is no browser test to share the harness with, so the single-file plain-grid shape used by the other `ui-components/__tests__` primitive sentinels is the smaller footprint.

No overlap with open coverage work: #14511 (merged, inspector search/detail), #14539 (core component primitives), #14550 (form field chrome), #14551 (form input chrome) are component sentinels; none snapshots `ui5` `Flex` as a primitive, and `pnpm visual-coverage --changed --prs` on this branch reports no pending files. #14523 is not modified.

[Sanity UI/Flex Layouts story rendered in Storybook](https://cursor.com/agents/bc-4ab4c99b-336c-4a9b-a7d5-65fbdaffe3f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_ui5_flex_layouts_sentinel_story.png)

### What to review

- `packages/sanity/src/ui-components/__tests__/FlexLayouts.stories.tsx` — the only file. Check that the section list matches the prop mappings you care about from #14523 and that the fixture copy reads as fixture copy.
- Tags are `['!dev', '!autodocs', 'vrt-only']`: the story is out of the sidebar but in the index, so Chromatic snapshots it (one snapshot) and addon-vitest renders it.
- Only `packages/sanity` (test-only file) is affected; no production code changes.

### Testing

- `pnpm check:oxlint` (full run, includes type checking) — passes.
- `pnpm exec oxfmt --check` on the file — passes.
- `pnpm --filter sanity-storybook exec vitest run FlexLayouts` — the story renders in chromium browser mode (`1 passed`).
- `pnpm dev:storybook` — `index.json` lists `sanity-ui-flex-layouts--layouts` with tags `test`, `manifest`, `vrt-only`; screenshot above taken from the running Storybook.
- `pnpm visual-coverage --changed --prs` — `0 changed UI files`; the same script on the 45 files of #14523 — `skipped 45 non-UI or missing files`.

### Notes for release

N/A – Internal only

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ab4c99b-336c-4a9b-a7d5-65fbdaffe3f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ab4c99b-336c-4a9b-a7d5-65fbdaffe3f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

