### PR TITLE
feat(structure): keep panes when creating from a nested pane

### DIFF
--- a/packages/sanity/src/structure/getIntentState.test.ts
+++ b/packages/sanity/src/structure/getIntentState.test.ts
@@ -1,10 +1,14 @@
 import {beforeEach, describe, expect, it} from 'vitest'
 
 import {getIntentState, setActivePanes} from './getIntentState'
-import {type PaneNode} from './types'
+import {type PaneNode, type RouterPanes} from './types'
 
 describe('getIntentState', () => {
   beforeEach(() => setActivePanes([]))
+
+  // `StructureTool` reports the implicit root pane first, so active pane
+  // indexes always sit one ahead of the router panes.
+  const rootPane = {id: 'root', type: 'list'} as unknown as PaneNode
 
   it('preserves the `path` param when an open documentList pane handles an edit intent', () => {
     // An active documentList pane that can resolve the edit intent for type "post".
@@ -46,5 +50,303 @@ describe('getIntentState', () => {
   it('falls back to intent resolution when no open pane can handle it', () => {
     const result = getIntentState('edit', {id: 'doc1', type: 'post'}, {panes: []}, undefined)
     expect(result).toEqual({intent: 'edit', params: {id: 'doc1', type: 'post'}, payload: undefined})
+  })
+
+  describe('keepPanesOnCreate', () => {
+    // Panes that refuse every intent, which is what a nested structure looks
+    // like: `documentTypeList().child()` swaps the default handler for
+    // `shallowIntentChecker`, which answers only for panes at index 0 or 1.
+    const declining = {canHandleIntent: () => false}
+
+    // The auto "+" affordance a `documentList` gets from its templates.
+    const subpagesPane = (parentId: string) =>
+      ({
+        ...declining,
+        id: `subpages-${parentId}`,
+        type: 'documentList',
+        schemaTypeName: 'page',
+        options: {filter: '_type == "page" && parent._ref == $parentId'},
+        initialValueTemplates: [
+          {
+            type: 'initialValueTemplateItem',
+            id: 'page-with-parent',
+            templateId: 'page-with-parent',
+            parameters: {parentId},
+          },
+        ],
+      }) as unknown as PaneNode
+
+    // The explicit `.menuItems(S.menuItemsFromInitialValueTemplateItems(...))`
+    // affordance, the only way a hand-built `S.list()` can offer a create
+    // action.
+    const pageNodePane = (parentId: string) =>
+      ({
+        ...declining,
+        id: `page-node-${parentId}`,
+        type: 'list',
+        menuItems: [
+          {
+            title: 'New article',
+            intent: {
+              type: 'create',
+              params: [{type: 'article', template: 'article-with-parent'}, {parentId}],
+            },
+          },
+        ],
+      }) as unknown as PaneNode
+
+    const marketPane = {...declining, id: 'market', type: 'list'} as unknown as PaneNode
+    const openDocumentPane = {...declining, id: 'page-2', type: 'document'} as unknown as PaneNode
+
+    const openPanes: RouterPanes = [
+      [{id: 'market'}],
+      [{id: 'page-1'}],
+      [{id: 'subpages'}],
+      [{id: 'page-2'}],
+    ]
+
+    it('opens a template-driven create action as its own pane’s child', () => {
+      setActivePanes([
+        rootPane,
+        marketPane,
+        pageNodePane('page-1'),
+        subpagesPane('page-1'),
+        openDocumentPane,
+      ])
+
+      const result = getIntentState(
+        'create',
+        {id: 'newDoc', type: 'page', template: 'page-with-parent'},
+        {panes: openPanes},
+        {parentId: 'page-1'},
+        true,
+      )
+
+      // The path up to and including the offering pane survives, the pane open
+      // beyond it closes, and the editor becomes the offering pane's child. The
+      // `__edit__` prefix is what keeps that pane's own `child` resolver from
+      // claiming the new document.
+      expect(result).toEqual({
+        panes: [
+          [{id: 'market'}],
+          [{id: 'page-1'}],
+          [{id: 'subpages'}],
+          [
+            {
+              id: '__edit__newDoc',
+              params: {type: 'page', template: 'page-with-parent'},
+              payload: {parentId: 'page-1'},
+            },
+          ],
+        ],
+      })
+    })
+
+    it('recognises a create action offered through pane menu items', () => {
+      setActivePanes([rootPane, marketPane, pageNodePane('page-1')])
+
+      const result = getIntentState(
+        'create',
+        {type: 'article', template: 'article-with-parent'},
+        {panes: openPanes.slice(0, 2)},
+        {parentId: 'page-1'},
+        true,
+      )
+
+      expect('panes' in result).toBe(true)
+      if (!('panes' in result)) return
+      expect(result.panes).toHaveLength(3)
+      const [appended] = result.panes[2]
+      expect(appended.id).toMatch(/^__edit__.+/)
+      expect(appended.params).toEqual({type: 'article', template: 'article-with-parent'})
+    })
+
+    it('picks the pane whose template parameters match the intent, not the deepest', () => {
+      // Every level of a page tree offers the same template and differs only in
+      // its parent id, so the parameters are the only thing distinguishing the
+      // "create" the editor actually clicked from a descendant's.
+      setActivePanes([
+        rootPane,
+        marketPane,
+        subpagesPane('page-1'),
+        marketPane,
+        subpagesPane('page-2'),
+      ])
+
+      const result = getIntentState(
+        'create',
+        {id: 'newDoc', type: 'page', template: 'page-with-parent'},
+        {panes: openPanes},
+        {parentId: 'page-1'},
+        true,
+      )
+
+      expect('panes' in result).toBe(true)
+      if (!('panes' in result)) return
+      // Sliced to the ancestor pane that offers those parameters (active pane
+      // index 2), not to the deeper one carrying `page-2`.
+      expect(result.panes).toHaveLength(3)
+      expect(result.panes[1]).toEqual([{id: 'page-1'}])
+    })
+
+    it('picks the deepest pane when several offer the identical action', () => {
+      setActivePanes([rootPane, subpagesPane('page-1'), marketPane, subpagesPane('page-1')])
+
+      const result = getIntentState(
+        'create',
+        {id: 'newDoc', type: 'page', template: 'page-with-parent'},
+        {panes: openPanes},
+        {parentId: 'page-1'},
+        true,
+      )
+
+      expect('panes' in result).toBe(true)
+      if (!('panes' in result)) return
+      expect(result.panes).toHaveLength(4)
+      expect(result.panes[2]).toEqual([{id: 'subpages'}])
+    })
+
+    it('ignores `initialValueTemplates` on a list pane, which renders no create button', () => {
+      // `S.list()` serializes the field, but `ListPaneHeader` never forwards it
+      // to `PaneHeaderActions`, so there is no button it could have come from.
+      const listPaneWithTemplates = {
+        ...declining,
+        id: 'page-node',
+        type: 'list',
+        initialValueTemplates: [
+          {
+            type: 'initialValueTemplateItem',
+            id: 'page-with-parent',
+            templateId: 'page-with-parent',
+            parameters: {parentId: 'page-1'},
+          },
+        ],
+      } as unknown as PaneNode
+
+      setActivePanes([rootPane, listPaneWithTemplates])
+
+      const result = getIntentState(
+        'create',
+        {id: 'newDoc', type: 'page', template: 'page-with-parent'},
+        {panes: openPanes},
+        {parentId: 'page-1'},
+        true,
+      )
+
+      expect(result).toEqual({
+        intent: 'create',
+        params: {id: 'newDoc', type: 'page', template: 'page-with-parent'},
+        payload: {parentId: 'page-1'},
+      })
+    })
+
+    it('hands over to intent resolution when no open pane offers the action', () => {
+      // The navbar’s own "create new document" reaches this whenever the type
+      // has no list pane open: nothing in the path advertises it, so the
+      // structure-wide search still runs and jumps to where that type belongs.
+      setActivePanes([rootPane, marketPane, pageNodePane('page-1'), subpagesPane('page-1')])
+
+      const result = getIntentState(
+        'create',
+        {id: 'newDoc', type: 'settings', template: 'settings'},
+        {panes: openPanes},
+        undefined,
+        true,
+      )
+
+      expect(result).toEqual({
+        intent: 'create',
+        params: {id: 'newDoc', type: 'settings', template: 'settings'},
+        payload: undefined,
+      })
+    })
+
+    it('hands over to intent resolution when the intent carries no document type', () => {
+      // The fallback editor throws without a type, and `IntentResolver` is the
+      // only place a missing one gets recovered, via the document store.
+      setActivePanes([rootPane, subpagesPane('page-1')])
+
+      const result = getIntentState(
+        'create',
+        {template: 'page-with-parent'},
+        {panes: openPanes},
+        {parentId: 'page-1'},
+        true,
+      )
+
+      expect(result).toEqual({
+        intent: 'create',
+        params: {template: 'page-with-parent'},
+        payload: {parentId: 'page-1'},
+      })
+    })
+
+    it('leaves edit intents to the existing matcher', () => {
+      // Opening an existing document already keeps the panes, so edit intents
+      // that match nothing keep their current behaviour.
+      setActivePanes([rootPane, subpagesPane('page-1')])
+
+      const result = getIntentState(
+        'edit',
+        {id: 'page-9', type: 'page'},
+        {panes: openPanes},
+        undefined,
+        true,
+      )
+
+      expect(result).toEqual({
+        intent: 'edit',
+        params: {id: 'page-9', type: 'page'},
+        payload: undefined,
+      })
+    })
+
+    it('leaves an intent the matcher already handles alone', () => {
+      // A pane that answers the matcher keeps today's routing, plain document
+      // id and all - the new branch is a fallback, not a replacement.
+      setActivePanes([
+        rootPane,
+        {
+          type: 'documentList',
+          schemaTypeName: 'page',
+          options: {filter: '_type == $type'},
+          initialValueTemplates: [
+            {type: 'initialValueTemplateItem', id: 'page', templateId: 'page'},
+          ],
+        } as unknown as PaneNode,
+      ])
+
+      const result = getIntentState(
+        'create',
+        {id: 'newDoc', type: 'page', template: 'page'},
+        {panes: openPanes},
+        undefined,
+        true,
+      )
+
+      expect(result).toEqual({
+        panes: [
+          [{id: 'market'}],
+          [{id: 'newDoc', params: {template: 'page', version: undefined}, payload: undefined}],
+        ],
+      })
+    })
+
+    it('is off by default', () => {
+      setActivePanes([rootPane, marketPane, subpagesPane('page-1')])
+
+      const result = getIntentState(
+        'create',
+        {id: 'newDoc', type: 'page', template: 'page-with-parent'},
+        {panes: openPanes},
+        {parentId: 'page-1'},
+      )
+
+      expect(result).toEqual({
+        intent: 'create',
+        params: {id: 'newDoc', type: 'page', template: 'page-with-parent'},
+        payload: {parentId: 'page-1'},
+      })
+    })
   })
 })

--- a/packages/sanity/src/structure/getIntentState.ts
+++ b/packages/sanity/src/structure/getIntentState.ts
@@ -1,7 +1,9 @@
 import {uuid} from '@sanity/uuid'
+import {dequal} from 'dequal/lite'
 
 import {EMPTY_PARAMS, type LOADING_PANE} from './constants'
-import {type PaneNode, type RouterPanes} from './types'
+import {type BaseIntentParams} from './structureBuilder/Intent'
+import {type PaneNode, type RouterPanes, type RouterPaneSibling} from './types'
 
 const state: {
   activePanes: Array<PaneNode | typeof LOADING_PANE>
@@ -22,6 +24,7 @@ export function getIntentState(
   params: Record<string, string>,
   routerState: {panes?: RouterPanes} | undefined,
   payload: unknown,
+  keepPanesOnCreate?: boolean,
 ): {panes: RouterPanes} | {intent: string; params: Record<string, string>; payload: unknown} {
   const panes = routerState?.panes || []
   const activePanes = state.activePanes || []
@@ -53,9 +56,131 @@ export function getIntentState(
           .concat([[{id: editDocumentId, params: paneParams, payload}]]) as RouterPanes,
       }
     }
+
+    // The intent matcher above declined, yet this pane's own header offers the
+    // very create action being requested. That happens routinely in a nested
+    // structure: `documentTypeList().child()` swaps the default intent handler
+    // for `shallowIntentChecker`, which answers only for panes at index 0 or 1,
+    // so every pane below the second declines. Left alone, the intent falls
+    // through to `resolveIntent`, which searches the whole structure and -
+    // finding no match - replaces the entire pane path with a lone editor, so
+    // the editor loses their place in the tree.
+    //
+    // Since the affordance lives on this pane, this pane's path is where the
+    // document belongs: open it as this pane's child, closing panes beyond it,
+    // exactly as opening an existing document from a list does.
+    if (
+      keepPanesOnCreate &&
+      intent === 'create' &&
+      // The fallback editor cannot render without a type, and `IntentResolver`
+      // is the only place a missing one gets recovered (it asks the document
+      // store, see `ensureDocumentIdAndType`).
+      typeof params.type === 'string' &&
+      params.type.length > 0 &&
+      paneOffersCreateIntent(pane, params, payload)
+    ) {
+      return {
+        panes: [...panes.slice(0, i), [getFallbackEditorPane(editDocumentId, params, payload)]],
+      }
+    }
   }
 
   return {intent: intent, params, payload}
+}
+
+/**
+ * Whether this pane's header offers the create action the intent describes.
+ *
+ * Mirrors how `PaneHeaderActions` builds the pane's create button, from two
+ * sources, keyed by template id and falling back to the document type name:
+ *
+ * - the pane's own `initialValueTemplates`. Only `documentList` panes are
+ *   considered, because only `DocumentListPaneHeader` forwards them to
+ *   `PaneHeaderActions`. A `list` pane also serializes the field, but its
+ *   header ignores it, so no button exists for it to have come from.
+ * - every menu item carrying a `create` intent, which is the only way a
+ *   hand-built `S.list()` can offer one.
+ *
+ * The template parameters have to match too. In a page tree every level offers
+ * the same template and differs only in its parameters (the parent id), so
+ * without this the search - which runs deepest pane first - would claim an
+ * ancestor pane's "create" for whichever descendant happens to be open.
+ */
+function paneOffersCreateIntent(
+  pane: PaneNode,
+  params: Record<string, string>,
+  payload: unknown,
+): boolean {
+  const requested = params.template || params.type
+  if (!requested) return false
+
+  if (pane.type === 'documentList') {
+    const offered = (pane.initialValueTemplates ?? []).some(
+      (template) =>
+        template.templateId === requested && sameTemplateParameters(template.parameters, payload),
+    )
+    if (offered) return true
+  }
+
+  return (pane.menuItems ?? []).some((menuItem) => {
+    if (menuItem.intent?.type !== 'create') return false
+
+    // `Intent.params` is either the intent params alone, or a tuple of those
+    // and the template parameters, which travel as the intent's payload.
+    const [intentParams, templateParameters]: [BaseIntentParams | undefined, unknown] =
+      Array.isArray(menuItem.intent.params)
+        ? [menuItem.intent.params[0], menuItem.intent.params[1]]
+        : [menuItem.intent.params, undefined]
+
+    return (
+      (intentParams?.template || intentParams?.type) === requested &&
+      sameTemplateParameters(templateParameters, payload)
+    )
+  })
+}
+
+/**
+ * Compares an affordance's template parameters with the intent payload that
+ * carries them, treating "absent" and "empty" as the same thing: a create
+ * action without parameters sends no payload at all.
+ */
+function sameTemplateParameters(parameters: unknown, payload: unknown): boolean {
+  if (isEmptyParameters(parameters) && isEmptyParameters(payload)) return true
+  return dequal(parameters, payload)
+}
+
+function isEmptyParameters(value: unknown): boolean {
+  if (value === undefined || value === null) return true
+  return typeof value === 'object' && Object.keys(value).length === 0
+}
+
+/**
+ * Builds the router pane for the implicit fallback document editor, the same
+ * pane `resolveIntent` falls back to when the intent matches nothing in the
+ * structure.
+ *
+ * The `__edit__` prefix is what makes it a document editor: it is intercepted
+ * by `fallbackEditorChild` in `createResolvedPaneNodeStream` at any depth,
+ * regardless of the parent pane's `child` resolver. That matters here, because
+ * a pane reached this far by declining the intent - so its `child` resolver
+ * cannot be trusted to open the document. A `documentTypeList` with a custom
+ * `.child()` opens that child pane instead (sanity-io/sanity#8861).
+ */
+function getFallbackEditorPane(
+  documentId: string,
+  params: Record<string, string>,
+  payload: unknown,
+): RouterPaneSibling {
+  // `id` identifies the document and is carried by the pane id itself. Every
+  // other param is forwarded, mirroring `resolveIntent`'s fallback - notably
+  // `type`, which the fallback editor requires, plus `template` and `version`.
+  const {id: _id, ...rest} = params
+
+  return {
+    id: `__edit__${documentId}`,
+    params: rest,
+    payload,
+  }
 }
 
 function getPaneParams(intent: string, params: Record<string, string>): Record<string, string> {

--- a/packages/sanity/src/structure/structureResolvers/__tests__/createResolvedPaneNodeStream.test.ts
+++ b/packages/sanity/src/structure/structureResolvers/__tests__/createResolvedPaneNodeStream.test.ts
@@ -1,0 +1,129 @@
+import {filter, firstValueFrom, of} from 'rxjs'
+import {type SchemaPluginOptions} from 'sanity'
+import {describe, expect, it} from 'vitest'
+
+import {getMockSource} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
+import {createStructureBuilder} from '../../structureBuilder/createStructureBuilder'
+import {type RouterPanes, type UnresolvedPaneNode} from '../../types'
+import {createResolvedPaneNodeStream} from '../createResolvedPaneNodeStream'
+
+const mockSchema: SchemaPluginOptions = {
+  name: 'mockSchema',
+  types: [
+    {
+      name: 'page',
+      title: 'Page',
+      type: 'document',
+      fields: [
+        {name: 'title', type: 'string'},
+        {name: 'parent', type: 'reference', to: [{type: 'page'}]},
+      ],
+    },
+  ],
+}
+
+/**
+ * A page tree: a nested `documentTypeList` whose own `.child()` opens another
+ * list of the page's subpages, rather than the document editor. This is the
+ * shape that makes the `__edit__` prefix load-bearing.
+ */
+async function getPageTreeStructure() {
+  const source = await getMockSource({config: {schema: mockSchema}})
+  // @ts-expect-error -- matches the cast in `resolveIntent.test.ts`
+  const S = createStructureBuilder({source})
+
+  const rootPaneNode = S.list()
+    .title('Content')
+    .items([
+      S.listItem()
+        .id('pages')
+        .title('Pages')
+        .child(
+          S.documentTypeList('page')
+            .id('subpages')
+            .apiVersion('2024-01-01')
+            .filter('_type == "page" && parent._ref == $parentId')
+            .params({parentId: 'root'})
+            .child(() => S.list().id('page-node').title('Page node').items([])),
+        ),
+    ]) as unknown as UnresolvedPaneNode
+
+  return {rootPaneNode, structureContext: S.context}
+}
+
+async function resolvePanes(routerPanes: RouterPanes) {
+  const {rootPaneNode, structureContext} = await getPageTreeStructure()
+
+  return firstValueFrom(
+    createResolvedPaneNodeStream({
+      routerPanesStream: of(routerPanes),
+      rootPaneNode,
+      structureContext,
+    }).pipe(
+      // the stream emits progressively, with not-yet-resolved panes reported as
+      // loading placeholders - wait for the settled emission
+      filter((metas) => metas.every((meta) => meta.type === 'resolvedMeta')),
+    ),
+  )
+}
+
+describe('createResolvedPaneNodeStream', () => {
+  it('resolves an `__edit__` pane to the document editor, keeping the panes before it', async () => {
+    // This is the pane path `getIntentState` produces with
+    // `keepPanesOnCreate`: the navigation panes untouched, with the implicit
+    // fallback editor appended as the offering pane's child.
+    const resolvedPanes = await resolvePanes([
+      [{id: 'pages'}],
+      [{id: '__edit__page123', params: {type: 'page'}}],
+    ])
+
+    // The implicit root pane, the subpages list, then the document editor.
+    expect(resolvedPanes).toHaveLength(3)
+    expect(resolvedPanes[1].paneNode?.type).toBe('documentList')
+
+    const editorPane = resolvedPanes[2].paneNode
+    expect(editorPane?.type).toBe('document')
+    expect(editorPane?.type === 'document' && editorPane.options).toEqual({
+      id: 'page123',
+      type: 'page',
+    })
+  })
+
+  it('resolves an `__edit__` pane appended to a deeper path', async () => {
+    // Three panes deep, and the pane it is appended to is a plain `S.list()`
+    // with no `child` of its own - the prefix is what lets the editor open
+    // there at all.
+    const resolvedPanes = await resolvePanes([
+      [{id: 'pages'}],
+      [{id: 'page-1'}],
+      [{id: '__edit__page456', params: {type: 'page'}}],
+    ])
+
+    expect(resolvedPanes).toHaveLength(4)
+    expect(resolvedPanes.map((meta) => meta.paneNode?.id)).toEqual([
+      'content',
+      'subpages',
+      'page-node',
+      // the id the fallback editor gives itself
+      'editor',
+    ])
+
+    const editorPane = resolvedPanes[3].paneNode
+    expect(editorPane?.type).toBe('document')
+    expect(editorPane?.type === 'document' && editorPane.options).toEqual({
+      id: 'page456',
+      type: 'page',
+    })
+  })
+
+  it('resolves a plain document id through the parent pane’s own `child`', async () => {
+    // The contrast that makes the `__edit__` prefix necessary: appending the
+    // plain document id runs the `documentTypeList`'s `.child()`, which here
+    // opens the subpage list rather than the document editor.
+    const resolvedPanes = await resolvePanes([[{id: 'pages'}], [{id: 'page123'}]])
+
+    expect(resolvedPanes).toHaveLength(3)
+    expect(resolvedPanes[2].paneNode?.id).toBe('page-node')
+    expect(resolvedPanes[2].paneNode?.type).toBe('list')
+  })
+})

--- a/packages/sanity/src/structure/structureTool.ts
+++ b/packages/sanity/src/structure/structureTool.ts
@@ -15,7 +15,7 @@ import {changesInspector} from './panes/document/inspectors/changes'
 import {incomingReferencesInspector} from './panes/document/inspectors/incomingReferences'
 import {validationInspector} from './panes/document/inspectors/validation'
 import {router} from './router'
-import {type StructureToolOptions} from './types'
+import {type RouterPanes, type StructureToolOptions} from './types'
 
 const documentActions = [
   usePublishAction,
@@ -132,7 +132,16 @@ export const structureTool = definePlugin<StructureToolOptions | void>((options)
           if (intent === 'edit') return canHandleEditIntent(params)
           return false
         },
-        getIntentState,
+        getIntentState: (intent, params, routerState, payload) =>
+          getIntentState(
+            intent,
+            params,
+            // `Tool['getIntentState']` types this as the whole `RouterState`;
+            // the structure tool's own router state is the panes state.
+            routerState as {panes?: RouterPanes} | undefined,
+            payload,
+            options?.keepPanesOnCreate,
+          ),
         // Controlled by sanity/src/structure/components/structureTool/StructureTitle.tsx
         controlsDocumentTitle: true,
         options,

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -166,6 +166,33 @@ export interface StructureToolOptions {
    * The title that will be displayed for the tool. Defaults to Structure
    */
   title?: string
+  /**
+   * Keeps the navigation panes in place when a document is created from a pane
+   * that sits deeper than the intent matcher looks.
+   *
+   * The matcher only answers for the two outermost panes, and a
+   * `documentTypeList().child()` drops its intent handler entirely, so a
+   * "create" action offered by a deeper pane is handed to structure-wide intent
+   * resolution instead. Finding no match there, the studio replaces the whole
+   * pane path with a lone document editor, and the editor loses their place in
+   * the tree.
+   *
+   * With this enabled, a create action offered by one of the open panes opens
+   * the new document as that pane's child, the way opening an existing document
+   * from a list does: the navigation panes stay visible and collapse when there
+   * is not enough room.
+   *
+   * Only create actions offered by a pane that is currently open are affected,
+   * matched on the template and its parameters. Anything the structure search
+   * has to find is untouched and still jumps to the matching location: deep
+   * links, intents from other tools, and create actions for a type no open pane
+   * offers. Note that a pane offering the requested action counts even when the
+   * action was triggered elsewhere, so the navbar's "create new document" opens
+   * in an open list pane for that type rather than navigating to another one.
+   *
+   * @beta
+   */
+  keepPanesOnCreate?: boolean
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> **Ported from a fork.** This is [#14580](https://github.com/sanity-io/sanity/pull/14580) by @mikael-karlsson-weapp, moved onto a branch in this repo so CI can run against it. The original commit is preserved unmodified (`1f027d2`, authored by @mikael-karlsson-weapp) — the branch is that single commit on top of `main`, with no rebase or amend, so authorship and credit stay intact. Please close the fork PR in favour of this one.
>
> The description below is the author's own, carried over verbatim. A "Verification of the port" section has been appended to Testing.

### Description

Fixes #14486.

In a structure built as a page tree, creating a document from a nested pane destroys the whole navigation pane path. The editor is dropped into a lone document editor with no indication of where in the tree the document was created, and has to navigate back down the tree afterwards. Opening an *existing* document from the same pane behaves as you would expect: the panes stay, and collapse when the viewport runs out of room. Creating one does not.

**Root cause**

`getIntentState` walks the open panes looking for one that can handle the `create` intent. Two things conspire so that none ever does in a nested structure:

- `DocumentTypeListBuilder.child()` swaps out the default intent handler (`structureBuilder/DocumentTypeList.ts`), so a `documentTypeList(...).child(...)` falls back to `shallowIntentChecker`.
- `shallowIntentChecker` is `index <= 1 && defaultIntentChecker(...)` (`structureBuilder/GenericList.ts`), so it declines for every pane below the second.

With no match, the router receives an intent state and `panes` is dropped, which is what makes the navigation vanish. `IntentResolver` then runs the structure-wide `resolveIntent`, which applies the same two checks and so also finds nothing, and its `fallbackEditorPanes` returns a single root group holding `__edit__<id>` — replacing the entire path.

That is why the reporter sees this "already at one or two levels": the checker answers for the outermost two panes and nothing deeper.

**The change**

A new opt-in `StructureToolOptions.keepPanesOnCreate`. When it is on and the standard matcher has declined, `getIntentState` asks whether that open pane *itself offers* the requested create action. If it does, the new document opens as that pane's child and panes beyond it close, which is exactly what opening an existing document from a list already does.

The affordance is read the way `PaneHeaderActions` builds the pane header's create button, from two sources keyed by template id with a fallback to the type name:

- the pane's own `initialValueTemplates`, considered for `documentList` panes only. A `list` pane serializes the field too, but `ListPaneHeader` never forwards it to `PaneHeaderActions`, so no button exists there for an intent to have come from.
- any menu item carrying a `create` intent, which is the only way a hand-built `S.list()` can offer one, through `.menuItems(S.menuItemsFromInitialValueTemplateItems(...))`.

The template **parameters** have to match as well, compared against the intent payload that carries them. This matters in exactly the structure that motivated the issue: every level of a page tree offers the same template and differs only in its parent id, so without it the search — which runs deepest pane first — would claim an ancestor pane's create action for whichever descendant happened to be open, and file the document under a parent the editor did not pick.

The appended router pane keeps the `__edit__` prefix, so it resolves through `fallbackEditorChild` to a document editor at any depth. A plain document id would instead run the parent pane's `child` resolver, which for a `documentList` with a custom `.child()` opens that child pane rather than the editor — #8861.

### Why this approach

The signal is the crux, so it is worth being explicit. **Every create button an editor can physically click lives on a pane that is currently open.** So "this open pane advertises this exact create action, with these parameters" is a precise statement that the new document belongs in this pane's path, not a heuristic. That keeps the blast radius to the case that is broken today.

Three alternatives were tried or considered and rejected:

1. **Append inside `IntentResolver`, after `resolveIntent` returns its fallback.** Semantically the cleanest reading of "unresolved", and it would get the document type for free via `ensureDocumentIdAndType`. But by the time it runs the panes are already gone from the router, so the navigation still blinks away for the duration of a structure-wide search. In the reporter's studio that search issues a GROQ query per tree node, so the symptom being fixed would still be visible for seconds on every create.
2. **Carry `panes` alongside the intent in router state**, so nothing downstream loses the path. Not possible: the intent route and the `/:panes` route are sibling branches, and `_resolvePathFromState` throws on state keys it cannot map to a URL. Such a state does not round-trip through the address bar, it raises.
3. **Trigger on "no open pane matched at all"** (an earlier revision of this PR). Instant and blink-free, but it skips the structure-wide search for *every* unmatched intent, so it also gives up the jump-to-location behaviour that navbar create, reference links and deep links rely on. It additionally needed a guard against `edit` intents carrying only an id, which are real — the Portable Text block reference link sends exactly that — and which only `IntentResolver` can complete.

What does and does not change, with the option on:

| Intent | Behaviour |
| --- | --- |
| Create action offered by an open pane, any depth | Opens as that pane's child, panes beyond it close |
| Create action for a type no open pane offers | Unchanged: searches the structure, jumps to the match |
| Reference links, deep links, other tools | Unchanged: searches the structure, jumps to the match |
| Anything at all with the option off | Unchanged |

One consequence worth stating rather than burying: a pane counts as offering an action even when the action was triggered somewhere else. A `documentTypeList` gets inferred templates whose id is the type name, so navbar "create new document" for a type whose list pane happens to be open in the current path now opens there instead of navigating to another instance of that list. That seems right — it is the location the search would look for anyway — but it is a behaviour change and I would rather it be reviewed than discovered.

### Questions for maintainers

- **Should the option be `unstable_keepPanesOnCreate`?** The repo's precedent for opt-in experiments is that prefix (`unstable_languageFilter`, `unstable_comments`). I left it unprefixed with `@beta` in the TSDoc, on the grounds that the behaviour is a fix rather than an experiment, but I have no attachment to either.
- **Should there be a flag at all?** With the option off, `getIntentState` returns exactly what it returns today and the new branch is unreachable. It is opt-in because the fix changes routing, and therefore URLs, for studios with nested create affordances, which felt wrong to ship unannounced in a minor. If you would rather treat it as a straight bug fix, the flag is one condition in one `if`.
- **Do you want `dev/test-studio` wiring and an `e2e/tests/structure` spec?** Neither is here. A nested tree structure plus the flag in the dev studio would let a reviewer see this in a browser in one command, and I am happy to add both, but they seemed like the kind of thing to agree on rather than assume.

### What to review

Four files plus tests, all under `packages/sanity/src/structure`.

1. `getIntentState.ts` — the new branch inside the active-pane loop, and the three helpers below it. Two ordering details are deliberate: the branch is evaluated *after* the existing matcher for each pane, so a pane that answers the matcher keeps today's routing untouched; and the loop runs deepest-first, so among panes offering the same action with the same parameters the nearest one wins.
2. `paneOffersCreateIntent` against `components/paneHeaderActions/PaneHeaderActions.tsx` — it is meant to mirror how that component derives the create button, including the array form of intent params and the template-id-to-type-name fallback. Divergence there is the likeliest place for a bug. It deliberately does *not* replicate that component's `useTemplates()` existence check or its permission gating, both of which are display concerns; an intent for a template that does not exist has bigger problems than which pane it lands in.
3. `types.ts` — the public option and its TSDoc.
4. `structureTool.ts` — `getIntentState` is now wrapped so the tool's option reaches it. The wrapper casts `routerState` once, because `Tool['getIntentState']` types it as the whole `RouterState` while the structure tool's own router state is the panes state.

To exercise it, a structure needs a create affordance more than two panes deep: a `documentTypeList` with `.filter()`, `.initialValueTemplates()` and `.child()`, nested under a couple of list items, is enough. Without the option the panes disappear on create; with it they stay and collapse.

Verified by hand against a real page-tree studio — market → page tree → page node → subpages, four panes deep, with create affordances of both kinds — built from the v6.12.0 release tag with this change applied, rather than only against unit tests.

### Testing

`packages/sanity/src/structure`: 58 files, 460 tests, no type errors. `pnpm check:oxlint` and `pnpm check:format` clean.

- `getIntentState.test.ts` gains twelve cases: both affordance styles; parameters selecting the correct pane rather than the deepest; the deepest pane winning when several offer the identical action; panes beyond the offering pane closing; `initialValueTemplates` on a `list` pane being ignored; a create action no open pane offers handed to resolution; a create intent with no document type handed to resolution; `edit` intents left to the existing matcher; an intent the matcher already handles keeping its current routing; and the option being off by default. Fixtures lead with the implicit root pane, since `activePanes` indexes sit one ahead of the router panes and the slicing depends on that offset.
- A new `structureResolvers/__tests__/createResolvedPaneNodeStream.test.ts` drives the real resolver stream over a nested page tree and asserts that the appended `__edit__` pane resolves to a document editor two and three panes deep, including onto a plain `S.list()` with no `child` of its own. Its last case asserts the contrast — a plain document id resolving to the custom child pane instead — so the reason for the prefix is pinned rather than assumed.

Not covered, and called out rather than left to be found: split (sibling) panes with an appended editor, and release perspectives beyond `version` being forwarded as a pane param. Fixtures are hand-built pane objects rather than builder output, matching the existing tests in that file.

### Known limitations

- **Split panes and the pane slice.** `panes.slice(0, i)` indexes router *groups* with an `activePanes` *flat* index, which diverge once a group has split siblings. This is pre-existing in the matcher above and the new branch follows it for consistency; the effect is that panes which should close do not, so the path keeps a stale pane. The `__edit__` prefix means the editor still resolves correctly either way. Fixing it properly means threading `groupIndex` through `setActivePanes`, which changes the existing matcher's behaviour too, so it belongs in its own PR.
- **Shallow panes keep the #8861 hijack.** At index 0 or 1 the existing matcher answers first and returns a plain document id, so a shallow `documentTypeList().child()` still opens its child pane instead of the editor. Making the prefix unconditional there would change URLs for everyone, including studios that are working fine, so it is left alone.
- **Unresolvable `edit` intents.** A reference to a document type absent from the structure still replaces the pane path. Same fallback, same benefit available, but a separate trigger and a separate bug.

While reading the resolver, one more latent pre-existing bug turned up: the `__edit__` branch in `createResolvedPaneNodeStream.ts` passes `parent` where the sibling branch passes `paneNode`, so a fallback editor is handed its grandparent. Inert today, because `fallbackEditorChild` ignores `context.parent`. Untouched here, flagged so it is not lost.

### Verification of the port

Run on this branch in a Cursor Cloud VM, on top of `main` at `b29dbc7`:

- `pnpm check:format` and `pnpm check:oxlint` (which includes type checking) both clean.
- The two suites this PR touches pass: 12 tests in `getIntentState.test.ts` and 3 in `structureResolvers/__tests__/createResolvedPaneNodeStream.test.ts`, no type errors.
- Full `pnpm test`: 6673 passed, 2 failed. Both failures are pre-existing environment artifacts unrelated to this change — `core/network/isUsingLegacyHttp.test.ts` fails identically on a clean `main`, and `core/divergence/collateDocumentDivergences.test.ts` is a matcher timeout under full-suite load that passes in isolation on this branch.

Also verified by hand in `dev/test-studio`, independently of the author's own page-tree studio. The existing "Books by author" item is not a reproduction — its `.child()` sits on the *author* list, so the book list that offers create keeps `defaultIntentChecker` and the panes already survive. Moving `.child()` onto the book list itself reproduces the reporter's shape (a level that both offers create and descends), and reproduces the bug: creating from that pane replaces the path and drops the editor into an unrelated `documentTypeList('book')` that the structure-wide search happened to find.

With `keepPanesOnCreate: true`, the same click keeps the path and appends the editor:

```
/test/structure/keep-panes-repro;<authorId>;__edit__<uuid>,template=book-by-author,type=book,<payload>
```

The new document also shows up live in the "Books by author" pane beside it, so the template parameters are being applied to the right parent. Both the repro structure and the flag were local-only and are not part of this branch — the author's open question about committing `dev/test-studio` wiring and an `e2e/tests/structure` spec is still a maintainer decision.

### Notes for release

The structure tool takes a new opt-in option, `keepPanesOnCreate`:

```ts
import {structureTool} from 'sanity/structure'

export default defineConfig({
  // ...
  plugins: [structureTool({structure, keepPanesOnCreate: true})],
})
```

With it enabled, creating a document from a pane's own "create" button keeps the navigation panes visible instead of replacing them with a single document editor. The new document opens as that pane's child, and the panes before it collapse when there is not enough room — the same behaviour as opening an existing document from a list. This matters most for structures built as trees, where the pane path is the editor's only indication of where in the tree they are working.

It applies only to create actions offered by a pane that is currently open, matched on both the initial value template and its parameters. Deep links, reference links, and create actions for a type that no open pane offers are unaffected and still navigate to the matching location in the structure. The option defaults to off, so nothing changes unless you enable it.

Limitations: an `edit` intent that matches nothing in the structure still replaces the pane path; and with split panes open, panes that would otherwise close can remain in the path.

---

### Demo

Recorded in `dev/test-studio` with a local-only page-tree repro (a `documentTypeList` that both offers create and has its own `.child()`).

[before_fix_create_from_nested_pane_destroys_navigation_panes.mp4](https://cursor.com/agents/bc-1caa5525-18be-482b-a523-4fa669e4471d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_create_from_nested_pane_destroys_navigation_panes.mp4)

Before: creating from the nested "Books by author" pane destroys the path. The "Authors" and "Books by author" panes are replaced by an unrelated "Books" list plus a lone editor.

[after_fix_create_from_nested_pane_keeps_navigation_panes.mp4](https://cursor.com/agents/bc-1caa5525-18be-482b-a523-4fa669e4471d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_create_from_nested_pane_keeps_navigation_panes.mp4)

After, with `keepPanesOnCreate: true`: both panes stay and the editor is appended as the pane's child. The new book appears live in the "Books by author" list beside it, so the template parameters landed on the right parent.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1caa5525-18be-482b-a523-4fa669e4471d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1caa5525-18be-482b-a523-4fa669e4471d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

