### PR TITLE
fix(core): keep draft chip avatar orange when no draft exists

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.test.tsx
@@ -1,0 +1,108 @@
+import {render, screen, within} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {useVersionContextMenu} from '../../hooks/useVersionContextMenu'
+import {type LATEST, PUBLISHED} from '../../util/const'
+import {VersionChip} from './VersionChip'
+
+vi.mock('../../hooks/useVersionContextMenu', () => ({
+  useVersionContextMenu: vi.fn(),
+}))
+
+const mockUseVersionContextMenu = vi.mocked(useVersionContextMenu)
+
+const contextValues = {
+  documentGroupId: 'foo',
+  versionId: 'foo',
+  documentType: 'author',
+  releases: [],
+  releasesLoading: false,
+  isVersion: false,
+}
+
+const noop = () => {}
+const emptyMenuAction = {
+  icon: undefined,
+  text: '',
+  tone: 'default' as const,
+  onClick: noop,
+  disabled: false,
+}
+
+function mockContextMenu(sourceReleasePerspective: typeof LATEST | typeof PUBLISHED) {
+  mockUseVersionContextMenu.mockReturnValue({
+    contextMenu: {open: false},
+    handleContextMenu: noop,
+    closeContextMenu: noop,
+    popoverRef: {current: null},
+    referenceElement: null,
+    setReferenceElement: noop,
+    dialogState: 'idle',
+    closeDialog: noop,
+    openDiscardDialog: noop,
+    openCreateReleaseDialog: noop,
+    handleCopyToDrafts: async () => {},
+    handleAddVersion: async () => {},
+    isScheduledDraft: false,
+    scheduledDraftMenuActions: {
+      actions: {
+        publishNow: emptyMenuAction,
+        editSchedule: emptyMenuAction,
+        deleteSchedule: {...emptyMenuAction, tone: 'critical'},
+        schedulePublish: emptyMenuAction,
+      },
+      dialogs: null,
+      isPerformingOperation: false,
+      selectedAction: null,
+      handleDialogClose: noop,
+    },
+    sourceReleasePerspective,
+  })
+}
+
+describe('VersionChip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    HTMLElement.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('keeps the draft avatar caution when the chip acts on the published document', async () => {
+    mockContextMenu(PUBLISHED)
+    const wrapper = await createTestProvider()
+
+    render(
+      <VersionChip
+        selected={false}
+        text="Draft"
+        tone="neutral"
+        onClick={noop}
+        contextValues={{...contextValues, bundleId: 'draft'}}
+      />,
+      {wrapper},
+    )
+
+    const chip = screen.getByRole('button', {name: 'Draft'})
+    expect(within(chip).getByTestId('release-avatar-caution')).toBeInTheDocument()
+    expect(within(chip).queryByTestId('release-avatar-positive')).not.toBeInTheDocument()
+  })
+
+  it('keeps the published avatar positive', async () => {
+    mockContextMenu(PUBLISHED)
+    const wrapper = await createTestProvider()
+
+    render(
+      <VersionChip
+        selected
+        text="Published"
+        tone="positive"
+        onClick={noop}
+        contextValues={{...contextValues, bundleId: 'published'}}
+      />,
+      {wrapper},
+    )
+
+    const chip = screen.getByRole('button', {name: 'Published'})
+    expect(within(chip).getByTestId('release-avatar-positive')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -12,6 +12,7 @@ import {useReleasesToolAvailable} from '../../../schedules/hooks/useReleasesTool
 import {getDraftId, getPublishedId, getVersionId} from '../../../util/draftUtils'
 import {isPausedCardinalityOneRelease} from '../../../util/releaseUtils'
 import {useVersionContextMenu} from '../../hooks/useVersionContextMenu'
+import {LATEST} from '../../util/const'
 import {Chip} from '../Chip'
 import {ReleaseAvatarIcon} from '../ReleaseAvatar'
 import {VersionContextMenuDialogs} from './contextMenu/VersionContextMenuDialogs'
@@ -123,6 +124,9 @@ export const VersionChip = memo(function VersionChip(props: {
   const contextMenuHandler = disabled || !releasesToolAvailable ? undefined : handleContextMenu
 
   const isPaused = isPausedCardinalityOneRelease(release)
+  // Draft chips may act on the published document when no draft exists (so "add
+  // to a release" copies what's on screen). The avatar still represents drafts.
+  const avatarRelease = bundleId === 'draft' ? LATEST : sourceReleasePerspective
 
   const rightIcon = useMemo(() => {
     if (isLinked) return <ComposeSparklesIcon />
@@ -145,7 +149,7 @@ export const VersionChip = memo(function VersionChip(props: {
             selected={selected}
             tone={tone}
             onContextMenu={contextMenuHandler}
-            icon={<ReleaseAvatarIcon release={sourceReleasePerspective} />}
+            icon={<ReleaseAvatarIcon release={avatarRelease} />}
             iconRight={rightIcon}
             text={text}
           />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

When a published document has no draft, the Draft chip still falls back to the published document id so “add to a release” copies what is on screen. That lookup also drove the chip avatar, so the Draft badge rendered with the published (green) tone.

The avatar now always uses the drafts perspective for `bundleId: 'draft'`. Context-menu actions still run against the published document when there is no draft.

Why not drop the published `versionId` fallback: that would break add-to-release from the empty Draft chip. Why not change `sourceReleasePerspective` in the context-menu hook: dialogs still need the document being acted on.

### What to review

- `VersionChip` avatar vs action identity (`bundleId` vs `versionId`)
- Confirm Published chips stay green

To test it you can use this link https://test-studio-git-cursor-fix-draft-badge-green-color-3242.sanity.dev/test-studio-variants-disabled/structure/book;elementaryScarab

### Testing

- Unit test: Draft chip with a published `sourceReleasePerspective` still renders `release-avatar-caution`
- Manual in `test-studio-variants-disabled` on author `087cdc38-b147-431c-b1a4-bde5cdf33130` (published, no draft)

Before (Draft dot green):

[Draft chip with green published avatar before the fix](https://cursor.com/agents/bc-cafd6d76-9e71-4e15-87b5-78069c913242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdraft_badge_before.png)

After, published selected (Draft dot orange):

[Draft chip with orange drafts avatar after the fix, published selected](https://cursor.com/agents/bc-cafd6d76-9e71-4e15-87b5-78069c913242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdraft_badge_after_published.png)

After, draft selected:

[Draft chip with orange drafts avatar after the fix, draft selected](https://cursor.com/agents/bc-cafd6d76-9e71-4e15-87b5-78069c913242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdraft_badge_after_draft.png)

### Notes for release

The Draft perspective chip in the document header now stays orange when the document is published and has no draft. Previously the badge inherited the published (green) color.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cafd6d76-9e71-4e15-87b5-78069c913242?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cafd6d76-9e71-4e15-87b5-78069c913242&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

