### PR TITLE
fix(core): treat empty variant conditions as an error

### DIFF
--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -144,7 +144,7 @@ When `beta.variants.conditions` is set (a static array or a function that may re
 - while the list loads, the rows render disabled with a spinner instead of a skeleton, so the ready state lands in place
 - existing conditions that are not in the list stay visible in a critical tone, are marked as errors, and block save
 - a load failure shows an error and retry; the form does not fall back to free-text
-- an empty list, or a list where every entry is dropped as invalid, is treated as that same load failure — not as a picker with no options
+- an empty list, or a list where every entry is dropped as invalid, is treated as that same load failure, not as a picker with no options
 - overview rows, detail condition rows, and navbar menu items show the same mismatch error after the list is ready
 
 `useVariantConditions` reads the resolved config from the workspace. Invalid keys and values are dropped by `normalizeVariantConditions` so the picker never offers them.

--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -144,6 +144,7 @@ When `beta.variants.conditions` is set (a static array or a function that may re
 - while the list loads, the rows render disabled with a spinner instead of a skeleton, so the ready state lands in place
 - existing conditions that are not in the list stay visible in a critical tone, are marked as errors, and block save
 - a load failure shows an error and retry; the form does not fall back to free-text
+- an empty list, or a list where every entry is dropped as invalid, is treated as that same load failure — not as a picker with no options
 - overview rows, detail condition rows, and navbar menu items show the same mismatch error after the list is ready
 
 `useVariantConditions` reads the resolved config from the workspace. Invalid keys and values are dropped by `normalizeVariantConditions` so the picker never offers them.

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -90,7 +90,7 @@ describe('CreateVariantDialog', () => {
 
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
-    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
+    await user.type(await screen.findByRole('combobox', {name: 'Key'}), 'audience')
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
     await user.type(screen.getByRole('combobox', {name: 'Value'}), 'loyal-customers')

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -4,6 +4,7 @@ import {type HTMLProps, type Ref} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type VariantConditions} from '../../../../config/types'
 import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
 import {type SystemVariant} from '../../../types'
@@ -541,11 +542,7 @@ describe('CreateVariantDialog mapped conditions', () => {
     variantOperationsMock.createVariant.mockResolvedValue(undefined)
   })
 
-  const renderMappedDialog = async (
-    conditions:
-      | typeof mappedConditions
-      | (() => Promise<typeof mappedConditions>) = mappedConditions,
-  ) => {
+  const renderMappedDialog = async (conditions: VariantConditions = mappedConditions) => {
     const wrapper = await createTestProvider({
       config: {
         beta: {
@@ -761,5 +758,23 @@ describe('CreateVariantDialog mapped conditions', () => {
     await user.click(screen.getByRole('button', {name: 'Retry'}))
 
     expect(screen.getByTestId('variant-form-conditions-loading')).toBeInTheDocument()
+  })
+
+  it('shows the conditions error when the configured list is empty', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const user = userEvent.setup()
+
+    await renderMappedDialog([])
+
+    expect(await screen.findByTestId('variant-form-conditions-error')).toBeInTheDocument()
+    expect(screen.queryByTestId('variant-form-condition-key-menu-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('variant-form-condition-value-menu-button')).not.toBeInTheDocument()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'No conditions')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
   })
 })

--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantConditions.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantConditions.test.ts
@@ -3,12 +3,14 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {type VariantConditionsContext} from '../../../config/types'
-import {useVariantConditions} from '../useVariantConditions'
+import {useVariantConditionMismatches, useVariantConditions} from '../useVariantConditions'
 
 describe('useVariantConditions', () => {
   beforeEach(() => {
-    // Resolver failures are logged for studio developers; keep the test output quiet.
+    // Resolver failures and dropped invalid entries are logged for studio developers;
+    // keep the test output quiet.
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
@@ -218,5 +220,131 @@ describe('useVariantConditions', () => {
     })
 
     expect(conditions).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats an empty static list as an error', async () => {
+    const wrapper = await createTestProvider({
+      config: {
+        beta: {
+          variants: {
+            enabled: true,
+            conditions: [],
+          },
+        },
+      },
+    })
+
+    const {result} = renderHook(() => useVariantConditions(), {wrapper})
+
+    expect(result.current).toMatchObject({
+      mode: 'mapped',
+      status: 'error',
+      error: expect.objectContaining({
+        message: 'Expected `beta.variants.conditions` to include at least one valid entry',
+      }),
+    })
+    expect(console.error).toHaveBeenCalledWith(
+      '[sanity] Failed to resolve `beta.variants.conditions`',
+      expect.objectContaining({
+        message: 'Expected `beta.variants.conditions` to include at least one valid entry',
+      }),
+    )
+  })
+
+  it('treats a static list of only invalid entries as an error', async () => {
+    const wrapper = await createTestProvider({
+      config: {
+        beta: {
+          variants: {
+            enabled: true,
+            conditions: [{name: '_system', values: ['ok']}],
+          },
+        },
+      },
+    })
+
+    const {result} = renderHook(() => useVariantConditions(), {wrapper})
+
+    expect(result.current).toMatchObject({
+      mode: 'mapped',
+      status: 'error',
+      error: expect.objectContaining({
+        message: 'Expected `beta.variants.conditions` to include at least one valid entry',
+      }),
+    })
+  })
+
+  it('treats an empty resolved list as an error that can be retried', async () => {
+    let empty = true
+    const conditions = async () => {
+      if (empty) {
+        return []
+      }
+
+      return [{name: 'locale', values: ['en-US']}]
+    }
+    const wrapper = await createTestProvider({
+      config: {
+        beta: {
+          variants: {
+            enabled: true,
+            conditions,
+          },
+        },
+      },
+    })
+
+    const {result} = renderHook(() => useVariantConditions(), {wrapper})
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        mode: 'mapped',
+        status: 'error',
+        error: expect.objectContaining({
+          message: 'Expected `beta.variants.conditions` to include at least one valid entry',
+        }),
+      })
+    })
+
+    empty = false
+
+    await act(async () => {
+      if (result.current.mode === 'mapped' && result.current.status === 'error') {
+        result.current.retry()
+      }
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        mode: 'mapped',
+        status: 'ready',
+        definitions: [
+          {
+            name: 'locale',
+            title: 'locale',
+            values: [{value: 'en-US', title: 'en-US'}],
+          },
+        ],
+      })
+    })
+  })
+
+  it('does not report mismatches while the configured list is empty', async () => {
+    const wrapper = await createTestProvider({
+      config: {
+        beta: {
+          variants: {
+            enabled: true,
+            conditions: [],
+          },
+        },
+      },
+    })
+
+    const {result} = renderHook(() => useVariantConditionMismatches({audience: 'loyal'}), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual([])
   })
 })

--- a/packages/sanity/src/core/variants/hooks/useVariantConditions.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantConditions.ts
@@ -52,6 +52,30 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error))
 }
 
+function emptyConditionsError(): Error {
+  return new Error('Expected `beta.variants.conditions` to include at least one valid entry')
+}
+
+function toReadyResult(value: unknown): Extract<UseVariantConditionsResult, {status: 'ready'}> {
+  const definitions = normalizeVariantConditions(value)
+
+  if (definitions.length === 0) {
+    throw emptyConditionsError()
+  }
+
+  return {mode: 'mapped', status: 'ready', definitions}
+}
+
+function toResolveError(
+  resolveError: unknown,
+  retry: () => void,
+): Extract<UseVariantConditionsResult, {status: 'error'}> {
+  const error = toError(resolveError)
+  console.error('[sanity] Failed to resolve `beta.variants.conditions`', error)
+
+  return {mode: 'mapped', status: 'error', error, retry}
+}
+
 function resolveConditions$(
   resolver: ConditionsResolver,
   context: VariantConditionsContext,
@@ -59,17 +83,8 @@ function resolveConditions$(
 ): Observable<UseVariantConditionsResult> {
   return defer(() => Promise.resolve(resolver(context))).pipe(
     timeout({first: RESOLVE_VARIANT_CONDITIONS_TIMEOUT_MS}),
-    map((value): UseVariantConditionsResult => ({
-      mode: 'mapped',
-      status: 'ready',
-      definitions: normalizeVariantConditions(value),
-    })),
-    catchError((resolveError: unknown) => {
-      const error = toError(resolveError)
-      console.error('[sanity] Failed to resolve `beta.variants.conditions`', error)
-
-      return of({mode: 'mapped', status: 'error', error, retry} as const)
-    }),
+    map(toReadyResult),
+    catchError((resolveError: unknown) => of(toResolveError(resolveError, retry))),
     startWith(LOADING_RESULT),
   )
 }
@@ -101,11 +116,11 @@ function getVariantConditions$(
   }
 
   if (Array.isArray(conditions)) {
-    return of({
-      mode: 'mapped',
-      status: 'ready',
-      definitions: normalizeVariantConditions(conditions),
-    })
+    try {
+      return of(toReadyResult(conditions))
+    } catch (error) {
+      return of(toResolveError(error, NOOP))
+    }
   }
 
   if (typeof conditions === 'function') {

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsMenu.test.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsMenu.test.tsx
@@ -84,4 +84,21 @@ describe('VariantsMenu', () => {
 
     expect(screen.queryByTestId('variant-condition-mismatch')).not.toBeInTheDocument()
   })
+
+  it('does not show a mismatch error when configured conditions resolve empty', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await renderMenu({
+      beta: {
+        variants: {
+          enabled: true,
+          conditions: [],
+        },
+      },
+    })
+
+    expect(screen.queryByTestId('variant-condition-mismatch')).not.toBeInTheDocument()
+
+    consoleError.mockRestore()
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

When `beta.variants.conditions` is set but resolves to no valid entries (empty array, or every key/value dropped), the hook still reported `mapped` + `ready`. The create/edit form then rendered the exclusive picker with no options, could not drop the required empty row, and could not save. Existing variants also looked mismatched because an empty ready list treats every stored key as unknown.

This does not fall back to free-text: config is set, so offering freeform would silently change the contract. An empty/all-invalid list now takes the same error + retry path as a failed resolver. Retry is a no-op for a static array and re-runs an async resolver (useful when a CDP later returns values).

Fixes the empty-conditions deadlock called out on #14500 (including Bugbot's "Empty conditions leave form stuck").

### What to review

- `useVariantConditions`: zero valid definitions after `normalizeVariantConditions` become `mapped`/`error`, sharing the existing resolve-failure log
- Form, overview, and navbar mismatch UI while not `ready` (no empty dropdowns, no unknown-key icons)
- Whether static empty lists should keep a Retry button (current UI reuse) vs hide it because retry is a no-op

Package: `sanity` (`core/variants`).

### Testing

- Hook: empty static list, all-invalid static list, empty async list then retry to a valid list, no mismatches while empty
- `CreateVariantDialog`: empty config shows the conditions error, no mapped menus, save does not create
- `VariantsMenu`: empty config does not show mismatch icons
- Freeform create-dialog test now waits for the key combobox so the existing mapped/loading initial emission does not flake the first assertion

### Notes for release

N/A – Part of beta variants

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50ac38bf-0813-4fb8-a018-7906a3cbbd63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50ac38bf-0813-4fb8-a018-7906a3cbbd63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

