### PR TITLE
refactor(tasks): migrate task components to vanilla-extract

### DIFF
--- a/packages/sanity/src/core/tasks/components/TasksUserAvatar.css.ts
+++ b/packages/sanity/src/core/tasks/components/TasksUserAvatar.css.ts
@@ -1,0 +1,25 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `${avatar.sizes[size].size}px` */
+export const avatarSizeVar = createVar()
+
+export const avatarRoot = style({
+  minHeight: avatarSizeVar,
+  minWidth: avatarSizeVar,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '50%',
+})
+
+/** Added next to `avatarRoot` when `border` is set */
+export const avatarRootBorder = style({
+  boxShadow: 'inset 0 0 0 1px var(--card-border-color)',
+})
+
+/** Added next to `avatarRoot` when `removeBg` is set */
+export const avatarRootRemoveBg = style({
+  vars: {
+    '--card-avatar-gray-bg-color': 'transparent',
+  },
+})

--- a/packages/sanity/src/core/tasks/components/TasksUserAvatar.tsx
+++ b/packages/sanity/src/core/tasks/components/TasksUserAvatar.tsx
@@ -1,28 +1,38 @@
 import {UserIcon} from '@sanity/icons/User'
 import {type User} from '@sanity/types'
-import {type AvatarSize, Text} from '@sanity/ui'
-import {getTheme_v2} from '@sanity/ui/theme'
-import {css, styled} from 'styled-components'
+import {type AvatarSize, Text, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ReactNode} from 'react'
 
 import {Tooltip} from '../../../ui-components/tooltip/Tooltip'
 import {AvatarSkeleton, UserAvatar} from '../../components/userAvatar/UserAvatar'
 import {useUser} from '../../store/user/hooks'
+import {
+  avatarRoot,
+  avatarRootBorder,
+  avatarRootRemoveBg,
+  avatarSizeVar,
+} from './TasksUserAvatar.css'
 
-const AvatarRoot = styled.div<{$size: AvatarSize; $border?: boolean; $removeBg?: boolean}>(
-  (props) => {
-    const theme = getTheme_v2(props.theme)
-    return css`
-      min-height: ${theme.avatar.sizes[props.$size]?.size}px;
-      min-width: ${theme.avatar.sizes[props.$size]?.size}px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 50%;
-      ${props.$border ? 'box-shadow: inset 0 0 0 1px var(--card-border-color);' : ''};
-      ${props.$removeBg ? '--card-avatar-gray-bg-color: transparent;' : ''}
-    `
-  },
-)
+function AvatarRoot(props: {
+  size: AvatarSize
+  border?: boolean
+  removeBg?: boolean
+  children: ReactNode
+}) {
+  const {size, border, removeBg, children} = props
+  const {avatar} = useThemeV2()
+
+  return (
+    <div
+      className={clsx(avatarRoot, border && avatarRootBorder, removeBg && avatarRootRemoveBg)}
+      style={assignInlineVars({[avatarSizeVar]: `${avatar.sizes[size]?.size}px`})}
+    >
+      {children}
+    </div>
+  )
+}
 
 export function TasksUserAvatar(props: {
   user?: User
@@ -39,7 +49,7 @@ export function TasksUserAvatar(props: {
 
   if (!user || !loadedUser) {
     return (
-      <AvatarRoot $size={size} $border={border}>
+      <AvatarRoot size={size} border={border}>
         <Text size={size}>
           <UserIcon />
         </Text>
@@ -55,7 +65,7 @@ export function TasksUserAvatar(props: {
       fallbackPlacements={['top', 'top-start']}
       placement="top-end"
     >
-      <AvatarRoot $size={size} $removeBg={!!loadedUser?.imageUrl}>
+      <AvatarRoot size={size} removeBg={!!loadedUser?.imageUrl}>
         <UserAvatar
           user={loadedUser}
           size={size}

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityCommentItem.css.ts
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityCommentItem.css.ts
@@ -1,0 +1,15 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `${space[2]}px` */
+export const space2Var = createVar()
+
+export const commentListItemRoot = style({})
+
+globalStyle(`${commentListItemRoot} [data-ui='CommentsListItem']`, {
+  paddingRight: space2Var,
+})
+
+// Increase the padding when the comment input is focused
+globalStyle(`${commentListItemRoot} [data-ui='CommentInputEditableWrap']:focus-within`, {
+  paddingBottom: space2Var,
+})

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityCommentItem.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityCommentItem.tsx
@@ -1,11 +1,12 @@
-import {getTheme_v2} from '@sanity/ui/theme'
-import {css, styled} from 'styled-components'
+import {useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 
 import {
   CommentsListItem,
   type CommentsListItemProps,
 } from '../../../comments/components/list/CommentsListItem'
 import {useTasksEnabled} from '../../context/enabled/useTasksEnabled'
+import {commentListItemRoot, space2Var} from './TasksActivityCommentItem.css'
 import {ActivityItem} from './TasksActivityItem'
 
 const COMMENTS_LIST_ITEM_AVATAR_CONFIG: CommentsListItemProps['avatarConfig'] = {
@@ -19,26 +20,14 @@ interface TasksActivityCommentItemProps extends Omit<CommentsListItemProps, 'mod
   // ...
 }
 
-const CommentListItemRoot = styled.div((props) => {
-  const theme = getTheme_v2(props.theme)
-  return css`
-    [data-ui='CommentsListItem'] {
-      padding-right: ${theme.space[2]}px;
-    }
-
-    // Increase the padding when the comment input is focused
-    [data-ui='CommentInputEditableWrap']:focus-within {
-      padding-bottom: ${theme.space[2]}px;
-    }
-  `
-})
 export function TasksActivityCommentItem(props: TasksActivityCommentItemProps) {
   const {parentComment} = props
   const {mode} = useTasksEnabled()
+  const {space} = useThemeV2()
 
   return (
     <ActivityItem userId={parentComment.authorId} avatarPaddingTop={3}>
-      <CommentListItemRoot>
+      <div className={commentListItemRoot} style={assignInlineVars({[space2Var]: `${space[2]}px`})}>
         <CommentsListItem
           {...props}
           avatarConfig={COMMENTS_LIST_ITEM_AVATAR_CONFIG}
@@ -46,7 +35,7 @@ export function TasksActivityCommentItem(props: TasksActivityCommentItemProps) {
           isSelected={false}
           mode={mode ?? 'default'}
         />
-      </CommentListItemRoot>
+      </div>
     </ActivityItem>
   )
 }

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityCreatedAt.css.ts
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityCreatedAt.css.ts
@@ -1,0 +1,5 @@
+import {style} from '@vanilla-extract/css'
+
+export const userSkeleton = style({
+  maxWidth: '15ch',
+})

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityCreatedAt.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityCreatedAt.tsx
@@ -1,6 +1,5 @@
 import {Text, TextSkeleton} from '@sanity/ui'
 import {memo} from 'react'
-import {styled} from 'styled-components'
 import {Flex} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -8,12 +7,8 @@ import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useUser} from '../../../store/user/hooks'
 import {tasksLocaleNamespace} from '../../i18n'
 import {NoWrap, useUpdatedTimeAgo} from './helpers'
+import {userSkeleton} from './TasksActivityCreatedAt.css'
 import {ActivityItem} from './TasksActivityItem'
-
-const UserSkeleton = styled(TextSkeleton)`
-  max-width: 15ch;
-  width: '100%';
-`
 
 interface TasksActivityCreatedAtProps {
   createdAt: string
@@ -32,7 +27,7 @@ export const TasksActivityCreatedAt = memo(
           <Text size={1} muted>
             <strong style={{fontWeight: 600}}>
               {loading ? (
-                <UserSkeleton />
+                <TextSkeleton className={userSkeleton} />
               ) : (
                 (user?.displayName ?? t('panel.activity.unknown-user'))
               )}{' '}

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityItem.css.ts
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityItem.css.ts
@@ -1,0 +1,9 @@
+import {style} from '@vanilla-extract/css'
+
+export const activityChildrenRoot = style({
+  height: '100%',
+})
+
+export const activityItemChildrenContainer = style({
+  width: '100%',
+})

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityItem.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityItem.tsx
@@ -1,14 +1,7 @@
-import {styled} from 'styled-components'
 import {Flex, Box, type Space} from 'ui5'
 
 import {TasksUserAvatar} from '../TasksUserAvatar'
-
-const ActivityChildrenRoot = styled(Flex)`
-  height: 100%;
-`
-const ActivityItemChildrenContainer = styled.div`
-  width: 100%;
-`
+import {activityChildrenRoot, activityItemChildrenContainer} from './TasksActivityItem.css'
 
 interface ActivityItemProps {
   userId: string
@@ -21,9 +14,9 @@ export function ActivityItem({avatarPaddingTop = 1, userId, children}: ActivityI
       <Box marginRight={3} paddingTop={avatarPaddingTop}>
         <TasksUserAvatar user={{id: userId}} size={0} />
       </Box>
-      <ActivityChildrenRoot alignItems="center" flexBasis="0%" flexGrow={1}>
-        <ActivityItemChildrenContainer>{children}</ActivityItemChildrenContainer>
-      </ActivityChildrenRoot>
+      <Flex alignItems="center" flexBasis="0%" flexGrow={1} className={activityChildrenRoot}>
+        <div className={activityItemChildrenContainer}>{children}</div>
+      </Flex>
     </Flex>
   )
 }

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
@@ -3,7 +3,6 @@ import {Stack, Text} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import {AnimatePresence, motion, type Variants} from 'motion/react'
 import {useMemo, useState} from 'react'
-import {styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {CommentDeleteDialog} from '../../../comments/components/CommentDeleteDialog'
@@ -45,7 +44,7 @@ const VARIANTS: Variants = {
   visible: {opacity: 1, x: 0},
 }
 
-const MotionStack = styled(motion.create(Stack))``
+const MotionStack = motion.create(Stack)
 
 interface TasksActivityLogProps {
   onChange: (patch: FormPatch | PatchEvent | FormPatch[]) => void

--- a/packages/sanity/src/core/tasks/components/activity/helpers/index.css.ts
+++ b/packages/sanity/src/core/tasks/components/activity/helpers/index.css.ts
@@ -1,0 +1,18 @@
+import {globalStyle, style} from '@vanilla-extract/css'
+
+export const strong = style({
+  fontWeight: 600,
+})
+
+export const noWrap = style({
+  whiteSpace: 'nowrap',
+})
+
+export const linkWrapper = style({})
+
+globalStyle(`${linkWrapper} > a`, {
+  color: 'var(--card-fg-muted-color)',
+  textDecoration: 'underline',
+  textUnderlineOffset: '1px',
+  fontWeight: 600,
+})

--- a/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
@@ -4,8 +4,9 @@ import {EditIcon} from '@sanity/icons/Edit'
 import {LinkIcon} from '@sanity/icons/Link'
 import {UserIcon} from '@sanity/icons/User'
 import {TextSkeleton} from '@sanity/ui'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 import {IntentLink} from 'sanity/router'
-import {styled} from 'styled-components'
 
 import {useDateTimeFormat, type UseDateTimeFormatOptions} from '../../../../hooks/useDateTimeFormat'
 import {type RelativeTimeOptions, useRelativeTime} from '../../../../hooks/useRelativeTime'
@@ -15,6 +16,7 @@ import {useUser} from '../../../../store/user/hooks'
 import {TASK_STATUS} from '../../../constants/TaskStatus'
 import {useDocumentPreviewValues} from '../../../hooks/useDocumentPreviewValues'
 import {type TaskTarget} from '../../../types'
+import {linkWrapper, noWrap, strong} from './index.css'
 import {type FieldChange} from './parseTransactions'
 
 const DATE_FORMAT_OPTIONS: UseDateTimeFormatOptions = {
@@ -30,12 +32,10 @@ const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {
   useTemporalPhrase: true,
 }
 
-const Strong = styled.strong`
-  font-weight: 600;
-`
-export const NoWrap = styled.span`
-  white-space: nowrap;
-`
+export function NoWrap(props: ComponentProps<'span'>) {
+  const {className, ...rest} = props
+  return <span {...rest} className={clsx(noWrap, className)} />
+}
 
 export function useUpdatedTimeAgo(timestamp: string) {
   const date = new Date(timestamp)
@@ -49,7 +49,11 @@ export function useUpdatedTimeAgo(timestamp: string) {
 
 export function UserName({userId}: {userId: string}) {
   const [user, isLoading] = useUser(userId)
-  return isLoading ? <TextSkeleton style={{width: '15ch'}} /> : <Strong>{user?.displayName}</Strong>
+  return isLoading ? (
+    <TextSkeleton style={{width: '15ch'}} />
+  ) : (
+    <strong className={strong}>{user?.displayName}</strong>
+  )
 }
 
 const DUE_BY_DATE_OPTIONS: UseDateTimeFormatOptions = {
@@ -64,20 +68,11 @@ function DueByChange({date}: {date: string}) {
   const formattedDate = dateFormatter.format(dueBy)
 
   return (
-    <Strong>
+    <strong className={strong}>
       <NoWrap>{formattedDate}</NoWrap>
-    </Strong>
+    </strong>
   )
 }
-
-const LinkWrapper = styled.span`
-  > a {
-    color: var(--card-fg-muted-color);
-    text-decoration: underline;
-    text-underline-offset: 1px;
-    font-weight: 600;
-  }
-`
 
 function TargetContentChange({target}: {target: TaskTarget}) {
   const schema = useSchema()
@@ -100,11 +95,11 @@ function TargetContentChange({target}: {target: TaskTarget}) {
   }
 
   return (
-    <LinkWrapper>
+    <span className={linkWrapper}>
       <IntentLink intent="edit" params={{id: documentId, type: documentType}}>
         {value?.title}
       </IntentLink>
-    </LinkWrapper>
+    </span>
   )
 }
 
@@ -119,7 +114,7 @@ export function getChangeDetails(activity: FieldChange): {
       return {
         text: 'changed status to',
         icon: TASK_STATUS.find((s) => s.value === activity.to)?.icon || <CircleIcon />,
-        changeTo: <Strong>{statusTitle}</Strong>,
+        changeTo: <strong className={strong}>{statusTitle}</strong>,
       }
     }
     case 'target':

--- a/packages/sanity/src/core/tasks/components/form/fields/FieldWrapper.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/FieldWrapper.css.ts
@@ -1,0 +1,15 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `font.text.weights.regular` */
+export const fontTextWeightRegularVar = createVar()
+
+export const fieldWrapperRoot = style({})
+
+// Reset the padding of the field header content box
+globalStyle(`${fieldWrapperRoot} [data-ui='fieldHeaderContentBox']`, {
+  padding: 0,
+})
+
+globalStyle(`${fieldWrapperRoot} [data-ui='fieldHeaderContentBox'] label`, {
+  fontWeight: fontTextWeightRegularVar,
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/FieldWrapper.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/FieldWrapper.tsx
@@ -1,25 +1,30 @@
-import {getTheme_v2} from '@sanity/ui/theme'
-import {css, styled} from 'styled-components'
+import {useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 
 import {type StringFieldProps} from '../../../../form/types/fieldProps'
+import {fieldWrapperRoot, fontTextWeightRegularVar} from './FieldWrapper.css'
 
 /**
  * @internal
  * Updates the padding and font weight of the field header content box.
  */
-export const FieldWrapperRoot = styled.div((props) => {
-  const theme = getTheme_v2(props.theme)
+export function FieldWrapperRoot(props: ComponentProps<'div'>) {
+  const {className, style, ...rest} = props
+  const {font} = useThemeV2()
 
-  return css`
-    // Reset the padding of the field header content box
-    [data-ui='fieldHeaderContentBox'] {
-      padding: 0;
-      label {
-        font-weight: ${theme.font.text.weights.regular};
-      }
-    }
-  `
-})
+  return (
+    <div
+      {...rest}
+      className={clsx(fieldWrapperRoot, className)}
+      style={{
+        ...assignInlineVars({[fontTextWeightRegularVar]: String(font.text.weights.regular)}),
+        ...style,
+      }}
+    />
+  )
+}
 
 export function FieldWrapper(props: StringFieldProps) {
   return <FieldWrapperRoot>{props.renderDefault(props)}</FieldWrapperRoot>

--- a/packages/sanity/src/core/tasks/components/form/fields/TargetField.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/TargetField.css.ts
@@ -1,0 +1,85 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `color.input.default.hovered.border` */
+export const inputHoveredBorderColorVar = createVar()
+/** `color.input.default.enabled.placeholder` */
+export const inputPlaceholderColorVar = createVar()
+
+export const emptyReferenceRoot = style({
+  selectors: {
+    // Card's `border` prop sets `border` with `&&` (0,2,0); the styled() wrapper's (0,2,0)
+    // pseudo-class rules only won by injection order, so match them with a second class.
+    '&&:focus': {
+      border: '1px solid var(--card-focus-ring-color)',
+    },
+    '&&:focus-visible': {
+      outline: 'none',
+      border: '1px solid var(--card-focus-ring-color)',
+    },
+    '&&:hover': {
+      borderColor: inputHoveredBorderColorVar,
+    },
+  },
+})
+
+export const placeholder = style({
+  marginLeft: '3px',
+  selectors: {
+    // Text sets `color` on itself
+    '&&': {
+      color: inputPlaceholderColorVar,
+    },
+  },
+})
+
+// This allows to hide and show the remove button on hover or focus.
+export const targetRoot = style({
+  position: 'relative',
+  selectors: {
+    '&:focus-within, &:hover': {
+      paddingRight: '36px',
+    },
+  },
+})
+
+export const showOnHover = style({
+  opacity: 0,
+  position: 'absolute',
+  right: '6px',
+  top: '4px',
+  display: 'flex',
+  selectors: {
+    [`${targetRoot}:focus-within &, ${targetRoot}:hover &`]: {
+      transition: 'opacity 200ms',
+      opacity: 1,
+    },
+  },
+})
+
+/* Hides the preview status dot, the button will take it's position. */
+globalStyle(
+  `${targetRoot}:focus-within [data-testid='compact-preview__status'], ${targetRoot}:hover [data-testid='compact-preview__status']`,
+  {
+    opacity: 0,
+  },
+)
+
+// Rendered as `<Card as={CardLink} data-as="button">`, so Card's `&[data-as='button']` rules
+// (0,2,0) share this element: `width: stretch` and `cursor: default` beat the single-class
+// `width`/`cursor` below, exactly as they did before the migration. The focus box-shadow tied
+// with Card's `box-shadow: var(--card-focus-ring-box-shadow)` and won by order, hence `&&`.
+export const styledIntentLink = style({
+  textDecoration: 'none',
+  width: '100%',
+  overflow: 'hidden',
+  cursor: 'pointer',
+  selectors: {
+    '&&:focus': {
+      boxShadow: '0 0 0 1px var(--card-focus-ring-color)',
+    },
+    '&&:focus-visible': {
+      outline: 'none',
+      boxShadow: '0 0 0 1px var(--card-focus-ring-color)',
+    },
+  },
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
@@ -1,10 +1,10 @@
 import {CloseIcon} from '@sanity/icons/Close'
 import {DocumentIcon} from '@sanity/icons/Document'
-import {Card, LayerProvider, Stack, Text} from '@sanity/ui'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {Card, LayerProvider, Stack, Text, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
 import {useCallback, useMemo, useState, type RefAttributes} from 'react'
 import {IntentLink} from 'sanity/router'
-import {css, styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
@@ -24,70 +24,15 @@ import {type FormMode, type TaskTarget} from '../../../types'
 import {CurrentWorkspaceProvider} from '../CurrentWorkspaceProvider'
 import {getTargetValue} from '../utils'
 import {FieldWrapperRoot} from './FieldWrapper'
-
-const EmptyReferenceRoot = styled(Card)((props) => {
-  const theme = getTheme_v2(props.theme)
-
-  return css`
-    &:focus {
-      border: 1px solid var(--card-focus-ring-color);
-    }
-    &:focus-visible {
-      outline: none;
-      border: 1px solid var(--card-focus-ring-color);
-    }
-    &:hover {
-      border-color: ${theme.color.input.default.hovered.border};
-    }
-  `
-})
-
-const Placeholder = styled(Text)((props) => {
-  const theme = getTheme_v2(props.theme)
-  return `
-      color: ${theme.color.input.default.enabled.placeholder};
-      margin-left: 3px;
-  `
-})
-
-// This allows to hide and show the remove button on hover or focus.
-const TargetRoot = styled(Card)`
-  position: relative;
-  [data-ui='show-on-hover'] {
-    opacity: 0;
-    position: absolute;
-    right: 6px;
-    top: 4px;
-    display: flex;
-  }
-  &:focus-within,
-  &:hover {
-    padding-right: 36px;
-    /* Hides the preview status dot, the button will take it's position. */
-    [data-testid='compact-preview__status'] {
-      opacity: 0;
-    }
-    [data-ui='show-on-hover'] {
-      transition: opacity 200ms;
-      opacity: 1;
-    }
-  }
-`
-const StyledIntentLink = styled(IntentLink)(() => {
-  return css`
-    text-decoration: none;
-    width: 100%;
-    overflow: hidden;
-    cursor: pointer;
-    &:focus {
-      box-shadow: 0 0 0 1px var(--card-focus-ring-color);
-    }
-    &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 1px var(--card-focus-ring-color);
-    }
-  `
-})
+import {
+  emptyReferenceRoot,
+  inputHoveredBorderColorVar,
+  inputPlaceholderColorVar,
+  placeholder,
+  showOnHover,
+  styledIntentLink,
+  targetRoot,
+} from './TargetField.css'
 
 function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
   const {value, handleRemove} = props
@@ -102,12 +47,13 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
       function LinkComponent(
         linkProps: React.ComponentPropsWithoutRef<'a'> & RefAttributes<HTMLAnchorElement>,
       ) {
-        const {ref, ...rest} = linkProps
+        const {className, ref, ...rest} = linkProps
         const versionId = getVersionFromId(documentId)
 
         return (
-          <StyledIntentLink
+          <IntentLink
             {...rest}
+            className={clsx(styledIntentLink, className)}
             intent="edit"
             params={{id: getPublishedId(documentId), type: documentType}}
             ref={ref}
@@ -122,7 +68,7 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
   }
 
   return (
-    <TargetRoot border radius={2} data-testid="task-target-field-preview">
+    <Card border className={targetRoot} radius={2} data-testid="task-target-field-preview">
       <Flex gap={1} alignItems={'center'} justifyContent={'space-between'}>
         <Card as={CardLink} radius={2} data-as="button">
           <SearchResultItemPreview
@@ -135,7 +81,7 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
           />
         </Card>
 
-        <div data-ui="show-on-hover">
+        <div className={showOnHover} data-ui="show-on-hover">
           <Button
             icon={CloseIcon}
             mode="bleed"
@@ -144,7 +90,7 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
           />
         </div>
       </Flex>
-    </TargetRoot>
+    </Card>
   )
 }
 
@@ -155,6 +101,7 @@ export function TargetField(
 ) {
   const [open, setOpen] = useState(false)
   const {dataset, projectId} = useWorkspace()
+  const {color} = useThemeV2()
   const {
     mode,
     inputProps: {onChange},
@@ -219,13 +166,17 @@ export function TargetField(
                 {value ? (
                   <Preview value={value} handleRemove={handleRemove} />
                 ) : (
-                  <EmptyReferenceRoot
+                  <Card
                     border
+                    className={emptyReferenceRoot}
                     radius={2}
                     paddingX={2}
                     paddingY={3}
                     onClick={handleOpenSearch}
                     onKeyDown={handleKeyDown}
+                    style={assignInlineVars({
+                      [inputHoveredBorderColorVar]: color.input.default.hovered.border,
+                    })}
                     tabIndex={0}
                   >
                     <Flex gap={1} justifyContent={'flex-start'} alignItems={'center'}>
@@ -234,11 +185,17 @@ export function TargetField(
                           <DocumentIcon />
                         </Text>
                       </Box>
-                      <Placeholder size={1}>
+                      <Text
+                        className={placeholder}
+                        size={1}
+                        style={assignInlineVars({
+                          [inputPlaceholderColorVar]: color.input.default.enabled.placeholder,
+                        })}
+                      >
                         {t('form.input.target.search.placeholder')}
-                      </Placeholder>
+                      </Text>
                     </Flex>
-                  </EmptyReferenceRoot>
+                  </Card>
                 )}
               </Stack>
               <SearchPopover

--- a/packages/sanity/src/core/tasks/components/form/fields/TitleField.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/TitleField.css.ts
@@ -1,0 +1,58 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `${space[3]}px` */
+export const space3Var = createVar()
+/** `font.text.family` */
+export const fontTextFamilyVar = createVar()
+/** `font.text.weights.semibold` */
+export const fontTextWeightSemiboldVar = createVar()
+/** `${font.text.sizes[3].fontSize}px` */
+export const fontTextSize3FontSizeVar = createVar()
+/** `${font.text.sizes[3].lineHeight}px` */
+export const fontTextSize3LineHeightVar = createVar()
+/** `color.input.default.enabled.fg` */
+export const inputFgColorVar = createVar()
+/** `color.input.default.enabled.placeholder` */
+export const inputPlaceholderColorVar = createVar()
+
+export const root = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr',
+  paddingTop: space3Var,
+})
+
+export const titleInput = style({
+  'resize': 'none',
+  'overflow': 'hidden',
+  'appearance': 'none',
+  'background': 'none',
+  'border': 0,
+  'padding': 0,
+  'borderRadius': 0,
+  'outline': 'none',
+  'width': '100%',
+  'boxSizing': 'border-box',
+  'fontFamily': fontTextFamilyVar,
+  'fontWeight': fontTextWeightSemiboldVar,
+  'fontSize': fontTextSize3FontSizeVar,
+  'lineHeight': fontTextSize3LineHeightVar,
+  'margin': 0,
+  'position': 'relative',
+  'zIndex': 1,
+  'display': 'block',
+  'transition': 'height 500ms',
+  'color': inputFgColorVar,
+  'selectors': {
+    /* NOTE: This is a hack to disable Chrome’s autofill styles */
+    '&:-webkit-autofill, &:-webkit-autofill:hover, &:-webkit-autofill:focus, &:-webkit-autofill:active':
+      {
+        // `!important` carried over from the original rule
+        WebkitTextFillColor: 'var(--input-fg-color) !important',
+        transition: 'background-color 5000s',
+        transitionDelay: '86400s' /* 24h */,
+      },
+  },
+  '::placeholder': {
+    color: inputPlaceholderColorVar,
+  },
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/TitleField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TitleField.tsx
@@ -1,61 +1,23 @@
 import {type Path} from '@sanity/types'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import {type ChangeEvent, useCallback, useEffect, useRef} from 'react'
-import {css, styled} from 'styled-components'
 
 import {set, unset} from '../../../../form/patch/patch'
 import {type PatchEvent} from '../../../../form/patch/PatchEvent'
 import {type FormPatch} from '../../../../form/patch/types'
 import {type StringFieldProps} from '../../../../form/types/fieldProps'
-
-const Root = styled.div((props) => {
-  const theme = getTheme_v2(props.theme)
-  return `
-      display: grid;
-      grid-template-columns: 1fr;
-      padding-top: ${theme.space[3]}px;
-    `
-})
-const TitleInput = styled.textarea((props) => {
-  const {color, font} = getTheme_v2(props.theme)
-
-  return css`
-    resize: none;
-    overflow: hidden;
-    appearance: none;
-    background: none;
-    border: 0;
-    padding: 0;
-    border-radius: 0;
-    outline: none;
-    width: 100%;
-    box-sizing: border-box;
-    font-family: ${font.text.family};
-    font-weight: ${font.text.weights.semibold};
-    font-size: ${font.text.sizes[3].fontSize}px;
-    line-height: ${font.text.sizes[3].lineHeight}px;
-    margin: 0;
-    position: relative;
-    z-index: 1;
-    display: block;
-    transition: height 500ms;
-    /* NOTE: This is a hack to disable Chrome’s autofill styles */
-    &:-webkit-autofill,
-    &:-webkit-autofill:hover,
-    &:-webkit-autofill:focus,
-    &:-webkit-autofill:active {
-      -webkit-text-fill-color: var(--input-fg-color) !important;
-      transition: background-color 5000s;
-      transition-delay: 86400s /* 24h */;
-    }
-
-    color: ${color.input.default.enabled.fg};
-
-    &::placeholder {
-      color: ${color.input.default.enabled.placeholder};
-    }
-  `
-})
+import {
+  fontTextFamilyVar,
+  fontTextSize3FontSizeVar,
+  fontTextSize3LineHeightVar,
+  fontTextWeightSemiboldVar,
+  inputFgColorVar,
+  inputPlaceholderColorVar,
+  root,
+  space3Var,
+  titleInput,
+} from './TitleField.css'
 
 export function Title(props: {
   value: string | undefined
@@ -65,6 +27,7 @@ export function Title(props: {
 }) {
   const {value, onChange, placeholder, path} = props
   const ref = useRef<HTMLTextAreaElement | null>(null)
+  const {color, font, space} = useThemeV2()
 
   useEffect(() => {
     // Set the height of the title to make it auto grow.
@@ -84,16 +47,25 @@ export function Title(props: {
   )
 
   return (
-    <Root>
-      <TitleInput
+    <div className={root} style={assignInlineVars({[space3Var]: `${space[3]}px`})}>
+      <textarea
+        className={titleInput}
         ref={ref}
         autoFocus={!value}
         value={value}
         placeholder={placeholder}
         onChange={handleChange}
         rows={1}
+        style={assignInlineVars({
+          [fontTextFamilyVar]: font.text.family,
+          [fontTextWeightSemiboldVar]: String(font.text.weights.semibold),
+          [fontTextSize3FontSizeVar]: `${font.text.sizes[3].fontSize}px`,
+          [fontTextSize3LineHeightVar]: `${font.text.sizes[3].lineHeight}px`,
+          [inputFgColorVar]: color.input.default.enabled.fg,
+          [inputPlaceholderColorVar]: color.input.default.enabled.placeholder,
+        })}
       />
-    </Root>
+    </div>
   )
 }
 

--- a/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeCreateFormField.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeCreateFormField.css.ts
@@ -1,0 +1,22 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `color.input.default.enabled.placeholder` */
+export const inputPlaceholderColorVar = createVar()
+
+export const focusableCard = style({
+  selectors: {
+    // Card sets `border: 0` on `&[data-as='button']` (0,2,0); the styled() wrapper only won by
+    // injection order, so the border override needs one more class.
+    "&&[data-as='button']": {
+      border: '1px solid var(--card-border-color)',
+    },
+    "&&[data-as='button']:focus-within": {
+      border: '1px solid var(--card-focus-ring-color)',
+    },
+    "&[data-as='button']": {
+      vars: {
+        '--card-muted-fg-color': inputPlaceholderColorVar,
+      },
+    },
+  },
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeCreateFormField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeCreateFormField.tsx
@@ -1,7 +1,6 @@
-import {Badge, Card, Text, TextSkeleton} from '@sanity/ui'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {Badge, Card, Text, TextSkeleton, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import {useCallback, useMemo} from 'react'
-import {css, styled} from 'styled-components'
 import {Flex} from 'ui5'
 
 import {set} from '../../../../../form/patch/patch'
@@ -10,23 +9,12 @@ import {useTranslation} from '../../../../../i18n/hooks/useTranslation'
 import {useMentionUser} from '../../../../context/mentionUser/useMentionUser'
 import {tasksLocaleNamespace} from '../../../../i18n'
 import {TasksUserAvatar} from '../../../TasksUserAvatar'
+import {focusableCard, inputPlaceholderColorVar} from './AssigneeCreateFormField.css'
 import {AssigneeSelectionMenu} from './AssigneeSelectionMenu'
-
-const FocusableCard = styled(Card)((props) => {
-  const theme = getTheme_v2(props.theme)
-  return css`
-    &[data-as='button'] {
-      border: 1px solid var(--card-border-color);
-      &:focus-within {
-        border: 1px solid var(--card-focus-ring-color);
-      }
-      --card-muted-fg-color: ${theme.color.input.default.enabled.placeholder};
-    }
-  `
-})
 
 export function AssigneeCreateFormField(props: StringInputProps) {
   const {value, onChange} = props
+  const {color} = useThemeV2()
   const {mentionOptions} = useMentionUser()
   const mentionedUser = useMemo(
     () => mentionOptions.data?.find((u) => u.id === value),
@@ -49,7 +37,16 @@ export function AssigneeCreateFormField(props: StringInputProps) {
       onSelect={onSelect}
       value={value}
       menuButton={
-        <FocusableCard data-as="button" padding={1} radius={2} tabIndex={0}>
+        <Card
+          className={focusableCard}
+          data-as="button"
+          padding={1}
+          radius={2}
+          style={assignInlineVars({
+            [inputPlaceholderColorVar]: color.input.default.enabled.placeholder,
+          })}
+          tabIndex={0}
+        >
           <Flex alignItems="center" gap={3}>
             <Flex alignItems="center" gap={1} flexBasis="0%" flexGrow={1}>
               <TasksUserAvatar user={mentionedUser} size={1} border={false} />
@@ -62,7 +59,7 @@ export function AssigneeCreateFormField(props: StringInputProps) {
               <Badge fontSize={1}>{t('form.input.assignee.unauthorized.text')}</Badge>
             )}
           </Flex>
-        </FocusableCard>
+        </Card>
       }
     />
   )

--- a/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeEditFormField.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeEditFormField.css.ts
@@ -1,0 +1,10 @@
+import {style} from '@vanilla-extract/css'
+
+export const styledButton = style({
+  selectors: {
+    // Button sets `padding: 0` on its root; `&&` beats it regardless of sheet order.
+    '&&': {
+      padding: '3px 6px',
+    },
+  },
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeEditFormField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeEditFormField.tsx
@@ -7,7 +7,6 @@ import {
   TextSkeleton,
 } from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
-import {styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {Tooltip} from '../../../../../../ui-components/tooltip/Tooltip'
@@ -19,11 +18,8 @@ import {useTranslation} from '../../../../../i18n/hooks/useTranslation'
 import {useMentionUser} from '../../../../context/mentionUser/useMentionUser'
 import {tasksLocaleNamespace} from '../../../../i18n'
 import {TasksUserAvatar} from '../../../TasksUserAvatar'
+import {styledButton} from './AssigneeEditFormField.css'
 import {AssigneeSelectionMenu} from './AssigneeSelectionMenu'
-
-const StyledButton = styled(Button)`
-  padding: 3px 6px;
-`
 
 interface AssigneeEditFormFieldProps {
   value: string | undefined
@@ -65,7 +61,7 @@ export function AssigneeEditFormField(props: AssigneeEditFormFieldProps) {
       onSelect={onSelect}
       value={value}
       menuButton={
-        <StyledButton mode="ghost" padding={0}>
+        <Button className={styledButton} mode="ghost" padding={0}>
           <Tooltip
             content={
               value
@@ -88,7 +84,7 @@ export function AssigneeEditFormField(props: AssigneeEditFormFieldProps) {
               )}
             </Flex>
           </Tooltip>
-        </StyledButton>
+        </Button>
       }
     />
   )

--- a/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeSelectionMenu.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeSelectionMenu.css.ts
@@ -1,0 +1,6 @@
+import {style} from '@vanilla-extract/css'
+
+export const styledMenu = style({
+  width: '308px',
+  borderRadius: '3px',
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeSelectionMenu.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/assignee/AssigneeSelectionMenu.tsx
@@ -7,7 +7,6 @@ import {
 } from '@sanity/ui/menu'
 import deburr from 'lodash-es/deburr.js'
 import {type ChangeEvent, type KeyboardEvent, useCallback, useMemo, useRef, useState} from 'react'
-import {styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {MenuButton} from '../../../../../../ui-components/menuButton/MenuButton'
@@ -17,6 +16,7 @@ import {useTranslation} from '../../../../../i18n/hooks/useTranslation'
 import {useMentionUser} from '../../../../context/mentionUser/useMentionUser'
 import {tasksLocaleNamespace} from '../../../../i18n'
 import {TasksUserAvatar} from '../../../TasksUserAvatar'
+import {styledMenu} from './AssigneeSelectionMenu.css'
 
 type SelectItemHandler = (id: string) => void
 
@@ -43,11 +43,6 @@ function MentionUserMenuItem(props: {
     </MenuItem>
   )
 }
-
-const StyledMenu = styled(Menu)`
-  width: 308px;
-  border-radius: 3px;
-`
 
 const IGNORED_KEYS = [
   'Control',
@@ -183,9 +178,9 @@ export function AssigneeSelectionMenu(props: {
       button={menuButton}
       id="assign-user-menu"
       menu={
-        <StyledMenu>
+        <Menu className={styledMenu}>
           <MentionsMenu onSelect={onSelect} value={value} />
-        </StyledMenu>
+        </Menu>
       }
       popover={{
         placement: 'bottom',

--- a/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/DescriptionInput.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/DescriptionInput.css.ts
@@ -1,0 +1,29 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `${space[1]}px 0px` in edit mode, `${space[3]}px ${space[2]}px` otherwise */
+export const editableWrapPaddingVar = createVar()
+/** `${Math.max($minHeight + verticalPadding, minHeight)}px` */
+export const editableWrapMinHeightVar = createVar()
+
+export const descriptionInputRoot = style({})
+
+/** Added next to `descriptionInputRoot` when `mode === 'edit'` */
+export const descriptionInputRootEdit = style({})
+
+/* select CommentInputEditableWrap and change the padding */
+globalStyle(`${descriptionInputRoot} [data-ui='CommentInputEditableWrap']`, {
+  overflow: 'hidden',
+  padding: editableWrapPaddingVar,
+  // `!important` is carried over from the original rule: it has to beat the (0,3,0)/(0,4,0)
+  // `min-height` rules CommentInputInner puts on the same element.
+  minHeight: `${editableWrapMinHeightVar} !important`,
+})
+
+globalStyle(`${descriptionInputRootEdit} #comment-input-root`, {
+  boxShadow: 'none',
+})
+
+globalStyle(`${descriptionInputRoot} [data-ui='CommentInputActions']`, {
+  // `!important` carried over from the original rule (see above)
+  display: 'none !important',
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/DescriptionInput.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/DescriptionInput.tsx
@@ -1,7 +1,8 @@
 import {type PortableTextBlock} from '@sanity/types'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
 import {startTransition, useCallback, useEffect, useState} from 'react'
-import {css, styled} from 'styled-components'
 
 import {CommentInput} from '../../../../../comments/components/pte/comment-input/CommentInput'
 import {set} from '../../../../../form/patch/patch'
@@ -11,31 +12,13 @@ import {useCurrentUser} from '../../../../../store/user/hooks'
 import {useMentionUser} from '../../../../context/mentionUser/useMentionUser'
 import {tasksLocaleNamespace} from '../../../../i18n'
 import {type FormMode} from '../../../../types'
+import {
+  descriptionInputRoot,
+  descriptionInputRootEdit,
+  editableWrapMinHeightVar,
+  editableWrapPaddingVar,
+} from './DescriptionInput.css'
 import {renderBlock} from './render/renderBlock'
-
-const DescriptionInputRoot = styled.div<{$mode: FormMode; $minHeight: number}>((props) => {
-  const theme = getTheme_v2(props.theme)
-  const verticalPadding = props.$mode === 'edit' ? theme.space[1] : theme.space[3]
-  const minHeight = props.$mode === 'edit' ? 120 : 200
-  return css`
-    /* select CommentInputEditableWrap and change the padding */
-    [data-ui='CommentInputEditableWrap'] {
-      overflow: hidden;
-      padding: ${
-        props.$mode === 'edit'
-          ? `${verticalPadding}px 0px`
-          : `${verticalPadding}px ${theme.space[2]}px`
-      };
-      min-height: ${Math.max(props.$minHeight + verticalPadding, minHeight)}px !important;
-    }
-    #comment-input-root {
-      box-shadow: ${props.$mode === 'edit' ? 'none' : ''};
-    }
-    [data-ui='CommentInputActions'] {
-      display: none !important;
-    }
-  `
-})
 
 export function DescriptionInput(props: ArrayFieldProps & {mode: FormMode}) {
   const {
@@ -46,6 +29,7 @@ export function DescriptionInput(props: ArrayFieldProps & {mode: FormMode}) {
   const value = _propValue as PortableTextBlock[] | undefined
   const currentUser = useCurrentUser()
   const {mentionOptions} = useMentionUser()
+  const {space} = useThemeV2()
 
   const handleChange = useCallback((next: PortableTextBlock[]) => onChange(set(next)), [onChange])
 
@@ -76,8 +60,20 @@ export function DescriptionInput(props: ArrayFieldProps & {mode: FormMode}) {
   }, [value, setTextboxHeight, rootRef])
 
   if (!currentUser) return null
+
+  const verticalPadding = mode === 'edit' ? space[1] : space[3]
+  const minHeight = mode === 'edit' ? 120 : 200
+
   return (
-    <DescriptionInputRoot $mode={mode} ref={handleSetRootRef} $minHeight={textBoxScrollHeight}>
+    <div
+      className={clsx(descriptionInputRoot, mode === 'edit' && descriptionInputRootEdit)}
+      ref={handleSetRootRef}
+      style={assignInlineVars({
+        [editableWrapPaddingVar]:
+          mode === 'edit' ? `${verticalPadding}px 0px` : `${verticalPadding}px ${space[2]}px`,
+        [editableWrapMinHeightVar]: `${Math.max(textBoxScrollHeight + verticalPadding, minHeight)}px`,
+      })}
+    >
       <CommentInput
         expandOnFocus={false}
         currentUser={currentUser}
@@ -89,6 +85,6 @@ export function DescriptionInput(props: ArrayFieldProps & {mode: FormMode}) {
         onDiscardConfirm={() => null}
         renderBlock={renderBlock}
       />
-    </DescriptionInputRoot>
+    </div>
   )
 }

--- a/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/blocks/DescriptionInputBlock.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/blocks/DescriptionInputBlock.css.ts
@@ -1,0 +1,5 @@
+import {style} from '@vanilla-extract/css'
+
+export const normalText = style({
+  wordBreak: 'break-word',
+})

--- a/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/blocks/DescriptionInputBlock.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/blocks/DescriptionInputBlock.tsx
@@ -1,11 +1,8 @@
 import {Text} from '@sanity/ui'
 import {type ReactNode} from 'react'
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
-const NormalText = styled(Text)`
-  word-break: break-word;
-`
+import {normalText} from './DescriptionInputBlock.css'
 
 interface NormalBlockProps {
   children: ReactNode
@@ -16,7 +13,9 @@ export function DescriptionInputBlock(props: NormalBlockProps) {
 
   return (
     <Box paddingTop={2} paddingBottom={3}>
-      <NormalText size={1}>{children}</NormalText>
+      <Text className={normalText} size={1}>
+        {children}
+      </Text>
     </Box>
   )
 }

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormEdit.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormEdit.css.ts
@@ -1,0 +1,11 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `${space[2]}px` */
+export const space2Var = createVar()
+/** `${space[3]}px` */
+export const space3Var = createVar()
+
+export const firstRow = style({
+  columnGap: space2Var,
+  rowGap: space3Var,
+})

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormEdit.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormEdit.tsx
@@ -3,11 +3,10 @@ import {LinkIcon} from '@sanity/icons/Link'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {type PortableTextBlock} from '@sanity/types'
-import {Card, Stack} from '@sanity/ui'
+import {Card, Stack, useTheme_v2 as useThemeV2} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import {useCallback, useMemo} from 'react'
-import {css, styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {MenuButton} from '../../../../../ui-components/menuButton/MenuButton'
@@ -38,14 +37,7 @@ import {StatusSelector} from '../fields/StatusSelector'
 import {Title} from '../fields/TitleField'
 import {RemoveTaskDialog} from '../RemoveTaskDialog'
 import {getMentionedUsers} from '../utils'
-
-const FirstRow = styled(Flex)((props) => {
-  const theme = getTheme_v2(props.theme)
-  return css`
-    column-gap: ${theme.space[2]}px;
-    row-gap: ${theme.space[3]}px;
-  `
-})
+import {firstRow, space2Var, space3Var} from './FormEdit.css'
 
 function FormActionsMenu({id, value}: {id: string; value: TaskDocument}) {
   const {setViewMode, handleCopyLinkToTask} = useTasksNavigation()
@@ -112,6 +104,7 @@ function FormEditInner(props: ObjectInputProps) {
   const value = props.value as TaskDocument
   const currentUser = useCurrentUser()
   const {t} = useTranslation(tasksLocaleNamespace)
+  const {space} = useThemeV2()
   const activityData = useActivityLog(value).changes
   const handleChangeAndSubscribe = useCallback(
     (patch: FormPatch | PatchEvent | FormPatch[]) => {
@@ -146,12 +139,17 @@ function FormEditInner(props: ObjectInputProps) {
       </Flex>
 
       <Card borderTop marginTop={3}>
-        <FirstRow
+        <Flex
+          className={firstRow}
           paddingBottom={3}
           paddingTop={4}
           alignItems="flex-start"
           justifyContent="flex-start"
           flexWrap="wrap"
+          style={assignInlineVars({
+            [space2Var]: `${space[2]}px`,
+            [space3Var]: `${space[3]}px`,
+          })}
         >
           <TooltipDelayGroupProvider>
             <StatusSelector
@@ -171,7 +169,7 @@ function FormEditInner(props: ObjectInputProps) {
               path={['dueBy']}
             />
           </TooltipDelayGroupProvider>
-        </FirstRow>
+        </Flex>
       </Card>
 
       {props.renderDefault(props)}

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.css.ts
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.css.ts
@@ -1,0 +1,15 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `rem(space[4])` */
+export const stackGridGapVar = createVar()
+
+export const formBuilderRoot = style({})
+
+// `grid-gap` (not `gap`) is what the original rule set; csstype marks it deprecated, so it is
+// spread in from a const object instead of suppressing the lint (same as DetailPreview.css.ts).
+const stackGridGap = {gridGap: stackGridGapVar} as const
+
+// Update spacing for the form builder
+globalStyle(`${formBuilderRoot} > [data-ui='Stack']`, {
+  ...stackGridGap,
+})

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
@@ -1,9 +1,8 @@
 import {type SanityDocument, type SanityDocumentLike} from '@sanity/types'
-import {rem} from '@sanity/ui'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {rem, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import {motion, type Variants} from 'motion/react'
 import {useEffect, useMemo, useState} from 'react'
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {LoadingBlock} from '../../../../components/loadingBlock/LoadingBlock'
@@ -20,6 +19,7 @@ import {useTasks} from '../../../context/tasks/useTasks'
 import {type TaskDocument, type TaskTarget} from '../../../types'
 import {TasksAddonWorkspaceProvider} from '../addonWorkspace/TasksAddOnWorkspaceProvider'
 import {getTargetValue} from '../utils'
+import {formBuilderRoot, stackGridGapVar} from './TasksFormBuilder.css'
 
 const VARIANTS: Variants = {
   hidden: {opacity: 0},
@@ -28,17 +28,6 @@ const VARIANTS: Variants = {
     transition: {duration: 0.2, delay: 0.2},
   },
 }
-
-const FormBuilderRoot = styled(motion.div)((props) => {
-  const theme = getTheme_v2(props.theme)
-
-  return `
-    // Update spacing for the form builder
-    & > [data-ui='Stack'] {
-      grid-gap: ${rem(theme.space[4])};
-    }
-`
-})
 
 /**
  * A partial task document with the `_id` and `_type` fields.
@@ -53,6 +42,7 @@ const TasksFormBuilderInner = ({
   initialValue?: TaskDocumentInitialValue
 }) => {
   const [patchChannel] = useState(() => createPatchChannel())
+  const {space} = useThemeV2()
 
   const {
     formState,
@@ -102,7 +92,14 @@ const TasksFormBuilderInner = ({
       {isLoading ? (
         <LoadingBlock showText />
       ) : (
-        <FormBuilderRoot id="wrapper" initial="hidden" animate="visible" variants={VARIANTS}>
+        <motion.div
+          className={formBuilderRoot}
+          id="wrapper"
+          initial="hidden"
+          animate="visible"
+          style={assignInlineVars({[stackGridGapVar]: `${rem(space[4])}`})}
+          variants={VARIANTS}
+        >
           <FormBuilder
             __internal_patchChannel={patchChannel}
             id="root"
@@ -127,7 +124,7 @@ const TasksFormBuilderInner = ({
             hasUpstreamVersion={false}
             hasBaseVariant={false}
           />
-        </FormBuilderRoot>
+        </motion.div>
       )}
     </Box>
   )

--- a/packages/sanity/src/core/tasks/components/list/DocumentPreview.css.ts
+++ b/packages/sanity/src/core/tasks/components/list/DocumentPreview.css.ts
@@ -1,0 +1,12 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `color.input.default.enabled.border` */
+export const inputBorderColorVar = createVar()
+
+// Rendered through `<Text as={Link}>`, so Text's classes share this anchor; Text sets `color` and
+// `& a` descendant rules only, none of which touch `text-decoration` on the root.
+export const styledIntentLink = style({
+  textDecoration: 'underline',
+  textDecorationColor: inputBorderColorVar,
+  textUnderlineOffset: '2px',
+})

--- a/packages/sanity/src/core/tasks/components/list/DocumentPreview.tsx
+++ b/packages/sanity/src/core/tasks/components/list/DocumentPreview.tsx
@@ -1,24 +1,16 @@
 import {DocumentIcon} from '@sanity/icons/Document'
-import {Text, TextSkeleton} from '@sanity/ui'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {Text, TextSkeleton, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
 import {useMemo, type RefAttributes} from 'react'
 import {IntentLink} from 'sanity/router'
-import {styled} from 'styled-components'
 import {Flex} from 'ui5'
 
 import {useSchema} from '../../../hooks/useSchema'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPreviewValues} from '../../hooks/useDocumentPreviewValues'
+import {inputBorderColorVar, styledIntentLink} from './DocumentPreview.css'
 
-const StyledIntentLink = styled(IntentLink)((props) => {
-  const theme = getTheme_v2(props.theme)
-
-  return `
-  text-decoration: underline;
-  text-decoration-color: ${theme.color.input.default.enabled.border};
-  text-underline-offset: 2px;
-`
-})
 export function DocumentPreview({
   documentId,
   documentType,
@@ -35,16 +27,19 @@ export function DocumentPreview({
     perspectiveStack,
     variant: selectedVariantName,
   })
+  const {color} = useThemeV2()
+  const inputBorderColor = color.input.default.enabled.border
 
   const Link = useMemo(
     () =>
       function LinkComponent(
         linkProps: React.ComponentPropsWithoutRef<'a'> & RefAttributes<HTMLAnchorElement>,
       ) {
-        const {ref, ...rest} = linkProps
+        const {className, ref, ...rest} = linkProps
         return (
-          <StyledIntentLink
+          <IntentLink
             {...rest}
+            className={clsx(styledIntentLink, className)}
             intent="edit"
             params={{id: documentId, type: documentType}}
             ref={ref}
@@ -66,7 +61,13 @@ export function DocumentPreview({
       {isLoading ? (
         <TextSkeleton size={1} muted />
       ) : (
-        <Text size={1} as={Link} weight="medium" style={{maxWidth: '20ch'}} textOverflow="ellipsis">
+        <Text
+          size={1}
+          as={Link}
+          weight="medium"
+          style={{maxWidth: '20ch', ...assignInlineVars({[inputBorderColorVar]: inputBorderColor})}}
+          textOverflow="ellipsis"
+        >
           {value?.title || 'Untitled'}
         </Text>
       )}

--- a/packages/sanity/src/core/tasks/components/list/EmptyStates.css.ts
+++ b/packages/sanity/src/core/tasks/components/list/EmptyStates.css.ts
@@ -1,0 +1,17 @@
+import {keyframes, style} from '@vanilla-extract/css'
+
+export const root = style({
+  maxWidth: '268px',
+  margin: '0 auto',
+  height: '100%',
+  marginTop: '40%',
+})
+
+const fadeIn = keyframes({
+  from: {opacity: 0},
+  to: {opacity: 1},
+})
+
+export const animatedText = style({
+  animation: `${fadeIn} 0.2s ease-in-out`,
+})

--- a/packages/sanity/src/core/tasks/components/list/EmptyStates.tsx
+++ b/packages/sanity/src/core/tasks/components/list/EmptyStates.tsx
@@ -1,7 +1,6 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {Stack, Text} from '@sanity/ui'
 import {useCallback} from 'react'
-import {styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
@@ -12,6 +11,7 @@ import {useTasksNavigation} from '../../context/navigation/useTasksNavigation'
 import {useTasks} from '../../context/tasks/useTasks'
 import {tasksLocaleNamespace} from '../../i18n'
 import {type TaskStatus} from '../../types'
+import {animatedText, root} from './EmptyStates.css'
 
 const HEADING_BY_STATUS: Record<
   TaskStatus,
@@ -88,25 +88,6 @@ const EMPTY_TASK_LIST: Record<
   },
 }
 
-const Root = styled.div`
-  max-width: 268px;
-  margin: 0 auto;
-  height: 100%;
-  margin-top: 40%;
-`
-
-const AnimatedText = styled(Text)`
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-  animation: fadeIn 0.2s ease-in-out;
-`
-
 export function EmptyTasksListState() {
   const {activeDocument} = useTasks()
   const {mode} = useTasksEnabled()
@@ -124,7 +105,7 @@ export function EmptyTasksListState() {
     setViewMode({type: 'create'})
   }, [setViewMode])
   return (
-    <Root>
+    <div className={root}>
       <Flex
         flexDirection={'column'}
         gap={3}
@@ -133,13 +114,13 @@ export function EmptyTasksListState() {
         flexGrow={1}
         justifyContent={'center'}
       >
-        <AnimatedText key={key} size={1} weight="semibold">
+        <Text className={animatedText} key={key} size={1} weight="semibold">
           {t(heading)}
-        </AnimatedText>
+        </Text>
         <Box paddingBottom={6} paddingTop={1}>
-          <AnimatedText key={key} size={1} align="center">
+          <Text className={animatedText} key={key} size={1} align="center">
             {t(text)}
-          </AnimatedText>
+          </Text>
         </Box>
         {mode !== 'upsell' && (
           <Button
@@ -149,6 +130,6 @@ export function EmptyTasksListState() {
           />
         )}
       </Flex>
-    </Root>
+    </div>
   )
 }

--- a/packages/sanity/src/core/tasks/components/list/TasksList.css.ts
+++ b/packages/sanity/src/core/tasks/components/list/TasksList.css.ts
@@ -1,0 +1,20 @@
+import {globalStyle, style} from '@vanilla-extract/css'
+
+export const detailsFlex = style({})
+
+globalStyle(`${detailsFlex} [data-ui='summary-icon']`, {
+  transition: 'transform 0.2s',
+  transform: 'rotate(-90deg)',
+})
+
+globalStyle(`${detailsFlex}[open] [data-ui='summary-icon']`, {
+  transform: 'rotate(0)',
+})
+
+globalStyle(`${detailsFlex} > summary::-webkit-details-marker`, {
+  display: 'none',
+})
+
+export const summaryBox = style({
+  listStyle: 'none',
+})

--- a/packages/sanity/src/core/tasks/components/list/TasksList.tsx
+++ b/packages/sanity/src/core/tasks/components/list/TasksList.tsx
@@ -2,12 +2,12 @@ import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {Stack, Text} from '@sanity/ui'
 import {MenuDivider} from '@sanity/ui/menu'
 import {Fragment, useMemo} from 'react'
-import {styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {TASK_STATUS} from '../../constants/TaskStatus'
 import {type TaskDocument, type TaskStatus} from '../../types'
 import {EmptyStatusListState, EmptyTasksListState} from './EmptyStates'
+import {detailsFlex, summaryBox} from './TasksList.css'
 import {TasksListItem} from './TasksListItem'
 
 const EMPTY_ARRAY: [] = []
@@ -16,22 +16,6 @@ const getLabelForStatus = (status: string) => {
   const statusConfig = TASK_STATUS.find((item) => item.value === status)
   return statusConfig?.title
 }
-
-const DetailsFlex = styled(Flex)`
-  [data-ui='summary-icon'] {
-    transition: transform 0.2s;
-    transform: rotate(-90deg);
-  }
-  &[open] [data-ui='summary-icon'] {
-    transform: rotate(0);
-  }
-  > summary::-webkit-details-marker {
-    display: none;
-  }
-`
-const SummaryBox = styled(Box)`
-  list-style: none;
-`
 
 interface TaskListProps {
   status: TaskStatus
@@ -43,8 +27,8 @@ function TaskList(props: TaskListProps) {
   const {status, tasks, onTaskSelect} = props
 
   return (
-    <DetailsFlex forwardedAs="details" flexDirection="column" open={status === 'open'}>
-      <SummaryBox forwardedAs="summary" paddingY={1}>
+    <Flex as="details" className={detailsFlex} flexDirection="column" open={status === 'open'}>
+      <Box as="summary" className={summaryBox} paddingY={1}>
         <Flex alignItems="center" gap={1} paddingY={1}>
           <Text size={1} weight="medium" muted>
             {getLabelForStatus(status)}
@@ -54,7 +38,7 @@ function TaskList(props: TaskListProps) {
             <ChevronDownIcon data-ui="summary-icon" />
           </Text>
         </Flex>
-      </SummaryBox>
+      </Box>
 
       <Stack gap={4} marginTop={3} paddingBottom={5}>
         {tasks?.length > 0 ? (
@@ -81,7 +65,7 @@ function TaskList(props: TaskListProps) {
           <EmptyStatusListState status={status} />
         )}
       </Stack>
-    </DetailsFlex>
+    </Flex>
   )
 }
 

--- a/packages/sanity/src/core/tasks/components/list/TasksListItem.css.ts
+++ b/packages/sanity/src/core/tasks/components/list/TasksListItem.css.ts
@@ -1,0 +1,12 @@
+import {style} from '@vanilla-extract/css'
+
+// Button only sets `width` when `width="fill"` is passed, which TitleButton does not.
+export const titleButton = style({
+  width: '100%',
+  maxWidth: '100%',
+})
+
+export const taskDetailsRoot = style({
+  /* Checkbox width is 17px and first row gap is 12px. */
+  marginLeft: '29px',
+})

--- a/packages/sanity/src/core/tasks/components/list/TasksListItem.tsx
+++ b/packages/sanity/src/core/tasks/components/list/TasksListItem.tsx
@@ -8,7 +8,6 @@ import {
 import {isThisISOWeek} from 'date-fns/isThisISOWeek'
 import {isToday} from 'date-fns/isToday'
 import {useMemo} from 'react'
-import {styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -16,6 +15,7 @@ import {useDateTimeFormat, type UseDateTimeFormatOptions} from '../../../hooks/u
 import {type TaskDocument} from '../../types'
 import {TasksUserAvatar} from '../TasksUserAvatar'
 import {DocumentPreview} from './DocumentPreview'
+import {taskDetailsRoot, titleButton} from './TasksListItem.css'
 import {TasksStatus} from './TasksStatus'
 
 interface TasksListItemProps extends Pick<
@@ -25,16 +25,6 @@ interface TasksListItemProps extends Pick<
   documentId: string
   onSelect: () => void
 }
-
-const TitleButton = styled(UIButton)`
-  width: 100%;
-  max-width: 100%;
-`
-
-const TaskDetailsRoot = styled(Flex)`
-  /* Checkbox width is 17px and first row gap is 12px. */
-  margin-left: 29px;
-`
 
 function getTargetDocumentMeta(target?: TaskDocument['target']) {
   if (!target?.document?._ref) {
@@ -101,18 +91,18 @@ export function TasksListItem(props: TasksListItemProps) {
         </Box>
 
         <Flex flexBasis="0%" flexGrow={1}>
-          <TitleButton onClick={onSelect} mode="bleed" padding={2}>
+          <UIButton className={titleButton} onClick={onSelect} mode="bleed" padding={2}>
             <Text size={1} textOverflow="ellipsis" weight="semibold">
               {title || 'Untitled'}
             </Text>
-          </TitleButton>
+          </UIButton>
         </Flex>
 
         <TasksUserAvatar user={assignedTo ? {id: assignedTo} : undefined} withTooltip />
       </Flex>
 
       {(dueBy || targetDocument) && (
-        <TaskDetailsRoot alignItems="center" gap={2} paddingX={0}>
+        <Flex className={taskDetailsRoot} alignItems="center" gap={2} paddingX={0}>
           {dueBy && <TaskDueDate dueBy={dueBy} />}
 
           {targetDocument && (
@@ -123,7 +113,7 @@ export function TasksListItem(props: TasksListItemProps) {
               />
             </Box>
           )}
-        </TaskDetailsRoot>
+        </Flex>
       )}
     </Stack>
   )

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksActiveTabNavigation.css.ts
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksActiveTabNavigation.css.ts
@@ -1,0 +1,10 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `color.input.default.enabled.border` */
+export const inputBorderColorVar = createVar()
+
+export const divider = style({
+  height: '25px',
+  width: '1px',
+  backgroundColor: inputBorderColorVar,
+})

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksActiveTabNavigation.tsx
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksActiveTabNavigation.tsx
@@ -1,9 +1,8 @@
 import {ChevronLeftIcon} from '@sanity/icons/ChevronLeft'
 import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
-import {Text} from '@sanity/ui'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {Text, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import {useCallback} from 'react'
-import {styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
@@ -13,20 +12,11 @@ import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useTasksNavigation} from '../../context/navigation/useTasksNavigation'
 import {tasksLocaleNamespace} from '../../i18n'
 import {type TaskDocument} from '../../types'
+import {divider, inputBorderColorVar} from './TasksActiveTabNavigation.css'
 
 interface TasksActiveTabNavigationProps {
   items: TaskDocument[]
 }
-
-const Divider = styled.div((props) => {
-  const theme = getTheme_v2(props.theme)
-
-  return `
-    height: 25px;
-    width: 1px;
-    background-color: ${theme.color.input.default.enabled.border};
-  `
-})
 
 /**
  * @internal
@@ -52,6 +42,7 @@ export function TasksActiveTabNavigation(props: TasksActiveTabNavigationProps) {
   }, [currentItemIndex, items, setViewMode])
 
   const {t} = useTranslation(tasksLocaleNamespace)
+  const {color} = useThemeV2()
 
   if (!items.length) return null
   return (
@@ -76,7 +67,10 @@ export function TasksActiveTabNavigation(props: TasksActiveTabNavigationProps) {
           icon={ChevronRightIcon}
           onClick={goToNextTask}
         />
-        <Divider />
+        <div
+          className={divider}
+          style={assignInlineVars({[inputBorderColorVar]: color.input.default.enabled.border})}
+        />
       </Flex>
     </TooltipDelayGroupProvider>
   )

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksHeaderDraftsMenu.css.ts
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksHeaderDraftsMenu.css.ts
@@ -1,0 +1,6 @@
+import {style} from '@vanilla-extract/css'
+
+// Menu's root is `styled(Box)` with only `outline`/`overflow`, so a plain class carries `width`.
+export const styledMenu = style({
+  width: '220px',
+})

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksHeaderDraftsMenu.tsx
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksHeaderDraftsMenu.tsx
@@ -3,7 +3,6 @@ import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {Text} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
 import {useCallback} from 'react'
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
@@ -16,6 +15,7 @@ import {useTasksNavigation} from '../../context/navigation/useTasksNavigation'
 import {useTasks} from '../../context/tasks/useTasks'
 import {tasksLocaleNamespace} from '../../i18n'
 import {type TaskDocument} from '../../types'
+import {styledMenu} from './TasksHeaderDraftsMenu.css'
 
 const MENU_BUTTON_POPOVER_PROPS: MenuButtonProps['popover'] = {
   constrainSize: true,
@@ -23,10 +23,6 @@ const MENU_BUTTON_POPOVER_PROPS: MenuButtonProps['popover'] = {
   placement: 'bottom-end',
   portal: true,
 }
-
-const StyledMenu = styled(Menu)`
-  width: 220px;
-`
 
 interface TasksDraftsMenuItemProps {
   isSelected: boolean
@@ -88,7 +84,7 @@ export function TasksHeaderDraftsMenu() {
       button={<Button text={t('buttons.draft.text')} mode="ghost" iconRight={ChevronDownIcon} />}
       id="edit-task-menu"
       menu={
-        <StyledMenu>
+        <Menu className={styledMenu}>
           <Box padding={3}>
             <Text size={1} weight="semibold">
               {t('panel.drafts.title')}
@@ -107,7 +103,7 @@ export function TasksHeaderDraftsMenu() {
               />
             )
           })}
-        </StyledMenu>
+        </Menu>
       }
       popover={MENU_BUTTON_POPOVER_PROPS}
     />

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksListTabs.tsx
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksListTabs.tsx
@@ -1,6 +1,5 @@
 import {TabList, Text} from '@sanity/ui'
-import {useCallback, useMemo} from 'react'
-import {type CSSProperties} from 'styled-components'
+import {useCallback, useMemo, type CSSProperties} from 'react'
 
 import {Tab} from '../../../../ui-components/tab/Tab'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksSidebar.css.ts
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksSidebar.css.ts
@@ -1,0 +1,23 @@
+import {style} from '@vanilla-extract/css'
+
+// Card also receives `flex={1}`; both rules set the same value, and Card never sets
+// `flex-direction`, so a plain class is enough.
+export const rootCard = style({
+  flex: 1,
+  flexDirection: 'column',
+})
+
+export const headerStack = style({
+  borderBottom: '1px solid var(--card-border-color)',
+})
+
+export const contentFlex = style({
+  selectors: {
+    // The ui5 Flex also gets `overflow="auto"` (`.sui-overflow-auto`, (0,1,0), in the static
+    // ui5 sheet); the styled() wrapper only won that tie by injection order, so add a second class.
+    '&&': {
+      overflowY: 'scroll',
+      overflowX: 'hidden',
+    },
+  },
+})

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksSidebar.tsx
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksSidebar.tsx
@@ -1,7 +1,6 @@
 import {Card, Spinner, Stack} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {useCallback, useMemo} from 'react'
-import {styled} from 'styled-components'
 import {Flex} from 'ui5'
 
 import {useCurrentUser} from '../../../store/user/hooks'
@@ -13,22 +12,10 @@ import {getTargetDocumentId} from '../form/utils'
 import {TasksList} from '../list/TasksList'
 import {TasksUpsellPanel} from '../upsell/TasksUpsellPanel'
 import {TasksListTabs} from './TasksListTabs'
+import {contentFlex, headerStack, rootCard} from './TasksSidebar.css'
 import {TasksSidebarHeader} from './TasksSidebarHeader'
 
 const MotionCard = motion.create(Card)
-const RootCard = styled(MotionCard)`
-  flex: 1;
-  flex-direction: column;
-`
-
-const HeaderStack = styled(Stack)`
-  border-bottom: 1px solid var(--card-border-color);
-`
-
-const ContentFlex = styled(Flex)`
-  overflow-y: scroll;
-  overflow-x: hidden;
-`
 
 /**
  * @internal
@@ -80,7 +67,8 @@ function TasksStudioSidebarInner() {
   }, [filteredList, isLoading, onTaskSelect, selectedTask, viewMode, mode])
 
   return (
-    <RootCard
+    <MotionCard
+      className={rootCard}
       display="flex"
       height="fill"
       flex={1}
@@ -88,14 +76,15 @@ function TasksStudioSidebarInner() {
       initial={{opacity: 0}}
       animate={{opacity: 1, transition: {duration: 0.2}}}
     >
-      <HeaderStack gap={3} padding={3} sizing="border">
+      <Stack className={headerStack} gap={3} padding={3} sizing="border">
         <TasksSidebarHeader items={filteredList} />
         {viewMode === 'list' && !isLoading && (
           <TasksListTabs activeTabId={activeTabId} onChange={setActiveTab} />
         )}
-      </HeaderStack>
+      </Stack>
 
-      <ContentFlex
+      <Flex
+        className={contentFlex}
         flexDirection="column"
         flexBasis="0%"
         flexGrow={1}
@@ -105,8 +94,8 @@ function TasksStudioSidebarInner() {
         paddingX={4}
       >
         {content}
-      </ContentFlex>
-    </RootCard>
+      </Flex>
+    </MotionCard>
   )
 }
 

--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.css.ts
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.css.ts
@@ -1,0 +1,11 @@
+import {globalStyle, style} from '@vanilla-extract/css'
+
+export const buttonContainer = style({
+  position: 'relative',
+})
+
+globalStyle(`${buttonContainer} [data-ui='Badge']`, {
+  position: 'absolute',
+  top: '-2px',
+  right: '-2px',
+})

--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
@@ -1,7 +1,6 @@
 import {TaskIcon} from '@sanity/icons/Task'
 import {Badge, useMediaIndex} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
-import {styled} from 'styled-components'
 
 import {Button} from '../../../ui-components/button/Button'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
@@ -9,15 +8,7 @@ import {getTargetDocumentId} from '../components/form/utils'
 import {useTasksNavigation} from '../context/navigation/useTasksNavigation'
 import {useTasks} from '../context/tasks/useTasks'
 import {tasksLocaleNamespace} from '../i18n'
-
-const ButtonContainer = styled.div`
-  position: relative;
-  [data-ui='Badge'] {
-    position: absolute;
-    top: -2px;
-    right: -2px;
-  }
-`
+import {buttonContainer} from './TasksFooterOpenTasks.css'
 
 /**
  * Button that shows how many pending tasks are assigned to the current document.
@@ -52,7 +43,7 @@ export function TasksFooterOpenTasks() {
 
   if (mediaIndex < 3) {
     return (
-      <ButtonContainer>
+      <div className={buttonContainer}>
         <Button
           mode="bleed"
           icon={TaskIcon}
@@ -67,7 +58,7 @@ export function TasksFooterOpenTasks() {
         <Badge data-testid="tasks-badge" tone="primary" fontSize={0}>
           {pendingTasks.length}
         </Badge>
-      </ButtonContainer>
+      </div>
     )
   }
   return (

--- a/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.css.ts
+++ b/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.css.ts
@@ -1,0 +1,50 @@
+import {style} from '@vanilla-extract/css'
+
+export const rootFlex = style({
+  'selectors': {
+    // The ui5 Flex defaults `minHeight="0"` through `.sui-min-height` (0,1,0) in the static ui5
+    // sheet; the styled() wrapper only won that tie by injection order, so add a second class.
+    '&&': {
+      minHeight: '100%',
+    },
+  },
+  '@media': {
+    // media[3] (POSITION_ABSOLUTE_MEDIA_INDEX)
+    '(max-width: 1200px)': {
+      position: 'relative',
+    },
+  },
+})
+
+export const sidebarMotionLayer = style({
+  'display': 'flex',
+  'flexDirection': 'column',
+  'height': '100%',
+  'width': '360px',
+  'borderLeft': '1px solid var(--card-border-color)',
+  'boxSizing': 'border-box',
+  'overflow': 'hidden',
+  'boxShadow':
+    '0px 6px 8px -4px var(--card-shadow-umbra-color), 0px 12px 17px -1px var(--card-shadow-penumbra-color)',
+  '@media': {
+    // media[3] (POSITION_ABSOLUTE_MEDIA_INDEX)
+    '(max-width: 1200px)': {
+      bottom: 0,
+      right: 0,
+      top: 0,
+      selectors: {
+        // Layer sets `position: relative` on its root (0,1,0); the styled() wrapper only won that
+        // tie by injection order, so add a second class.
+        '&&': {
+          position: 'absolute',
+        },
+      },
+    },
+    // media[1] (FULLSCREEN_MEDIA_INDEX)
+    '(max-width: 600px)': {
+      borderLeft: 0,
+      minWidth: '100%',
+      left: 0,
+    },
+  },
+})

--- a/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksStudioActiveToolLayout.tsx
@@ -1,59 +1,15 @@
 import {Layer, useMediaIndex} from '@sanity/ui'
 import {AnimatePresence} from 'motion/react'
-import {css, styled} from 'styled-components'
 import {Flex, Box} from 'ui5'
 
 import {type ActiveToolLayoutProps} from '../../config/studio/types'
 import {TasksStudioSidebar} from '../components/sidebar/TasksSidebar'
 import {useTasksEnabled} from '../context/enabled/useTasksEnabled'
 import {useTasksNavigation} from '../context/navigation/useTasksNavigation'
+import {rootFlex, sidebarMotionLayer} from './TasksStudioActiveToolLayout.css'
 
+// The `(max-width: 600px)` breakpoint in TasksStudioActiveToolLayout.css.ts mirrors this index.
 const FULLSCREEN_MEDIA_INDEX = 1
-const POSITION_ABSOLUTE_MEDIA_INDEX = 3
-
-const RootFlex = styled(Flex)(({theme}) => {
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const media = theme.sanity.media
-
-  return css`
-    min-height: 100%;
-
-    @media (max-width: ${media[POSITION_ABSOLUTE_MEDIA_INDEX]}px) {
-      position: relative;
-    }
-  `
-})
-const SidebarMotionLayer = styled(Layer)(({theme}) => {
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const media = theme.sanity.media
-
-  return css`
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    width: 360px;
-    border-left: 1px solid var(--card-border-color);
-    box-sizing: border-box;
-    overflow: hidden;
-
-    box-shadow:
-      0px 6px 8px -4px var(--card-shadow-umbra-color),
-      0px 12px 17px -1px var(--card-shadow-penumbra-color);
-
-    @media (max-width: ${media[POSITION_ABSOLUTE_MEDIA_INDEX]}px) {
-      bottom: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
-
-    @media (max-width: ${media[FULLSCREEN_MEDIA_INDEX]}px) {
-      border-left: 0;
-      min-width: 100%;
-      left: 0;
-    }
-  `
-})
 
 function TasksStudioActiveToolLayoutInner(props: ActiveToolLayoutProps) {
   const mediaIndex = useMediaIndex()
@@ -64,19 +20,19 @@ function TasksStudioActiveToolLayoutInner(props: ActiveToolLayoutProps) {
   // Lock the scroll when the sidebar is open in fullscreen mode
   const scrollLock = mediaIndex <= FULLSCREEN_MEDIA_INDEX && isOpen
   return (
-    <RootFlex height="100%">
+    <Flex className={rootFlex} height="100%">
       <Box flexBasis="0%" flexGrow={1} height="100%" overflow={scrollLock ? 'hidden' : 'auto'}>
         {props.renderDefault(props)}
       </Box>
 
       <AnimatePresence initial={false}>
         {isOpen && (
-          <SidebarMotionLayer zOffset={100} height="fill">
+          <Layer className={sidebarMotionLayer} zOffset={100} height="fill">
             <TasksStudioSidebar />
-          </SidebarMotionLayer>
+          </Layer>
         )}
       </AnimatePresence>
-    </RootFlex>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This is 8/12 in the stacked styled-components to vanilla-extract migration. It isolates the Tasks migration as a 50-file review layer.

### What to review

Review task form fields, activity items, list/sidebar layout, and plugin chrome styles. This PR is based on #14622.

### Testing

Split unchanged from #14566's focused Tasks migration commit.

### Notes for release

N/A – Internal styling migration.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f17cdeb-a5b2-47f6-8407-a16eb28c6d4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f17cdeb-a5b2-47f6-8407-a16eb28c6d4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

