### PR TITLE
fix(core): render the workspace menu project name without a layout shift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,30 @@ Two traps when unit testing a component or hook that suspends on a promise with 
   React throws `Update hook called on initial render` as a recoverable error — which vitest can
   catch as an unhandled error and fail the run. Once a load has started, keep calling `use()` on
   the same cached promise on every render instead of re-checking the environment.
+- **`use()` inside a hidden `<Activity>` tree can trip React's "A component suspended inside an
+  `act` scope, but the `act` call was not awaited" warning even when the thenable is already
+  fulfilled.** A sync `act` (what `render` uses) stops flushing as soon as a yielded render has
+  called `use()` with any thenable (`didUsePromise`), and a closed popover's pre-render yields
+  once its tree is big enough. Nothing actually suspended; mount with
+  `await act(async () => { render(...) })` (see `WorkspaceMenuButton.test.tsx`).
+
+#### react-rx: `useObservablePromise` and `use()` live in different components
+
+react-rx v7 ([react-rx#515](https://github.com/sanity-io/react-rx/pull/515)) never subscribes
+during a mounting render, and a hidden `<Activity>` tree never subscribes at all until it is
+revealed. Two consequences for Suspense code:
+
+- Never `use()` the promise returned by `useObservablePromise` in the same component. The
+  component suspends before the commit that would start the fetch and deadlocks (verified against
+  the v7 build). Call the hook in a parent and pass the promise to a child that reads it under a
+  `<Suspense>` boundary.
+- For content inside a closed popover or any other hidden `<Activity>` tree, call the hook in a
+  visible ancestor and pass the promise down, as `WorkspaceMenuButton` does for `ManageMenu`.
+  The fetch then starts when the ancestor commits, and the data is settled before the reveal.
+
+`useObservable` and `useSyncObservable` require an `initialValue` in v7 and render it on the first
+pass regardless of synchronous emissions, so do not rely on a replayed value winning the first
+paint through them; that is what `useObservablePromise` plus `use()` is for.
 
 #### Custom matchers shipped in node_modules (e.g. `get-it/vitest`)
 
@@ -842,6 +866,7 @@ No Docker, databases, or other local services are required for unit tests, lint,
 - **Snapshot lockfile drift can fail `pnpm check:oxlint` in untouched files.** The VM image may have `node_modules` resolved to newer in-range versions than the committed `pnpm-lock.yaml` (e.g. `@sanity/client` 8.4.0 vs the locked 8.3.0), and `pnpm install` — even with `--frozen-lockfile` — keeps rewriting the lockfile to match instead of downgrading. Type errors in files you never touched (e.g. `@sanity/vision`'s `useDatasets.test.ts` missing a `description` field) are this drift, not your change: revert the churn with `git checkout -- pnpm-lock.yaml`, never commit it, and rely on CI (which installs from the committed lockfile) for the authoritative type check of those files.
 - **Do not run oxlint type checking (`pnpm check:oxlint`) while the dev studio is running.** Both are memory-hungry and running them concurrently has exhausted the VM's memory and frozen it for hours (unkillable thrashing). Stop `sanity dev` first (Ctrl-C in its tmux session), run the checks, then restart the studio.
 - **`sanity dev` in bundledDev mode (`unstable_bundledDev: true`, on by default in `dev/test-studio`, `dev/design-studio`, `dev/radar`, `dev/auth-test-studio`) grows by roughly 300 MB of RSS per distinct lazy chunk (`/@vite/lazy?id=...`) it compiles, on top of a ~2 GB baseline.** Page reloads, fresh client ids and re-requests of an already compiled chunk cost nothing, but a studio session that touches every plugin's lazy entry points can push the server past 10 GB (13.6 GB observed on vite 8.2.2, freezing the 16 GB VM). Classic mode sits at ~1 GB for the same actions. When you need a long-running studio or plan to exercise many tools, either flip `unstable_bundledDev` off locally or run the server with a PID watchdog (`while sleep 5; do r=$(ps -o rss= -p $PID) || break; [ "${r:-0}" -gt 5000000 ] && kill $PID; done`) and restart it when it trips. This is upstream vite/rolldown behavior, not something the studio config can tune.
+- **`sanity dev` can keep serving a stale revision after two edits of the same file land within a second or two** (observed in bundledDev mode when a script rewrote `useProject.ts` twice in quick succession: the terminal logged one `hmr update` and then served the first revision, and `touch` did not trigger another). Before measuring anything in the browser after scripted or rapid edits, check the `sanity dev` terminal for an `hmr update` line matching your last edit, and restart the server if it is missing.
 - **Simulating Presentation preview failure states.** The `/test` workspace's presentation tool allows any localhost origin (`allowOrigins: ['https://*.sanity.dev', 'http://localhost:*']`), so failure UIs can be triggered deterministically by pointing the preview at a throwaway local server via the `?preview=` search param, e.g. `http://localhost:3333/test/presentation?preview=http%3A%2F%2Flocalhost%3A3398%2F`. A plain HTML page that never runs `@sanity/visual-editing` exercises the overlays connection timeout path (loading overlay → "connecting" status card after 5s → caution card with "Continue anyway" after 3s more); a server that accepts connections but never responds (`createServer(() => {})`) keeps the iframe `load` event from firing and exercises the 15s load timeout → error card → "Retry" path. Note the demo screen recordings are time-compressed, so verify real timings from the `sanity dev` terminal log — the studio pipes browser `console.error` output there with timestamps.
 - **Verifying a production studio build (`sanity build`) must happen on an allow-listed origin.** `sanity build` for `dev/test-studio` bundles the _built_ `sanity` package (run `pnpm build` first — only `sanity dev` resolves monorepo sources via the `monorepo` export condition). Serve `dev/test-studio/dist` statically on **port 3333** (e.g. `python3 -m http.server 3333`, after stopping the dev server): project `ppsg7ml5` only allow-lists `http://localhost:3333`, so from any other port API requests fail CORS and the bifur `/socket/` WebSocket is rejected during its handshake (close code 1006 + retry loop). The static server has no SPA fallback, so load `http://localhost:3333/#token=…` (root path) and let the client-side router redirect, rather than deep-linking to a workspace path.
 

--- a/packages/sanity/src/core/store/project/projectStore.test.ts
+++ b/packages/sanity/src/core/store/project/projectStore.test.ts
@@ -80,6 +80,50 @@ describe('createProjectStore getOrganizationId', () => {
     subscription.unsubscribe()
   })
 
+  it('shares one request between getProjectName and getOrganizationId', async () => {
+    const project = {...createMockProjectData('org-shared'), displayName: 'Shared project'}
+    const client = createMockClient({
+      projectId: 'shared-request-project',
+      requestImplementation: () => of(project),
+    })
+
+    const store = createProjectStore({client})
+
+    const names: Array<string | null> = []
+    const organizationIds: Array<string | null> = []
+    const subscription = store.getProjectName().subscribe((value) => names.push(value))
+    subscription.add(store.getOrganizationId().subscribe((value) => organizationIds.push(value)))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(names).toEqual(['Shared project'])
+    expect(organizationIds).toEqual(['org-shared'])
+    expect(client.observable.request).toHaveBeenCalledTimes(1)
+
+    let replayed: string | null | undefined
+    subscription.add(store.getProjectName().subscribe((value) => (replayed = value)))
+    expect(replayed).toBe('Shared project')
+    expect(client.observable.request).toHaveBeenCalledTimes(1)
+
+    subscription.unsubscribe()
+  })
+
+  it('emits null from getProjectName when the request fails', async () => {
+    const client = createMockClient({
+      projectId: 'failing-name-project',
+      requestImplementation: () => throwError(() => new Error('persistent failure')),
+    })
+
+    const store = createProjectStore({client})
+
+    const names: Array<string | null> = []
+    const subscription = store.getProjectName().subscribe((value) => names.push(value))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(names).toEqual([null])
+
+    subscription.unsubscribe()
+  })
+
   it('emits null only when no organization id has ever been resolved', async () => {
     const client = createMockClient({
       projectId: 'always-failing-project',

--- a/packages/sanity/src/core/store/project/projectStore.ts
+++ b/packages/sanity/src/core/store/project/projectStore.ts
@@ -116,6 +116,7 @@ export function createProjectStore(context: {client: SanityClient}): ProjectStor
     get,
     getDatasets,
     getGrants: () => getProjectGrants(versionedClient),
+    getProjectName: () => projectOrgData$.pipe(map((res) => res?.displayName ?? null)),
     getOrganizationData: () => projectOrgData$.pipe(map((res) => res?.organization ?? null)),
     getOrganizationId: () => projectOrgData$.pipe(map((res) => res?.organizationId ?? null)),
   }

--- a/packages/sanity/src/core/store/project/types.ts
+++ b/packages/sanity/src/core/store/project/types.ts
@@ -82,6 +82,7 @@ export type ProjectGrants = Record<
 export interface ProjectStore {
   get: () => Observable<ProjectData>
   getDatasets: () => Observable<ProjectDatasetData[]>
+  getProjectName: () => Observable<string | null>
   getOrganizationData: () => Observable<ProjectOrganizationData | null>
   getOrganizationId: () => Observable<string | null>
   getGrants: () => Observable<ProjectGrants>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
@@ -1,20 +1,31 @@
 import {AddUserIcon} from '@sanity/icons/AddUser'
 import {CogIcon} from '@sanity/icons/Cog'
-import {Stack, Text} from '@sanity/ui'
+import {Stack, Text, TextSkeleton} from '@sanity/ui'
+import {Suspense, use} from 'react'
+import {type ObservablePromise} from 'react-rx'
 import {Flex} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
-import {useProject} from '../../../../store/project/useProject'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher/useActiveWorkspace'
 import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {useWorkspace} from '../../../workspace'
 import {useCanInviteProjectMembers} from '../useCanInviteMembers'
 import {WorkspacePreviewIcon} from './WorkspacePreview'
 
-export function ManageMenu({multipleWorkspaces}: {multipleWorkspaces: boolean}) {
+function ProjectName({promise}: {promise: ObservablePromise<string | null>}) {
+  const name = use(promise)
+  return name ? <Text size={0}>{name}</Text> : null
+}
+
+export function ManageMenu({
+  multipleWorkspaces,
+  projectNamePromise,
+}: {
+  multipleWorkspaces: boolean
+  projectNamePromise: ObservablePromise<string | null>
+}) {
   const {projectId} = useWorkspace()
-  const project = useProject()
   const {activeWorkspace} = useActiveWorkspace()
   const envAwareWebsiteUrl = useEnvAwareSanityWebsiteUrl()
 
@@ -27,7 +38,9 @@ export function ManageMenu({multipleWorkspaces}: {multipleWorkspaces: boolean}) 
       <Flex alignItems="center">
         <WorkspacePreviewIcon icon={activeWorkspace.icon} size="large" />
         <Stack marginLeft={2} gap={2}>
-          <Text size={0}>{project?.displayName}</Text>
+          <Suspense fallback={<TextSkeleton size={0} animated style={{width: '8ch'}} />}>
+            <ProjectName promise={projectNamePromise} />
+          </Suspense>
           <Text size={2} weight="medium">
             {activeWorkspace.title}
           </Text>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -6,7 +6,8 @@ import {
   Text,
 } from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
-import {useCallback, useState} from 'react'
+import {useCallback, useMemo, useState} from 'react'
+import {useObservablePromise} from 'react-rx'
 import {take} from 'rxjs/operators'
 import {Box, Flex} from 'ui5'
 
@@ -14,6 +15,7 @@ import {MenuButton, type MenuButtonProps} from '../../../../../ui-components/men
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {probeWorkspaceAuth} from '../../../../store/authStore/probeWorkspaceAuth'
+import {useProjectStore} from '../../../../store/datastores'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher/useActiveWorkspace'
 import {useVisibleWorkspaces} from '../../../workspaces/useVisibleWorkspaces'
 import {ManageMenu} from './ManageMenu'
@@ -31,6 +33,11 @@ export function WorkspaceMenuButton() {
   const {activeWorkspace} = useActiveWorkspace()
   const {t} = useTranslation()
   const [scrollbarWidth, setScrollbarWidth] = useState(0)
+
+  const projectStore = useProjectStore()
+  const projectNamePromise = useObservablePromise(
+    useMemo(() => projectStore.getProjectName(), [projectStore]),
+  )
 
   const stackRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -77,7 +84,10 @@ export function WorkspaceMenuButton() {
       id="workspace-menu"
       menu={
         <Menu padding={0} style={{maxWidth: '350px', minWidth: '250px', overflowY: 'hidden'}}>
-          <ManageMenu multipleWorkspaces={visibleWorkspaces.length > 1} />
+          <ManageMenu
+            multipleWorkspaces={visibleWorkspaces.length > 1}
+            projectNamePromise={projectNamePromise}
+          />
           {visibleWorkspaces.length > 1 && (
             <>
               <MenuDivider style={{padding: 0}} />

--- a/packages/sanity/src/core/studio/components/navbar/workspace/__tests__/ManageMenu.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/__tests__/ManageMenu.test.tsx
@@ -1,0 +1,70 @@
+import {LayerProvider, ThemeProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
+import {act, render, screen} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {preloadObservablePromise} from 'react-rx'
+import {of, Subject} from 'rxjs'
+import {describe, expect, it, vi} from 'vitest'
+
+import {type WorkspaceSummary} from '../../../../../config/types'
+import {ManageMenu} from '../ManageMenu'
+
+vi.mock('../../../../../i18n/hooks/useTranslation', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}))
+vi.mock('../../../../workspace', () => ({useWorkspace: () => ({projectId: 'abc123'})}))
+vi.mock('../../../../hooks/useEnvAwareSanityWebsiteUrl', () => ({
+  useEnvAwareSanityWebsiteUrl: () => 'https://www.sanity.io',
+}))
+vi.mock('../../useCanInviteMembers', () => ({useCanInviteProjectMembers: () => false}))
+vi.mock('../../../../activeWorkspaceMatcher/useActiveWorkspace', () => ({
+  useActiveWorkspace: () => ({
+    activeWorkspace: {name: 'test', title: 'Test Studio'} as unknown as WorkspaceSummary,
+  }),
+}))
+
+const theme = buildTheme()
+const wrapper = ({children}: {children: ReactNode}) => (
+  <ThemeProvider theme={theme}>
+    <LayerProvider>{children}</LayerProvider>
+  </ThemeProvider>
+)
+
+const projectNameSkeleton = () => document.querySelector('[data-ui="TextSkeleton"]')
+
+describe('ManageMenu', () => {
+  it('renders a settled project name on the first render, without a fallback pass', () => {
+    const promise = preloadObservablePromise(of('Sanity Studio Test Data'))
+
+    render(<ManageMenu multipleWorkspaces={false} projectNamePromise={promise} />, {wrapper})
+
+    expect(screen.getByText('Sanity Studio Test Data')).toBeInTheDocument()
+    expect(projectNameSkeleton()).toBeNull()
+  })
+
+  it('holds the name row with a skeleton until the promise settles', async () => {
+    const name$ = new Subject<string | null>()
+    const promise = preloadObservablePromise(name$)
+
+    // oxlint-disable-next-line testing-library/no-unnecessary-act -- the mount has to happen inside an awaited act so React can resume the suspended tree
+    await act(async () => {
+      render(<ManageMenu multipleWorkspaces={false} projectNamePromise={promise} />, {wrapper})
+    })
+    expect(projectNameSkeleton()).not.toBeNull()
+    expect(screen.getByText('Test Studio')).toBeInTheDocument()
+    expect(screen.queryByText('Sanity Studio Test Data')).not.toBeInTheDocument()
+
+    await act(async () => name$.next('Sanity Studio Test Data'))
+    expect(projectNameSkeleton()).toBeNull()
+    expect(screen.getByText('Sanity Studio Test Data')).toBeInTheDocument()
+  })
+
+  it('renders no name row when the project name is unknown', () => {
+    const promise = preloadObservablePromise(of<string | null>(null))
+
+    render(<ManageMenu multipleWorkspaces={false} projectNamePromise={promise} />, {wrapper})
+
+    expect(projectNameSkeleton()).toBeNull()
+    expect(screen.getByText('Test Studio')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/studio/components/navbar/workspace/__tests__/WorkspaceMenuButton.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/__tests__/WorkspaceMenuButton.test.tsx
@@ -1,28 +1,59 @@
 import {LayerProvider, ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
-import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {type ReactNode} from 'react'
-import {defer, NEVER} from 'rxjs'
+import {type ReactNode, Suspense, use} from 'react'
+import {type ObservablePromise} from 'react-rx'
+import {defer, NEVER, type Observable, ReplaySubject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {type WorkspaceSummary} from '../../../../../config/types'
 import {WorkspaceMenuButton} from '../WorkspaceMenuButton'
 
-const {mockProbeWorkspaceAuth, probeSubscriptions} = vi.hoisted(() => ({
-  mockProbeWorkspaceAuth: vi.fn(),
-  probeSubscriptions: {count: 0},
-}))
+const {mockProbeWorkspaceAuth, probeSubscriptions, projectName$, projectNameSubscriptions} =
+  vi.hoisted(() => ({
+    mockProbeWorkspaceAuth: vi.fn(),
+    probeSubscriptions: {count: 0},
+    projectName$: {current: null as null | Observable<string | null>},
+    projectNameSubscriptions: {count: 0},
+  }))
 
 vi.mock('../../../../../store/authStore/probeWorkspaceAuth', () => ({
   probeWorkspaceAuth: mockProbeWorkspaceAuth,
 }))
+vi.mock('../../../../../store/datastores', () => {
+  const projectStore = {
+    getProjectName: () =>
+      defer(() => {
+        projectNameSubscriptions.count += 1
+        return projectName$.current ?? NEVER
+      }),
+  }
+  return {useProjectStore: () => projectStore}
+})
 vi.mock('../../../../../i18n/hooks/useTranslation', () => ({
   useTranslation: () => ({t: (key: string) => key}),
 }))
 vi.mock('../ManageMenu', () => ({
-  ManageMenu: () => <div data-testid="manage-menu" />,
+  ManageMenu: ({projectNamePromise}: {projectNamePromise: ObservablePromise<string | null>}) => (
+    <div data-testid="manage-menu">
+      <Suspense fallback={<span data-testid="project-name-pending" />}>
+        <ProjectNameProbe promise={projectNamePromise} />
+      </Suspense>
+    </div>
+  ),
 }))
+
+function ProjectNameProbe({promise}: {promise: ObservablePromise<string | null>}) {
+  return <span data-testid="project-name">{use(promise)}</span>
+}
+
+async function renderButton() {
+  // oxlint-disable-next-line testing-library/no-unnecessary-act -- the probe reads the promise with use() during the hidden menu's yielding pre-render, which React's sync act reports as an unflushed suspension
+  await act(async () => {
+    render(<WorkspaceMenuButton />, {wrapper})
+  })
+}
 
 const workspaceA = {
   name: 'workspace-a',
@@ -55,6 +86,10 @@ describe('WorkspaceMenuButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     probeSubscriptions.count = 0
+    projectNameSubscriptions.count = 0
+    const held$ = new ReplaySubject<string | null>(1)
+    held$.next('Sanity Studio Test Data')
+    projectName$.current = held$
     // One subscription = one would-be `/auth/id` request.
     // Creating the observable is free and happens during render;
     // only subscribing fires the request. So: count subscriptions.
@@ -67,7 +102,7 @@ describe('WorkspaceMenuButton', () => {
   })
 
   it('keeps the closed menu content mounted without subscribing any auth probe', async () => {
-    render(<WorkspaceMenuButton />, {wrapper})
+    await renderButton()
 
     // Closed popovers keep children mounted (`<Activity>`, @sanity/ui v4).
     // So: content is in the DOM, probe observables got created…
@@ -84,7 +119,7 @@ describe('WorkspaceMenuButton', () => {
   })
 
   it('subscribes the auth probes when the menu opens without a preceding hover or focus', async () => {
-    render(<WorkspaceMenuButton />, {wrapper})
+    await renderButton()
 
     // oxlint-disable-next-line testing-library/prefer-user-event -- userEvent.click emits hover and focus first, which would trigger the preload; this test needs a bare click so the only probe trigger is the reveal itself
     fireEvent.click(screen.getByRole('button', {name: /Workspace A/}))
@@ -93,8 +128,16 @@ describe('WorkspaceMenuButton', () => {
     await waitFor(() => expect(probeSubscriptions.count).toBe(2))
   })
 
+  it('settles the project name from the visible button while the menu is still closed', async () => {
+    await renderButton()
+
+    expect(await screen.findByTestId('project-name')).toHaveTextContent('Sanity Studio Test Data')
+    expect(screen.queryByTestId('project-name-pending')).not.toBeInTheDocument()
+    expect(projectNameSubscriptions.count).toBe(1)
+  })
+
   it('subscribes the auth probes on hover while the menu stays closed', async () => {
-    render(<WorkspaceMenuButton />, {wrapper})
+    await renderButton()
 
     await userEvent.hover(screen.getByRole('button', {name: /Workspace A/}))
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

**TL;DR.** The workspace menu header no longer shifts on first open. The project name now comes from the `/projects/<id>` request the studio already makes at boot, read as a promise in the always-visible `WorkspaceMenuButton` and handed to `ManageMenu`, which renders it under a `Suspense` boundary with a same-height `TextSkeleton`. One redundant request per first open is gone. `useProject()` and `ProjectStore.get()` are untouched.

What was broken. Opening the workspace menu for the first time painted an empty project-name row, then `Sanity Studio Test Data` arrived about 200 ms later and pushed `Test Studio` down by 2.5 px. The second open was fine because the value was already in component state.

Root cause. `useProject()` fired its own `GET /projects/<id>` (`tag: get-project`) on first subscription, i.e. on menu open, and rendered `null` until the response came back. `StudioTelemetryProvider` requests the same document at boot through `projectStore.getOrganizationId()`, and `getProjectOrg` keeps it replayed for five minutes.

Why this shape. react-rx v7 ([react-rx#515](https://github.com/sanity-io/react-rx/pull/515)) never subscribes during a mounting render and never fetches from a hidden `<Activity>` tree, which is what a closed popover is. So the hook lives in the visible button, the fetch starts at boot, and the child reads the settled promise with `use()`. Calling `use(useObservablePromise(...))` inside the menu instead deadlocks under v7 (verified against the PR build, see Testing).

### What to review

Four commits, in dependency order. Core files first.

1. `feat(core): expose the project display name from the project store`. `projectStore.ts`, `types.ts` (one new `ProjectStore` method, `getProjectName(): Observable<string | null>`), `projectStore.test.ts`.
2. `test(core): specify that the workspace menu header keeps its height while the project name loads`. `ManageMenu.test.tsx` (new), `WorkspaceMenuButton.test.tsx`. Red against `main` (7 failures), green after the next commit.
3. `fix(core): render the workspace menu project name without a layout shift`. `WorkspaceMenuButton.tsx` (calls `useObservablePromise(projectStore.getProjectName())`, passes the promise down), `ManageMenu.tsx` (`ProjectName` child with `use()`, `Suspense` fallback `TextSkeleton size={0}` at `8ch`). This is the only commit that changes runtime behavior.
4. `docs(agents)`. `AGENTS.md` only: the react-rx v7 Suspense rules, a React `act` false positive that `use()` inside a hidden `<Activity>` tree can trigger, and the stale HMR gotcha.

Things worth a second look:

- `ProjectStore` is `@hidden @beta` and publicly exported; the added method is additive.
- Boot still issues exactly one `/projects` request for the name, shared with `StudioTelemetryProvider`. Measured: three `/projects` requests before and after (two of them from `useUnclaimedProject`), none after the click.
- The `TextSkeleton` fallback shows only while the boot request is still in flight when the menu opens. In the normal case the name is settled long before the first open, so the skeleton is never seen.

### Testing

- `ManageMenu.test.tsx`: a settled promise renders the name on the first render with a synchronous `render` and no fallback; a pending promise shows the `TextSkeleton` and swaps to the name when it settles; `null` renders no name row.
- `WorkspaceMenuButton.test.tsx`: the three existing probe tests, plus the name settling from the visible button while the menu is still closed, with exactly one subscription to `getProjectName()`.
- `projectStore.test.ts`: `getProjectName()` and `getOrganizationId()` share one request, a late subscriber gets the value synchronously, failures emit `null`.
- react-rx v7: built `react-rx` from #515 (commit `aaa3453`), swapped its `dist` into `node_modules`, ran the affected suites (27 tests pass). A probe with a held `ReplaySubject` confirms the changeset: `use(useObservablePromise())` in one component stays on the fallback for good under v7; the parent-hook/child-`use()` shape renders the name under both v6 and v7. The dev studio cannot run under v7 yet because unrelated code still uses `useObservableEvent` and single-argument `useObservable`.
- Dev studio (react-rx 6), Playwright, `requestAnimationFrame` sampling of the popover header on first open.
  - Warm store (normal first open): 0 frames without the name, the name on the first popover frame, no `/projects` request after the click.
  - Cold store (`/projects` org request delayed with `page.route`, menu opened before it resolved): skeleton for ~6 s then the name; skeleton row and text row both 7.0 px tall; the workspace title at one offset within the popover (48.5 px) in both states.

>Workspace menu header before and after the fix
<img width="2240" height="1120" alt="Workspace menu header before and after the fix" src="https://github.com/user-attachments/assets/2f5f474f-bcd2-4642-83ea-957a4ae19c89" />

>Workspace menu while the project request is still pending: an 8ch skeleton holds the name row
<img width="1280" height="720" alt="Workspace menu while the project request is still pending: an 8ch skeleton holds the name row" src="https://github.com/user-attachments/assets/f638f76c-ad15-4caa-86a4-320bf3c7995a" />


### Notes for release

The workspace menu no longer shifts its header on first open. The studio also stops issuing a redundant `/projects/<id>` request each time the menu is first opened; the project name now comes from the request already made at boot.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68884118-462a-4340-9386-db58f374b164?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68884118-462a-4340-9386-db58f374b164&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

