### PR TITLE
feat(test-studio): add style outline debug panel

### DIFF
--- a/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
+++ b/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
@@ -2,7 +2,6 @@ import {useEffect, useState} from 'react'
 
 import {
   checkbox,
-  collapse,
   dot,
   header,
   panel,
@@ -133,18 +132,16 @@ export function StyleOutlinePanel() {
     <div className={root} data-testid="style-outline">
       {open ? (
         <fieldset className={panel} aria-label="Style outline" data-testid="style-outline-panel">
-          <div className={header}>
-            <span>Style outline</span>
-            <button
-              type="button"
-              className={collapse}
-              aria-label="Hide style outline"
-              onClick={toggleOpen}
-              data-testid="style-outline-collapse"
-            >
-              ×
-            </button>
-          </div>
+          <button
+            type="button"
+            className={header}
+            title="Collapse"
+            aria-expanded
+            onClick={toggleOpen}
+            data-testid="style-outline-collapse"
+          >
+            Style outline
+          </button>
           {STYLE_SYSTEMS.map((system) => (
             <label key={system.id} className={row}>
               <span className={dot} style={{background: system.color}} />
@@ -155,7 +152,6 @@ export function StyleOutlinePanel() {
                 className={checkbox}
                 checked={active.includes(system.id)}
                 onChange={() => toggleSystem(system.id)}
-                style={{accentColor: system.color}}
                 data-testid={`style-outline-toggle-${system.id}`}
               />
             </label>
@@ -166,7 +162,7 @@ export function StyleOutlinePanel() {
           type="button"
           className={trigger}
           title="Style outline"
-          aria-label="Show style outline"
+          aria-label="Style outline"
           aria-expanded={false}
           onClick={toggleOpen}
           data-testid="style-outline-trigger"

--- a/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
+++ b/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
@@ -1,0 +1,185 @@
+import {useEffect, useState} from 'react'
+
+import {
+  checkbox,
+  collapse,
+  dot,
+  header,
+  panel,
+  root,
+  row,
+  rowCount,
+  rowLabel,
+  trigger,
+} from './styleOutline.css'
+import {
+  STYLE_OUTLINE_ATTRIBUTE,
+  STYLE_OUTLINE_STORAGE_KEY,
+  STYLE_SYSTEMS,
+  type StyleSystemId,
+} from './styleSystems'
+
+interface PanelState {
+  open: boolean
+  active: StyleSystemId[]
+}
+
+type Counts = ReadonlyMap<StyleSystemId, number>
+
+const DEFAULT_STATE: PanelState = {open: false, active: []}
+
+function isStyleSystemId(value: unknown): value is StyleSystemId {
+  return STYLE_SYSTEMS.some((system) => system.id === value)
+}
+
+function inRegistryOrder(ids: ReadonlySet<StyleSystemId>): StyleSystemId[] {
+  return STYLE_SYSTEMS.filter((system) => ids.has(system.id)).map((system) => system.id)
+}
+
+function readStoredState(): PanelState {
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem(STYLE_OUTLINE_STORAGE_KEY) ?? 'null')
+    if (typeof parsed !== 'object' || parsed === null) return DEFAULT_STATE
+    if (!('open' in parsed) || !('active' in parsed)) return DEFAULT_STATE
+    const {open, active} = parsed
+    if (typeof open !== 'boolean' || !Array.isArray(active)) return DEFAULT_STATE
+    const ids: unknown[] = active
+    return {open, active: inRegistryOrder(new Set(ids.filter(isStyleSystemId)))}
+  } catch {
+    return DEFAULT_STATE
+  }
+}
+
+function writeStoredState(state: PanelState): void {
+  try {
+    localStorage.setItem(STYLE_OUTLINE_STORAGE_KEY, JSON.stringify(state))
+  } catch {}
+}
+
+function toggleId(active: StyleSystemId[], id: StyleSystemId): StyleSystemId[] {
+  const next = new Set(active)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  return inRegistryOrder(next)
+}
+
+function countNodes(): Counts {
+  return new Map(
+    STYLE_SYSTEMS.map((system): [StyleSystemId, number] => [
+      system.id,
+      document.querySelectorAll(system.selector).length,
+    ]),
+  )
+}
+
+function sameCounts(a: Counts | null, b: Counts): boolean {
+  return a !== null && STYLE_SYSTEMS.every((system) => a.get(system.id) === b.get(system.id))
+}
+
+function formatCount(count: number | undefined, total: number): string {
+  if (count === undefined || total === 0) return '—'
+  return `${count.toLocaleString()} · ${Math.round((count / total) * 100)}%`
+}
+
+export function StyleOutlinePanel() {
+  const [state, setState] = useState(readStoredState)
+  const [counts, setCounts] = useState<Counts | null>(null)
+  const {open, active} = state
+
+  useEffect(() => {
+    writeStoredState(state)
+  }, [state])
+
+  useEffect(() => {
+    const html = document.documentElement
+    if (active.length > 0) html.setAttribute(STYLE_OUTLINE_ATTRIBUTE, active.join(' '))
+    else html.removeAttribute(STYLE_OUTLINE_ATTRIBUTE)
+    return () => html.removeAttribute(STYLE_OUTLINE_ATTRIBUTE)
+  }, [active])
+
+  useEffect(() => {
+    if (!open) return undefined
+    let frame: number | null = null
+    const recount = () => {
+      frame = null
+      const next = countNodes()
+      setCounts((prev) => (sameCounts(prev, next) ? prev : next))
+    }
+    const schedule = () => {
+      if (frame === null) frame = requestAnimationFrame(recount)
+    }
+    const observer = new MutationObserver(schedule)
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'data-ui'],
+    })
+    schedule()
+    return () => {
+      observer.disconnect()
+      if (frame !== null) cancelAnimationFrame(frame)
+    }
+  }, [open])
+
+  const total = counts
+    ? STYLE_SYSTEMS.reduce((sum, system) => sum + (counts.get(system.id) ?? 0), 0)
+    : 0
+  const toggleOpen = () => setState((prev) => ({...prev, open: !prev.open}))
+  const toggleSystem = (id: StyleSystemId) =>
+    setState((prev) => ({...prev, active: toggleId(prev.active, id)}))
+
+  return (
+    <div className={root} data-testid="style-outline">
+      {open ? (
+        <fieldset className={panel} aria-label="Style outline" data-testid="style-outline-panel">
+          <div className={header}>
+            <span>Style outline</span>
+            <button
+              type="button"
+              className={collapse}
+              aria-label="Hide style outline"
+              onClick={toggleOpen}
+              data-testid="style-outline-collapse"
+            >
+              ×
+            </button>
+          </div>
+          {STYLE_SYSTEMS.map((system) => (
+            <label key={system.id} className={row}>
+              <span className={dot} style={{background: system.color}} />
+              <span className={rowLabel}>{system.label}</span>
+              <span className={rowCount}>{formatCount(counts?.get(system.id), total)}</span>
+              <input
+                type="checkbox"
+                className={checkbox}
+                checked={active.includes(system.id)}
+                onChange={() => toggleSystem(system.id)}
+                style={{accentColor: system.color}}
+                data-testid={`style-outline-toggle-${system.id}`}
+              />
+            </label>
+          ))}
+        </fieldset>
+      ) : (
+        <button
+          type="button"
+          className={trigger}
+          title="Style outline"
+          aria-label="Show style outline"
+          aria-expanded={false}
+          onClick={toggleOpen}
+          data-testid="style-outline-trigger"
+        >
+          {STYLE_SYSTEMS.map((system) => (
+            <span
+              key={system.id}
+              className={dot}
+              style={{background: system.color, opacity: active.includes(system.id) ? 1 : 0.3}}
+            />
+          ))}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/dev/test-studio/plugins/style-outline/plugin.tsx
+++ b/dev/test-studio/plugins/style-outline/plugin.tsx
@@ -1,0 +1,21 @@
+import {definePlugin, type LayoutProps} from 'sanity'
+
+import {StyleOutlinePanel} from './StyleOutlinePanel'
+
+function StyleOutlineLayout(props: LayoutProps) {
+  return (
+    <>
+      {props.renderDefault(props)}
+      <StyleOutlinePanel />
+    </>
+  )
+}
+
+export const styleOutline = definePlugin({
+  name: 'style-outline',
+  studio: {
+    components: {
+      layout: StyleOutlineLayout,
+    },
+  },
+})

--- a/dev/test-studio/plugins/style-outline/styleOutline.css.ts
+++ b/dev/test-studio/plugins/style-outline/styleOutline.css.ts
@@ -1,0 +1,109 @@
+import {globalStyle, style} from '@vanilla-extract/css'
+
+import {STYLE_OUTLINE_ATTRIBUTE, STYLE_SYSTEMS} from './styleSystems'
+
+for (const {id, color, selector} of STYLE_SYSTEMS) {
+  globalStyle(`html[${STYLE_OUTLINE_ATTRIBUTE}~="${id}"] ${selector}`, {
+    outline: `1px solid ${color} !important`,
+    outlineOffset: '-1px',
+  })
+}
+
+const glass = style({
+  background: 'rgba(18, 18, 22, 0.92)',
+  backdropFilter: 'blur(12px)',
+  border: '1px solid rgba(255, 255, 255, 0.1)',
+  boxShadow: '0 8px 24px rgba(0, 0, 0, 0.35)',
+})
+
+export const root = style({
+  position: 'fixed',
+  bottom: 12,
+  left: 12,
+  zIndex: 10000,
+  fontSize: 13,
+  fontWeight: 500,
+  lineHeight: 1.4,
+  colorScheme: 'dark',
+})
+
+export const trigger = style([
+  glass,
+  {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 3,
+    width: 36,
+    height: 36,
+    padding: 0,
+    borderRadius: '50%',
+    cursor: 'pointer',
+  },
+])
+
+export const panel = style([
+  glass,
+  {
+    margin: 0,
+    borderRadius: 12,
+    padding: '12px 14px',
+    minWidth: 260,
+    color: '#ececf1',
+  },
+])
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 10,
+  marginBottom: 4,
+})
+
+export const collapse = style({
+  'font': 'inherit',
+  'fontSize': 16,
+  'lineHeight': 1,
+  'padding': '2px 6px',
+  'border': 0,
+  'borderRadius': 6,
+  'background': 'transparent',
+  'color': 'inherit',
+  'cursor': 'pointer',
+  ':hover': {
+    background: 'rgba(255, 255, 255, 0.08)',
+  },
+})
+
+export const row = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  padding: '6px 0',
+  cursor: 'pointer',
+})
+
+export const dot = style({
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  flexShrink: 0,
+})
+
+export const rowLabel = style({
+  flex: 1,
+})
+
+export const rowCount = style({
+  fontVariantNumeric: 'tabular-nums',
+  fontSize: 12,
+  color: 'rgba(236, 236, 241, 0.55)',
+})
+
+export const checkbox = style({
+  width: 16,
+  height: 16,
+  margin: 0,
+  cursor: 'pointer',
+})

--- a/dev/test-studio/plugins/style-outline/styleOutline.css.ts
+++ b/dev/test-studio/plugins/style-outline/styleOutline.css.ts
@@ -54,25 +54,18 @@ export const panel = style([
 ])
 
 export const header = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 10,
-  marginBottom: 4,
-})
-
-export const collapse = style({
+  'display': 'block',
+  'width': '100%',
   'font': 'inherit',
-  'fontSize': 16,
-  'lineHeight': 1,
-  'padding': '2px 6px',
+  'fontWeight': 600,
+  'textAlign': 'left',
+  'padding': '2px 0 8px',
   'border': 0,
-  'borderRadius': 6,
   'background': 'transparent',
   'color': 'inherit',
   'cursor': 'pointer',
   ':hover': {
-    background: 'rgba(255, 255, 255, 0.08)',
+    color: '#ffffff',
   },
 })
 
@@ -106,4 +99,5 @@ export const checkbox = style({
   height: 16,
   margin: 0,
   cursor: 'pointer',
+  accentColor: '#5e6ad2',
 })

--- a/dev/test-studio/plugins/style-outline/styleSystems.ts
+++ b/dev/test-studio/plugins/style-outline/styleSystems.ts
@@ -1,0 +1,38 @@
+export type StyleSystemId = 'ui5' | 'ui4' | 'styled'
+
+export interface StyleSystem {
+  id: StyleSystemId
+  label: string
+  color: string
+  selector: string
+}
+
+interface Fingerprint extends Omit<StyleSystem, 'selector'> {
+  match: string
+}
+
+// Ordered by precedence: a node belongs to the first fingerprint it matches, so a
+// `styled(ui5Box)` counts as ui5 and a `styled(ui4Card)` counts as ui4.
+const FINGERPRINTS: readonly Fingerprint[] = [
+  {id: 'ui5', label: 'ui5', color: '#22d3ee', match: '[class^="sui-"], [class*=" sui-"]'},
+  {id: 'ui4', label: '@sanity/ui v4', color: '#f5a524', match: '[data-ui]'},
+  {
+    id: 'styled',
+    label: 'styled-components',
+    color: '#ff4fa3',
+    // Prebuilt studio bundles emit `<Name>-sc-<hash>` ids; `sanity dev` resolves the studio from
+    // source without the styled-components transform, so ids are bare `sc-<hash>` tokens.
+    match: '[class*="-sc-"], [class^="sc-"], [class*=" sc-"]',
+  },
+]
+
+export const STYLE_SYSTEMS: readonly StyleSystem[] = FINGERPRINTS.map(
+  ({match, ...system}, index) => {
+    const preceding = FINGERPRINTS.slice(0, index).map((other) => other.match)
+    const exclusions = preceding.length > 0 ? `:not(${preceding.join(', ')})` : ''
+    return {...system, selector: `:is(${match})${exclusions}`}
+  },
+)
+
+export const STYLE_OUTLINE_ATTRIBUTE = 'data-style-outline'
+export const STYLE_OUTLINE_STORAGE_KEY = 'sanity-test-studio:style-outline'

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -47,6 +47,7 @@ import {autoCloseBrackets} from './plugins/input/auto-close-brackets-plugin'
 import {wave} from './plugins/input/wave-plugin'
 import {languageFilter} from './plugins/language-filter/plugin'
 import {routerDebugTool} from './plugins/router-debug/plugin'
+import {styleOutline} from './plugins/style-outline/plugin'
 import {useArchiveAndDeleteCustomAction} from './releases/customReleaseActions'
 import {createSchemaTypes} from './schema'
 import {StegaDebugger} from './schema/debug/components/DebugStega'
@@ -262,6 +263,7 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       }),
       themerTool(),
       routerDebugTool(),
+      styleOutline(),
       formBuilderReproTool(),
       errorReportingTestPlugin(),
       media(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`dev/test-studio` gets a floating "Style outline" panel, fixed bottom-left in every workspace. It has a text-only header and three rows, one per styling system, each with a colored dot, a label, a live node count with its share of the classified DOM, and a checkbox. Checking a row draws a 1px outline around every node that system owns, borders only, no labels. ui5 is cyan, @sanity/ui v4 is amber, and the studio's own leftover styled-components are pink. Checked boxes fill periwinkle with a white check. Rows toggle independently and instantly. State survives reloads through `localStorage`. Clicking the header collapses the panel to a three-dot trigger that keeps the outlines on and shows which systems are active.

Inspired by Kenneth Skovhus's styled-components to StyleX demo: https://x.com/kenneth_skovhus/status/2071566843492417540

How it works. `styleSystems.ts` holds one ordered table, `STYLE_SYSTEMS`. Each entry has a DOM fingerprint. ui5 is a `sui-` class token, ui4 is a `data-ui` attribute, and styled-components is a `-sc-` or `sc-` class token. The table derives each selector as `:is(<fingerprint>):not(<all preceding fingerprints>)`, so a node belongs to the first system it matches and the three counts partition the DOM. `styleOutline.css.ts` turns the table into three `globalStyle` rules keyed on `html[data-style-outline~="<id>"]`. The panel only flips that attribute, so re-renders and body-level portals need no observer for the outlines. A `MutationObserver` exists only for the counts, coalesced to one `querySelectorAll` pass per animation frame while the panel is open.

Tradeoffs.

- A layout middleware (`studio.components.layout`) instead of a Tool. A Tool replaces the active tool's content, so it cannot float over Structure or Presentation. The middleware wraps every workspace that uses `sharedSettings`, including `custom-components`, where it stacks with `CustomLayout`.
- Plain HTML plus vanilla-extract for the panel. Any @sanity/ui, ui5 or styled-components markup inside it would match its own detectors and outline itself. The constraint is loud at runtime rather than lint-enforced.
- Under `sanity dev` the studio resolves from source, so its styled-components ids are bare `sc-<hash>` tokens rather than the `<Name>-sc-<hash>` shape of prebuilt bundles. The styled fingerprint matches both.
- Studio components that set their own `data-ui`, such as pane headers and timeline items, count as ui4. The issue defines ui4 the same way. Keep it in mind when you read the numbers.

### What to review

- `dev/test-studio/plugins/style-outline/styleSystems.ts` for the fingerprints and the precedence order.
- `dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx` for the `localStorage` parsing and the count observer.
- `dev/test-studio/sanity.config.ts` registers `styleOutline()` in `sharedSettings`, so every workspace shows the trigger. Nothing in `packages/*` changes.

### Testing

No unit test project covers `dev/test-studio`. Verified against the dev studio started with `pnpm dev:test-studio:studio`, using a throwaway Playwright script on `/test/structure/author` with a document open.

- The partition is exact. 4,564 nodes match some fingerprint and 0 match two. Counts are 837 ui5, 3,384 ui4, and 343 styled.
- Each toggle outlines exactly its count in its color. The script reads the computed `outline` of every element. 0 outlined elements sit inside the panel.
- The header is a text-only `<button>` with `aria-expanded`. Checked boxes compute to `accent-color: rgb(94, 106, 210)`.
- The `data-style-outline` attribute reflects the active set in registry order and disappears when nothing is on.
- State persists across a reload. The panel renders in the `custom-components` workspace. The panel reads well in the light color scheme.
- `oxfmt --check` passes on the changed files. `oxlint --disable-nested-config`, which includes type checking, passes on them. `knip --dependencies` reports only the pre-existing `lefthook` baseline.
- A jsdom check confirms the derived selectors equal the hand-written ones and classify fixture nodes as expected.

[Panel close-up with all three toggled](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_panel_closeup_all_on.png)
[Panel open with live counts, nothing toggled](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_panel_open_nothing_on.png)
[ui5 toggled, cyan outlines](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_ui5_cyan.png)
[@sanity/ui v4 toggled, amber outlines](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_ui4_amber.png)
[styled-components toggled, pink outlines](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_styled_components_pink.png)
[All three toggled](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_all_three_on.png)
[Collapsed trigger with ui5 still on](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_collapsed_trigger_ui5_on.png)

[style_outline_v2_demo_sequence_walkthrough.mp4](https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v2_demo_sequence_walkthrough.mp4)

### Notes for release

N/A: Internal only, `dev/test-studio`.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11798067-4f03-433b-be0b-65e9074b48b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11798067-4f03-433b-be0b-65e9074b48b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

