### PR TITLE
fix(test-studio): count styled ui v5 components as both systems

### DIFF
--- a/dev/test-studio/plugins/style-outline/styleOutline.css.ts
+++ b/dev/test-studio/plugins/style-outline/styleOutline.css.ts
@@ -2,6 +2,9 @@ import {globalStyle, style} from '@vanilla-extract/css'
 
 import {STYLE_OUTLINE_ATTRIBUTE, STYLE_SYSTEMS} from './styleSystems'
 
+// Overlapping nodes (eg a `styled(ui5Box)`) match several systems at once, and styled-components
+// must win so the debt stays visible. Its exclusion `:not()` gives it the higher specificity today;
+// keep it last in STYLE_SYSTEMS so it still wins on order should that exclusion ever go away.
 for (const {id, color, selector} of STYLE_SYSTEMS) {
   globalStyle(`html[${STYLE_OUTLINE_ATTRIBUTE}~="${id}"] ${selector}`, {
     outline: `1px solid ${color} !important`,

--- a/dev/test-studio/plugins/style-outline/styleSystems.ts
+++ b/dev/test-studio/plugins/style-outline/styleSystems.ts
@@ -8,23 +8,36 @@ export interface StyleSystem {
 }
 
 interface Fingerprint extends Omit<StyleSystem, 'selector'> {
+  exclude?: readonly string[]
   match: string
 }
 
-// Ordered by precedence: a node belongs to the first fingerprint it matches, so a
-// `styled(ui5Box)` counts as ui5 and a `styled(ui4Card)` counts as ui4.
+const UI5_MATCH = '[class^="sui-"], [class*=" sui-"]'
+const UI4_MATCH = '[data-ui]'
+const UI4_ONLY_MATCH = `:is(${UI4_MATCH}):not(${UI5_MATCH})`
+
+// UI v5 and styled-components may coexist on the same node while it is being migrated, so those
+// fingerprints deliberately overlap, even if the v5 node also has data-ui. UI v4 still yields to
+// v5 in the adoption count, and resolved v4 nodes remain excluded from the styled-components count.
 const FINGERPRINTS: readonly Fingerprint[] = [
   {
     id: 'ui5',
     label: '@sanity/ui v5',
     color: '#3fb950',
-    match: '[class^="sui-"], [class*=" sui-"]',
+    match: UI5_MATCH,
   },
-  {id: 'ui4', label: '@sanity/ui v4', color: '#e2604f', match: '[data-ui]'},
+  {
+    id: 'ui4',
+    label: '@sanity/ui v4',
+    color: '#e2604f',
+    exclude: [UI5_MATCH],
+    match: UI4_MATCH,
+  },
   {
     id: 'styled',
     label: 'styled-components',
     color: '#ff4fa3',
+    exclude: [UI4_ONLY_MATCH],
     // Prebuilt studio bundles emit `<Name>-sc-<hash>` ids; `sanity dev` resolves the studio from
     // source without the styled-components transform, so ids are bare `sc-<hash>` tokens.
     match: '[class*="-sc-"], [class^="sc-"], [class*=" sc-"]',
@@ -32,9 +45,8 @@ const FINGERPRINTS: readonly Fingerprint[] = [
 ]
 
 export const STYLE_SYSTEMS: readonly StyleSystem[] = FINGERPRINTS.map(
-  ({match, ...system}, index) => {
-    const preceding = FINGERPRINTS.slice(0, index).map((other) => other.match)
-    const exclusions = preceding.length > 0 ? `:not(${preceding.join(', ')})` : ''
+  ({exclude = [], match, ...system}) => {
+    const exclusions = exclude.length > 0 ? `:not(${exclude.join(', ')})` : ''
     return {...system, selector: `:is(${match})${exclusions}`}
   },
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to [#14615](https://github.com/sanity-io/sanity/pull/14615), which is already merged. That PR left the style migrations panel's fingerprints mutually exclusive, so a UI v5 component wrapped in styled-components was counted only as v5 and drew only the v5 outline — hiding real styled-components debt.

The fingerprints in `dev/test-studio/plugins/style-outline/styleSystems.ts` now express overlap explicitly, via a per-fingerprint `exclude` list instead of "exclude everything earlier in the array". Counting (`countNodes`) and the debug outline rules (`styleOutline.css.ts`) both consume the same `system.selector`, so the two can't drift:

- **UI v5 and styled-components overlap.** A `styled(ui5Box)` node counts in both the v5 adoption number and the styled-components escape number, and matches both outline rules. With both toggles on, styled-components wins, so nodes we still want to eliminate stay magenta.
- **UI v4 stays exclusive.** v4 continues to yield to v5 in adoption counting, and nodes that resolve as v4 remain excluded from the styled-components count and outline — most v4 components are styled-components and many always will be, so counting them would drown the metric.
- A v5 node that also carries `data-ui` still counts as v5 + styled-components. The styled-components exclusion targets the *resolved* v4 selector (`:is([data-ui]):not(<v5 match>)`) rather than every `data-ui` node, so the v5 overlap survives.

### What to review

- The three `exclude` declarations and the `UI4_ONLY_MATCH` constant in `styleSystems.ts` — that constant is what keeps a `data-ui` + `sui-*` node inside the styled-components set.
- The precedence note added to `styleOutline.css.ts`. The magenta win is a *specificity* property: the styled-components exclusion `:not()` raises its selector to `(0,4,1)` against the v5 rule's `(0,2,1)`, so it wins irrespective of rule order (verified by emitting the rules reversed). Rule order is the backup tie-break if that exclusion is ever removed, which is what the note asks future edits to preserve.

### Testing

Selector resolution checked against synthetic DOM nodes covering plain v5, plain v4, plain styled-components, v5 + styled-components, v5 + `data-ui` + styled-components, and v4 + styled-components — each resolves to the intended set of systems.

The emitted outline CSS was then checked separately, since matching selectors alone don't prove which colour a browser paints. Rules generated exactly as `styleOutline.css.ts` generates them were loaded in headless Chrome and `getComputedStyle().outlineColor` read for all 6 node kinds across all 7 toggle combinations (42 cases); every case matches the intended winner, including magenta on v5 overlaps and coral red retained on v4 + styled-components. Reversing the emission order leaves the magenta win intact, confirming it rests on specificity.

Verified in the test studio (`SANITY_STUDIO_STYLE_OUTLINE=true`): the styled-components count rises from 145 to 228 now that v5 overlaps are included. With v5 + styled-components enabled, overlapping nodes such as the "Divider title" header switch from green to magenta while v5-only nodes stay green; with v4 + styled-components enabled, v4 nodes stay coral red.

`pnpm check:format` and `pnpm check:oxlint` pass. This dev-only debug panel has no automated test coverage.

[UI v5 and styled-components enabled together: overlapping nodes are magenta, v5-only nodes stay green](https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v5_and_styled_overlap.webp)

[UI v4 and styled-components enabled together: resolved v4 nodes stay coral red](https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v4_stays_excluded.webp)

[style_outline_v5_styled_overlap_precedence.mp4](https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstyle_outline_v5_styled_overlap_precedence.mp4)

### Notes for release

N/A: Internal test-studio tooling only.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3fa2301-a37b-47a8-a47f-e2277005f69a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3fa2301-a37b-47a8-a47f-e2277005f69a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

