### PR TITLE
feat(diagnostics): report styled components css size

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.test.tsx
@@ -165,7 +165,7 @@ const diagnostics: StudioDiagnostics = {
     workspaceName: 'default',
     workspaceTitle: 'Test workspace',
   },
-  styles: {styledComponents: [{ruleCount: 1_234, version: '6.5.3'}]},
+  styles: {styledComponents: [{ruleCount: 1_234, sizeBytes: 12_345, version: '6.5.3'}]},
   user: {
     id: 'user-id',
     provider: 'sanity',
@@ -220,6 +220,8 @@ describe('DiagnosticsReport', () => {
     expect(styledComponents.getByText('1')).toBeInTheDocument()
     expect(styledComponents.getByText('CSS rules inserted by JS')).toBeInTheDocument()
     expect(styledComponents.getByText((1_234).toLocaleString())).toBeInTheDocument()
+    expect(styledComponents.getByText('CSS size inserted by JS')).toBeInTheDocument()
+    expect(styledComponents.getByText('12.35 kB')).toBeInTheDocument()
     expect(styledComponents.queryByText('Expected 1')).not.toBeInTheDocument()
     expect(
       styledComponents.queryByTestId('diagnostics-styled-components-sheets'),
@@ -293,7 +295,12 @@ describe('DiagnosticsReport', () => {
         <DiagnosticsReport
           diagnostics={{
             ...diagnostics,
-            styles: {styledComponents: [{ruleCount: 900, version: '6.5.3'}, {ruleCount: 120}]},
+            styles: {
+              styledComponents: [
+                {ruleCount: 900, sizeBytes: 12_000, version: '6.5.3'},
+                {ruleCount: 120, sizeBytes: 450},
+              ],
+            },
           }}
           onRunAgain={vi.fn()}
         />
@@ -306,8 +313,9 @@ describe('DiagnosticsReport', () => {
     expect(styledComponents.getByText('2')).toBeInTheDocument()
     expect(styledComponents.getByText('Expected 1')).toBeInTheDocument()
     expect(styledComponents.getByText((1_020).toLocaleString())).toBeInTheDocument()
+    expect(styledComponents.getByText('12.45 kB')).toBeInTheDocument()
     expect(styledComponents.getByTestId('diagnostics-styled-components-sheets')).toHaveTextContent(
-      '6.5.3: 900 rules · unknown version: 120 rules',
+      '6.5.3: 900 rules, 12 kB · unknown version: 120 rules, 450 B',
     )
   })
 

--- a/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.test.tsx
@@ -221,7 +221,7 @@ describe('DiagnosticsReport', () => {
     expect(styledComponents.getByText('CSS rules inserted by JS')).toBeInTheDocument()
     expect(styledComponents.getByText((1_234).toLocaleString())).toBeInTheDocument()
     expect(styledComponents.getByText('CSS size inserted by JS')).toBeInTheDocument()
-    expect(styledComponents.getByText('12.35 kB')).toBeInTheDocument()
+    expect(styledComponents.getByText(formatExpectedByteSize(12_345))).toBeInTheDocument()
     expect(styledComponents.queryByText('Expected 1')).not.toBeInTheDocument()
     expect(
       styledComponents.queryByTestId('diagnostics-styled-components-sheets'),
@@ -313,9 +313,9 @@ describe('DiagnosticsReport', () => {
     expect(styledComponents.getByText('2')).toBeInTheDocument()
     expect(styledComponents.getByText('Expected 1')).toBeInTheDocument()
     expect(styledComponents.getByText((1_020).toLocaleString())).toBeInTheDocument()
-    expect(styledComponents.getByText('12.45 kB')).toBeInTheDocument()
+    expect(styledComponents.getByText(formatExpectedByteSize(12_450))).toBeInTheDocument()
     expect(styledComponents.getByTestId('diagnostics-styled-components-sheets')).toHaveTextContent(
-      '6.5.3: 900 rules, 12 kB · unknown version: 120 rules, 450 B',
+      `6.5.3: 900 rules, ${formatExpectedByteSize(12_000)} · unknown version: 120 rules, ${formatExpectedByteSize(450)}`,
     )
   })
 
@@ -449,4 +449,14 @@ function formatUtcTime(value: string): string {
     second: '2-digit',
     timeZone: 'UTC',
   })
+}
+
+function formatExpectedByteSize(value: number): string {
+  const units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB'] as const
+  const unitIndex = Math.min(
+    Math.max(0, Math.floor(Math.log(Math.max(value, 1)) / Math.log(1_000))),
+    units.length - 1,
+  )
+  const amount = value / 1_000 ** unitIndex
+  return `${amount.toLocaleString(undefined, {maximumFractionDigits: 2})} ${units[unitIndex]}`
 }

--- a/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.test.tsx
@@ -319,6 +319,25 @@ describe('DiagnosticsReport', () => {
     )
   })
 
+  it('omits invalid styled-components CSS sizes', () => {
+    render(
+      <ThemeProvider theme={buildTheme()}>
+        <DiagnosticsReport
+          diagnostics={{
+            ...diagnostics,
+            styles: {styledComponents: [{ruleCount: 12, sizeBytes: Number.NaN, version: '6.5.3'}]},
+          }}
+          onRunAgain={vi.fn()}
+        />
+      </ThemeProvider>,
+    )
+
+    const styledComponents = within(screen.getByTestId('diagnostics-styled-components'))
+    expect(styledComponents.getByText('CSS size inserted by JS')).toBeInTheDocument()
+    expect(styledComponents.getByText('Unknown')).toBeInTheDocument()
+    expect(styledComponents.queryByText('NaN undefined')).not.toBeInTheDocument()
+  })
+
   it('omits the styled-components card when no sheet is on the page', () => {
     render(
       <ThemeProvider theme={buildTheme()}>

--- a/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.tsx
@@ -491,10 +491,12 @@ function formatMilliseconds(value?: number): string | undefined {
 }
 
 function formatByteSize(value?: number): string | undefined {
-  if (value === undefined) return undefined
+  if (value === undefined || !Number.isFinite(value) || value < 0) return undefined
 
-  const unitIndex =
-    value === 0 ? 0 : Math.min(Math.floor(Math.log(value) / Math.log(1_000)), BYTE_UNITS.length - 1)
+  const unitIndex = Math.min(
+    Math.max(0, Math.floor(Math.log(Math.max(value, 1)) / Math.log(1_000))),
+    BYTE_UNITS.length - 1,
+  )
   const amount = value / 1_000 ** unitIndex
 
   return `${amount.toLocaleString(undefined, {maximumFractionDigits: 2})} ${BYTE_UNITS[unitIndex]}`

--- a/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/DiagnosticsReport.tsx
@@ -29,6 +29,8 @@ const DIAGNOSTIC_STATUS_LABELS: Record<DiagnosticStatus, string> = {
   unsupported: 'Unsupported',
 }
 
+const BYTE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB'] as const
+
 const CodeValue = styled.span`
   font-family: var(--card-code-family, monospace);
   overflow-wrap: anywhere;
@@ -292,6 +294,9 @@ function DetailRow({
 function StyledComponentsReport({sheets}: {sheets: StyleSheetDiagnostic[]}) {
   const versions = Array.from(new Set(sheets.map((sheet) => sheet.version ?? 'unknown version')))
   const ruleCount = sheets.reduce((sum, sheet) => sum + sheet.ruleCount, 0)
+  const sizeBytes = sheets.every((sheet) => sheet.sizeBytes !== undefined)
+    ? sheets.reduce((sum, sheet) => sum + (sheet.sizeBytes ?? 0), 0)
+    : undefined
   const multipleRuntimes = sheets.length > 1
 
   return (
@@ -318,12 +323,13 @@ function StyledComponentsReport({sheets}: {sheets: StyleSheetDiagnostic[]}) {
         }
       />
       <DetailRow label="CSS rules inserted by JS" value={ruleCount.toLocaleString()} wideLabel />
+      <DetailRow label="CSS size inserted by JS" value={formatByteSize(sizeBytes)} wideLabel />
       {multipleRuntimes ? (
         <Text data-testid="diagnostics-styled-components-sheets" muted size={1}>
           {sheets
             .map(
               (sheet) =>
-                `${sheet.version ?? 'unknown version'}: ${sheet.ruleCount.toLocaleString()} rules`,
+                `${sheet.version ?? 'unknown version'}: ${sheet.ruleCount.toLocaleString()} rules, ${formatByteSize(sheet.sizeBytes) ?? 'unknown size'}`,
             )
             .join(' · ')}
         </Text>
@@ -482,6 +488,16 @@ function formatHeaderTime(value: string, useUtc: boolean): string {
 
 function formatMilliseconds(value?: number): string | undefined {
   return formatOptional(value, (milliseconds) => `${Math.round(milliseconds).toLocaleString()} ms`)
+}
+
+function formatByteSize(value?: number): string | undefined {
+  if (value === undefined) return undefined
+
+  const unitIndex =
+    value === 0 ? 0 : Math.min(Math.floor(Math.log(value) / Math.log(1_000)), BYTE_UNITS.length - 1)
+  const amount = value / 1_000 ** unitIndex
+
+  return `${amount.toLocaleString(undefined, {maximumFractionDigits: 2})} ${BYTE_UNITS[unitIndex]}`
 }
 
 function formatElapsedDuration(start: string, end: string): string | undefined {

--- a/packages/sanity/src/core/studio/components/navbar/resources/__tests__/DiagnosticsReport.stories.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/__tests__/DiagnosticsReport.stories.tsx
@@ -1,0 +1,14 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+
+import {DiagnosticsReportStory} from './DiagnosticsReportStory'
+
+const meta = {
+  title: 'Studio/Diagnostics Report',
+  component: DiagnosticsReportStory,
+} satisfies Meta<typeof DiagnosticsReportStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Complete report including generated CSS metrics for multiple styled-components runtimes. */
+export const MultipleStyledComponentsRuntimes: Story = {}

--- a/packages/sanity/src/core/studio/components/navbar/resources/__tests__/DiagnosticsReportStory.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/__tests__/DiagnosticsReportStory.tsx
@@ -1,0 +1,91 @@
+import {Card} from '@sanity/ui'
+
+import {TestWrapper} from '../../../../../../../test/browser/TestWrapper'
+import {type StudioDiagnostics} from '../../../../diagnostics/gatherStudioDiagnostics'
+import {DiagnosticsReport} from '../DiagnosticsReport'
+
+const listen = {
+  durationMs: 42,
+  path: '/listen?query=*',
+  status: 'success',
+  timedOut: false,
+} as const
+
+const diagnostics: StudioDiagnostics = {
+  browser: {
+    hardwareConcurrency: 8,
+    language: 'en-US',
+    localStorage: {status: 'success'},
+    online: true,
+    timezone: 'UTC',
+    userAgent: 'Storybook browser',
+    viewport: {height: 900, width: 1_280},
+  },
+  diagnosticVersion: 1,
+  durationMs: 128,
+  generatedAt: '2026-08-21T12:00:00.128Z',
+  network: {
+    listen: {first: listen, secondWhileFirstOpen: listen},
+    protocol: {
+      durationMs: 42,
+      protocol: 'h2',
+      responseOk: true,
+      responseStatus: 200,
+      status: 'success',
+      timedOut: false,
+    },
+    requestHistory: {
+      dataset: 'production',
+      entries: [],
+      maxEntries: 500,
+      projectId: 'storybook',
+      sessionSummary: {
+        buckets: [],
+        startedAt: '2026-08-21T11:30:00.000Z',
+        totalRequests: 24,
+      },
+      totalRequests: 24,
+      truncated: false,
+    },
+    requests: [],
+  },
+  schema: {documentTypes: 12, objectTypes: 24, primitiveTypes: 7},
+  startedAt: '2026-08-21T12:00:00.000Z',
+  studio: {
+    apiHost: 'https://storybook.api.sanity.io',
+    autoUpdates: false,
+    dataset: 'production',
+    projectId: 'storybook',
+    reactVersion: '19.2.0',
+    uniqueTargetCount: 1,
+    version: '4.0.0',
+    workspaceCount: 1,
+    workspaceName: 'default',
+    workspaceTitle: 'Storybook workspace',
+  },
+  styles: {
+    styledComponents: [
+      {ruleCount: 1_234, sizeBytes: 112_450, version: '6.1.19'},
+      {ruleCount: 86, sizeBytes: 8_720, version: '5.3.11'},
+    ],
+  },
+  user: {
+    id: 'storybook-user',
+    provider: 'sanity',
+    roles: [{name: 'administrator', title: 'Administrator'}],
+  },
+}
+
+/**
+ * Shows a complete diagnostics report with multiple styled-components runtimes so the rule count,
+ * generated CSS size, version warning, and per-runtime summary stay visually covered.
+ */
+export function DiagnosticsReportStory() {
+  return (
+    <TestWrapper schemaTypes={[]}>
+      <Card padding={4}>
+        <DiagnosticsReport diagnostics={diagnostics} onRunAgain={() => undefined} />
+      </Card>
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.test.ts
+++ b/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.test.ts
@@ -61,4 +61,22 @@ describe('getStylesDiagnostics', () => {
     expect(sheet).toMatchObject({ruleCount: 2, version: '6.5.3'})
     expect(sheet?.sizeBytes).toBeGreaterThan(0)
   })
+
+  it('falls back to textContent when cssRules is inaccessible', () => {
+    const node = appendStyledSheet('.a{color:red}', '6.5.3')
+    Object.defineProperty(node, 'sheet', {
+      configurable: true,
+      get() {
+        return {
+          get cssRules(): CSSRuleList {
+            throw new DOMException('The operation is insecure.', 'SecurityError')
+          },
+        }
+      },
+    })
+
+    expect(getStylesDiagnostics().styledComponents).toEqual([
+      {ruleCount: 0, sizeBytes: 13, version: '6.5.3'},
+    ])
+  })
 })

--- a/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.test.ts
+++ b/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.test.ts
@@ -4,13 +4,14 @@ import {getStylesDiagnostics} from './getStylesDiagnostics'
 
 const styleNodes: HTMLStyleElement[] = []
 
-function appendStyledSheet(css: string, version?: string): void {
+function appendStyledSheet(css: string, version?: string): HTMLStyleElement {
   const node = document.createElement('style')
   node.dataset.styled = 'active'
   if (version) node.dataset.styledVersion = version
   node.textContent = css
   document.head.appendChild(node)
   styleNodes.push(node)
+  return node
 }
 
 afterEach(() => {
@@ -26,15 +27,38 @@ describe('getStylesDiagnostics', () => {
     appendStyledSheet('.a{color:red}.b{color:blue}', '6.5.3')
     appendStyledSheet('.c{color:green}')
 
-    expect(getStylesDiagnostics().styledComponents).toEqual([
-      {ruleCount: 2, sizeBytes: 27, version: '6.5.3'},
-      {ruleCount: 1, sizeBytes: 15, version: undefined},
-    ])
+    const [first, second] = getStylesDiagnostics().styledComponents
+    expect(first).toMatchObject({ruleCount: 2, version: '6.5.3'})
+    expect(second).toMatchObject({ruleCount: 1, version: undefined})
+    expect(first?.sizeBytes).toBeGreaterThan(0)
+    expect(second?.sizeBytes).toBeGreaterThan(0)
+    expect(first?.sizeBytes).toBeGreaterThan(second?.sizeBytes ?? 0)
   })
 
   it('counts multibyte characters as they would be encoded in a CSS file', () => {
-    appendStyledSheet('.a::before{content:"é😀"}')
+    appendStyledSheet('.a::before{content:"e"}')
+    const ascii = getStylesDiagnostics().styledComponents[0]?.sizeBytes
 
-    expect(getStylesDiagnostics().styledComponents[0]?.sizeBytes).toBe(28)
+    for (const node of styleNodes.splice(0)) node.remove()
+    appendStyledSheet('.a::before{content:"é😀"}')
+    const multibyte = getStylesDiagnostics().styledComponents[0]?.sizeBytes
+
+    expect(ascii).toBeGreaterThan(0)
+    expect(multibyte).toBeGreaterThan(ascii ?? 0)
+  })
+
+  it('measures CSSOM-injected sheets whose style tags have empty innerHTML', () => {
+    const node = document.createElement('style')
+    node.dataset.styled = 'active'
+    node.dataset.styledVersion = '6.5.3'
+    document.head.appendChild(node)
+    styleNodes.push(node)
+    node.sheet?.insertRule('.a{color:red}')
+    node.sheet?.insertRule('.b{color:blue}')
+
+    expect(node.innerHTML).toBe('')
+    const [sheet] = getStylesDiagnostics().styledComponents
+    expect(sheet).toMatchObject({ruleCount: 2, version: '6.5.3'})
+    expect(sheet?.sizeBytes).toBeGreaterThan(0)
   })
 })

--- a/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.test.ts
+++ b/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.test.ts
@@ -22,13 +22,19 @@ describe('getStylesDiagnostics', () => {
     expect(getStylesDiagnostics()).toEqual({styledComponents: []})
   })
 
-  it('reports rule counts and versions for each styled-components sheet', () => {
+  it('reports rule counts, UTF-8 sizes, and versions for each styled-components sheet', () => {
     appendStyledSheet('.a{color:red}.b{color:blue}', '6.5.3')
     appendStyledSheet('.c{color:green}')
 
     expect(getStylesDiagnostics().styledComponents).toEqual([
-      {ruleCount: 2, version: '6.5.3'},
-      {ruleCount: 1, version: undefined},
+      {ruleCount: 2, sizeBytes: 27, version: '6.5.3'},
+      {ruleCount: 1, sizeBytes: 15, version: undefined},
     ])
+  })
+
+  it('counts multibyte characters as they would be encoded in a CSS file', () => {
+    appendStyledSheet('.a::before{content:"é😀"}')
+
+    expect(getStylesDiagnostics().styledComponents[0]?.sizeBytes).toBe(28)
   })
 })

--- a/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
+++ b/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
@@ -18,6 +18,8 @@ export interface StylesDiagnostics {
   styledComponents: StyleSheetDiagnostic[]
 }
 
+const textEncoder = new TextEncoder()
+
 /** @internal */
 export function getStylesDiagnostics(): StylesDiagnostics {
   if (typeof document === 'undefined') return {styledComponents: []}
@@ -35,7 +37,7 @@ export function getStylesDiagnostics(): StylesDiagnostics {
 }
 
 function getStyleSheetSizeBytes(node: HTMLStyleElement): number {
-  return new TextEncoder().encode(serializeStyleSheet(node.sheet) || node.innerHTML).byteLength
+  return textEncoder.encode(serializeStyleSheet(node.sheet) || node.textContent || '').byteLength
 }
 
 function serializeStyleSheet(sheet: CSSStyleSheet | null): string {

--- a/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
+++ b/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
@@ -2,6 +2,8 @@
 export interface StyleSheetDiagnostic {
   /** `sheet.cssRules.length` of a `<style data-styled>` element; 0 when the sheet is unavailable */
   ruleCount: number
+  /** UTF-8 byte length of the element's `innerHTML`; optional for reports from older studios */
+  sizeBytes?: number
   /** The element's `data-styled-version` attribute, the version of the runtime that owns it */
   version?: string
 }
@@ -25,6 +27,7 @@ export function getStylesDiagnostics(): StylesDiagnostics {
       document.querySelectorAll<HTMLStyleElement>('style[data-styled]'),
       (node) => ({
         ruleCount: node.sheet?.cssRules.length ?? 0,
+        sizeBytes: new TextEncoder().encode(node.innerHTML).byteLength,
         version: node.dataset.styledVersion || undefined,
       }),
     ),

--- a/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
+++ b/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
@@ -2,7 +2,7 @@
 export interface StyleSheetDiagnostic {
   /** `sheet.cssRules.length` of a `<style data-styled>` element; 0 when the sheet is unavailable */
   ruleCount: number
-  /** UTF-8 byte length of the element's `innerHTML`; optional for reports from older studios */
+  /** UTF-8 byte length of the generated CSS, as it would be in an external stylesheet */
   sizeBytes?: number
   /** The element's `data-styled-version` attribute, the version of the runtime that owns it */
   version?: string
@@ -27,9 +27,18 @@ export function getStylesDiagnostics(): StylesDiagnostics {
       document.querySelectorAll<HTMLStyleElement>('style[data-styled]'),
       (node) => ({
         ruleCount: node.sheet?.cssRules.length ?? 0,
-        sizeBytes: new TextEncoder().encode(node.innerHTML).byteLength,
+        sizeBytes: getStyleSheetSizeBytes(node),
         version: node.dataset.styledVersion || undefined,
       }),
     ),
   }
+}
+
+function getStyleSheetSizeBytes(node: HTMLStyleElement): number {
+  return new TextEncoder().encode(serializeStyleSheet(node.sheet) || node.innerHTML).byteLength
+}
+
+function serializeStyleSheet(sheet: CSSStyleSheet | null): string {
+  if (!sheet) return ''
+  return Array.from(sheet.cssRules, (rule) => rule.cssText).join('')
 }

--- a/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
+++ b/packages/sanity/src/core/studio/diagnostics/getStylesDiagnostics.ts
@@ -27,20 +27,30 @@ export function getStylesDiagnostics(): StylesDiagnostics {
   return {
     styledComponents: Array.from(
       document.querySelectorAll<HTMLStyleElement>('style[data-styled]'),
-      (node) => ({
-        ruleCount: node.sheet?.cssRules.length ?? 0,
-        sizeBytes: getStyleSheetSizeBytes(node),
-        version: node.dataset.styledVersion || undefined,
-      }),
+      (node) => {
+        const {css, ruleCount} = readStyleSheet(node)
+        return {
+          ruleCount,
+          sizeBytes: textEncoder.encode(css).byteLength,
+          version: node.dataset.styledVersion || undefined,
+        }
+      },
     ),
   }
 }
 
-function getStyleSheetSizeBytes(node: HTMLStyleElement): number {
-  return textEncoder.encode(serializeStyleSheet(node.sheet) || node.textContent || '').byteLength
-}
+function readStyleSheet(node: HTMLStyleElement): {css: string; ruleCount: number} {
+  try {
+    const rules = node.sheet?.cssRules
+    if (rules) {
+      return {
+        css: Array.from(rules, (rule) => rule.cssText).join(''),
+        ruleCount: rules.length,
+      }
+    }
+  } catch {
+    // Cross-origin or otherwise inaccessible CSSOM sheets throw on `cssRules`.
+  }
 
-function serializeStyleSheet(sheet: CSSStyleSheet | null): string {
-  if (!sheet) return ''
-  return Array.from(sheet.cssRules, (rule) => rule.cssText).join('')
+  return {css: node.textContent ?? '', ruleCount: 0}
 }

--- a/packages/sanity/src/core/studio/diagnostics/parseStudioDiagnostics.test.ts
+++ b/packages/sanity/src/core/studio/diagnostics/parseStudioDiagnostics.test.ts
@@ -55,7 +55,12 @@ describe('parseStudioDiagnostics', () => {
     const extended: StudioDiagnostics = {
       ...report,
       studio: {...report.studio, autoUpdates: true},
-      styles: {styledComponents: [{ruleCount: 1234, version: '6.5.3'}, {ruleCount: 12}]},
+      styles: {
+        styledComponents: [
+          {ruleCount: 1234, sizeBytes: 18_500, version: '6.5.3'},
+          {ruleCount: 12, sizeBytes: 240},
+        ],
+      },
     }
 
     expect(parse(extended)).toEqual(extended)
@@ -71,6 +76,15 @@ describe('parseStudioDiagnostics', () => {
     expect(() => parse({...report, styles: {styledComponents: [{version: '6.5.3'}]}})).toThrow(
       'not a supported Studio diagnostics report',
     )
+  })
+
+  it('rejects a non-numeric styled-components size', () => {
+    expect(() =>
+      parse({
+        ...report,
+        styles: {styledComponents: [{ruleCount: 1, sizeBytes: '100'}]},
+      }),
+    ).toThrow('not a supported Studio diagnostics report')
   })
 
   it('rejects a non-boolean auto-updates flag', () => {

--- a/packages/sanity/src/core/studio/diagnostics/parseStudioDiagnostics.ts
+++ b/packages/sanity/src/core/studio/diagnostics/parseStudioDiagnostics.ts
@@ -155,6 +155,7 @@ function isStylesDiagnostics(value: unknown): boolean {
     (node) =>
       isRecord(node) &&
       typeof node.ruleCount === 'number' &&
+      (node.sizeBytes === undefined || typeof node.sizeBytes === 'number') &&
       (node.version === undefined || typeof node.version === 'string'),
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Rule counts alone do not show the transfer-size impact of CSS generated by styled-components. Record each style element's generated CSS as UTF-8 bytes—the size those contents would have as an external CSS resource—and show human-readable decimal file-size units while keeping older reports parseable.

Production styled-components injects via CSSOM (`insertRule`), so the `<style>` tag's markup is empty even when hundreds of rules are present. Size is therefore measured from `sheet.cssRules`, with `textContent` as a fallback when the CSSOM sheet is missing or inaccessible.

### What to review

Review the UTF-8 measurement and backwards-compatible diagnostics parser, plus aggregate and per-runtime formatting in the `sanity` diagnostics report. A deterministic Storybook state covers the multi-runtime warning and CSS metrics.

### Testing

- Focused collector, parser, and report unit tests, including CSSOM-injected empty markup, inaccessible `cssRules`, and invalid byte-size formatting
- Diagnostics Storybook story renders successfully in Chromium
- Storybook static build passes
- Changed files pass formatting and oxlint
- Visual coverage reports `DiagnosticsReport.tsx` covered by the new story

### Notes for release

The Studio diagnostics panel now reports the generated styled-components CSS size alongside its rule count.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7033667a-009e-43c1-a4f7-e6666f031098?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7033667a-009e-43c1-a4f7-e6666f031098&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

