### PR TITLE
refactor(field): migrate diff and preview styling

### DIFF
--- a/packages/sanity/src/core/field/diff/components/ChangeList.css.ts
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.css.ts
@@ -1,0 +1,6 @@
+import {style} from '@vanilla-extract/css'
+
+export const changeListWrapper = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr)',
+})

--- a/packages/sanity/src/core/field/diff/components/ChangeList.styled.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.styled.tsx
@@ -1,6 +1,10 @@
-import {styled} from 'styled-components'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 
-export const ChangeListWrapper = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-`
+import {changeListWrapper} from './ChangeList.css'
+
+export function ChangeListWrapper(props: ComponentProps<'div'>) {
+  const {className, ...rest} = props
+
+  return <div {...rest} className={clsx(changeListWrapper, className)} />
+}

--- a/packages/sanity/src/core/field/diff/components/ChangeTitleSegment.css.ts
+++ b/packages/sanity/src/core/field/diff/components/ChangeTitleSegment.css.ts
@@ -1,0 +1,25 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `rem(radius[2])` */
+export const radius2Var = createVar()
+/** `rem(space[1])` */
+export const space1Var = createVar()
+
+export const roundedCard = style({
+  padding: space1Var,
+  selectors: {
+    // Rendered through `DiffCard as={RoundedCard}`, which sets its own border-radius on the same
+    // element; `&&` keeps this rule winning without depending on stylesheet order.
+    '&&': {
+      borderRadius: radius2Var,
+    },
+  },
+})
+
+export const annotationText = style({
+  selectors: {
+    '&:not([hidden])': {
+      color: 'inherit',
+    },
+  },
+})

--- a/packages/sanity/src/core/field/diff/components/ChangeTitleSegment.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeTitleSegment.tsx
@@ -1,22 +1,36 @@
-import {rem, Text} from '@sanity/ui'
-import {styled} from 'styled-components'
+import {rem, Text, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 import {Box} from 'ui5'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {type Annotation, type FieldChangeNode, type FromToIndex} from '../../types'
 import {getAnnotationAtPath} from '../annotations/helpers'
+import {annotationText, radius2Var, roundedCard, space1Var} from './ChangeTitleSegment.css'
 import {DiffCard} from './DiffCard'
 
-const RoundedCard = styled.div`
-  border-radius: ${({theme}) => rem(theme.sanity.radius[2]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  padding: ${({theme}) => rem(theme.sanity.space[1]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-`
+function RoundedCard(props: ComponentProps<'div'>) {
+  const {className, style, ...rest} = props
+  const {radius, space} = useThemeV2()
 
-const AnnotationText = styled(Text)`
-  &:not([hidden]) {
-    color: inherit;
-  }
-`
+  return (
+    <div
+      {...rest}
+      className={clsx(roundedCard, className)}
+      style={{
+        ...assignInlineVars({[radius2Var]: `${rem(radius[2])}`, [space1Var]: `${rem(space[1])}`}),
+        ...style,
+      }}
+    />
+  )
+}
+
+function AnnotationText(props: ComponentProps<typeof Text>) {
+  const {className, ...rest} = props
+
+  return <Text {...rest} className={clsx(annotationText, className)} />
+}
 
 /** @internal */
 export function ChangeTitleSegment(props: {
@@ -80,7 +94,7 @@ function CreatedTitleSegment(props: {
   if (annotation) {
     return (
       <DiffCard annotation={annotation} tooltip={{description}} as={RoundedCard}>
-        <AnnotationText size={1} weight="medium" forwardedAs="ins" style={{textDecoration: 'none'}}>
+        <AnnotationText size={1} weight="medium" as="ins" style={{textDecoration: 'none'}}>
           {content}
         </AnnotationText>
       </DiffCard>
@@ -101,7 +115,7 @@ function DeletedTitleSegment(props: {annotation: Annotation | undefined; fromInd
   const description = t('changes.array.item-removed-from-position', {position: readableIndex})
   return (
     <DiffCard annotation={annotation || null} as={RoundedCard} tooltip={{description}}>
-      <AnnotationText size={1} weight="medium" forwardedAs="del">
+      <AnnotationText size={1} weight="medium" as="del">
         #{readableIndex}
       </AnnotationText>
     </DiffCard>

--- a/packages/sanity/src/core/field/diff/components/DiffCard.css.ts
+++ b/packages/sanity/src/core/field/diff/components/DiffCard.css.ts
@@ -1,0 +1,43 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `rem(radius[2])` */
+export const diffCardRadiusVar = createVar()
+/** Annotation background (`useAnnotationColor(...).background`) */
+export const diffCardBgColorVar = createVar()
+/** Annotation text color (`useAnnotationColor(...).text`) */
+export const diffCardFgColorVar = createVar()
+
+export const diffCard = style({
+  maxWidth: '100%',
+  position: 'relative',
+  borderRadius: diffCardRadiusVar,
+  backgroundColor: diffCardBgColorVar,
+  color: diffCardFgColorVar,
+  zIndex: 1,
+  selectors: {
+    '&:not(del)': {
+      textDecoration: 'none',
+    },
+    '&[data-hover]::after': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      bottom: 0,
+    },
+    '&[data-hover]:hover, [data-from-to-layout]:hover &[data-hover]': {
+      borderBottomLeftRadius: 0,
+      borderBottomRightRadius: 0,
+    },
+    '&[data-hover]:hover::after, [data-from-to-layout]:hover &[data-hover]::after': {
+      bottom: '-3px',
+      // Pre-existing typo (three dashes) carried over verbatim: the variable never resolves, so the
+      // declaration is invalid at computed-value time and no top border renders.
+      borderTop: '1px solid var(---diff-card-bg-color)',
+      borderBottom: '2px solid currentColor',
+      borderBottomLeftRadius: diffCardRadiusVar,
+      borderBottomRightRadius: diffCardRadiusVar,
+    },
+  },
+})

--- a/packages/sanity/src/core/field/diff/components/DiffCard.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffCard.tsx
@@ -1,11 +1,13 @@
 import {type Path} from '@sanity/types'
-import {Card, rem} from '@sanity/ui'
+import {rem, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
 import {type ElementType, type HTMLProps, type ReactNode, useMemo} from 'react'
-import {styled} from 'styled-components'
 
 import {type Annotation, type Diff} from '../../types'
 import {getAnnotationAtPath} from '../annotations/helpers'
 import {useAnnotationColor} from '../annotations/hooks'
+import {diffCard, diffCardBgColorVar, diffCardFgColorVar, diffCardRadiusVar} from './DiffCard.css'
 import {DiffTooltip} from './DiffTooltip'
 
 /** @internal */
@@ -18,63 +20,6 @@ export interface DiffCardProps {
   tooltip?: {description?: ReactNode} | boolean
 }
 
-interface StyledCardProps {
-  $annotationColor: {backgroundColor: string; color: string}
-}
-
-const StyledCard = styled(Card)<StyledCardProps>`
-  --diff-card-radius: ${({theme}) => rem(theme.sanity.radius[2]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  --diff-card-bg-color: ${({theme}) => theme.sanity.color.card.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-
-  max-width: 100%;
-  position: relative;
-  border-radius: var(--diff-card-radius);
-  background-color: ${({$annotationColor}) => $annotationColor.backgroundColor};
-  color: ${({$annotationColor}) => $annotationColor.color};
-  z-index: 1;
-
-  &:not(del) {
-    text-decoration: none;
-  }
-
-  &[data-hover] {
-    &::after {
-      content: '';
-      display: block;
-      position: absolute;
-      left: 0;
-      right: 0;
-      bottom: 0;
-    }
-
-    &:hover {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
-
-      &::after {
-        bottom: -3px;
-        border-top: 1px solid var(---diff-card-bg-color);
-        border-bottom: 2px solid currentColor;
-        border-bottom-left-radius: var(--diff-card-radius);
-        border-bottom-right-radius: var(--diff-card-radius);
-      }
-    }
-
-    [data-from-to-layout]:hover & {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
-
-      &::after {
-        bottom: -3px;
-        border-top: 1px solid var(---diff-card-bg-color);
-        border-bottom: 2px solid currentColor;
-        border-bottom-left-radius: var(--diff-card-radius);
-        border-bottom-right-radius: var(--diff-card-radius);
-      }
-    }
-  }
-`
-
 const EMPTY_PATH: Path = []
 
 /** @internal */
@@ -82,7 +27,7 @@ export function DiffCard(props: DiffCardProps & Omit<HTMLProps<HTMLElement>, 'as
   const {
     ref,
     annotation: annotationProp,
-    as = 'div',
+    as: Component = 'div',
     children,
     className,
     diff,
@@ -92,6 +37,7 @@ export function DiffCard(props: DiffCardProps & Omit<HTMLProps<HTMLElement>, 'as
     tooltip,
     ...restProps
   } = props
+  const {radius} = useThemeV2()
 
   const annotation = useMemo(
     () => annotationProp || getAnnotationAtPath(diff!, path),
@@ -101,20 +47,24 @@ export function DiffCard(props: DiffCardProps & Omit<HTMLProps<HTMLElement>, 'as
   const color = useAnnotationColor(annotation)
 
   const element = (
-    <StyledCard
+    <Component
       {...restProps}
-      as={as}
-      className={className}
+      className={clsx(diffCard, className)}
       data-hover={disableHoverEffect || !annotation ? undefined : ''}
       data-ui="diff-card"
       ref={ref}
-      radius={1}
       // Added annotation color to the card using css to make it possible to override by the ReleaseReview
-      $annotationColor={{backgroundColor: color.background, color: color.text}}
-      style={style}
+      style={{
+        ...assignInlineVars({
+          [diffCardRadiusVar]: `${rem(radius[2])}`,
+          [diffCardBgColorVar]: color.background,
+          [diffCardFgColorVar]: color.text,
+        }),
+        ...style,
+      }}
     >
       {children}
-    </StyledCard>
+    </Component>
   )
 
   if (tooltip && annotation) {

--- a/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.css.ts
+++ b/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.css.ts
@@ -1,0 +1,12 @@
+import {style} from '@vanilla-extract/css'
+
+export const codeWrapper = style({
+  overflowX: 'auto',
+  position: 'relative',
+})
+
+export const meta = style({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+})

--- a/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.tsx
@@ -1,31 +1,37 @@
 import {Card, Stack, Text} from '@sanity/ui'
 import {Code} from '@sanity/ui/code'
-import {type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
-import {type ExecutionProps, styled} from 'styled-components'
+import {clsx} from 'clsx'
+import {
+  type ComponentProps,
+  type ElementType,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import {Box, type BoxProps} from 'ui5'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {pathToString} from '../../paths/helpers'
 import {type FieldChangeNode} from '../../types'
+import {codeWrapper, meta} from './DiffInspectWrapper.css'
 import {FromToArrow} from './FromToArrow'
 
 /** @internal */
 export interface DiffInspectWrapperProps {
   children: ReactNode
   change: FieldChangeNode
-  as?: ExecutionProps['as']
+  as?: ElementType
 }
 
-const CodeWrapper = styled.pre`
-  overflow-x: auto;
-  position: relative;
-`
+// Kept as a component (rather than `as="pre"`) so Card does not see `data-as="pre"` and apply its
+// `font: inherit` rule, matching the previous styled.pre rendering.
+function CodeWrapper(props: ComponentProps<'pre'>) {
+  const {className, ...rest} = props
 
-const Meta = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-`
+  return <pre {...rest} className={clsx(codeWrapper, className)} />
+}
 
 /** @internal */
 export function DiffInspectWrapper(
@@ -59,7 +65,7 @@ export function DiffInspectWrapper(
 }
 
 const MetaLabel = ({title}: {title: string}) => (
-  <Box padding={3} display="inline-block" as={Meta}>
+  <Box padding={3} display="inline-block" className={meta}>
     <Text muted size={1} weight="medium">
       {title}
     </Text>

--- a/packages/sanity/src/core/field/diff/components/DiffString.css.ts
+++ b/packages/sanity/src/core/field/diff/components/DiffString.css.ts
@@ -1,0 +1,38 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+/** `rem(radius[1])` */
+export const radius1Var = createVar()
+
+export const roundedCard = style({
+  selectors: {
+    // Rendered through `DiffCard as={RoundedCard}`, which sets its own border-radius on the same
+    // element; `&&` keeps this rule winning without depending on stylesheet order.
+    '&&': {
+      borderRadius: radius1Var,
+    },
+  },
+})
+
+export const changeSegment = style({
+  selectors: {
+    '&:not([hidden])': {
+      display: 'inline',
+      lineHeight: 'calc(1.25em + 2px)',
+    },
+    '&:hover': {
+      backgroundImage: `linear-gradient(
+      to bottom,
+      var(--card-bg-color) 0,
+      var(--card-bg-color) 33.333%,
+      currentColor 33.333%,
+      currentColor 100%
+    )`,
+      backgroundSize: '1px 3px',
+      backgroundRepeat: 'repeat-x',
+      backgroundPositionY: 'bottom',
+      paddingBottom: '3px',
+      boxShadow: '0 0 0 1px var(--card-bg-color)',
+      zIndex: 1,
+    },
+  },
+})

--- a/packages/sanity/src/core/field/diff/components/DiffString.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffString.tsx
@@ -1,37 +1,33 @@
-import {Card, rem, Text} from '@sanity/ui'
-import {styled} from 'styled-components'
+import {Card, rem, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {type StringDiff, type StringDiffSegment} from '../../types'
 import {DiffCard} from './DiffCard'
+import {changeSegment, radius1Var, roundedCard} from './DiffString.css'
 
-const RoundedCard = styled.span`
-  border-radius: ${({theme}) => rem(theme.sanity.radius[1]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-`
+function RoundedCard(props: ComponentProps<'span'>) {
+  const {className, style, ...rest} = props
+  const {radius} = useThemeV2()
 
-const ChangeSegment = styled(Text)`
-  &:not([hidden]) {
-    display: inline;
-    line-height: calc(1.25em + 2px);
-  }
+  return (
+    <span
+      {...rest}
+      className={clsx(roundedCard, className)}
+      style={{...assignInlineVars({[radius1Var]: `${rem(radius[1])}`}), ...style}}
+    />
+  )
+}
 
-  &:hover {
-    background-color: none !important;
-    background-image: linear-gradient(
-      to bottom,
-      var(--card-bg-color) 0,
-      var(--card-bg-color) 33.333%,
-      currentColor 33.333%,
-      currentColor 100%
-    );
-    background-size: 1px 3px;
-    background-repeat: repeat-x;
-    background-position-y: bottom;
-    padding-bottom: 3px;
-    box-shadow: 0 0 0 1px var(--card-bg-color);
-    z-index: 1;
-  }
-`
+// Previously `styled(Text)` rendered with `as="ins" | "del"`, which replaced `Text` with the plain
+// element, so only the class (never Text's own styles) applied. Render the element directly.
+function ChangeSegment(props: ComponentProps<'ins'> & {as: 'ins' | 'del'}) {
+  const {as: Component, className, ...rest} = props
+
+  return <Component {...rest} className={clsx(changeSegment, className)} />
+}
 
 /** @internal */
 export function DiffStringSegment(props: {segment: StringDiffSegment}): React.JSX.Element {

--- a/packages/sanity/src/core/field/diff/components/Event.css.ts
+++ b/packages/sanity/src/core/field/diff/components/Event.css.ts
@@ -1,0 +1,58 @@
+import {createVar, style, styleVariants} from '@vanilla-extract/css'
+
+/** `theme.avatar.sizes[0].size` (px) */
+export const avatarSize0Var = createVar()
+/** `theme.avatar.sizes[1].size` (px) */
+export const avatarSize1Var = createVar()
+/** `theme.font.text.sizes[0].lineHeight` (px) */
+export const textLineHeight0Var = createVar()
+
+export const iconBox = style({
+  boxShadow: '0 0 0 1px var(--card-bg-color)',
+  position: 'absolute',
+  width: avatarSize0Var,
+  height: avatarSize0Var,
+  right: '-3px',
+  bottom: '-3px',
+  borderRadius: '50%',
+})
+
+// `theme.color.avatar[<hue>].{fg,bg}`, read through the variables the nearest Card publishes.
+export const iconBoxColor = styleVariants(
+  {
+    gray: 'gray',
+    blue: 'blue',
+    purple: 'purple',
+    magenta: 'magenta',
+    red: 'red',
+    orange: 'orange',
+    yellow: 'yellow',
+    green: 'green',
+    cyan: 'cyan',
+  },
+  (hue) => ({
+    vars: {'--card-icon-color': `var(--card-avatar-${hue}-fg-color)`},
+    backgroundColor: `var(--card-avatar-${hue}-bg-color)`,
+  }),
+)
+
+export const avatarSkeleton = style({
+  selectors: {
+    // `&&`: Skeleton is self-styled; `border-radius`/`width`/`height` are among its own declarations.
+    '&&': {
+      borderRadius: '50%',
+      width: avatarSize1Var,
+      height: avatarSize1Var,
+    },
+  },
+})
+
+export const nameSkeleton = style({
+  selectors: {
+    // `&&`: Skeleton is self-styled; `width`/`height` are among its own declarations.
+    '&&': {
+      width: '6ch',
+      height: textLineHeight0Var,
+    },
+  },
+})

--- a/packages/sanity/src/core/field/diff/components/Event.tsx
+++ b/packages/sanity/src/core/field/diff/components/Event.tsx
@@ -1,7 +1,15 @@
-import {type AvatarSize, AvatarStack, Skeleton, Stack, Text} from '@sanity/ui'
-import {getTheme_v2, type ThemeColorAvatarColorKey} from '@sanity/ui/theme'
-import {useMemo} from 'react'
-import {css, styled} from 'styled-components'
+import {
+  type AvatarSize,
+  AvatarStack,
+  Skeleton,
+  Stack,
+  Text,
+  useTheme_v2 as useThemeV2,
+} from '@sanity/ui'
+import {type ThemeColorAvatarColorKey} from '@sanity/ui/theme'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ComponentProps, useMemo} from 'react'
 import {Box, Flex} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -26,6 +34,15 @@ import {
   TIMELINE_ITEM_EVENT_TONE,
   TIMELINE_ITEM_I18N_KEY_MAPPING,
 } from './constants'
+import {
+  avatarSize0Var,
+  avatarSize1Var,
+  avatarSkeleton,
+  iconBox,
+  iconBoxColor,
+  nameSkeleton,
+  textLineHeight0Var,
+} from './Event.css'
 
 interface UserAvatarStackProps {
   maxLength?: number
@@ -44,45 +61,52 @@ function UserAvatarStack({maxLength, userIds, size, withTooltip = true}: UserAva
   )
 }
 
-const IconBox = styled(Flex)<{$color: ThemeColorAvatarColorKey}>((props) => {
-  const theme = getTheme_v2(props.theme)
-  const color = props.$color
+function IconBox(props: ComponentProps<typeof Flex> & {$color: ThemeColorAvatarColorKey}) {
+  const {$color, className, style, ...rest} = props
+  const {avatar} = useThemeV2()
 
-  return css`
-    --card-icon-color: ${theme.color.avatar[color].fg};
-    background-color: ${theme.color.avatar[color].bg};
-    box-shadow: 0 0 0 1px var(--card-bg-color);
-
-    position: absolute;
-    width: ${theme.avatar.sizes[0].size}px;
-    height: ${theme.avatar.sizes[0].size}px;
-    right: -3px;
-    bottom: -3px;
-    border-radius: 50%;
-  `
-})
+  return (
+    <Flex
+      {...rest}
+      className={clsx(iconBox, iconBoxColor[$color], className)}
+      style={{...assignInlineVars({[avatarSize0Var]: `${avatar.sizes[0].size}px`}), ...style}}
+    />
+  )
+}
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {
   minimal: true,
   useTemporalPhrase: true,
 }
 
-const AvatarSkeleton = styled(Skeleton)((props) => {
-  const theme = getTheme_v2(props.theme)
-  return css`
-    border-radius: 50%;
-    width: ${theme.avatar.sizes[1].size}px;
-    height: ${theme.avatar.sizes[1].size}px;
-  `
-})
+function AvatarSkeleton(props: ComponentProps<typeof Skeleton>) {
+  const {className, style, ...rest} = props
+  const {avatar} = useThemeV2()
 
-const NameSkeleton = styled(Skeleton)((props) => {
-  const theme = getTheme_v2(props.theme)
-  return css`
-    width: 6ch;
-    height: ${theme.font.text.sizes[0].lineHeight}px;
-  `
-})
+  return (
+    <Skeleton
+      {...rest}
+      className={clsx(avatarSkeleton, className)}
+      style={{...assignInlineVars({[avatarSize1Var]: `${avatar.sizes[1].size}px`}), ...style}}
+    />
+  )
+}
+
+function NameSkeleton(props: ComponentProps<typeof Skeleton>) {
+  const {className, style, ...rest} = props
+  const {font} = useThemeV2()
+
+  return (
+    <Skeleton
+      {...rest}
+      className={clsx(nameSkeleton, className)}
+      style={{
+        ...assignInlineVars({[textLineHeight0Var]: `${font.text.sizes[0].lineHeight}px`}),
+        ...style,
+      }}
+    />
+  )
+}
 
 const UserLine = ({userId}: {userId: string}) => {
   const [user, loading] = useUser(userId)

--- a/packages/sanity/src/core/field/diff/components/FieldChange.css.ts
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.css.ts
@@ -1,0 +1,36 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `color.solid.critical.enabled.bg` (v2: `color.button.default.critical.enabled.bg`) */
+export const fieldChangeErrorVar = createVar()
+/** `rem(space[1])` */
+export const diffInspectPaddingXSmallVar = createVar()
+/** `rem(space[2])` */
+export const diffInspectPaddingSmallVar = createVar()
+
+export const fieldChangeContainer = style({})
+
+globalStyle(
+  `${fieldChangeContainer}[data-revert-all-changes-hover] [data-revert-all-hover]::before`,
+  {
+    borderLeft: `2px solid ${fieldChangeErrorVar}`,
+  },
+)
+
+export const diffBorder = style({
+  position: 'relative',
+  padding: `${diffInspectPaddingXSmallVar} 0 ${diffInspectPaddingXSmallVar} ${diffInspectPaddingSmallVar}`,
+  selectors: {
+    '&::before': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      bottom: 0,
+      borderLeft: '1px solid var(--card-border-color)',
+    },
+    '&[data-error]:hover::before, &[data-revert-field-hover]:hover::before': {
+      borderLeft: `2px solid ${fieldChangeErrorVar}`,
+    },
+  },
+})

--- a/packages/sanity/src/core/field/diff/components/FieldChange.styled.tsx
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.styled.tsx
@@ -1,34 +1,48 @@
-import {rem} from '@sanity/ui'
-import {styled} from 'styled-components'
+import {rem, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 
-export const FieldChangeContainer = styled.div`
-  --field-change-error: ${({theme}) => theme.sanity.color.solid.critical.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  &[data-revert-all-changes-hover] [data-revert-all-hover]::before {
-    border-left: 2px solid var(--field-change-error);
-  }
-`
+import {
+  diffBorder,
+  diffInspectPaddingSmallVar,
+  diffInspectPaddingXSmallVar,
+  fieldChangeContainer,
+  fieldChangeErrorVar,
+} from './FieldChange.css'
 
-export const DiffBorder = styled.div`
-  --field-change-error: ${({theme}) => theme.sanity.color.solid.critical.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  --diff-inspect-padding-xsmall: ${({theme}) => rem(theme.sanity.space[1]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  --diff-inspect-padding-small: ${({theme}) => rem(theme.sanity.space[2]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
+export function FieldChangeContainer(props: ComponentProps<'div'>) {
+  const {className, style, ...rest} = props
+  const {color} = useThemeV2()
 
-  position: relative;
-  padding: var(--diff-inspect-padding-xsmall) 0 var(--diff-inspect-padding-xsmall)
-    var(--diff-inspect-padding-small);
+  return (
+    <div
+      {...rest}
+      className={clsx(fieldChangeContainer, className)}
+      style={{
+        ...assignInlineVars({[fieldChangeErrorVar]: color.button.default.critical.enabled.bg}),
+        ...style,
+      }}
+    />
+  )
+}
 
-  &::before {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    border-left: 1px solid var(--card-border-color);
-  }
+export function DiffBorder(props: ComponentProps<'div'>) {
+  const {className, style, ...rest} = props
+  const {color, space} = useThemeV2()
 
-  &[data-error]:hover::before,
-  &[data-revert-field-hover]:hover::before {
-    border-left: 2px solid var(--field-change-error);
-  }
-`
+  return (
+    <div
+      {...rest}
+      className={clsx(diffBorder, className)}
+      style={{
+        ...assignInlineVars({
+          [fieldChangeErrorVar]: color.button.default.critical.enabled.bg,
+          [diffInspectPaddingXSmallVar]: `${rem(space[1])}`,
+          [diffInspectPaddingSmallVar]: `${rem(space[2])}`,
+        }),
+        ...style,
+      }}
+    />
+  )
+}

--- a/packages/sanity/src/core/field/diff/components/GroupChange.css.ts
+++ b/packages/sanity/src/core/field/diff/components/GroupChange.css.ts
@@ -1,0 +1,33 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+export const changeListWrapper = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr)',
+})
+
+/** `color.solid.critical.enabled.bg` (v2: `color.button.default.critical.enabled.bg`) */
+export const fieldChangeErrorVar = createVar()
+/** `rem(space[1])` */
+export const diffInspectPaddingXSmallVar = createVar()
+/** `rem(space[2])` */
+export const diffInspectPaddingSmallVar = createVar()
+
+export const groupChangeContainer = style({
+  position: 'relative',
+  padding: `${diffInspectPaddingXSmallVar} ${diffInspectPaddingSmallVar}`,
+  selectors: {
+    '&::before': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      bottom: 0,
+      borderLeft: '1px solid var(--card-border-color)',
+    },
+    '&[data-error]:hover::before, &[data-revert-group-hover]:hover::before, &[data-revert-all-groups-hover]::before':
+      {
+        borderLeft: `2px solid ${fieldChangeErrorVar}`,
+      },
+  },
+})

--- a/packages/sanity/src/core/field/diff/components/GroupChange.styled.tsx
+++ b/packages/sanity/src/core/field/diff/components/GroupChange.styled.tsx
@@ -1,32 +1,38 @@
-import {rem} from '@sanity/ui'
-import {styled} from 'styled-components'
+import {rem, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 
-export const ChangeListWrapper = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-`
+import {
+  changeListWrapper,
+  diffInspectPaddingSmallVar,
+  diffInspectPaddingXSmallVar,
+  fieldChangeErrorVar,
+  groupChangeContainer,
+} from './GroupChange.css'
 
-export const GroupChangeContainer = styled.div`
-  --field-change-error: ${({theme}) => theme.sanity.color.solid.critical.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  --diff-inspect-padding-xsmall: ${({theme}) => rem(theme.sanity.space[1]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  --diff-inspect-padding-small: ${({theme}) => rem(theme.sanity.space[2]) /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
+export function ChangeListWrapper(props: ComponentProps<'div'>) {
+  const {className, ...rest} = props
 
-  position: relative;
-  padding: var(--diff-inspect-padding-xsmall) var(--diff-inspect-padding-small);
+  return <div {...rest} className={clsx(changeListWrapper, className)} />
+}
 
-  &::before {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    border-left: 1px solid var(--card-border-color);
-  }
+export function GroupChangeContainer(props: ComponentProps<'div'>) {
+  const {className, style, ...rest} = props
+  const {color, space} = useThemeV2()
 
-  &[data-error]:hover::before,
-  &[data-revert-group-hover]:hover::before,
-  &[data-revert-all-groups-hover]::before {
-    border-left: 2px solid var(--field-change-error);
-  }
-`
+  return (
+    <div
+      {...rest}
+      className={clsx(groupChangeContainer, className)}
+      style={{
+        ...assignInlineVars({
+          [fieldChangeErrorVar]: color.button.default.critical.enabled.bg,
+          [diffInspectPaddingXSmallVar]: `${rem(space[1])}`,
+          [diffInspectPaddingSmallVar]: `${rem(space[2])}`,
+        }),
+        ...style,
+      }}
+    />
+  )
+}

--- a/packages/sanity/src/core/field/diff/components/JsonFieldDiff.css.ts
+++ b/packages/sanity/src/core/field/diff/components/JsonFieldDiff.css.ts
@@ -1,0 +1,12 @@
+import {style} from '@vanilla-extract/css'
+
+/**
+ * Horizontal scroll only. Avoid `overflow-x: auto` on `pre`: CSS pairs it with
+ * `overflow-y: auto`, which spuriously shows a vertical scrollbar in flex layouts.
+ */
+export const codeWrapper = style({
+  maxWidth: '100%',
+  minWidth: 0,
+  overflowX: 'auto',
+  overflowY: 'hidden',
+})

--- a/packages/sanity/src/core/field/diff/components/JsonFieldDiff.tsx
+++ b/packages/sanity/src/core/field/diff/components/JsonFieldDiff.tsx
@@ -1,7 +1,6 @@
 import {Card, Stack, Text} from '@sanity/ui'
 import {Code} from '@sanity/ui/code'
 import {type CSSProperties} from 'react'
-import {styled} from 'styled-components'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {type DiffComponent} from '../../types'
@@ -9,17 +8,7 @@ import {useChangeVerb} from '../hooks/useChangeVerb'
 import {DiffCard} from './DiffCard'
 import {DiffTooltip} from './DiffTooltip'
 import {FromToArrow} from './FromToArrow'
-
-/**
- * Horizontal scroll only. Avoid `overflow-x: auto` on `pre`: CSS pairs it with
- * `overflow-y: auto`, which spuriously shows a vertical scrollbar in flex layouts.
- */
-const CodeWrapper = styled.div`
-  max-width: 100%;
-  min-width: 0;
-  overflow-x: auto;
-  overflow-y: hidden;
-`
+import {codeWrapper} from './JsonFieldDiff.css'
 
 const cardStyles: CSSProperties = {
   flex: 1,
@@ -42,21 +31,21 @@ export const JsonFieldDiff: DiffComponent = ({diff}) => {
 
   const from = diff.fromValue !== undefined && diff.fromValue !== null && (
     <DiffCard as="del" diff={diff} style={cardStyles}>
-      <CodeWrapper>
+      <div className={codeWrapper}>
         <Code language="json" size={1}>
           {jsonify(diff.fromValue)}
         </Code>
-      </CodeWrapper>
+      </div>
     </DiffCard>
   )
 
   const to = diff.toValue !== undefined && diff.toValue !== null && (
     <DiffCard as="ins" diff={diff} style={cardStyles}>
-      <CodeWrapper>
+      <div className={codeWrapper}>
         <Code language="json" size={1}>
           {jsonify(diff.toValue)}
         </Code>
-      </CodeWrapper>
+      </div>
     </DiffCard>
   )
 

--- a/packages/sanity/src/core/field/diff/components/MetaInfo.css.ts
+++ b/packages/sanity/src/core/field/diff/components/MetaInfo.css.ts
@@ -1,0 +1,11 @@
+import {style} from '@vanilla-extract/css'
+
+export const metaText = style({
+  selectors: {
+    // `&&`: Text sets `color` on itself at (0,1,0); double the class so `inherit` wins regardless
+    // of stylesheet order.
+    '&&': {
+      color: 'inherit',
+    },
+  },
+})

--- a/packages/sanity/src/core/field/diff/components/MetaInfo.tsx
+++ b/packages/sanity/src/core/field/diff/components/MetaInfo.tsx
@@ -1,7 +1,9 @@
 import {Stack, Text} from '@sanity/ui'
-import {type ComponentType, type ReactNode} from 'react'
-import {styled} from 'styled-components'
+import {clsx} from 'clsx'
+import {type ComponentProps, type ComponentType, type ReactNode} from 'react'
 import {Box, Flex} from 'ui5'
+
+import {metaText} from './MetaInfo.css'
 
 /** @internal */
 export interface MetaInfoProps {
@@ -12,9 +14,11 @@ export interface MetaInfoProps {
   markRemoved?: boolean
 }
 
-const MetaText = styled(Text)`
-  color: inherit;
-`
+function MetaText(props: ComponentProps<typeof Text>) {
+  const {className, ...rest} = props
+
+  return <Text {...rest} className={clsx(metaText, className)} />
+}
 
 /** @internal */
 export function MetaInfo(props: MetaInfoProps) {
@@ -24,19 +28,14 @@ export function MetaInfo(props: MetaInfoProps) {
     <Flex padding={2} alignItems="center">
       {Icon && (
         <Box padding={2}>
-          <MetaText size={4} forwardedAs={markRemoved ? 'del' : 'div'}>
+          <MetaText size={4} as={markRemoved ? 'del' : 'div'}>
             <Icon />
           </MetaText>
         </Box>
       )}
 
       <Stack gap={2} paddingLeft={2}>
-        <MetaText
-          size={1}
-          weight="medium"
-          forwardedAs={markRemoved ? 'del' : 'h3'}
-          textOverflow="ellipsis"
-        >
+        <MetaText size={1} weight="medium" as={markRemoved ? 'del' : 'h3'} textOverflow="ellipsis">
           {title}
         </MetaText>
 

--- a/packages/sanity/src/core/field/diff/components/RevertChangesButton.css.ts
+++ b/packages/sanity/src/core/field/diff/components/RevertChangesButton.css.ts
@@ -1,0 +1,34 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `color.solid.critical.enabled.bg` (v2: `color.button.default.critical.enabled.bg`) */
+export const revertChangesFgColorVar = createVar()
+
+export const revertChangesButton = style({
+  selectors: {
+    // `&&`: Button's own hovered/pressed rules set the same `--card-*` variables from
+    // `.btn:not([data-disabled='true']):hover` (0,3,0); the extra class keeps this override winning
+    // regardless of stylesheet order.
+    "&&:not([data-disabled='true']):hover, &&:not([data-disabled='true']):focus": {
+      vars: {
+        '--card-fg-color': revertChangesFgColorVar,
+        '--card-bg-color': 'transparent',
+        '--card-border-color': 'transparent',
+      },
+    },
+  },
+})
+
+globalStyle(`${revertChangesButton} [data-ui='Text']`, {
+  fontWeight: 'normal',
+})
+
+globalStyle(`${revertChangesButton} div[data-ui='Box']`, {
+  display: 'none',
+})
+
+globalStyle(
+  `${revertChangesButton}:not([data-disabled='true']):hover div[data-ui='Box'], ${revertChangesButton}:not([data-disabled='true']):focus div[data-ui='Box']`,
+  {
+    display: 'block',
+  },
+)

--- a/packages/sanity/src/core/field/diff/components/RevertChangesButton.tsx
+++ b/packages/sanity/src/core/field/diff/components/RevertChangesButton.tsx
@@ -1,30 +1,12 @@
 import {RevertIcon} from '@sanity/icons/Revert'
+import {useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
 import {type HTMLProps, type RefAttributes} from 'react'
-import {styled} from 'styled-components'
 
 import {Button, type ButtonProps} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
-
-const Root = styled(Button)`
-  [data-ui='Text'] {
-    font-weight: normal;
-  }
-
-  div[data-ui='Box'] {
-    display: none;
-  }
-
-  &:not([data-disabled='true']):hover,
-  &:not([data-disabled='true']):focus {
-    --card-fg-color: ${({theme}) => theme.sanity.color.solid.critical.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-    --card-bg-color: transparent;
-    --card-border-color: transparent;
-
-    div[data-ui='Box'] {
-      display: block;
-    }
-  }
-`
+import {revertChangesButton, revertChangesFgColorVar} from './RevertChangesButton.css'
 
 /** @internal */
 export function RevertChangesButton(
@@ -33,11 +15,12 @@ export function RevertChangesButton(
       changeCount: number
     } & RefAttributes<HTMLButtonElement>,
 ) {
-  const {ref, selected, changeCount, ...restProps} = props
+  const {ref, selected, changeCount, className, style, ...restProps} = props
   const {t} = useTranslation()
+  const {color} = useThemeV2()
 
   return (
-    <Root
+    <Button
       icon={RevertIcon}
       selected={selected}
       text={t('changes.action.revert-changes-confirm-change', {count: changeCount})}
@@ -45,6 +28,11 @@ export function RevertChangesButton(
       ref={ref}
       tooltipProps={null}
       {...restProps}
+      className={clsx(revertChangesButton, className)}
+      style={{
+        ...assignInlineVars({[revertChangesFgColorVar]: color.button.default.critical.enabled.bg}),
+        ...style,
+      }}
     />
   )
 }

--- a/packages/sanity/src/core/field/types/datetime/preview/DatetimePreview.css.ts
+++ b/packages/sanity/src/core/field/types/datetime/preview/DatetimePreview.css.ts
@@ -1,0 +1,5 @@
+import {style} from '@vanilla-extract/css'
+
+export const datetimeWrapper = style({
+  wordWrap: 'break-word',
+})

--- a/packages/sanity/src/core/field/types/datetime/preview/DatetimePreview.tsx
+++ b/packages/sanity/src/core/field/types/datetime/preview/DatetimePreview.tsx
@@ -1,20 +1,16 @@
 import {type StringSchemaType} from '@sanity/types'
 import * as legacyDateFormat from '@sanity/util/legacyDateFormat'
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {type FieldPreviewComponent} from '../../../preview/types'
-
-const DatetimeWrapper = styled.div`
-  word-wrap: break-word;
-`
+import {datetimeWrapper} from './DatetimePreview.css'
 
 export const DatetimePreview: FieldPreviewComponent<string> = function DatetimePreview({
   value,
   schemaType,
 }) {
   return (
-    <Box as={DatetimeWrapper} paddingX={2} paddingY={1}>
+    <Box className={datetimeWrapper} paddingX={2} paddingY={1}>
       {formatDateTime(value, schemaType)}
     </Box>
   )

--- a/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.css.ts
+++ b/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.css.ts
@@ -1,0 +1,24 @@
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+/** `color.solid.positive.enabled.bg` (v2: `color.button.default.positive.enabled.bg`) */
+export const sizeDiffPositiveVar = createVar()
+/** `color.solid.critical.enabled.bg` (v2: `color.button.default.critical.enabled.bg`) */
+export const sizeDiffNegativeVar = createVar()
+
+export const sizeDiff = style({
+  selectors: {
+    // Rendered as the element of a `Card`, whose own `&:not([hidden]) {display: block}` is (0,2,0);
+    // `&&` keeps this rule winning regardless of stylesheet order.
+    '&&:not([hidden])': {
+      display: 'inline-block',
+    },
+  },
+})
+
+globalStyle(`${sizeDiff} [data-number='positive']`, {
+  color: sizeDiffPositiveVar,
+})
+
+globalStyle(`${sizeDiff} [data-number='negative']`, {
+  color: sizeDiffNegativeVar,
+})

--- a/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.tsx
@@ -1,7 +1,8 @@
 import {DocumentIcon} from '@sanity/icons/Document'
-import {Card, Text} from '@sanity/ui'
-import {useMemo} from 'react'
-import {styled} from 'styled-components'
+import {Card, Text, useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
+import {type ComponentProps, useMemo} from 'react'
 import {Box, Flex} from 'ui5'
 
 import {useUnitFormatter} from '../../../../hooks/useUnitFormatter'
@@ -13,26 +14,30 @@ import {FromTo} from '../../../diff/components/FromTo'
 import {MetaInfo} from '../../../diff/components/MetaInfo'
 import {useRefValue} from '../../../diff/hooks/useRefValue'
 import {type DiffComponent, type ObjectDiff} from '../../../types'
+import {sizeDiff, sizeDiffNegativeVar, sizeDiffPositiveVar} from './FileFieldDiff.css'
 import {getHumanFriendlyBytes, getSizeDiff} from './helpers'
 import {type File, type FileAsset} from './types'
 
-const SizeDiff = styled.div`
-  ${({theme}) => `
-    --size-diff-positive: ${theme.sanity.color.solid.positive.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-    --size-diff-negative: ${theme.sanity.color.solid.critical.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-  `}
-  &:not([hidden]) {
-    display: inline-block;
-  }
+// Stays the `as` target of the Card below (rather than a `className`) so the theme is read inside
+// the Card's own `ThemeColorProvider`, exactly where the previous styled.div resolved its colors.
+function SizeDiff(props: ComponentProps<'div'>) {
+  const {className, style, ...rest} = props
+  const {color} = useThemeV2()
 
-  [data-number='positive'] {
-    color: var(--size-diff-positive);
-  }
-
-  [data-number='negative'] {
-    color: var(--size-diff-negative);
-  }
-`
+  return (
+    <div
+      {...rest}
+      className={clsx(sizeDiff, className)}
+      style={{
+        ...assignInlineVars({
+          [sizeDiffPositiveVar]: color.button.default.positive.enabled.bg,
+          [sizeDiffNegativeVar]: color.button.default.critical.enabled.bg,
+        }),
+        ...style,
+      }}
+    />
+  )
+}
 
 export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType}) => {
   const {fromValue, toValue, fields} = diff

--- a/packages/sanity/src/core/field/types/image/diff/ImagePreview.css.ts
+++ b/packages/sanity/src/core/field/types/image/diff/ImagePreview.css.ts
@@ -1,0 +1,65 @@
+import {hues} from '@sanity/color'
+import {globalStyle, style} from '@vanilla-extract/css'
+
+export const imageWrapper = style({
+  height: '100%',
+  maxHeight: '190px',
+  position: 'relative',
+
+  // Ideally the checkerboard component currently in the form builder should be made available and used here
+  backgroundColor: hues.gray[100].hex,
+  backgroundImage: `
+    linear-gradient(45deg, ${hues.gray[50].hex} 25%, transparent 25%),
+    linear-gradient(-45deg, ${hues.gray[50].hex} 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, ${hues.gray[50].hex} 75%),
+    linear-gradient(-45deg, transparent 75%, ${hues.gray[50].hex} 75%)`,
+  backgroundSize: '16px 16px',
+  backgroundPosition: `
+    0 0,
+    0 8px,
+    8px -8px,
+    -8px 0`,
+
+  selectors: {
+    '&::after': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      boxShadow: 'inset 0 0 0 1px var(--card-border-color)',
+      pointerEvents: 'none',
+    },
+    '&[data-changed]': {
+      opacity: 0.45,
+    },
+  },
+})
+
+export const image = style({
+  display: 'block',
+  flex: 1,
+  minHeight: 0,
+  objectFit: 'contain',
+  width: '100%',
+  height: '100%',
+
+  selectors: {
+    "&[data-action='removed']": {
+      opacity: 0.45,
+    },
+  },
+})
+
+export const hotspotDiff = style({})
+
+globalStyle(`${hotspotDiff} svg`, {
+  display: 'block',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+})

--- a/packages/sanity/src/core/field/types/image/diff/ImagePreview.tsx
+++ b/packages/sanity/src/core/field/types/image/diff/ImagePreview.tsx
@@ -1,10 +1,8 @@
 import {getImageDimensions, isDefaultCrop, isDefaultHotspot} from '@sanity/asset-utils'
-import {hues} from '@sanity/color'
 import {ImageIcon} from '@sanity/icons/Image'
 import {createImageUrlBuilder} from '@sanity/image-url'
 import {Card, Text} from '@sanity/ui'
 import {type SyntheticEvent, useMemo, useState} from 'react'
-import {styled} from 'styled-components'
 import {Box, Flex} from 'ui5'
 
 import {useClient} from '../../../../hooks/useClient'
@@ -14,6 +12,7 @@ import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../studioClient'
 import {MetaInfo} from '../../../diff/components/MetaInfo'
 import {getDeviceDpr, simpleHash} from './helpers'
 import {HotspotCropSVG} from './HotspotCropSVG'
+import {hotspotDiff, image, imageWrapper} from './ImagePreview.css'
 import {type ImagePreviewProps, type MinimalAsset} from './types'
 
 const ASSET_FIELDS = ['originalFilename']
@@ -36,66 +35,6 @@ export const NoImagePreview = () => {
     </Card>
   )
 }
-
-const ImageWrapper = styled.div`
-  height: 100%;
-  max-height: 190px;
-  position: relative;
-
-  /* Ideally the checkerboard component currently in the form builder should be made available and used here */
-  background-color: ${hues.gray[100].hex};
-  background-image:
-    linear-gradient(45deg, ${hues.gray[50].hex} 25%, transparent 25%),
-    linear-gradient(-45deg, ${hues.gray[50].hex} 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, ${hues.gray[50].hex} 75%),
-    linear-gradient(-45deg, transparent 75%, ${hues.gray[50].hex} 75%);
-  background-size: 16px 16px;
-  background-position:
-    0 0,
-    0 8px,
-    8px -8px,
-    -8px 0;
-
-  &::after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    box-shadow: inset 0 0 0 1px var(--card-border-color);
-    pointer-events: none;
-  }
-
-  &[data-changed] {
-    opacity: 0.45;
-  }
-`
-
-const Image = styled.img`
-  display: block;
-  flex: 1;
-  min-height: 0;
-  object-fit: contain;
-  width: 100%;
-  height: 100%;
-
-  &[data-action='removed'] {
-    opacity: 0.45;
-  }
-`
-
-const HotspotDiff = styled.div`
-  svg {
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-`
 
 export function ImagePreview(props: ImagePreviewProps): React.JSX.Element {
   const {id, action, diff, hotspot, crop, is} = props
@@ -129,13 +68,14 @@ export function ImagePreview(props: ImagePreviewProps): React.JSX.Element {
     <Flex flexDirection="column" height="100%" flexBasis="0%" flexGrow={1}>
       <Box flexBasis="0%" flexGrow={1} padding={2} paddingBottom={0}>
         <Flex
-          as={ImageWrapper}
+          className={imageWrapper}
           flexDirection="column"
           data-changed={is === 'from' && assetChanged ? '' : undefined}
           data-error={imageError ? '' : undefined}
         >
           {!assetIsDeleted && !imageError && (
-            <Image
+            <img
+              className={image}
               src={imageSource.toString() || ''}
               alt={title}
               data-action={metaAction}
@@ -153,7 +93,7 @@ export function ImagePreview(props: ImagePreviewProps): React.JSX.Element {
             </Box>
           )}
 
-          <HotspotDiff>
+          <div className={hotspotDiff}>
             <HotspotCropSVG
               crop={crop && !isDefaultCrop(crop) ? crop : undefined}
               diff={diff}
@@ -162,7 +102,7 @@ export function ImagePreview(props: ImagePreviewProps): React.JSX.Element {
               width={dimensions.width}
               height={dimensions.height}
             />
-          </HotspotDiff>
+          </div>
         </Flex>
       </Box>
 

--- a/packages/sanity/src/core/field/types/number/preview/NumberPreview.css.ts
+++ b/packages/sanity/src/core/field/types/number/preview/NumberPreview.css.ts
@@ -1,0 +1,5 @@
+import {style} from '@vanilla-extract/css'
+
+export const numberWrapper = style({
+  wordBreak: 'break-all',
+})

--- a/packages/sanity/src/core/field/types/number/preview/NumberPreview.tsx
+++ b/packages/sanity/src/core/field/types/number/preview/NumberPreview.tsx
@@ -1,17 +1,13 @@
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {type FieldPreviewComponent} from '../../../preview/types'
-
-const NumberWrapper = styled.div`
-  word-break: break-all;
-`
+import {numberWrapper} from './NumberPreview.css'
 
 export const NumberPreview: FieldPreviewComponent<string> = (props) => {
   const {value} = props
 
   return (
-    <Box as={NumberWrapper} paddingX={2} paddingY={1}>
+    <Box className={numberWrapper} paddingX={2} paddingY={1}>
       {value}
     </Box>
   )

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.css.ts
@@ -1,0 +1,31 @@
+import {globalStyle, style} from '@vanilla-extract/css'
+
+import {previewContainer} from './styledComponents.css'
+
+export const annotationWrapper = style({
+  textDecoration: 'none',
+  display: 'inline',
+  position: 'relative',
+  border: '0',
+  padding: '0',
+  borderBottom: '2px dotted currentColor',
+  boxShadow: 'inset 0 0 0 1px var(--card-border-color)',
+  whiteSpace: 'nowrap',
+  alignItems: 'center',
+  // Pre-existing declaration carried over verbatim: `color(<var> a(10%))` is not valid CSS color
+  // syntax, so browsers drop it at computed-value time and no background renders.
+  backgroundColor: 'color(var(--card-fg-color) a(10%))',
+
+  selectors: {
+    '&[data-changed]': {
+      cursor: 'pointer',
+    },
+    '&[data-removed]': {
+      textDecoration: 'line-through',
+    },
+  },
+})
+
+globalStyle(`${annotationWrapper}:hover ${previewContainer}`, {
+  opacity: 1,
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
@@ -2,7 +2,9 @@ import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {isKeySegment, type ObjectSchemaType, type Path, type PortableTextChild} from '@sanity/types'
 import {Text, useClickOutsideEvent} from '@sanity/ui'
 import {toString} from '@sanity/util/paths'
+import {clsx} from 'clsx'
 import {
+  type ComponentProps,
   type MouseEvent,
   type ReactNode,
   useCallback,
@@ -13,7 +15,6 @@ import {
   useState,
 } from 'react'
 import {DiffContext, ReviewChangesContext} from 'sanity/_singletons'
-import {styled} from 'styled-components'
 import {Flex} from 'ui5'
 
 import {Popover} from '../../../../../../ui-components/popover/Popover'
@@ -24,6 +25,7 @@ import {ChangeList} from '../../../../diff/components/ChangeList'
 import {DiffTooltip} from '../../../../diff/components/DiffTooltip'
 import {type ObjectDiff} from '../../../../types'
 import {isEmptyObject} from '../helpers'
+import {annotationWrapper} from './Annotation.css'
 import {InlineBox, InlineText, PopoverContainer, PreviewContainer} from './styledComponents'
 
 interface AnnotationProps {
@@ -34,30 +36,11 @@ interface AnnotationProps {
   children: ReactNode
 }
 
-const AnnotationWrapper = styled.div`
-  text-decoration: none;
-  display: inline;
-  position: relative;
-  border: 0;
-  padding: 0;
-  border-bottom: 2px dotted currentColor;
-  box-shadow: inset 0 0 0 1px var(--card-border-color);
-  white-space: nowrap;
-  align-items: center;
-  background-color: color(var(--card-fg-color) a(10%));
+function AnnotationWrapper(props: ComponentProps<'div'>) {
+  const {className, ...rest} = props
 
-  &[data-changed] {
-    cursor: pointer;
-  }
-
-  &[data-removed] {
-    text-decoration: line-through;
-  }
-
-  &:hover ${PreviewContainer} {
-    opacity: 1;
-  }
-`
+  return <div {...rest} className={clsx(annotationWrapper, className)} />
+}
 
 export function Annotation({
   children,

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Blockquote.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Blockquote.css.ts
@@ -1,0 +1,5 @@
+import {style} from '@vanilla-extract/css'
+
+export const quote = style({
+  margin: '0',
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Blockquote.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Blockquote.tsx
@@ -1,14 +1,11 @@
 import {type ReactNode} from 'react'
-import {styled} from 'styled-components'
 
-const Quote = styled.blockquote`
-  margin: 0;
-`
+import {quote} from './Blockquote.css'
 
 export function Blockquote({children}: {children: ReactNode}): React.JSX.Element {
   return (
     <div>
-      <Quote>{children}</Quote>
+      <blockquote className={quote}>{children}</blockquote>
     </div>
   )
 }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Decorator.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Decorator.css.ts
@@ -1,0 +1,22 @@
+import {createVar, style, styleVariants} from '@vanilla-extract/css'
+
+/** `font.code.family` */
+export const codeFontFamilyVar = createVar()
+/** `color.muted.default.enabled.bg` (v2: `color.button.ghost.default.enabled.bg`) */
+export const codeBackgroundVar = createVar()
+
+export const decoratorWrapper = style({
+  display: 'inline',
+})
+
+export const decoration = styleVariants({
+  'strong': {fontWeight: 'bold'},
+  'em': {fontStyle: 'italic'},
+  'underline': {textDecoration: 'underline'},
+  'overline': {textDecoration: 'overline'},
+  'strike-through': {textDecoration: 'line-through'},
+  'code': {
+    fontFamily: codeFontFamilyVar,
+    background: codeBackgroundVar,
+  },
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Decorator.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Decorator.tsx
@@ -1,30 +1,29 @@
-import {styled} from 'styled-components'
+import {useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {clsx} from 'clsx'
 
-const DecoratorWrapper = styled.span<{decoration: string}>`
-  display: inline;
-  ${({theme, decoration}) => {
-    switch (decoration) {
-      case 'strong':
-        return 'font-weight: bold;'
-      case 'em':
-        return 'font-style: italic;'
-      case 'underline':
-        return 'text-decoration: underline;'
-      case 'overline':
-        return 'text-decoration: overline;'
-      case 'strike-through':
-        return 'text-decoration: line-through;'
-      case 'code':
-        return `
-          font-family: ${theme.sanity.fonts.code.family /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-          background: ${theme.sanity.color.muted.default.enabled.bg /* oxlint-disable-line no-deprecated -- will fix in follow up PR */};
-        `
-      default:
-        return ''
-    }
-  }}
-`
+import {codeBackgroundVar, codeFontFamilyVar, decoration, decoratorWrapper} from './Decorator.css'
+
+function isKnownDecoration(mark: string): mark is keyof typeof decoration {
+  return Object.hasOwn(decoration, mark)
+}
 
 export function Decorator({mark, children}: {mark: string; children: React.JSX.Element}) {
-  return <DecoratorWrapper decoration={mark}>{children}</DecoratorWrapper>
+  const {color, font} = useThemeV2()
+
+  return (
+    <span
+      className={clsx(decoratorWrapper, isKnownDecoration(mark) && decoration[mark])}
+      style={
+        mark === 'code'
+          ? assignInlineVars({
+              [codeFontFamilyVar]: font.code.family,
+              [codeBackgroundVar]: color.button.ghost.default.enabled.bg,
+            })
+          : undefined
+      }
+    >
+      {children}
+    </span>
+  )
 }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Header.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Header.css.ts
@@ -1,0 +1,15 @@
+import {style} from '@vanilla-extract/css'
+
+export const styledHeading = style({
+  selectors: {
+    // `&&`: Heading's own `&:not([hidden]) {display: block}` is (0,2,0).
+    '&&:not([hidden])': {
+      display: 'inline',
+      textTransform: 'none',
+      margin: '0',
+    },
+    '&&:not([hidden])::before, &&:not([hidden])::after': {
+      content: 'unset',
+    },
+  },
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Header.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Header.tsx
@@ -1,6 +1,7 @@
 import {Heading} from '@sanity/ui'
 import {type ReactNode} from 'react'
-import {styled} from 'styled-components'
+
+import {styledHeading} from './Header.css'
 
 const headingSizes: Record<string, number | undefined> = {
   h1: 2,
@@ -11,19 +12,10 @@ const headingSizes: Record<string, number | undefined> = {
   h6: 0,
 }
 
-const StyledHeading = styled(Heading)`
-  &:not([hidden]) {
-    display: inline;
-    text-transform: none;
-    margin: 0;
-
-    &::before,
-    &::after {
-      content: unset;
-    }
-  }
-`
-
 export function Header({style, children}: {style: string; children: ReactNode}): React.JSX.Element {
-  return <StyledHeading size={headingSizes[style]}>{children}</StyledHeading>
+  return (
+    <Heading className={styledHeading} size={headingSizes[style]}>
+      {children}
+    </Heading>
+  )
 }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.css.ts
@@ -1,0 +1,24 @@
+import {globalStyle, style} from '@vanilla-extract/css'
+
+import {inlineBox} from './styledComponents.css'
+
+export const inlineObjectWrapper = style({
+  selectors: {
+    // `&&`: Card's own `&:not([hidden]) {display: block}` is (0,2,0).
+    '&&:not([hidden])': {
+      display: 'inline',
+      cursor: 'pointer',
+      whiteSpace: 'nowrap',
+      alignItems: 'center',
+    },
+    '&:not([hidden])[data-removed]': {
+      textDecoration: 'line-through',
+    },
+  },
+})
+
+// `inlineBox` sets its own display from `&&:not([hidden])` (0,3,0); doubling the wrapper class keeps
+// this descendant override above it regardless of stylesheet order.
+globalStyle(`${inlineObjectWrapper}${inlineObjectWrapper}:not([hidden]) ${inlineBox}`, {
+  display: 'inline-flex',
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
@@ -8,9 +8,18 @@ import {
 } from '@sanity/types'
 import {Card, Text, useClickOutsideEvent} from '@sanity/ui'
 import {FOCUS_TERMINATOR, toString} from '@sanity/util/paths'
-import {type MouseEvent, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react'
+import {clsx} from 'clsx'
+import {
+  type ComponentProps,
+  type MouseEvent,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {DiffContext, ReviewChangesContext} from 'sanity/_singletons'
-import {styled} from 'styled-components'
 import {Flex} from 'ui5'
 
 import {Popover} from '../../../../../../ui-components/popover/Popover'
@@ -22,6 +31,7 @@ import {ChangeList} from '../../../../diff/components/ChangeList'
 import {DiffTooltip} from '../../../../diff/components/DiffTooltip'
 import {type ObjectDiff} from '../../../../types'
 import {isEmptyObject} from '../helpers'
+import {inlineObjectWrapper} from './InlineObject.css'
 import {InlineBox, InlineText, PopoverContainer, PreviewContainer} from './styledComponents'
 
 interface InlineObjectProps {
@@ -31,22 +41,11 @@ interface InlineObjectProps {
   schemaType?: ObjectSchemaType
 }
 
-const InlineObjectWrapper = styled(Card)`
-  &:not([hidden]) {
-    display: inline;
-    cursor: pointer;
-    white-space: nowrap;
-    align-items: center;
+function InlineObjectWrapper(props: ComponentProps<typeof Card>) {
+  const {className, ...rest} = props
 
-    &[data-removed] {
-      text-decoration: line-through;
-    }
-
-    ${InlineBox} {
-      display: inline-flex;
-    }
-  }
-`
+  return <Card {...rest} className={clsx(inlineObjectWrapper, className)} />
+}
 
 export function InlineObject({diff, object, schemaType, ...restProps}: InlineObjectProps) {
   const {t} = useTranslation()

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.css.ts
@@ -1,0 +1,9 @@
+import {style} from '@vanilla-extract/css'
+
+// This can contain nested <div> elements, so it's not rendered as a <p> element
+export const styledParagraph = style({
+  textTransform: 'none',
+  whiteSpace: 'wrap',
+  overflowWrap: 'break-word',
+  margin: '0',
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.tsx
@@ -1,14 +1,7 @@
 import {type ReactNode} from 'react'
-import {styled} from 'styled-components'
 
-// This can contain nested <div> elements, so it's not rendered as a <p> element
-const StyledParagraph = styled.div`
-  text-transform: none;
-  white-space: wrap;
-  overflow-wrap: break-word;
-  margin: 0;
-`
+import {styledParagraph} from './Paragraph.css'
 
 export function Paragraph({children}: {children: ReactNode}): React.JSX.Element {
-  return <StyledParagraph>{children}</StyledParagraph>
+  return <div className={styledParagraph}>{children}</div>
 }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/styledComponents.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/styledComponents.css.ts
@@ -1,0 +1,50 @@
+import {globalStyle, style} from '@vanilla-extract/css'
+
+export const inlineBox = style({
+  selectors: {
+    // `&&`: ui5 Box's own display utility (`.sui-display-block:not([hidden])`) is (0,2,0).
+    '&&:not([hidden])': {
+      display: 'inline',
+      alignItems: 'center',
+    },
+    '&:not([hidden])[data-changed]': {
+      cursor: 'pointer',
+    },
+  },
+})
+
+export const inlineText = style({
+  selectors: {
+    // `&&`: Text's own `&:not([hidden]) {display: block}` is (0,2,0); the same block also beats
+    // Text's plain (0,1,0) `color` rule.
+    '&&:not([hidden])': {
+      display: 'inline',
+      color: 'inherit',
+    },
+  },
+})
+
+export const previewContainer = style({
+  selectors: {
+    // `&&`: ui5 Box's own display utility (`.sui-display-block:not([hidden])`) is (0,2,0).
+    '&&:not([hidden])': {
+      display: 'inline-flex',
+      alignItems: 'center',
+    },
+  },
+})
+
+globalStyle(`${previewContainer}:not([hidden]) ${inlineBox} [data-ui="Text"]`, {
+  opacity: 0.5,
+})
+
+export const popoverContainer = style({
+  maxHeight: '40vh',
+  overflowY: 'auto',
+  selectors: {
+    // `&&`: ui5 Box sets `min-width` on itself by default (`.sui-min-width`, (0,1,0)).
+    '&&': {
+      minWidth: '160px',
+    },
+  },
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/styledComponents.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/styledComponents.tsx
@@ -1,38 +1,30 @@
 import {Text} from '@sanity/ui'
-import {styled} from 'styled-components'
+import {clsx} from 'clsx'
+import {type ComponentProps} from 'react'
 import {Box} from 'ui5'
 
-export const InlineBox = styled(Box)`
-  &:not([hidden]) {
-    display: inline;
-    align-items: center;
+import {inlineBox, inlineText, popoverContainer, previewContainer} from './styledComponents.css'
 
-    &[data-changed] {
-      cursor: pointer;
-    }
-  }
-`
+export function InlineBox(props: ComponentProps<typeof Box>) {
+  const {className, ...rest} = props
 
-export const InlineText = styled(Text)`
-  &:not([hidden]) {
-    display: inline;
-    color: inherit;
-  }
-`
+  return <Box {...rest} className={clsx(inlineBox, className)} />
+}
 
-export const PreviewContainer = styled(Box)`
-  &:not([hidden]) {
-    display: inline-flex;
-    align-items: center;
+export function InlineText(props: ComponentProps<typeof Text>) {
+  const {className, ...rest} = props
 
-    ${InlineBox} [data-ui="Text"] {
-      opacity: 0.5;
-    }
-  }
-`
+  return <Text {...rest} className={clsx(inlineText, className)} />
+}
 
-export const PopoverContainer = styled(Box)`
-  min-width: 160px;
-  max-height: 40vh;
-  overflow-y: auto;
-`
+export function PreviewContainer(props: ComponentProps<typeof Box>) {
+  const {className, ...rest} = props
+
+  return <Box {...rest} className={clsx(previewContainer, className)} />
+}
+
+export function PopoverContainer(props: ComponentProps<typeof Box>) {
+  const {className, ...rest} = props
+
+  return <Box {...rest} className={clsx(popoverContainer, className)} />
+}

--- a/packages/sanity/src/core/field/types/reference/preview/ReferencePreview.css.ts
+++ b/packages/sanity/src/core/field/types/reference/preview/ReferencePreview.css.ts
@@ -1,0 +1,5 @@
+import {style} from '@vanilla-extract/css'
+
+export const referenceWrapper = style({
+  wordWrap: 'break-word',
+})

--- a/packages/sanity/src/core/field/types/reference/preview/ReferencePreview.tsx
+++ b/packages/sanity/src/core/field/types/reference/preview/ReferencePreview.tsx
@@ -1,16 +1,12 @@
 import {type Reference} from '@sanity/types'
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {Preview} from '../../../../preview/components/Preview'
 import {type FieldPreviewComponent} from '../../../preview/types'
-
-const ReferenceWrapper = styled.div`
-  word-wrap: break-word;
-`
+import {referenceWrapper} from './ReferencePreview.css'
 
 export const ReferencePreview: FieldPreviewComponent<Reference> = ({value, schemaType}) => (
-  <Box as={ReferenceWrapper} padding={2}>
+  <Box className={referenceWrapper} padding={2}>
     <Preview schemaType={schemaType} value={value} layout="default" />
   </Box>
 )

--- a/packages/sanity/src/core/field/types/slug/preview/SlugPreview.css.ts
+++ b/packages/sanity/src/core/field/types/slug/preview/SlugPreview.css.ts
@@ -1,0 +1,6 @@
+import {style} from '@vanilla-extract/css'
+
+export const slugWrapper = style({
+  wordBreak: 'break-all',
+  whiteSpace: 'pre-wrap',
+})

--- a/packages/sanity/src/core/field/types/slug/preview/SlugPreview.tsx
+++ b/packages/sanity/src/core/field/types/slug/preview/SlugPreview.tsx
@@ -1,19 +1,14 @@
 import {type Slug} from '@sanity/types'
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {type FieldPreviewComponent} from '../../../preview/types'
-
-const SlugWrapper = styled.div`
-  word-break: break-all;
-  white-space: pre-wrap;
-`
+import {slugWrapper} from './SlugPreview.css'
 
 export const SlugPreview: FieldPreviewComponent<Slug> = (props) => {
   const {value} = props
 
   return (
-    <Box as={SlugWrapper} paddingX={2} paddingY={1}>
+    <Box className={slugWrapper} paddingX={2} paddingY={1}>
       {value.current}
     </Box>
   )

--- a/packages/sanity/src/core/field/types/string/diff/StringFieldDiff.css.ts
+++ b/packages/sanity/src/core/field/types/string/diff/StringFieldDiff.css.ts
@@ -1,0 +1,6 @@
+import {style} from '@vanilla-extract/css'
+
+export const stringWrapper = style({
+  whiteSpace: 'pre-wrap',
+  wordWrap: 'break-word',
+})

--- a/packages/sanity/src/core/field/types/string/diff/StringFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/string/diff/StringFieldDiff.tsx
@@ -1,14 +1,8 @@
-import {styled} from 'styled-components'
-
 import {DiffFromTo} from '../../../diff/components/DiffFromTo'
 import {DiffString} from '../../../diff/components/DiffString'
 import {type DiffComponent, type StringDiff} from '../../../types'
 import {StringPreview} from '../preview/StringPreview'
-
-const StringWrapper = styled.div`
-  white-space: pre-wrap;
-  word-wrap: break-word;
-`
+import {stringWrapper} from './StringFieldDiff.css'
 
 export const StringFieldDiff: DiffComponent<StringDiff> = ({diff, schemaType}) => {
   const {options} = schemaType
@@ -20,8 +14,8 @@ export const StringFieldDiff: DiffComponent<StringDiff> = ({diff, schemaType}) =
   }
 
   return (
-    <StringWrapper>
+    <div className={stringWrapper}>
       <DiffString diff={diff} />
-    </StringWrapper>
+    </div>
   )
 }

--- a/packages/sanity/src/core/field/types/string/preview/StringPreview.css.ts
+++ b/packages/sanity/src/core/field/types/string/preview/StringPreview.css.ts
@@ -1,0 +1,6 @@
+import {style} from '@vanilla-extract/css'
+
+export const stringWrapper = style({
+  wordBreak: 'break-all',
+  whiteSpace: 'pre-wrap',
+})

--- a/packages/sanity/src/core/field/types/string/preview/StringPreview.tsx
+++ b/packages/sanity/src/core/field/types/string/preview/StringPreview.tsx
@@ -1,18 +1,13 @@
-import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {type FieldPreviewComponent} from '../../../preview/types'
-
-const StringWrapper = styled.div`
-  word-break: break-all;
-  white-space: pre-wrap;
-`
+import {stringWrapper} from './StringPreview.css'
 
 export const StringPreview: FieldPreviewComponent<string> = (props) => {
   const {value} = props
 
   return (
-    <Box as={StringWrapper} paddingX={2} paddingY={1}>
+    <Box className={stringWrapper} paddingX={2} paddingY={1}>
       {value}
     </Box>
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This is 10/12 in the stacked styled-components to vanilla-extract migration. It isolates field diff and preview components in a 52-file layer.

### What to review

Review diff emphasis/state selectors and type-specific preview translations, especially Portable Text diff rendering. This PR is based on #14624.

### Testing

Split unchanged from #14566's focused field migration commit.

### Notes for release

N/A – Internal styling migration.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f17cdeb-a5b2-47f6-8407-a16eb28c6d4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f17cdeb-a5b2-47f6-8407-a16eb28c6d4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

