### PR TITLE
fix(e2e): write flake report outputs relative to the invoking directory

### DIFF
--- a/.github/workflows/e2e-flake-report.yml
+++ b/.github/workflows/e2e-flake-report.yml
@@ -32,15 +32,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPORT_DAYS: ${{ inputs.days || '7' }}
-        run: pnpm e2e:flake-report --days "$REPORT_DAYS" --out flake-report.md --json flake-report.json
+        # The script runs inside e2e/, so name the outputs by absolute path.
+        run: pnpm e2e:flake-report --days "$REPORT_DAYS" --out "$GITHUB_WORKSPACE/flake-report.md" --json "$GITHUB_WORKSPACE/flake-report.json"
 
       - name: Publish the report as the job summary
-        run: cat flake-report.md >> "$GITHUB_STEP_SUMMARY"
+        run: cat "$GITHUB_WORKSPACE/flake-report.md" >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/upload-artifact@v7
         with:
           name: e2e-flake-report
           path: |
-            flake-report.md
-            flake-report.json
+            ${{ github.workspace }}/flake-report.md
+            ${{ github.workspace }}/flake-report.json
           retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,7 @@ dev/test-studio/.react-compiler-bailout-report.json
 # absolute paths, so they must not be tracked. Only relevant for clones whose
 # core.hooksPath still points here from the pre-lefthook husky setup.
 .husky/
+
+# Local output of `pnpm e2e:flake-report`
+flake-report.md
+flake-report.json

--- a/e2e/scripts/flakeReport/index.ts
+++ b/e2e/scripts/flakeReport/index.ts
@@ -107,12 +107,20 @@ function parseOptions(): Options | undefined {
     throw new Error(`Invalid --limit value "${values.limit}": expected a positive integer`)
   }
 
+  // `pnpm e2e:flake-report` runs this script inside e2e/, so relative paths are resolved
+  // against the directory pnpm was invoked from (INIT_CWD), which is what the caller means.
+  const invokedFrom = process.env.INIT_CWD || process.cwd()
+  const resolveFromInvocation = (file: string | undefined) =>
+    file === undefined ? undefined : path.resolve(invokedFrom, file)
+
   return {
     allShards: values['all-shards'],
-    cacheDir: values['cache-dir'] ?? path.join(os.tmpdir(), 'sanity-e2e-flake-report'),
-    json: values.json,
+    cacheDir:
+      resolveFromInvocation(values['cache-dir']) ??
+      path.join(os.tmpdir(), 'sanity-e2e-flake-report'),
+    json: resolveFromInvocation(values.json),
     limit,
-    out: values.out,
+    out: resolveFromInvocation(values.out),
     repo: values.repo,
     since,
     workflow: values.workflow,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The first manual run of the `E2E flake report` workflow ([33783424068](https://github.com/sanity-io/sanity/actions/runs/33783424068)) generated the report but failed on the next step with `cat: flake-report.md: No such file or directory`. `pnpm e2e:flake-report` runs the script inside `e2e/`, so `--out flake-report.md` was written to `e2e/flake-report.md` while the summary and artifact steps looked at the repo root.

Relative `--out`, `--json`, and `--cache-dir` paths now resolve against `INIT_CWD` (the directory pnpm was invoked from), which is what a caller typing `pnpm e2e:flake-report --out flake-report.md` at the root means. The workflow also names its outputs by absolute path so it does not depend on that, and the local output filenames are gitignored.

### What to review

- `e2e/scripts/flakeReport/index.ts` — path resolution in `parseOptions`.
- `.github/workflows/e2e-flake-report.yml` — `$GITHUB_WORKSPACE`-absolute paths for the three steps.
- Affected packages: `e2e`.

### Testing

- Ran `pnpm e2e:flake-report --days 1 --limit 3 --out flake-report.md --json flake-report.json` from the repo root: both files now land at the root, nothing under `e2e/`.
- `e2e` unit tests 35/35, oxlint clean.

### Notes for release

N/A – Internal only (e2e tooling)

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fb2f7d5-c112-4e85-bfbc-d8d467d35edd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fb2f7d5-c112-4e85-bfbc-d8d467d35edd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

