### PR TITLE
test(storybook): add ui5 flex sentinels for structure chrome

### DIFF
--- a/packages/sanity/src/structure/components/__tests__/FixturePreviewStoreProvider.tsx
+++ b/packages/sanity/src/structure/components/__tests__/FixturePreviewStoreProvider.tsx
@@ -1,0 +1,171 @@
+import {type StackablePerspective} from '@sanity/client'
+import {type DocumentSystem, type SanityDocument} from '@sanity/types'
+import {type ReactNode, useMemo} from 'react'
+import {of} from 'rxjs'
+import {
+  type DocumentAvailability,
+  type DocumentPreviewStore,
+  getPublishedId,
+  type Previewable,
+  type PreviewPath,
+  prepareForPreview,
+  useResourceCache,
+} from 'sanity'
+import {ResourceCacheContext} from 'sanity/_singletons'
+
+const READABLE: DocumentAvailability = {available: true, reason: 'READABLE'}
+const NOT_FOUND: DocumentAvailability = {available: false, reason: 'NOT_FOUND'}
+
+function idOf(value: Previewable): string | undefined {
+  if ('_ref' in value && typeof value._ref === 'string') return value._ref
+  if ('_id' in value && typeof value._id === 'string') return value._id
+  return undefined
+}
+
+function pick(document: SanityDocument, paths: (string | PreviewPath)[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const path of paths) {
+    const segments = Array.isArray(path) ? path : path.split('.')
+    let source: unknown = document
+    let target = result
+    segments.forEach((key, index) => {
+      source =
+        source && typeof source === 'object' ? (source as Record<string, unknown>)[key] : undefined
+      if (index === segments.length - 1) {
+        target[key] = source
+        return
+      }
+      target[key] ??= {}
+      target = target[key] as Record<string, unknown>
+    })
+  }
+  return result
+}
+
+/**
+ * An in-memory `DocumentPreviewStore` over a fixed set of documents. The
+ * shared `TestWrapper` mock client answers every query with `null`, which the
+ * real store cannot reassemble into previews, so harnesses that render
+ * document previews (pane items, version badges, referring documents) swap
+ * this store in instead. Perspective lookups follow the studio's layering:
+ * `versions.<release>.<id>` for a release layer, `drafts.<id>` for drafts,
+ * then the published document.
+ */
+function createFixturePreviewStore(documents: SanityDocument[]): DocumentPreviewStore {
+  const byId = new Map(documents.map((document) => [document._id, document]))
+
+  const idForLayer = (publishedId: string, layer: StackablePerspective): string =>
+    layer === 'published'
+      ? publishedId
+      : layer === 'drafts'
+        ? `drafts.${publishedId}`
+        : `versions.${layer}.${publishedId}`
+
+  const resolve = (
+    id: string,
+    perspective?: StackablePerspective[],
+  ): SanityDocument | undefined => {
+    const publishedId = getPublishedId(id)
+    for (const layer of perspective ?? []) {
+      const document = byId.get(idForLayer(publishedId, layer))
+      if (document) return document
+    }
+    return byId.get(id) ?? byId.get(publishedId) ?? byId.get(`drafts.${publishedId}`)
+  }
+
+  const availability = (id: string): DocumentAvailability => (byId.has(id) ? READABLE : NOT_FOUND)
+
+  const versionIds = (publishedId: string): string[] =>
+    documents
+      .map((document) => document._id)
+      .filter((id) => getPublishedId(id) === publishedId)
+      .sort()
+
+  return {
+    observePaths: (value, paths, _apiConfig, perspective) => {
+      const id = idOf(value)
+      const document = id ? resolve(id, perspective) : undefined
+      return of(document ? pick(document, paths) : null)
+    },
+    observeForPreview: (value, type, options) => {
+      const id = idOf(value)
+      const document = id ? resolve(id, options?.perspective) : undefined
+      return of({type, snapshot: document ? prepareForPreview(document, type) : null})
+    },
+    observeDocumentTypeFromId: (id) => of(resolve(id)?._type),
+    observeDocumentSystemFromId: (id) => of(resolve(id)?._system as DocumentSystem | undefined),
+    unstable_observeDocumentPairAvailability: (id) => {
+      const publishedId = getPublishedId(id)
+      return of({
+        draft: availability(`drafts.${publishedId}`),
+        published: availability(publishedId),
+      })
+    },
+    unstable_observeDocumentStackAvailability: (id, perspectiveStack) =>
+      of(
+        perspectiveStack.map((layer) => {
+          const layerId = idForLayer(getPublishedId(id), layer)
+          return {id: layerId, availability: availability(layerId)}
+        }),
+      ),
+    unstable_observePathsDocumentPair: (id, paths) => {
+      const publishedId = getPublishedId(id)
+      const draft = byId.get(`drafts.${publishedId}`)
+      const published = byId.get(publishedId)
+      return of({
+        id: publishedId,
+        type: (draft ?? published)?._type ?? null,
+        draft: {
+          availability: availability(`drafts.${publishedId}`),
+          snapshot: draft ? (pick(draft, paths) as never) : undefined,
+        },
+        published: {
+          availability: availability(publishedId),
+          snapshot: published ? (pick(published, paths) as never) : undefined,
+        },
+      })
+    },
+    unstable_observeDocumentIdSet: (filter) => {
+      // Enough GROQ to serve the incoming-references query: an optional
+      // `references("<id>")` clause and an optional `_type == "<type>"` clause.
+      const referenced = /references\("([^"]+)"\)/.exec(filter)?.[1]
+      const type = /_type == "([^"]+)"/.exec(filter)?.[1]
+      const documentIds = documents
+        .filter((document) => !type || document._type === type)
+        .filter(
+          (document) => !referenced || JSON.stringify(document).includes(`"_ref":"${referenced}"`),
+        )
+        .map((document) => document._id)
+        .sort()
+      return of({status: 'connected', documentIds})
+    },
+    unstable_observeVersionDocumentIds: (publishedId) => of(versionIds(publishedId)),
+    unstable_observeDocument: (id) => of(byId.get(id)),
+    unstable_observeDocuments: (ids) => of(ids.map((id) => byId.get(id))),
+  }
+}
+
+/**
+ * Serves `useDocumentPreviewStore()` from a fixture store for everything
+ * rendered underneath, while every other resource-cache namespace keeps
+ * resolving through the enclosing `TestWrapper`. Mount inside `TestWrapper`.
+ */
+export function FixturePreviewStoreProvider(props: {
+  documents: SanityDocument[]
+  children: ReactNode
+}) {
+  const {documents, children} = props
+  const parent = useResourceCache()
+  const cache = useMemo<ReturnType<typeof useResourceCache>>(() => {
+    const store = createFixturePreviewStore(documents)
+    return {
+      get: (options) =>
+        options.namespace === 'documentPreviewStore' ? (store as never) : parent.get(options),
+      set: (options) => {
+        if (options.namespace !== 'documentPreviewStore') parent.set(options)
+      },
+    }
+  }, [documents, parent])
+
+  return <ResourceCacheContext.Provider value={cache}>{children}</ResourceCacheContext.Provider>
+}

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.stories.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.stories.tsx
@@ -1,0 +1,45 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {expect, userEvent, waitFor, within} from 'storybook/test'
+
+import {ConfirmDeleteDialogStory} from './ConfirmDeleteDialogStory'
+
+/**
+ * Chromatic sentinel: the confirm-delete dialog and its referring-documents
+ * body ahead of the ui5 Flex migration. Fixture references only.
+ */
+const meta = {
+  title: 'Structure/Confirm Delete Dialog',
+  component: ConfirmDeleteDialogStory,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof ConfirmDeleteDialogStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Dialog: Story = {
+  args: {mode: 'dialog'},
+  // TestWrapper suspends on the mock workspace and Storybook resolves render
+  // on the first commit, so wait for the dialog before touching focus.
+  // @sanity/ui Dialog then deterministically focuses its first focusable
+  // descendant; blur it so the snapshot is about layout, not a focus ring.
+  play: async () => {
+    const body = within(document.body)
+    await waitFor(() => expect(body.getByRole('dialog')).toBeVisible(), {timeout: 5000})
+    await waitFor(() => expect(document.activeElement).not.toBe(document.body))
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+  },
+}
+
+export const ReferringDocuments: Story = {
+  args: {mode: 'referring-documents'},
+  // The cross-dataset references render inside a collapsed <details>; open
+  // it so the project/dataset/document-id table is part of the snapshot.
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement)
+    const details = await canvas.findByTestId('cross-dataset-references', {}, {timeout: 5000})
+    const summary = details.querySelector('summary')
+    if (summary) await userEvent.click(summary)
+    await waitFor(() => expect(details).toHaveAttribute('open'))
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+  },
+}

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialogStory.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialogStory.tsx
@@ -1,0 +1,232 @@
+import {defineField, defineType, type SanityDocument} from '@sanity/types'
+import {Card, Stack, Text} from '@sanity/ui'
+import noop from 'lodash-es/noop.js'
+import {type HTMLProps, type ReactNode, useContext, useMemo} from 'react'
+import {LocaleProvider, useSchema} from 'sanity'
+import {DocumentPaneContext, PaneRouterContext} from 'sanity/_singletons'
+
+import {TestWrapper} from '../../../../../test/browser/TestWrapper'
+import {type DocumentPaneContextValue} from '../../../panes/document/DocumentPaneContext'
+import {FixturePreviewStoreProvider} from '../../__tests__/FixturePreviewStoreProvider'
+import {type ReferenceChildLinkProps} from '../../paneRouter/types'
+import {ConfirmDeleteDialog} from '../ConfirmDeleteDialog'
+import {ConfirmDeleteDialogBody} from '../ConfirmDeleteDialogBody'
+import {OtherReferenceCount} from '../ConfirmDeleteDialogBody.styles'
+import {VersionsPreviewList} from '../VersionsPreviewList'
+
+const SCHEMA_TYPES = [
+  defineType({
+    name: 'author',
+    type: 'document',
+    title: 'Author',
+    fields: [defineField({name: 'name', type: 'string'})],
+    preview: {select: {title: 'name'}},
+  }),
+  defineType({
+    name: 'book',
+    type: 'document',
+    title: 'Book',
+    fields: [
+      defineField({name: 'title', type: 'string'}),
+      defineField({name: 'author', type: 'reference', to: [{type: 'author'}]}),
+    ],
+    preview: {select: {title: 'title'}},
+  }),
+]
+
+const DOCUMENT_ID = 'author-1'
+const TIMESTAMPS = {
+  _rev: 'rev1',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-02T00:00:00Z',
+}
+const AUTHOR_REF = {_type: 'reference', _ref: DOCUMENT_ID}
+
+const DOCUMENTS: SanityDocument[] = [
+  {_id: DOCUMENT_ID, _type: 'author', name: 'Jane Doe', ...TIMESTAMPS},
+  {_id: `drafts.${DOCUMENT_ID}`, _type: 'author', name: 'Jane Doe (draft)', ...TIMESTAMPS},
+  {_id: `versions.rSummerSale.${DOCUMENT_ID}`, _type: 'author', name: 'Jane Doe', ...TIMESTAMPS},
+  {_id: 'book-1', _type: 'book', title: 'The Long Road Home', author: AUTHOR_REF, ...TIMESTAMPS},
+  {
+    _id: 'drafts.book-2',
+    _type: 'book',
+    title:
+      'A second book with a title long enough to truncate inside the compact referring document row',
+    author: AUTHOR_REF,
+    ...TIMESTAMPS,
+  },
+]
+
+const ALL_VERSIONS = [DOCUMENT_ID, `drafts.${DOCUMENT_ID}`, `versions.rSummerSale.${DOCUMENT_ID}`]
+
+const INTERNAL_REFERENCES = {
+  totalCount: 4,
+  references: [
+    {_id: 'book-1', _type: 'book'},
+    {_id: 'drafts.book-2', _type: 'book'},
+    {_id: 'legacy-doc-1', _type: 'retiredType'},
+  ],
+}
+
+const CROSS_DATASET_REFERENCES = {
+  totalCount: 3,
+  references: [
+    {projectId: 'abc123xy', datasetName: 'production', documentId: 'landingPage-front'},
+    {projectId: 'abc123xy', datasetName: 'production', documentId: 'campaign-summer-2024'},
+    {projectId: 'zz9plural'},
+  ],
+}
+
+export type ConfirmDeleteDialogStoryMode = 'dialog' | 'referring-documents'
+
+/**
+ * `ReferencePreviewLink` wraps each referring document in the pane router's
+ * `ReferenceChildLink`, whose default implementation throws outside the
+ * structure tool. A plain anchor stands in; nothing navigates in a snapshot.
+ */
+function StubReferenceChildLink(
+  props: ReferenceChildLinkProps & Omit<HTMLProps<HTMLAnchorElement>, 'children'>,
+) {
+  const {documentId, documentType, parentRefPath, template, ...rest} = props
+  return <a href="#" {...rest} />
+}
+
+/**
+ * `DocTitle` (rendered by the dialog copy) reads the document pane for the
+ * title preview and `ReferencePreviewLink` reads the pane router; only the
+ * fields they touch are stubbed. `LocaleProvider` backs the relative-time
+ * copy in the version status tooltips, which `@sanity/ui` keeps mounted.
+ */
+function PaneStubs({children}: {children: ReactNode}) {
+  const schema = useSchema()
+  const paneRouter = useContext(PaneRouterContext)
+  const paneRouterValue = useMemo(
+    () => ({...paneRouter, ReferenceChildLink: StubReferenceChildLink}),
+    [paneRouter],
+  )
+  const documentPaneValue = useMemo(
+    () =>
+      ({
+        connectionState: 'connected',
+        schemaType: schema.get('author'),
+        isDeleted: false,
+        lastRevisionDocument: null,
+        value: DOCUMENTS[0],
+        editState: null,
+      }) as unknown as DocumentPaneContextValue,
+    [schema],
+  )
+
+  return (
+    <LocaleProvider>
+      <PaneRouterContext.Provider value={paneRouterValue}>
+        <DocumentPaneContext.Provider value={documentPaneValue}>
+          {children}
+        </DocumentPaneContext.Provider>
+      </PaneRouterContext.Provider>
+    </LocaleProvider>
+  )
+}
+
+function Section({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <Stack gap={2}>
+      <Text muted size={1} weight="medium">
+        {label}
+      </Text>
+      {children}
+    </Stack>
+  )
+}
+
+/**
+ * The body states that need referring documents: internal references (two
+ * books that resolve through the fixture preview store, one with a truncating
+ * title, plus an unknown type that falls back to the "preview unavailable"
+ * row), the "other references" overflow row, the collapsible cross-dataset
+ * table with copy-id buttons and an unavailable dataset, and the shorter
+ * unpublish copy. The CSF file expands the cross-dataset details before
+ * capture.
+ */
+function ReferringDocuments() {
+  return (
+    <Card padding={4} style={{maxWidth: 560}}>
+      <Stack gap={5}>
+        <Section label="delete with internal and cross-dataset references">
+          <ConfirmDeleteDialogBody
+            action="delete"
+            crossDatasetReferences={CROSS_DATASET_REFERENCES}
+            datasetNames={['production']}
+            documentId={DOCUMENT_ID}
+            documentTitle="Jane Doe"
+            documentType="author"
+            documentVersions={ALL_VERSIONS}
+            hasUnknownDatasetNames
+            internalReferences={INTERNAL_REFERENCES}
+            isLoading={false}
+            onReferenceLinkClick={noop}
+            projectIds={['abc123xy', 'zz9plural']}
+            totalCount={7}
+          />
+        </Section>
+        <Section label="unpublish without references">
+          <ConfirmDeleteDialogBody
+            action="unpublish"
+            crossDatasetReferences={{totalCount: 0, references: []}}
+            datasetNames={[]}
+            documentId={DOCUMENT_ID}
+            documentTitle="Jane Doe"
+            documentType="author"
+            documentVersions={[DOCUMENT_ID]}
+            hasUnknownDatasetNames={false}
+            internalReferences={{totalCount: 0, references: []}}
+            isLoading={false}
+            onReferenceLinkClick={noop}
+            projectIds={[]}
+            totalCount={0}
+          />
+        </Section>
+        <Section label="versions: draft and published only">
+          <VersionsPreviewList
+            documentType="author"
+            documentVersions={[`drafts.${DOCUMENT_ID}`, DOCUMENT_ID]}
+          />
+        </Section>
+        <Section label="other reference count">
+          <OtherReferenceCount totalCount={12} references={[{}, {}]} />
+        </Section>
+      </Stack>
+    </Card>
+  )
+}
+
+/**
+ * Chromatic sentinel for the confirm-delete dialog ahead of the ui5 Flex
+ * migration. `dialog` mounts the real dialog with reference checks disabled
+ * (the variant-unpublish path, which the mock client can serve) so the header,
+ * confirmation copy, the draft/published/release version rows and the footer
+ * buttons are captured together; `referring-documents` lays the body states
+ * out inline. Previews come from the fixture preview store; no network.
+ */
+export function ConfirmDeleteDialogStory(props: {mode: ConfirmDeleteDialogStoryMode}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <FixturePreviewStoreProvider documents={DOCUMENTS}>
+        <PaneStubs>
+          {props.mode === 'dialog' ? (
+            <ConfirmDeleteDialog
+              action="delete"
+              checkIncomingReferences={false}
+              id={DOCUMENT_ID}
+              onCancel={noop}
+              onConfirm={noop}
+              type="author"
+            />
+          ) : (
+            <ReferringDocuments />
+          )}
+        </PaneStubs>
+      </FixturePreviewStoreProvider>
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx
@@ -1,0 +1,19 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+
+import {IncomingReferencesStory} from './IncomingReferencesStory'
+
+/**
+ * Chromatic sentinel: the incoming-references field decoration ahead of the
+ * ui5 Flex migration (header row, populated and empty lists, row actions,
+ * error card, cross-dataset rows). Fixture documents only.
+ */
+const meta = {
+  title: 'Structure/Incoming References',
+  component: IncomingReferencesStory,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof IncomingReferencesStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const States: Story = {}

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx
@@ -11,6 +11,9 @@ const meta = {
   title: 'Structure/Incoming References',
   component: IncomingReferencesStory,
   tags: ['!dev', '!autodocs', 'vrt-only'],
+  // Reference rows fade in through a JS-driven `motion` animation, which
+  // Chromatic cannot pause the way it pauses CSS animations.
+  parameters: {chromatic: {delay: 500}},
 } satisfies Meta<typeof IncomingReferencesStory>
 
 export default meta

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferencesStory.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferencesStory.tsx
@@ -1,0 +1,249 @@
+import {DocumentIcon} from '@sanity/icons/Document'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {defineField, defineType, type SanityDocument} from '@sanity/types'
+import {Card, Stack, Text} from '@sanity/ui'
+import noop from 'lodash-es/noop.js'
+import {type HTMLProps, type ReactNode, useContext, useMemo} from 'react'
+import {LocaleProvider} from 'sanity'
+import {DocumentPaneContext, PaneRouterContext} from 'sanity/_singletons'
+
+import {TestWrapper} from '../../../../../test/browser/TestWrapper'
+import {type DocumentPaneContextValue} from '../../../panes/document/DocumentPaneContext'
+import {FixturePreviewStoreProvider} from '../../__tests__/FixturePreviewStoreProvider'
+import {type ChildLinkProps} from '../../paneRouter/types'
+import {CrossDatasetIncomingReferenceDocumentPreview} from '../CrossDatasetIncomingReference/CrossDatasetIncomingReferenceDocumentPreview'
+import {type CrossDatasetIncomingReferenceDocument} from '../CrossDatasetIncomingReference/getCrossDatasetIncomingReferences'
+import {IncomingReferenceDocument} from '../IncomingReferenceDocument'
+import {IncomingReferencesDecoration} from '../IncomingReferencesDecoration'
+import {IncomingReferencesList} from '../IncomingReferencesList'
+import {IncomingReferencesType} from '../IncomingReferencesType'
+import {type CrossDatasetIncomingReference, type IncomingReferenceAction} from '../types'
+
+const SCHEMA_TYPES = [
+  defineType({
+    name: 'author',
+    type: 'document',
+    title: 'Author',
+    fields: [defineField({name: 'name', type: 'string'})],
+    preview: {select: {title: 'name'}},
+  }),
+  defineType({
+    name: 'book',
+    type: 'document',
+    title: 'Book',
+    fields: [
+      defineField({name: 'title', type: 'string'}),
+      defineField({name: 'author', type: 'reference', to: [{type: 'author'}]}),
+    ],
+    preview: {select: {title: 'title'}},
+  }),
+  defineType({
+    name: 'article',
+    type: 'document',
+    title: 'Article',
+    fields: [
+      defineField({name: 'headline', type: 'string'}),
+      defineField({name: 'author', type: 'reference', to: [{type: 'author'}]}),
+    ],
+    preview: {select: {title: 'headline'}},
+  }),
+]
+
+const AUTHOR_ID = 'author-1'
+const TIMESTAMPS = {
+  _rev: 'rev1',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-02T00:00:00Z',
+}
+const AUTHOR_REF = {_type: 'reference', _ref: AUTHOR_ID}
+
+const AUTHOR: SanityDocument = {_id: AUTHOR_ID, _type: 'author', name: 'Jane Doe', ...TIMESTAMPS}
+const BOOKS: SanityDocument[] = [
+  {_id: 'book-1', _type: 'book', title: 'The Long Road Home', author: AUTHOR_REF, ...TIMESTAMPS},
+  {
+    _id: 'drafts.book-2',
+    _type: 'book',
+    title: 'A second book whose title is long enough to truncate inside the incoming reference row',
+    author: AUTHOR_REF,
+    ...TIMESTAMPS,
+  },
+]
+const DOCUMENTS = [AUTHOR, ...BOOKS]
+
+const UNLINK_ACTION: IncomingReferenceAction = () => ({
+  label: 'Unlink from author',
+  icon: TrashIcon,
+  tone: 'critical',
+  onHandle: noop,
+})
+
+const CROSS_DATASET_TYPE: CrossDatasetIncomingReference = {
+  type: 'landingPage',
+  title: 'Landing pages',
+  dataset: 'marketing',
+  preview: {select: {title: 'title'}},
+  studioUrl: ({id}) => `https://marketing.sanity.studio/desk/landingPage;${id}`,
+}
+
+const CROSS_DATASET_DOCUMENTS: CrossDatasetIncomingReferenceDocument[] = [
+  {
+    id: 'landingPage-front',
+    type: 'landingPage',
+    availability: {available: true, reason: 'READABLE'},
+    preview: {
+      published: {title: 'Front page', subtitle: 'Dataset: marketing', media: <DocumentIcon />},
+    },
+    projectId: 'abc123xy',
+    dataset: 'marketing',
+  },
+  {
+    id: 'landingPage-hidden',
+    type: 'landingPage',
+    availability: {available: false, reason: 'PERMISSION_DENIED'},
+    preview: {published: undefined},
+    projectId: 'abc123xy',
+    dataset: 'marketing',
+  },
+]
+
+/**
+ * `IncomingReferencePreview` links each row through the pane router's
+ * `ChildLink`, whose default implementation throws outside the structure
+ * tool. A plain anchor stands in; nothing navigates in a snapshot.
+ */
+function StubChildLink(props: ChildLinkProps & Omit<HTMLProps<HTMLAnchorElement>, 'children'>) {
+  const {childId, childParameters, childPayload, ...rest} = props
+  return <a href="#" {...rest} />
+}
+
+/**
+ * The list reads the referenced document from the document pane; only the
+ * fields the incoming-reference components touch are stubbed. `LocaleProvider`
+ * backs the relative-time copy in the version status tooltips, which
+ * `@sanity/ui` keeps mounted.
+ */
+function PaneStubs({children}: {children: ReactNode}) {
+  const paneRouter = useContext(PaneRouterContext)
+  const paneRouterValue = useMemo(() => ({...paneRouter, ChildLink: StubChildLink}), [paneRouter])
+  const documentPaneValue = useMemo(
+    () =>
+      ({
+        documentId: AUTHOR_ID,
+        documentType: 'author',
+        displayed: AUTHOR,
+        editState: {
+          id: AUTHOR_ID,
+          type: 'author',
+          ready: true,
+          liveEdit: false,
+          transactionSyncLock: null,
+          draft: null,
+          published: AUTHOR,
+          version: undefined,
+        },
+      }) as unknown as DocumentPaneContextValue,
+    [],
+  )
+
+  return (
+    <LocaleProvider>
+      <PaneRouterContext.Provider value={paneRouterValue}>
+        <DocumentPaneContext.Provider value={documentPaneValue}>
+          {children}
+        </DocumentPaneContext.Provider>
+      </PaneRouterContext.Provider>
+    </LocaleProvider>
+  )
+}
+
+function Section({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <Stack gap={2}>
+      <Text muted size={1} weight="medium">
+        {label}
+      </Text>
+      {children}
+    </Stack>
+  )
+}
+
+/**
+ * Chromatic sentinel for the incoming-references field decoration ahead of
+ * the ui5 Flex migration: the decoration header row, a populated list with
+ * truncating titles and the per-row actions menu, the "link existing" button
+ * variant next to an empty type, the multi-type headings, the no-types
+ * critical card, the unknown-type row error, and the cross-dataset preview
+ * rows with and without a studio link. Referring documents come from the
+ * fixture preview store; the cross-dataset list itself needs the references
+ * API and is represented by its row component. No network.
+ */
+export function IncomingReferencesStory() {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <FixturePreviewStoreProvider documents={DOCUMENTS}>
+        <PaneStubs>
+          <Card padding={4} style={{maxWidth: 560}}>
+            <Stack gap={5}>
+              <Section label="field decoration with actions">
+                <IncomingReferencesDecoration
+                  actions={[UNLINK_ACTION]}
+                  description="Books whose author field points at this document."
+                  name="books"
+                  title="Books by this author"
+                  types={[{type: 'book'}]}
+                />
+              </Section>
+              <Section label="multiple types, link existing documents">
+                <IncomingReferencesList
+                  creationAllowed
+                  name="mentions"
+                  onLinkDocument={() => false}
+                  types={[
+                    {type: 'book', title: 'Books'},
+                    {type: 'article', title: 'Articles'},
+                  ]}
+                />
+              </Section>
+              <Section label="single type without actions or creation">
+                <IncomingReferencesType
+                  actions={undefined}
+                  creationAllowed={false}
+                  fieldName="books"
+                  filter={undefined}
+                  filterParams={undefined}
+                  onLinkDocument={undefined}
+                  referenced={{id: AUTHOR_ID, type: 'author'}}
+                  shouldRenderTitle={false}
+                  type={{type: 'book'}}
+                />
+              </Section>
+              <Section label="no types configured">
+                <IncomingReferencesList name="broken" types={[]} />
+              </Section>
+              <Section label="row for a document of an unknown type">
+                <IncomingReferenceDocument
+                  actions={undefined}
+                  document={{_id: 'legacy-1', _type: 'retiredType', ...TIMESTAMPS}}
+                  referenceToId={AUTHOR_ID}
+                />
+              </Section>
+              <Section label="cross-dataset rows: studio link, no access">
+                <Card border padding={1} radius={2}>
+                  <Stack>
+                    <CrossDatasetIncomingReferenceDocumentPreview
+                      document={CROSS_DATASET_DOCUMENTS[0]}
+                      type={CROSS_DATASET_TYPE}
+                    />
+                    <CrossDatasetIncomingReferenceDocumentPreview
+                      document={CROSS_DATASET_DOCUMENTS[1]}
+                    />
+                  </Stack>
+                </Card>
+              </Section>
+            </Stack>
+          </Card>
+        </PaneStubs>
+      </FixturePreviewStoreProvider>
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/structure/components/pane/__tests__/PaneChrome.stories.tsx
+++ b/packages/sanity/src/structure/components/pane/__tests__/PaneChrome.stories.tsx
@@ -1,0 +1,35 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {expect, userEvent, waitFor, within} from 'storybook/test'
+
+import {PaneChromeStory} from './PaneChromeStory'
+
+/**
+ * Chromatic sentinel: structure pane chrome ahead of the ui5 Flex migration
+ * (pane layout, headers with actions and tabs, pane item previews). Fixture
+ * documents only.
+ */
+const meta = {
+  title: 'Structure/Pane Chrome',
+  component: PaneChromeStory,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof PaneChromeStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Expanded: Story = {}
+
+/**
+ * Clicking a non-last pane's title collapses it: the header rotates into a
+ * vertical strip and the pane shrinks to its collapsed width.
+ */
+export const Collapsed: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement)
+    const title = await canvas.findByText(/Authors, contributors and editors/, {}, {timeout: 5000})
+    const pane = title.closest('[data-testid="pane"]')
+    await userEvent.click(title)
+    await waitFor(() => expect(pane).toHaveAttribute('data-pane-collapsed'))
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+  },
+}

--- a/packages/sanity/src/structure/components/pane/__tests__/PaneChromeStory.tsx
+++ b/packages/sanity/src/structure/components/pane/__tests__/PaneChromeStory.tsx
@@ -1,0 +1,209 @@
+import {ArrowLeftIcon} from '@sanity/icons/ArrowLeft'
+import {EyeOpenIcon} from '@sanity/icons/EyeOpen'
+import {PublishIcon} from '@sanity/icons/Publish'
+import {SortIcon} from '@sanity/icons/Sort'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {defineField, defineType, type SanityDocument} from '@sanity/types'
+import {Badge, Card, Stack, TabList, Text, TextInput} from '@sanity/ui'
+import {
+  type DocumentPresence,
+  LocaleProvider,
+  PreviewCard,
+  useDocumentPreviewStore,
+  useSchema,
+} from 'sanity'
+
+import {TestWrapper} from '../../../../../test/browser/TestWrapper'
+import {Button} from '../../../../ui-components/button/Button'
+import {Tab} from '../../../../ui-components/tab/Tab'
+import {type PaneMenuItem, type PaneMenuItemGroup} from '../../../types'
+import {FixturePreviewStoreProvider} from '../../__tests__/FixturePreviewStoreProvider'
+import {PaneHeaderActions} from '../../paneHeaderActions/PaneHeaderActions'
+import {PaneItemPreview} from '../../paneItem/PaneItemPreview'
+import {Pane} from '../Pane'
+import {PaneContent} from '../PaneContent'
+import {PaneHeader} from '../PaneHeader'
+import {PaneLayout} from '../PaneLayout'
+
+const SCHEMA_TYPES = [
+  defineType({
+    name: 'author',
+    type: 'document',
+    title: 'Author',
+    fields: [
+      defineField({name: 'name', type: 'string'}),
+      defineField({name: 'role', type: 'string'}),
+    ],
+    preview: {select: {title: 'name', subtitle: 'role'}},
+  }),
+]
+
+const TIMESTAMPS = {
+  _rev: 'rev1',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-02T00:00:00Z',
+}
+
+const DOCUMENTS: SanityDocument[] = [
+  {_id: 'author-1', _type: 'author', name: 'Jane Doe', role: 'Editor in chief', ...TIMESTAMPS},
+  {
+    _id: 'drafts.author-1',
+    _type: 'author',
+    name: 'Jane Doe',
+    role: 'Editor in chief',
+    ...TIMESTAMPS,
+  },
+  {
+    _id: 'drafts.author-2',
+    _type: 'author',
+    name: 'An author with a name long enough to truncate inside the pane item preview row',
+    role: 'Contributor',
+    ...TIMESTAMPS,
+  },
+  {_id: 'author-3', _type: 'author', name: 'Sam Smith', ...TIMESTAMPS},
+  {
+    _id: 'versions.rSummerSale.author-3',
+    _type: 'author',
+    name: 'Sam Smith',
+    _system: {
+      bundleId: 'rSummerSale',
+      release: {_ref: '_.releases.rSummerSale', _weak: true},
+      group: {_ref: 'author-3', _weak: true},
+      scopeId: 'rSummerSale',
+    },
+    ...TIMESTAMPS,
+  },
+]
+
+const PRESENCE: DocumentPresence[] = [
+  {
+    user: {id: 'user-a', displayName: 'Ada Lovelace'},
+    path: ['name'],
+    sessionId: 'session-a',
+    lastActiveAt: '2024-01-02T00:00:00Z',
+    documentId: 'drafts.author-1',
+  },
+  {
+    user: {id: 'user-b', displayName: 'Grace Hopper'},
+    path: ['role'],
+    sessionId: 'session-b',
+    lastActiveAt: '2024-01-02T00:00:00Z',
+    documentId: 'drafts.author-1',
+  },
+]
+
+const MENU_ITEMS: PaneMenuItem[] = [
+  {title: 'Publish', icon: PublishIcon, action: 'publish', showAsAction: true},
+  {title: 'Preview', icon: EyeOpenIcon, action: 'preview', showAsAction: true, selected: true},
+  {title: 'Sort by title', icon: SortIcon, action: 'setSortOrder', group: 'sorting'},
+  {title: 'Sort by last edited', icon: SortIcon, action: 'setSortOrder', group: 'sorting'},
+  {title: 'Delete', icon: TrashIcon, action: 'delete', tone: 'critical'},
+]
+
+const MENU_ITEM_GROUPS: PaneMenuItemGroup[] = [{id: 'sorting', title: 'Sort'}]
+
+// Published with presence, published plus a release version, draft only.
+const LIST_ITEMS = [
+  {_id: 'author-1', _type: 'author'},
+  {_id: 'author-3', _type: 'author'},
+  {_id: 'drafts.author-2', _type: 'author'},
+]
+
+const LONG_TITLE =
+  'Authors, contributors and editors: a pane title long enough to truncate before the actions'
+
+function AuthorList() {
+  const schema = useSchema()
+  const documentPreviewStore = useDocumentPreviewStore()
+  const schemaType = schema.get('author')
+  if (!schemaType) return null
+
+  return (
+    <Stack gap={1} padding={2}>
+      {LIST_ITEMS.map((value, index) => (
+        <PreviewCard key={value._id} __unstable_focusRing as="a" href="#" radius={2}>
+          <PaneItemPreview
+            documentPreviewStore={documentPreviewStore}
+            icon={false}
+            layout="default"
+            presence={index === 0 ? PRESENCE : undefined}
+            schemaType={schemaType}
+            value={value}
+          />
+        </PreviewCard>
+      ))}
+    </Stack>
+  )
+}
+
+/**
+ * Chromatic sentinel for structure pane chrome ahead of the ui5 Flex
+ * migration. Two panes in a `PaneLayout`: a list pane whose header has a back
+ * button, a truncating title, header actions (two action buttons and the
+ * critical context menu), tabs plus a sub-action, over document rows with
+ * presence avatars and version status; and a document pane whose header has an
+ * appended badge and a `contentAfter` slot. The CSF file adds a collapsed
+ * variant by clicking the first pane's title. Previews come from the fixture
+ * preview store; no network. No create button: its template permissions go
+ * through the grants store, which the mock client cannot serve.
+ */
+export function PaneChromeStory() {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <FixturePreviewStoreProvider documents={DOCUMENTS}>
+        <LocaleProvider>
+          <div style={{height: 520}}>
+            <PaneLayout height="fill" minWidth={512}>
+              <Pane id="authors" minWidth={320}>
+                <PaneHeader
+                  actions={
+                    <PaneHeaderActions menuItemGroups={MENU_ITEM_GROUPS} menuItems={MENU_ITEMS} />
+                  }
+                  backButton={
+                    <Button
+                      as="a"
+                      href="#"
+                      icon={ArrowLeftIcon}
+                      mode="bleed"
+                      tooltipProps={{content: 'Back'}}
+                    />
+                  }
+                  border
+                  subActions={<Button icon={SortIcon} mode="bleed" text="Sort" />}
+                  tabs={
+                    <TabList gap={1}>
+                      <Tab aria-controls="all" id="all-tab" label="All" selected />
+                      <Tab aria-controls="recent" id="recent-tab" label="Recently edited" />
+                    </TabList>
+                  }
+                  title={LONG_TITLE}
+                />
+                <PaneContent overflow="auto">
+                  <AuthorList />
+                </PaneContent>
+              </Pane>
+              <Pane id="document" flex={2}>
+                <PaneHeader
+                  appendTitle={<Badge fontSize={0}>Draft</Badge>}
+                  contentAfter={
+                    <Card borderTop padding={2}>
+                      <TextInput fontSize={1} placeholder="Search in document" readOnly />
+                    </Card>
+                  }
+                  title="Jane Doe"
+                />
+                <PaneContent overflow="auto">
+                  <Card padding={4}>
+                    <Text muted size={1}>
+                      Document content
+                    </Text>
+                  </Card>
+                </PaneContent>
+              </Pane>
+            </PaneLayout>
+          </div>
+        </LocaleProvider>
+      </FixturePreviewStoreProvider>
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/structure/components/requestPermissionDialog/__tests__/RequestPermissionDialog.stories.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/__tests__/RequestPermissionDialog.stories.tsx
@@ -1,0 +1,31 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {expect, waitFor, within} from 'storybook/test'
+
+import {RequestPermissionDialogStory} from './RequestPermissionDialogStory'
+
+/**
+ * Chromatic sentinel: the "ask to edit" dialog ahead of the ui5 Flex
+ * migration. Description, note input with counter, cancel/confirm footer.
+ */
+const meta = {
+  title: 'Structure/Request Permission Dialog',
+  component: RequestPermissionDialogStory,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof RequestPermissionDialogStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  // TestWrapper suspends on the mock workspace and Storybook resolves render
+  // on the first commit, so wait for the dialog before touching focus.
+  // @sanity/ui Dialog then deterministically focuses its first focusable
+  // descendant (the note input); blur it so the snapshot is about layout,
+  // not a focus ring.
+  play: async () => {
+    const body = within(document.body)
+    await waitFor(() => expect(body.getByRole('dialog')).toBeVisible(), {timeout: 5000})
+    await waitFor(() => expect(document.activeElement).not.toBe(document.body))
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+  },
+}

--- a/packages/sanity/src/structure/components/requestPermissionDialog/__tests__/RequestPermissionDialogStory.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/__tests__/RequestPermissionDialogStory.tsx
@@ -1,0 +1,21 @@
+import noop from 'lodash-es/noop.js'
+
+import {TestWrapper} from '../../../../../test/browser/TestWrapper'
+import {RequestPermissionDialog} from '../RequestPermissionDialog'
+
+/**
+ * Chromatic sentinel for the request-permission dialog ahead of the ui5 Flex
+ * migration: body copy, the note input with its character counter, and the
+ * cancel/confirm footer row. The mock client answers the roles lookup with
+ * `null`, which the dialog treats as "no editor role" and falls back to
+ * requesting administrator access, so the rendered copy is stable. Harness
+ * for the co-located Storybook CSF file, which waits for the dialog and blurs
+ * auto-focus.
+ */
+export function RequestPermissionDialogStory() {
+  return (
+    <TestWrapper schemaTypes={[]}>
+      <RequestPermissionDialog onClose={noop} onRequestSubmitted={noop} />
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/structure/components/structureTool/__tests__/NoDocumentTypesScreen.stories.tsx
+++ b/packages/sanity/src/structure/components/structureTool/__tests__/NoDocumentTypesScreen.stories.tsx
@@ -1,0 +1,18 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+
+import {NoDocumentTypesScreenStory} from './NoDocumentTypesScreenStory'
+
+/**
+ * Chromatic sentinel: the structure tool's empty schema screen ahead of the
+ * ui5 Flex migration (centering Flex, icon and copy row).
+ */
+const meta = {
+  title: 'Structure/No Document Types Screen',
+  component: NoDocumentTypesScreenStory,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof NoDocumentTypesScreenStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const States: Story = {}

--- a/packages/sanity/src/structure/components/structureTool/__tests__/NoDocumentTypesScreenStory.tsx
+++ b/packages/sanity/src/structure/components/structureTool/__tests__/NoDocumentTypesScreenStory.tsx
@@ -1,0 +1,18 @@
+import {TestWrapper} from '../../../../../test/browser/TestWrapper'
+import {NoDocumentTypesScreen} from '../NoDocumentTypesScreen'
+
+/**
+ * Chromatic sentinel for the empty structure tool screen ahead of the ui5
+ * Flex migration: the fill-height centering Flex around the caution card and
+ * the icon-plus-copy row inside it. The fixed-height frame stands in for the
+ * tool root the screen normally fills. Locale copy only.
+ */
+export function NoDocumentTypesScreenStory() {
+  return (
+    <TestWrapper schemaTypes={[]}>
+      <div style={{height: 480}}>
+        <NoDocumentTypesScreen />
+      </div>
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/structure/diffView/versionMode/components/__tests__/VersionModeHeader.stories.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/__tests__/VersionModeHeader.stories.tsx
@@ -1,0 +1,25 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+
+import {VersionModeHeaderStory} from './VersionModeHeaderStory'
+
+/**
+ * Chromatic sentinel: the diff view's version-mode header ahead of the ui5
+ * Flex migration, with the release menu and document-group-picker variants.
+ * Fixture versions only; pickers stay closed.
+ */
+const meta = {
+  title: 'Structure/Diff View Version Mode Header',
+  component: VersionModeHeaderStory,
+  tags: ['!dev', '!autodocs', 'vrt-only'],
+} satisfies Meta<typeof VersionModeHeaderStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const VersionMenu: Story = {
+  args: {mode: 'version-menu'},
+}
+
+export const GroupPicker: Story = {
+  args: {mode: 'group-picker'},
+}

--- a/packages/sanity/src/structure/diffView/versionMode/components/__tests__/VersionModeHeaderStory.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/__tests__/VersionModeHeaderStory.tsx
@@ -1,0 +1,110 @@
+import {defineField, defineType, type SanityDocument} from '@sanity/types'
+import noop from 'lodash-es/noop.js'
+import {type ReactNode} from 'react'
+import {LocaleProvider} from 'sanity'
+import {route, RouterProvider, type RouterState} from 'sanity/router'
+
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+import {FixturePreviewStoreProvider} from '../../../../components/__tests__/FixturePreviewStoreProvider'
+import {
+  DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER,
+  DIFF_VIEW_SEARCH_PARAMETER,
+} from '../../../constants'
+import {DocumentGroupPickerMenu} from '../DocumentGroupPickerMenu'
+import {VersionModeHeader} from '../VersionModeHeader'
+
+const SCHEMA_TYPES = [
+  defineType({
+    name: 'author',
+    type: 'document',
+    title: 'Author',
+    fields: [defineField({name: 'name', type: 'string'})],
+    preview: {select: {title: 'name'}},
+  }),
+]
+
+const DOCUMENT_ID = 'author-1'
+const PREVIOUS_ID = DOCUMENT_ID
+const NEXT_ID = `versions.rSummerSale.${DOCUMENT_ID}`
+const TIMESTAMPS = {
+  _rev: 'rev1',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-02T00:00:00Z',
+}
+
+const DOCUMENTS: SanityDocument[] = [
+  {_id: DOCUMENT_ID, _type: 'author', name: 'Jane Doe', ...TIMESTAMPS},
+  {_id: `drafts.${DOCUMENT_ID}`, _type: 'author', name: 'Jane Doe (draft)', ...TIMESTAMPS},
+  {
+    _id: NEXT_ID,
+    _type: 'author',
+    name: 'Jane Doe (summer sale)',
+    _system: {
+      bundleId: 'rSummerSale',
+      release: {_ref: '_.releases.rSummerSale', _weak: true},
+      group: {_ref: DOCUMENT_ID, _weak: true},
+      scopeId: 'rSummerSale',
+    },
+    ...TIMESTAMPS,
+  },
+]
+
+const router = route.create('/', [route.intents('/intent')])
+
+// The header reads which two documents are being compared from the router's
+// search params, so the harness nests a router carrying a ready diff state.
+const DIFF_VIEW_ROUTER_STATE: RouterState = {
+  _searchParams: [
+    [DIFF_VIEW_SEARCH_PARAMETER, 'version'],
+    [DIFF_VIEW_PREVIOUS_DOCUMENT_SEARCH_PARAMETER, `author,${PREVIOUS_ID}`],
+    [DIFF_VIEW_NEXT_DOCUMENT_SEARCH_PARAMETER, `author,${NEXT_ID}`],
+  ],
+}
+
+export type VersionModeHeaderStoryMode = 'version-menu' | 'group-picker'
+
+function DiffViewRouter({children}: {children: ReactNode}) {
+  return (
+    <RouterProvider router={router} state={DIFF_VIEW_ROUTER_STATE} onNavigate={noop}>
+      {children}
+    </RouterProvider>
+  )
+}
+
+/**
+ * Chromatic sentinel for the diff view's version-mode header ahead of the
+ * ui5 Flex migration: the three-column header grid with the title, the two
+ * version pickers, the transfer icon and the close button. `version-menu`
+ * renders the default release menu buttons (published on the left, a release
+ * version on the right); `group-picker` enables the document group inventory
+ * beta so the header renders `DocumentGroupPickerMenu` buttons instead. The
+ * pickers stay closed. Versions come from the fixture preview store; no
+ * network.
+ */
+export function VersionModeHeaderStory(props: {mode: VersionModeHeaderStoryMode}) {
+  const groupPicker = props.mode === 'group-picker'
+  return (
+    <TestWrapper
+      betaFeatures={groupPicker ? {documentGroupInventory: {enabled: true}} : undefined}
+      schemaTypes={SCHEMA_TYPES}
+    >
+      <FixturePreviewStoreProvider documents={DOCUMENTS}>
+        <LocaleProvider>
+          <DiffViewRouter>
+            <VersionModeHeader documentId={DOCUMENT_ID} state="ready" />
+            {groupPicker && (
+              <div style={{padding: 16}}>
+                <DocumentGroupPickerMenu
+                  document={{id: `drafts.${DOCUMENT_ID}`, type: 'author'}}
+                  onSelectDocument={noop}
+                  role="previous"
+                />
+              </div>
+            )}
+          </DiffViewRouter>
+        </LocaleProvider>
+      </FixturePreviewStoreProvider>
+    </TestWrapper>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

#14506 (`chore: migrate flex in misc structure directories`) moves 85 `Flex` instances across 17 files in `packages/sanity/src/structure` outside `panes/` from `@sanity/ui` to ui5, with prop renames (`direction`→`flexDirection`, `align`→`alignItems`, `justify`→`justifyContent`, `height="fill"`→`height="100%"`, dropped `sizing="border"`, `flex="none"` spelled out). The visual-coverage comment on that PR reports its 19 changed UI files as 19 uncovered, so nothing would catch a layout shift today. This PR adds Chromatic baselines for that UI off `main`, before the migration lands, without touching the migration branch.

Six sentinel stories, one per surface, all tagged `vrt-only` so they stay out of the Storybook sidebar:

- `Structure/Confirm Delete Dialog` (`confirmDeleteDialog/__tests__/ConfirmDeleteDialog.stories.tsx`): the real dialog on its `checkIncomingReferences={false}` path with draft, published and release version rows and the "Delete all versions" footer; and the body laid out inline with internal references (a truncating title and a "preview unavailable" unknown type), the "other references" overflow row, the cross-dataset table expanded by a `play` function so the copy-id rows are captured, plus the unpublish copy. Covers `ConfirmDeleteDialog.tsx`, `ConfirmDeleteDialogBody.tsx`, `ConfirmDeleteDialogBody.styles.tsx` (via its `OtherReferenceCount` component), `VersionsPreviewList.tsx`.
- `Structure/Incoming References` (`incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx`): decoration header with description over a populated list with per-row actions; a two-type list with the "link existing" button next to an empty type; a single type without actions; the no-types critical card; the unknown-type row error; and cross-dataset preview rows with and without a studio link. Covers `IncomingReferencesDecoration.tsx`, `IncomingReferencesList.tsx`, `IncomingReferencesType.tsx`, `IncomingReferenceDocument.tsx`, `CrossDatasetIncomingReferenceDocumentPreview.tsx`.
- `Structure/Pane Chrome` (`pane/__tests__/PaneChrome.stories.tsx`): a two-pane `PaneLayout`. The list pane header has a back button, a truncating title, two action buttons and the critical context menu, tabs plus a sub-action, over pane item rows with presence avatars, version status dots and a truncating title; the document pane header has an appended badge and a `contentAfter` slot. A second story clicks the first title so the collapsed, rotated header is captured too. Covers `Pane.tsx`, `PaneHeader.tsx`, `PaneHeaderActions.tsx`, `PaneItemPreview.tsx`.
- `Structure/Request Permission Dialog` (`requestPermissionDialog/__tests__/RequestPermissionDialog.stories.tsx`): description, note input with counter, cancel/confirm footer. Covers `RequestPermissionDialog.tsx`.
- `Structure/No Document Types Screen` (`structureTool/__tests__/NoDocumentTypesScreen.stories.tsx`): the fill-height centering Flex around the caution card. Covers `NoDocumentTypesScreen.tsx`.
- `Structure/Diff View Version Mode Header` (`diffView/versionMode/components/__tests__/VersionModeHeader.stories.tsx`): the header grid with the release menu buttons (published vs. a release version), and the same header with the document group inventory beta on so `DocumentGroupPickerMenu` renders, plus a standalone draft picker. Covers `VersionModeHeader.tsx`, `DocumentGroupPickerMenu.tsx`.

Two of the 19 files stay uncovered on purpose:

- `CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx` subscribes to `fetchCrossDatasetReferences`, which calls `client.getDataUrl` and the references API. The `TestWrapper` mock client has neither, the error is not caught anywhere in that pipeline, and it rejects the `use()` promise, so the component cannot render in a harness. Its row component is covered directly instead.
- `pane/PaneHeader.styles.tsx` is rendered by every `PaneHeader` in the pane chrome story, but `scripts/visualCoverage.ts` only inherits coverage into `.css.ts` and `.styled.tsx` modules, not `.styles.tsx`, and the file exports styled primitives only, so there is nothing to import directly without gaming the report. Recognizing `.styles.tsx` in `isStyleModule` would flip it (and similar files) to covered; left for a follow-up since this PR does not touch the script.

Why a fixture preview store: the mock client answers every query with `null`, which `observeFields` cannot reassemble, so anything resolving previews through `useDocumentPreviewStore()` (pane items, version badges, referring documents, incoming reference rows) crashed. `components/__tests__/FixturePreviewStoreProvider.tsx` serves that one resource-cache namespace from an in-memory store over fixture documents and delegates everything else to `TestWrapper`. The alternative, only rendering states that avoid previews, would have left the migrated row layouts out of the snapshots. Not added: the create button in pane header actions (its template permissions go through the grants store, which also throws on the mock client) and the request-permission dialog's denied/limit state (only reachable through a failed submit).

### What to review

- `FixturePreviewStoreProvider.tsx`: the perspective layering (`versions.<release>.<id>`, `drafts.<id>`, published) and the two-clause GROQ parse in `unstable_observeDocumentIdSet`. Everything is `of(...)`, no network.
- The context stubs in the confirm-delete and incoming-references harnesses: `PaneRouterContext` gets plain anchors for `ChildLink`/`ReferenceChildLink`, `DocumentPaneContext` gets only the fields those components read, and `LocaleProvider` is mounted because `TestWrapper` does not provide `LocaleContext` and the version status tooltips (kept mounted by `@sanity/ui`) call `useRelativeTime`.
- `play` functions: dialog stories wait for the dialog and blur auto-focus (same pattern as the existing dialog sentinels); the referring-documents story opens the `<details>`; the collapsed pane story clicks the title.
- Rendering rows that call `useDocumentPresence` logs bifur WebSocket handshake failures against the mock host to the console. No visual effect and the runner does not fail on it.
- Only `packages/sanity` is affected, and only files under `__tests__`.

### Testing

Coverage report for the 19 files from the migration PR, run on this branch:

### Visual regression coverage

19 UI files: 17 covered, 0 pending, 2 uncovered.

| File | Status | Evidence |
| ---- | ------ | -------- |
| `packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx` | covered | `packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.stories.tsx` |
| `packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx` | covered | `packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.stories.tsx` |
| `packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx` | covered | `packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.stories.tsx` |
| `packages/sanity/src/structure/components/confirmDeleteDialog/VersionsPreviewList.tsx` | covered | `packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.stories.tsx` |
| `packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesDecoration.tsx` | covered | `packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx` |
| `packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesList.tsx` | covered | `packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx` |
| `packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx` | covered | `packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx` |
| `packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferenceDocument.tsx` | covered | `packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx` |
| `packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceDocumentPreview.tsx` | covered | `packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferences.stories.tsx` |
| `packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx` | uncovered |  |
| `packages/sanity/src/structure/components/pane/Pane.tsx` | covered | `packages/sanity/src/structure/components/pane/__tests__/PaneChrome.stories.tsx` |
| `packages/sanity/src/structure/components/pane/PaneHeader.tsx` | covered | `packages/sanity/src/structure/components/pane/__tests__/PaneChrome.stories.tsx` |
| `packages/sanity/src/structure/components/pane/PaneHeader.styles.tsx` | uncovered |  |
| `packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderActions.tsx` | covered | `packages/sanity/src/structure/components/pane/__tests__/PaneChrome.stories.tsx` |
| `packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx` | covered | `packages/sanity/src/structure/components/pane/__tests__/PaneChrome.stories.tsx` |
| `packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx` | covered | `packages/sanity/src/structure/components/requestPermissionDialog/__tests__/RequestPermissionDialog.stories.tsx` |
| `packages/sanity/src/structure/components/structureTool/NoDocumentTypesScreen.tsx` | covered | `packages/sanity/src/structure/components/structureTool/__tests__/NoDocumentTypesScreen.stories.tsx` |
| `packages/sanity/src/structure/diffView/versionMode/components/DocumentGroupPickerMenu.tsx` | covered | `packages/sanity/src/structure/diffView/versionMode/components/__tests__/VersionModeHeader.stories.tsx` |
| `packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx` | covered | `packages/sanity/src/structure/diffView/versionMode/components/__tests__/VersionModeHeader.stories.tsx` |

`pnpm visual-coverage --changed --prs` on this branch reports 0 changed UI files (this PR only adds `__tests__` files), and none of the 19 files is `pending` in another open PR (#14550 and #14551 cover form chrome, disjoint from structure).

All nine stories pass through the addon-vitest browser runner (`pnpm --filter sanity-storybook exec vitest run <the six story files>`, chromium; 6 files, 9 tests). Each story was also loaded in the Storybook dev server and checked for render errors and missing-provider crashes. `pnpm check:oxlint` (type-aware) and `oxfmt --check` pass.

Rendered stories:

[Confirm delete dialog: delete path with three version rows](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_confirm_delete_dialog.png)
[Confirm delete body: internal references, other-reference count, expanded cross-dataset table, unpublish copy, version list](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_confirm_delete_referring_documents.png)
[Incoming references: decoration header, populated and empty lists, row actions, error cards, cross-dataset rows](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_incoming_references.png)
[Pane chrome, expanded: list pane header with back button, truncating title, actions, tabs, sub-action; pane item rows with presence; document pane header with badge and contentAfter](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_pane_chrome_expanded.png)
[Pane chrome, collapsed: first pane collapsed to a rotated header strip](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_pane_chrome_collapsed.png)
[Version mode header with release menu buttons](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_version_mode_header_version_menu.png)
[Version mode header with document group picker buttons and a standalone draft picker](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_version_mode_header_group_picker.png)
[Request permission dialog](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_request_permission_dialog.png)
[No document types screen](https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_no_document_types_screen.png)

### Notes for release

N/A – Internal only

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a87c1c59-8f58-4208-a352-ccb7d1d3ad5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

