### PR TITLE
fix(test-studio): shorten style panel labels and use green and red ui colors

### DIFF
--- a/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
+++ b/dev/test-studio/plugins/style-outline/StyleOutlinePanel.tsx
@@ -265,13 +265,13 @@ export default function StyleOutlinePanel() {
                 <span className={escapeCountValue}>
                   {styledCount === undefined ? '—' : styledCount.toLocaleString()}
                 </span>
-                <span className={metricLabel}>component instances</span>
+                <span className={metricLabel}>components</span>
               </div>
               <div
                 className={rowCount}
                 title={`${metrics?.stylesheets.inaccessible ?? 0} unreadable stylesheets`}
               >
-                {formatPercentage(styledRulePercentage)} of readable CSS rules
+                {formatPercentage(styledRulePercentage)} of CSS rules
               </div>
             </div>
             <div

--- a/dev/test-studio/plugins/style-outline/styleSystems.ts
+++ b/dev/test-studio/plugins/style-outline/styleSystems.ts
@@ -17,10 +17,10 @@ const FINGERPRINTS: readonly Fingerprint[] = [
   {
     id: 'ui5',
     label: '@sanity/ui v5',
-    color: '#3ecf8e',
+    color: '#3fb950',
     match: '[class^="sui-"], [class*=" sui-"]',
   },
-  {id: 'ui4', label: '@sanity/ui v4', color: '#e5565b', match: '[data-ui]'},
+  {id: 'ui4', label: '@sanity/ui v4', color: '#e2604f', match: '[data-ui]'},
   {
     id: 'styled',
     label: 'styled-components',

--- a/dev/test-studio/plugins/style-outline/styleSystems.ts
+++ b/dev/test-studio/plugins/style-outline/styleSystems.ts
@@ -17,10 +17,10 @@ const FINGERPRINTS: readonly Fingerprint[] = [
   {
     id: 'ui5',
     label: '@sanity/ui v5',
-    color: '#22d3ee',
+    color: '#3ecf8e',
     match: '[class^="sui-"], [class*=" sui-"]',
   },
-  {id: 'ui4', label: '@sanity/ui v4', color: '#f5a524', match: '[data-ui]'},
+  {id: 'ui4', label: '@sanity/ui v4', color: '#e5565b', match: '[data-ui]'},
   {
     id: 'styled',
     label: 'styled-components',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Three fixes to the test-studio style migrations panel (`dev/test-studio/plugins/style-outline`, mounted when `SANITY_STUDIO_STYLE_OUTLINE=true`):

- Shortened the Styled-components escape metrics to "components" and "% of CSS rules" so both halves fit on one line at the panel's fixed 320px width. The tooltip still reports unreadable stylesheets.
- Changed `@sanity/ui v5` to green (`#3fb950`) and `@sanity/ui v4` to coral red (`#e2604f`). Both work as 1px debug outlines and remain comfortable in the 20/80 donut; v4 stays distinct from the magenta used for styled-components.
- UI v5 and styled-components fingerprints now deliberately overlap. A v5 node carrying a styled-components class contributes to both counts and matches both outline rules. The styled-components selector wins when both toggles are enabled, making migration debt magenta. UI v4 behavior remains intentionally exclusive: v4 yields to v5 in adoption counting, and nodes resolved as v4 are excluded from styled-components counting/outlining. A v5 node may also retain `data-ui`; it still counts as both v5 and styled-components because it resolves as v5 rather than v4.

### What to review

- The explicit `exclude` entries in `styleSystems.ts`: v4 excludes the v5 fingerprint; styled-components excludes the resolved v4 selector rather than every `data-ui` node.
- Combined v5 + styled-components outline precedence: overlapping nodes should be magenta.
- Combined v4 + styled-components behavior: resolved v4 nodes should remain coral red.
- The shortened visible labels; accessibility text retains the precise "readable CSS rules" wording.

### Testing

- Selector checks against synthetic DOM nodes pass for plain v5, plain v4, plain styled-components, v5 + styled-components, v5 + `data-ui` + styled-components, and v4 + styled-components.
- Live Studio verification shows the styled-components count rise to 228 with v5 overlap included. With v5 + styled enabled, "Divider title" changes from green to magenta while v5-only nodes remain green. With v4 + styled enabled, resolved v4 nodes remain coral red.
- `pnpm check:format` and `pnpm check:oxlint` pass.

[UI v5 and styled-components enabled together; overlapping nodes are magenta while v5-only nodes remain green](https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v5_and_styled_overlap.webp)

[UI v4 and styled-components enabled together; resolved v4 nodes remain coral red](https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v4_stays_excluded.webp)

[style_outline_v5_styled_overlap_precedence.mp4](https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v5_styled_overlap_precedence.mp4)

### Notes for release

N/A: Internal test-studio tooling only.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3fa2301-a37b-47a8-a47f-e2277005f69a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

