### PR TITLE
refactor(sanity): move target scope selector to reusable React hook

### DIFF
--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -941,6 +941,7 @@ export {
   type TargetDocumentState,
   useTargetDocumentState,
 } from '../core/hooks/useTargetDocumentState'
+export {type TargetScopeIdOptions, useTargetScopeId} from '../core/hooks/useTargetScopeId'
 export {useTemplates} from '../core/hooks/useTemplates'
 // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
 export {type TimeAgoOpts, useTimeAgo} from '../core/hooks/useTimeAgo'

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -33,20 +33,18 @@ import {useSchema} from '../hooks/useSchema'
 import {
   getCreatableVariantTarget,
   getPairTarget,
-  getTargetScopeId,
   getTargetSiblings,
   useTargetDocumentState,
 } from '../hooks/useTargetDocumentState'
+import {useTargetScopeId} from '../hooks/useTargetScopeId'
 import {useValidationStatus} from '../hooks/useValidationStatus'
 import {getSelectedPerspective} from '../perspective/getSelectedPerspective'
 import {type ReleaseId} from '../perspective/types'
 import {usePerspective} from '../perspective/usePerspective'
 import {useDocumentVersions} from '../releases/hooks/useDocumentVersions'
-import {useDocumentVersionTypeSortedList} from '../releases/hooks/useDocumentVersionTypeSortedList'
 import {useOnlyHasVersions} from '../releases/hooks/useOnlyHasVersions'
 import {isReleaseDocument} from '../releases/store/types'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
-import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
 import {isGoingToUnpublish} from '../releases/util/isGoingToUnpublish'
 import {isPublishedPerspective, isReleaseScheduledOrScheduling} from '../releases/util/util'
 import {usePresenceStore} from '../store/datastores'
@@ -174,11 +172,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   const schema = useSchema()
   const presenceStore = usePresenceStore()
   const {data: releases} = useActiveReleases()
-  const {
-    data: documentVersions,
-    versions: documentVersionStubs,
-    loading: documentVersionsLoading,
-  } = useDocumentVersions({
+  const {versions: documentVersionStubs, loading: documentVersionsLoading} = useDocumentVersions({
     documentId,
   })
   const {selectedVariantName, bundle} = usePerspective()
@@ -198,56 +192,9 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
   const telemetry = useTelemetry()
 
-  // if it only has versions then we need to make sure that whatever the first document that is allowed
-  // is a version document, but also that it has the right order
-  // this will make sure that then the right document appears and so does the right chip within the document header
-  const {sortedDocumentList} = useDocumentVersionTypeSortedList({documentId})
   const onlyHasVersions = useOnlyHasVersions({documentId})
-  const firstVersion =
-    sortedDocumentList.length > 0
-      ? documentVersions.find(
-          (id) =>
-            getVersionFromId(id) === getReleaseIdFromReleaseDocumentId(sortedDocumentList[0]._id),
-        )
-      : undefined
 
-  // The bundle segment for the pair checkout (`useEditState` & co.). Variant targets use the
-  // stub-resolved opaque scope id exclusively: a missing/unresolved variant target must never
-  // fall back to another document (ops stay guarded, the form stays read-only). Non-variant
-  // targets keep the deterministic release derivation with its fallbacks — a release version id
-  // is derivable, so new documents under a release must check out the version pair for typing to
-  // create the release version (not the base draft), and documents that only have versions must
-  // check out their first version to display it.
-  const targetScopeId = useMemo(() => {
-    if (selectedVariantName) {
-      // The scope of the resolved target document (release id for release targets, opaque scope hash
-      // for variant targets), threaded through the version-editing pipeline. Undefined while the
-      // target is resolving or when the base draft/published pair applies.
-      return getTargetScopeId(targetDocumentState)
-    }
-    if (isSystemBundle(selectedPerspectiveName)) {
-      return undefined
-    }
-    // if a document version exists with the selected release id, then it should use that
-    if (documentVersions.some((id) => getVersionFromId(id) === selectedPerspectiveName)) {
-      return selectedPerspectiveName
-    }
-
-    // check if the selected version is the only version, if it isn't and it doesn't exist in the release
-    // then it needs to use the documentVersions
-    if (selectedPerspectiveName && (!documentVersions.length || !onlyHasVersions)) {
-      return selectedPerspectiveName
-    }
-
-    return getVersionFromId(firstVersion ?? '')
-  }, [
-    selectedVariantName,
-    targetDocumentState,
-    documentVersions,
-    onlyHasVersions,
-    selectedPerspectiveName,
-    firstVersion,
-  ])
+  const targetScopeId = useTargetScopeId({documentId, selectedPerspectiveName})
 
   const editState = useEditState(documentId, documentType, 'default', targetScopeId)
 

--- a/packages/sanity/src/core/hooks/useTargetScopeId.ts
+++ b/packages/sanity/src/core/hooks/useTargetScopeId.ts
@@ -1,0 +1,94 @@
+import {useMemo} from 'react'
+
+import {type ReleaseId} from '../perspective/types'
+import {usePerspective} from '../perspective/usePerspective'
+import {useDocumentVersions} from '../releases/hooks/useDocumentVersions'
+import {useDocumentVersionTypeSortedList} from '../releases/hooks/useDocumentVersionTypeSortedList'
+import {useOnlyHasVersions} from '../releases/hooks/useOnlyHasVersions'
+import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
+import {getVersionFromId, isSystemBundle} from '../util/draftUtils'
+import {getTargetScopeId, useTargetDocumentState} from './useTargetDocumentState'
+
+/**
+ * @internal
+ */
+export interface TargetScopeIdOptions {
+  /** The document group id (published id) the pair is checked out for. */
+  documentId: string
+  /**
+   * The perspective the consumer is displaying, which is not necessarily the
+   * globally selected one (e.g. a diff view pane pins its own).
+   */
+  selectedPerspectiveName?: ReleaseId | 'published'
+}
+
+/**
+ * The bundle segment for the pair checkout (`useEditState` & co.) of a document
+ * group under the given perspective.
+ *
+ * Variant targets use the stub-resolved opaque scope id exclusively: a
+ * missing/unresolved variant target must never fall back to another document
+ * (ops stay guarded, the form stays read-only). Non-variant targets keep the
+ * deterministic release derivation with its fallbacks — a release version id is
+ * derivable, so new documents under a release must check out the version pair
+ * for typing to create the release version (not the base draft), and documents
+ * that only have versions must check out their first version to display it.
+ *
+ * @internal
+ */
+export function useTargetScopeId(options: TargetScopeIdOptions): string | undefined {
+  const {documentId, selectedPerspectiveName} = options
+
+  const {data: documentVersions} = useDocumentVersions({documentId})
+  const {selectedVariantName} = usePerspective()
+  const targetDocumentState = useTargetDocumentState(documentId)
+  const onlyHasVersions = useOnlyHasVersions({documentId})
+
+  // if it only has versions then we need to make sure that whatever the first
+  // document that is allowed is a version document, but also that it has the
+  // right order this will make sure that then the right document appears and so
+  // does the right chip within the document header
+  const {sortedDocumentList} = useDocumentVersionTypeSortedList({documentId})
+  const firstVersion =
+    sortedDocumentList.length > 0
+      ? documentVersions.find(
+          (id) =>
+            getVersionFromId(id) === getReleaseIdFromReleaseDocumentId(sortedDocumentList[0]._id),
+        )
+      : undefined
+
+  return useMemo(() => {
+    if (selectedVariantName) {
+      // The scope of the resolved target document (release id for release
+      // targets, opaque scope hash for variant targets), threaded through the
+      // version-editing pipeline. Undefined while the target is resolving or
+      // when the base draft/published pair applies.
+      return getTargetScopeId(targetDocumentState)
+    }
+
+    if (isSystemBundle(selectedPerspectiveName)) {
+      return undefined
+    }
+
+    // if a document version exists with the selected release id, then it should
+    // use that
+    if (documentVersions.some((id) => getVersionFromId(id) === selectedPerspectiveName)) {
+      return selectedPerspectiveName
+    }
+
+    // check if the selected version is the only version, if it isn't and it
+    // doesn't exist in the release then it needs to use the documentVersions
+    if (selectedPerspectiveName && (!documentVersions.length || !onlyHasVersions)) {
+      return selectedPerspectiveName
+    }
+
+    return getVersionFromId(firstVersion ?? '')
+  }, [
+    selectedVariantName,
+    targetDocumentState,
+    documentVersions,
+    onlyHasVersions,
+    selectedPerspectiveName,
+    firstVersion,
+  ])
+}

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -718,6 +718,7 @@ exports[`exports snapshot 1`] = `
     "useStudioUrl": "function",
     "useSyncState": "function",
     "useTargetDocumentState": "function",
+    "useTargetScopeId": "function",
     "useTelemetryConsent": "function",
     "useTemplatePermissions": "function",
     "useTemplatePermissionsFromHookFactory": "function",


### PR DESCRIPTION
### Description

This branch simply moves the target scope id selection logic to a reusable `useTargetScopeId` React hook.

### What to review

The code moved into `useTargetScopeId`.

### Testing

Existing tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical move of existing logic with no intended behavior change; risk is limited to subtle regressions in document pair checkout if the extraction missed a dependency.
> 
> **Overview**
> Extracts **target scope id** selection (which document pair `useEditState`, connection, and sync hooks check out under releases, variants, and version-only documents) from `useDocumentForm` into a dedicated **`useTargetScopeId`** hook.
> 
> `useDocumentForm` now calls `useTargetScopeId({ documentId, selectedPerspectiveName })` instead of inlining the `useMemo` and related release/version hooks. The moved logic is unchanged, including variant-only scope resolution via `getTargetScopeId`, system-bundle handling, and fallbacks for version-only document groups.
> 
> **`useTargetScopeId`** and **`TargetScopeIdOptions`** are added to the public `sanity` package exports (marked `@internal`) so other consumers—e.g. diff panes that pin a perspective—can reuse the same checkout rules without duplicating the form hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d00b293a8c8bec89d00b5dc9315dc2a67a1f35d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->