### PR TITLE
feat(test-studio): split style migration metrics

### DIFF
--- a/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
+++ b/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
@@ -1,14 +1,27 @@
 import {useEffect, useState} from 'react'
 
 import {
+  adoption,
   checkbox,
+  cssMeter,
+  cssMeterFill,
   dot,
+  donut,
+  donutValue,
+  escapeCount,
+  escapeCountValue,
+  escapeDetails,
+  group,
+  groupHeading,
   header,
+  legend,
+  metricLabel,
   panel,
   root,
   row,
   rowCount,
   rowLabel,
+  sectionDivider,
   trigger,
 } from './styleOutline.css'
 import {
@@ -24,6 +37,17 @@ interface PanelState {
 }
 
 type Counts = ReadonlyMap<StyleSystemId, number>
+
+interface StyleSheetCounts {
+  inaccessible: number
+  styled: number
+  total: number
+}
+
+interface Metrics {
+  nodes: Counts
+  stylesheets: StyleSheetCounts
+}
 
 const DEFAULT_STATE: PanelState = {open: false, active: []}
 
@@ -71,18 +95,54 @@ function countNodes(): Counts {
   )
 }
 
-function sameCounts(a: Counts | null, b: Counts): boolean {
-  return a !== null && STYLE_SYSTEMS.every((system) => a.get(system.id) === b.get(system.id))
+function countStylesheetRules(): StyleSheetCounts {
+  let inaccessible = 0
+  let styled = 0
+  let total = 0
+
+  for (const sheet of document.styleSheets) {
+    try {
+      const ruleCount = sheet.cssRules.length
+      total += ruleCount
+      if (
+        sheet.ownerNode instanceof HTMLStyleElement &&
+        sheet.ownerNode.matches('style[data-styled]')
+      ) {
+        styled += ruleCount
+      }
+    } catch {
+      inaccessible += 1
+    }
+  }
+
+  return {inaccessible, styled, total}
 }
 
-function formatCount(count: number | undefined, total: number): string {
-  if (count === undefined || total === 0) return '—'
-  return `${count.toLocaleString()} · ${Math.round((count / total) * 100)}%`
+function countMetrics(): Metrics {
+  return {nodes: countNodes(), stylesheets: countStylesheetRules()}
+}
+
+function sameMetrics(a: Metrics | null, b: Metrics): boolean {
+  return (
+    a !== null &&
+    STYLE_SYSTEMS.every((system) => a.nodes.get(system.id) === b.nodes.get(system.id)) &&
+    a.stylesheets.inaccessible === b.stylesheets.inaccessible &&
+    a.stylesheets.styled === b.stylesheets.styled &&
+    a.stylesheets.total === b.stylesheets.total
+  )
+}
+
+function percentage(part: number, total: number): number | null {
+  return total === 0 ? null : Math.round((part / total) * 100)
+}
+
+function formatPercentage(value: number | null): string {
+  return value === null ? '—' : `${value}%`
 }
 
 export default function StyleOutlinePanel() {
   const [state, setState] = useState(readStoredState)
-  const [counts, setCounts] = useState<Counts | null>(null)
+  const [metrics, setMetrics] = useState<Metrics | null>(null)
   const {open, active} = state
 
   useEffect(() => {
@@ -101,29 +161,46 @@ export default function StyleOutlinePanel() {
     let frame: number | null = null
     const recount = () => {
       frame = null
-      const next = countNodes()
-      setCounts((prev) => (sameCounts(prev, next) ? prev : next))
+      const next = countMetrics()
+      setMetrics((prev) => (sameMetrics(prev, next) ? prev : next))
     }
     const schedule = () => {
       if (frame === null) frame = requestAnimationFrame(recount)
     }
-    const observer = new MutationObserver(schedule)
-    observer.observe(document.body, {
+    const bodyObserver = new MutationObserver(schedule)
+    const headObserver = new MutationObserver(schedule)
+    bodyObserver.observe(document.body, {
       childList: true,
       subtree: true,
       attributes: true,
       attributeFilter: ['class', 'data-ui'],
     })
+    headObserver.observe(document.head, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['data-styled', 'disabled', 'href', 'media', 'rel'],
+    })
+    document.addEventListener('load', schedule, true)
     schedule()
     return () => {
-      observer.disconnect()
+      bodyObserver.disconnect()
+      headObserver.disconnect()
+      document.removeEventListener('load', schedule, true)
       if (frame !== null) cancelAnimationFrame(frame)
     }
   }, [open])
 
-  const total = counts
-    ? STYLE_SYSTEMS.reduce((sum, system) => sum + (counts.get(system.id) ?? 0), 0)
-    : 0
+  const ui5Count = metrics?.nodes.get('ui5') ?? 0
+  const ui4Count = metrics?.nodes.get('ui4') ?? 0
+  const styledCount = metrics?.nodes.get('styled')
+  const uiTotal = ui5Count + ui4Count
+  const ui5Percentage = percentage(ui5Count, uiTotal)
+  const ui4Percentage = percentage(ui4Count, uiTotal)
+  const styledRulePercentage = metrics
+    ? percentage(metrics.stylesheets.styled, metrics.stylesheets.total)
+    : null
   const toggleOpen = () => setState((prev) => ({...prev, open: !prev.open}))
   const toggleSystem = (id: StyleSystemId) =>
     setState((prev) => ({...prev, active: toggleId(prev.active, id)}))
@@ -140,29 +217,98 @@ export default function StyleOutlinePanel() {
             onClick={toggleOpen}
             data-testid="style-outline-collapse"
           >
-            Style outline
+            Style migrations
           </button>
-          {STYLE_SYSTEMS.map((system) => (
-            <label key={system.id} className={row}>
-              <span className={dot} style={{background: system.color}} />
-              <span className={rowLabel}>{system.label}</span>
-              <span className={rowCount}>{formatCount(counts?.get(system.id), total)}</span>
-              <input
-                type="checkbox"
-                className={checkbox}
-                checked={active.includes(system.id)}
-                onChange={() => toggleSystem(system.id)}
-                data-testid={`style-outline-toggle-${system.id}`}
-              />
-            </label>
-          ))}
+          <section className={group} aria-labelledby="style-outline-ui-adoption">
+            <h2 className={groupHeading} id="style-outline-ui-adoption">
+              UI v5 adoption
+            </h2>
+            <div className={adoption}>
+              <div
+                className={donut}
+                style={{
+                  background: `conic-gradient(${STYLE_SYSTEMS[0].color} ${
+                    ui5Percentage ?? 0
+                  }%, ${STYLE_SYSTEMS[1].color} 0)`,
+                }}
+                role="img"
+                aria-label={`@sanity/ui v5 makes up ${formatPercentage(ui5Percentage)} of UI components`}
+                data-testid="style-outline-ui-adoption-chart"
+              >
+                <span className={donutValue}>{formatPercentage(ui5Percentage)}</span>
+              </div>
+              <div className={legend}>
+                <div className={row}>
+                  <span className={dot} style={{background: STYLE_SYSTEMS[0].color}} />
+                  <span className={rowLabel}>{STYLE_SYSTEMS[0].label}</span>
+                  <span className={rowCount}>
+                    {ui5Count.toLocaleString()} · {formatPercentage(ui5Percentage)}
+                  </span>
+                </div>
+                <div className={row}>
+                  <span className={dot} style={{background: STYLE_SYSTEMS[1].color}} />
+                  <span className={rowLabel}>{STYLE_SYSTEMS[1].label}</span>
+                  <span className={rowCount}>
+                    {ui4Count.toLocaleString()} · {formatPercentage(ui4Percentage)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </section>
+          <div className={sectionDivider} />
+          <section className={group} aria-labelledby="style-outline-styled-escape">
+            <h2 className={groupHeading} id="style-outline-styled-escape">
+              Styled-components escape
+            </h2>
+            <div className={escapeDetails}>
+              <div className={escapeCount}>
+                <span className={escapeCountValue}>
+                  {styledCount === undefined ? '—' : styledCount.toLocaleString()}
+                </span>
+                <span className={metricLabel}>component instances</span>
+              </div>
+              <div
+                className={rowCount}
+                title={`${metrics?.stylesheets.inaccessible ?? 0} unreadable stylesheets`}
+              >
+                {formatPercentage(styledRulePercentage)} of readable CSS rules
+              </div>
+            </div>
+            <div
+              className={cssMeter}
+              role="img"
+              aria-label={`styled-components supplies ${formatPercentage(styledRulePercentage)} of readable CSS rules`}
+              data-testid="style-outline-styled-rules-meter"
+            >
+              <span className={cssMeterFill} style={{width: `${styledRulePercentage ?? 0}%`}} />
+            </div>
+          </section>
+          <div className={sectionDivider} />
+          <section className={group} aria-labelledby="style-outline-debug">
+            <h2 className={groupHeading} id="style-outline-debug">
+              Debug outlines
+            </h2>
+            {STYLE_SYSTEMS.map((system) => (
+              <label key={system.id} className={row}>
+                <span className={dot} style={{background: system.color}} />
+                <span className={rowLabel}>{system.label}</span>
+                <input
+                  type="checkbox"
+                  className={checkbox}
+                  checked={active.includes(system.id)}
+                  onChange={() => toggleSystem(system.id)}
+                  data-testid={`style-outline-toggle-${system.id}`}
+                />
+              </label>
+            ))}
+          </section>
         </fieldset>
       ) : (
         <button
           type="button"
           className={trigger}
-          title="Style outline"
-          aria-label="Style outline"
+          title="Style migrations"
+          aria-label="Style migrations"
           aria-expanded={false}
           onClick={toggleOpen}
           data-testid="style-outline-trigger"

--- a/dev/test-studio/plugins/style-outline/styleOutline.css.ts
+++ b/dev/test-studio/plugins/style-outline/styleOutline.css.ts
@@ -48,7 +48,7 @@ export const panel = style([
     margin: 0,
     borderRadius: 12,
     padding: '12px 14px',
-    minWidth: 260,
+    width: 320,
     color: '#ececf1',
   },
 ])
@@ -69,11 +69,32 @@ export const header = style({
   },
 })
 
+export const group = style({
+  padding: '4px 0',
+})
+
+export const groupHeading = style({
+  margin: 0,
+  padding: '2px 0 6px',
+  fontSize: 11,
+  fontWeight: 600,
+  lineHeight: 1.4,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+  color: 'rgba(236, 236, 241, 0.55)',
+})
+
+export const sectionDivider = style({
+  height: 1,
+  margin: '7px 0',
+  background: 'rgba(255, 255, 255, 0.08)',
+})
+
 export const row = style({
   display: 'flex',
   alignItems: 'center',
   gap: 10,
-  padding: '6px 0',
+  minHeight: 26,
   cursor: 'pointer',
 })
 
@@ -92,6 +113,84 @@ export const rowCount = style({
   fontVariantNumeric: 'tabular-nums',
   fontSize: 12,
   color: 'rgba(236, 236, 241, 0.55)',
+})
+
+export const adoption = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 14,
+})
+
+export const donut = style({
+  position: 'relative',
+  display: 'grid',
+  width: 64,
+  height: 64,
+  borderRadius: '50%',
+  flexShrink: 0,
+  placeItems: 'center',
+  selectors: {
+    '&::after': {
+      content: '',
+      position: 'absolute',
+      inset: 11,
+      borderRadius: '50%',
+      background: '#202024',
+    },
+  },
+})
+
+export const donutValue = style({
+  position: 'relative',
+  zIndex: 1,
+  fontSize: 13,
+  fontWeight: 650,
+  fontVariantNumeric: 'tabular-nums',
+})
+
+export const legend = style({
+  flex: 1,
+})
+
+export const escapeDetails = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  justifyContent: 'space-between',
+  gap: 12,
+})
+
+export const escapeCount = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: 5,
+})
+
+export const escapeCountValue = style({
+  fontSize: 18,
+  fontWeight: 650,
+  fontVariantNumeric: 'tabular-nums',
+})
+
+export const metricLabel = style({
+  fontSize: 12,
+  color: 'rgba(236, 236, 241, 0.72)',
+})
+
+export const cssMeter = style({
+  height: 5,
+  marginTop: 8,
+  overflow: 'hidden',
+  borderRadius: 999,
+  background: 'rgba(255, 255, 255, 0.12)',
+})
+
+export const cssMeterFill = style({
+  display: 'block',
+  height: '100%',
+  minWidth: 1,
+  borderRadius: 'inherit',
+  background: '#ff4fa3',
+  transition: 'width 150ms ease-out',
 })
 
 export const checkbox = style({

--- a/dev/test-studio/plugins/style-outline/styleSystems.ts
+++ b/dev/test-studio/plugins/style-outline/styleSystems.ts
@@ -14,7 +14,12 @@ interface Fingerprint extends Omit<StyleSystem, 'selector'> {
 // Ordered by precedence: a node belongs to the first fingerprint it matches, so a
 // `styled(ui5Box)` counts as ui5 and a `styled(ui4Card)` counts as ui4.
 const FINGERPRINTS: readonly Fingerprint[] = [
-  {id: 'ui5', label: 'ui5', color: '#22d3ee', match: '[class^="sui-"], [class*=" sui-"]'},
+  {
+    id: 'ui5',
+    label: '@sanity/ui v5',
+    color: '#22d3ee',
+    match: '[class^="sui-"], [class*=" sui-"]',
+  },
   {id: 'ui4', label: '@sanity/ui v4', color: '#f5a524', match: '[data-ui]'},
   {
     id: 'styled',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The style outline panel currently compares UI component instances and styled-components instances with one denominator, even though they represent two independent migrations. This separates UI v5 adoption from the styled-components escape and measures the latter against readable CSS rules, while retaining the three outline controls.

### What to review

- The two denominator models and stylesheet access fallback in `StyleOutlinePanel.tsx`
- The compact grouped presentation in `styleOutline.css.ts`
- Test-studio only; no package output changes

### Testing

Verification in progress. This dev-only panel is outside the repository's Storybook and unit-test projects, so it will be validated with focused lint/build checks and an authenticated full-studio browser walkthrough.

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-834b800c-be3b-4027-b8f9-4141f66cb31b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-834b800c-be3b-4027-b8f9-4141f66cb31b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

