### PR TITLE
fix(util): combine abort signals without AbortSignal.any in the concurrency limiter

### DIFF
--- a/packages/@sanity/util/src/client/concurrency-limiter/__test__/anySignal.test.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/__test__/anySignal.test.ts
@@ -1,0 +1,77 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {anySignal} from '../anySignal'
+import {withoutAbortSignalAny} from './withoutAbortSignalAny'
+
+describe('anySignal', () => {
+  it('uses the native AbortSignal.any when it is available', () => {
+    const nativeAny = vi.spyOn(AbortSignal, 'any')
+    const first = new AbortController()
+    const second = new AbortController()
+    const reason = new Error('cancelled')
+
+    const combined = anySignal([first.signal, second.signal])
+    second.abort(reason)
+
+    expect(nativeAny).toHaveBeenCalledExactlyOnceWith([first.signal, second.signal])
+    expect(combined.aborted).toBe(true)
+    expect(combined.reason).toBe(reason)
+  })
+
+  describe('without a native AbortSignal.any', () => {
+    withoutAbortSignalAny()
+
+    it('runs against an environment without AbortSignal.any', () => {
+      expect(AbortSignal.any).toBeUndefined()
+    })
+
+    it('aborts with the reason of the first signal to abort', () => {
+      const first = new AbortController()
+      const second = new AbortController()
+      const reason = new Error('cancelled')
+
+      const combined = anySignal([first.signal, second.signal])
+      expect(combined.aborted).toBe(false)
+
+      second.abort(reason)
+      expect(combined.aborted).toBe(true)
+      expect(combined.reason).toBe(reason)
+
+      first.abort(new Error('too late'))
+      expect(combined.reason).toBe(reason)
+    })
+
+    it('is already aborted when one of the signals has already aborted', () => {
+      const reason = new Error('cancelled')
+      const pending = new AbortController()
+      const addEventListener = vi.spyOn(pending.signal, 'addEventListener')
+
+      const combined = anySignal([pending.signal, AbortSignal.abort(reason)])
+
+      expect(combined.aborted).toBe(true)
+      expect(combined.reason).toBe(reason)
+      expect(addEventListener).not.toHaveBeenCalled()
+    })
+
+    it('stops listening to the remaining signals once it has aborted', () => {
+      const first = new AbortController()
+      const second = new AbortController()
+      const removeEventListener = vi.spyOn(second.signal, 'removeEventListener')
+
+      anySignal([first.signal, second.signal])
+      first.abort()
+
+      expect(removeEventListener).toHaveBeenCalledExactlyOnceWith('abort', expect.any(Function))
+    })
+
+    it('does not abort the source signals', () => {
+      const first = new AbortController()
+      const second = new AbortController()
+
+      anySignal([first.signal, second.signal])
+      first.abort()
+
+      expect(second.signal.aborted).toBe(false)
+    })
+  })
+})

--- a/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/__test__/createClientConcurrencyLimiter.test.ts
@@ -5,6 +5,7 @@ import {firstValueFrom, from, NEVER, Observable, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createClientConcurrencyLimiter} from '../createClientConcurrencyLimiter'
+import {withoutAbortSignalAny} from './withoutAbortSignalAny'
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -281,5 +282,103 @@ describe('createConcurrencyLimitedClient', () => {
     await expect(result).rejects.toBe(reason)
     expect(fetchController.signal.aborted).toBe(false)
     expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  // Safari 17.3 and older browsers do not implement `AbortSignal.any`, which the limiter used to
+  // call whenever a fetch carried a signal.
+  describe('without a native AbortSignal.any', () => {
+    withoutAbortSignalAny()
+
+    it('runs an Observable fetch that carries a signal', async () => {
+      const controller = new AbortController()
+      const mockClient = {
+        observable: {fetch: vi.fn(() => of('result'))},
+      } as unknown as SanityClient
+      const client = createClientConcurrencyLimiter(1)(mockClient)
+
+      await expect(
+        firstValueFrom(client.observable.fetch('query', {}, {signal: controller.signal})),
+      ).resolves.toBe('result')
+      expect(mockClient.observable.fetch).toHaveBeenCalledExactlyOnceWith(
+        'query',
+        {},
+        {signal: controller.signal},
+      )
+    })
+
+    it('does not start a queued Observable fetch after its signal is aborted', async () => {
+      const mockClient = {
+        observable: {fetch: vi.fn(() => NEVER)},
+      } as unknown as SanityClient
+      const client = createClientConcurrencyLimiter(1)(mockClient)
+      const controller = new AbortController()
+      const reason = new Error('cancelled')
+
+      const active = client.observable.fetch('active').subscribe()
+      const queued = firstValueFrom(
+        client.observable.fetch('queued', {}, {signal: controller.signal}),
+      )
+      await tick()
+      controller.abort(reason)
+
+      await expect(queued).rejects.toBe(reason)
+      expect(mockClient.observable.fetch).toHaveBeenCalledExactlyOnceWith('active')
+      active.unsubscribe()
+    })
+
+    it('combines a default signal with a fetch signal', async () => {
+      const defaultController = new AbortController()
+      const fetchController = new AbortController()
+      const reason = new Error('validation cancelled')
+      const mockClient = {
+        fetch: vi.fn(
+          (_query: string, _params: object, {signal}: {signal: AbortSignal}) =>
+            new Promise((_resolve, reject) => {
+              signal.addEventListener('abort', () => reject(signal.reason), {once: true})
+            }),
+        ),
+      } as unknown as SanityClient
+      const client = createClientConcurrencyLimiter(1, defaultController.signal)(mockClient)
+      const result = client.fetch('query', {}, {signal: fetchController.signal})
+      await vi.waitFor(() => expect(mockClient.fetch).toHaveBeenCalledOnce())
+
+      fetchController.abort(reason)
+
+      await expect(result).rejects.toBe(reason)
+      expect(defaultController.signal.aborted).toBe(false)
+    })
+
+    it('combines a default signal with an Observable fetch signal', async () => {
+      const defaultController = new AbortController()
+      const fetchController = new AbortController()
+      const reason = new Error('validation cancelled')
+      const unsubscribe = vi.fn()
+      const mockClient = {
+        observable: {
+          fetch: vi.fn(
+            (_query: string, _params: object, {signal}: {signal: AbortSignal}) =>
+              new Observable((subscriber) => {
+                const onAbort = () => subscriber.error(signal.reason)
+                signal.addEventListener('abort', onAbort, {once: true})
+                return () => {
+                  signal.removeEventListener('abort', onAbort)
+                  unsubscribe()
+                }
+              }),
+          ),
+        },
+      } as unknown as SanityClient
+      const client = createClientConcurrencyLimiter(1, defaultController.signal)(mockClient)
+      const result = firstValueFrom(
+        client.observable.fetch('query', {}, {signal: fetchController.signal}),
+      )
+      await vi.waitFor(() => expect(mockClient.observable.fetch).toHaveBeenCalledOnce())
+
+      defaultController.abort(reason)
+
+      await expect(result).rejects.toBe(reason)
+      expect(fetchController.signal.aborted).toBe(false)
+      expect(unsubscribe).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/packages/@sanity/util/src/client/concurrency-limiter/__test__/withoutAbortSignalAny.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/__test__/withoutAbortSignalAny.ts
@@ -1,0 +1,25 @@
+import {afterEach, beforeEach} from 'vitest'
+
+/**
+ * Removes `AbortSignal.any` for the duration of each test in the enclosing `describe`, the way
+ * Safari 17.3 and older browsers behave, and restores the native implementation afterwards.
+ */
+export function withoutAbortSignalAny(): void {
+  const native = Object.getOwnPropertyDescriptor(AbortSignal, 'any')
+
+  beforeEach(() => {
+    Object.defineProperty(AbortSignal, 'any', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+  })
+
+  afterEach(() => {
+    if (native) {
+      Object.defineProperty(AbortSignal, 'any', native)
+    } else {
+      Reflect.deleteProperty(AbortSignal, 'any')
+    }
+  })
+}

--- a/packages/@sanity/util/src/client/concurrency-limiter/anySignal.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/anySignal.ts
@@ -1,0 +1,32 @@
+/**
+ * Returns a signal that aborts, with the same reason, as soon as any of the given signals aborts.
+ *
+ * This is `AbortSignal.any()`, which Safari only implements from 17.4 (March 2024). Studio
+ * requests that pass a signal through the concurrency limiter would otherwise throw a `TypeError`
+ * in the browsers just below that line, so the native implementation is used when present and the
+ * signals are composed manually when it is not.
+ */
+export function anySignal(signals: AbortSignal[]): AbortSignal {
+  if (typeof AbortSignal.any === 'function') return AbortSignal.any(signals)
+
+  const controller = new AbortController()
+  const abortedSignal = signals.find((signal) => signal.aborted)
+  if (abortedSignal) {
+    controller.abort(abortedSignal.reason)
+    return controller.signal
+  }
+
+  // Once the combined signal has aborted, the listeners would only keep it alive for as long as
+  // the source signals live, so they are removed as soon as they have served their purpose.
+  const removeListeners: Array<() => void> = []
+  const abort = (reason: unknown) => {
+    for (const removeListener of removeListeners) removeListener()
+    controller.abort(reason)
+  }
+  for (const signal of signals) {
+    const onAbort = () => abort(signal.reason)
+    signal.addEventListener('abort', onAbort)
+    removeListeners.push(() => signal.removeEventListener('abort', onAbort))
+  }
+  return controller.signal
+}

--- a/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
+++ b/packages/@sanity/util/src/client/concurrency-limiter/createClientConcurrencyLimiter.ts
@@ -2,12 +2,13 @@ import {type ObservableSanityClient, type SanityClient} from '@sanity/client'
 import {defer, finalize, Observable, switchMap} from 'rxjs'
 
 import {ConcurrencyLimiter} from '../../concurrency-limiter'
+import {anySignal} from './anySignal'
 
 function acquireSlot(limiter: ConcurrencyLimiter, signal?: AbortSignal): Observable<() => void> {
   return new Observable((subscriber) => {
     const subscriptionController = new AbortController()
     const waitSignal = signal
-      ? AbortSignal.any([signal, subscriptionController.signal])
+      ? anySignal([signal, subscriptionController.signal])
       : subscriptionController.signal
 
     void limiter.ready(waitSignal).then(
@@ -56,7 +57,7 @@ export function createClientConcurrencyLimiter(
   function resolveSignal(signal?: AbortSignal): AbortSignal | undefined {
     if (!defaultSignal || defaultSignal === signal) return signal || defaultSignal
     if (!signal) return defaultSignal
-    return AbortSignal.any([defaultSignal, signal])
+    return anySignal([defaultSignal, signal])
   }
 
   function wrapClient(client: SanityClient): SanityClient {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Studio-side part of [SAPP-4426](https://linear.app/sanity/issue/SAPP-4426/structure-tool-crashes-in-safari-173-when-concurrency-limiter-calls). `createClientConcurrencyLimiter` (from #14307, not released yet) called `AbortSignal.any()` whenever a fetch carried a signal. Safari only implements that method from 17.4, so on 17.3 every limited fetch with a signal threw `TypeError: AbortSignal.any is not a function` in the middle of a validation run. Both call sites now go through `anySignal()`, which uses the native method when present and otherwise composes the signals with an `AbortController`: it aborts with the first source's reason and detaches its listeners once fired, so long-lived source signals do not keep the composite alive.

Why not a global polyfill: `sanity` is a library consumed by Next.js apps, the repo's precedent is ponyfills (`promiseWithResolvers`), and the browserslist is `baseline 2024`, which already excludes Safari 17.3. A small helper keeps this code correct there without changing the support policy.

Not fixed here: the crash the customer actually hit on 6.11.0. None of the `AbortSignal.any` calls in this repo were released (checked `v6.11.0` and `v6.12.0`). Their `AbortSignal.any([a,e.signal])` is `get-it` 9's `buildFetchArgs` (`signal ? AbortSignal.any([signal, totalController.signal]) : totalController.signal`), reached through `@sanity/client` 8 whenever the studio passes a `signal` to a request. That matches the diagnostics in the ticket: the four probes that pass a signal through the client failed, the plain-`fetch` probe passed. `@sanity/client` 8 has the same pattern in `_observe()` and `defineRequester()`. Those need the same treatment in sanity-io/get-it and sanity-io/client followed by a dependency bump here, or a deliberate decision to polyfill or show a notice for browsers below the Baseline 2024 floor.

### What to review

- `packages/@sanity/util/src/client/concurrency-limiter/anySignal.ts`: fallback semantics (already-aborted input, reason propagation, listener cleanup).
- `createClientConcurrencyLimiter.ts`: two one-line call-site swaps.
- Only `@sanity/util` changes; `@sanity/validation` is the consumer and is untouched.

### Testing

- New `anySignal.test.ts` covers the native path and the fallback: reason of the first signal to abort, already-aborted input, listener removal after abort, source signals untouched.
- `createClientConcurrencyLimiter.test.ts` gains a `without a native AbortSignal.any` block that re-runs the signal-carrying scenarios with `AbortSignal.any` removed. Against the previous code these four tests fail with the customer's exact `TypeError: AbortSignal.any is not a function`.
- `pnpm --filter @sanity/util build`, the full `@sanity/util` and `@sanity/validation` suites (validation with `TZ=America/Los_Angeles`, see AGENTS.md), oxfmt, and type-aware oxlint on the changed files all pass.

### Notes for release

N/A – Fixes an unreleased change (#14307); shipped studios are unaffected.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C043ZRB9E4S/p1788452111998109?thread_ts=1788452111.998109&cid=C043ZRB9E4S)

<div><a href="https://cursor.com/agents/bc-5765ade0-16ca-560d-b9e0-96032ac1c4a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5765ade0-16ca-560d-b9e0-96032ac1c4a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

