### PR TITLE
chore(test): stop measuring vitest import durations

### DIFF
--- a/packages/@repo/test-config/vitest/index.mjs
+++ b/packages/@repo/test-config/vitest/index.mjs
@@ -35,15 +35,6 @@ export function defineConfig(config) {
       disableConsoleIntercept: config?.test?.disableConsoleIntercept ?? true,
       alias: {...config?.test?.alias, ...getViteAliases()},
       execArgv: [...workerExecArgv, ...(config?.test?.execArgv ?? [])],
-      experimental: {
-        // Print the slowest imports after test runs, to keep the cost of heavy
-        // import graphs (e.g. barrel files) visible in CI and local runs.
-        importDurations: {
-          limit: 10,
-          print: true,
-        },
-        ...config?.test?.experimental,
-      },
       typecheck: {
         ...config?.test?.typecheck,
         exclude: [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -15,14 +15,6 @@ const workerExecArgv = ['--no-experimental-webstorage']
 export default defineConfig({
   test: {
     execArgv: workerExecArgv,
-    experimental: {
-      // Print the slowest imports after test runs, to keep the cost of heavy
-      // import graphs (e.g. barrel files) visible in CI and local runs.
-      importDurations: {
-        limit: 10,
-        print: true,
-      },
-    },
     forceRerunTriggers: [
       '**/package.json/**',
       '**/vitest.config.*/**',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Import duration reporting was added during the debarreling effort to keep heavy import graphs visible in CI and local runs. That work is done, so we no longer need the experimental `importDurations` measurement overhead on every vitest run.

### What to review

- Shared defaults in `@repo/test-config` vitest helper
- Root `vitest.config.mts` (same opt-in removed)

### Testing

Ran focused vitest projects that use both configs:

- `pnpm vitest run --project=@sanity/types` — 23 files / 60 tests passed
- `pnpm vitest run --project=@sanity/mutator` — 15 files / 149 tests passed

Neither run printed an import-duration report; configs no longer contain `importDurations`.

### Notes for release

N/A – Internal only

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07b00-f490-78f3-ba7b-fe5904bc6962?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07b00-f490-78f3-ba7b-fe5904bc6962&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

