### PR TITLE
chore(radar): remove dots from doc ids, add skills

### DIFF
--- a/.agents/skills/sanity-bench/SKILL.md
+++ b/.agents/skills/sanity-bench/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: sanity-bench
+description: Run, dispatch and read the hermetic Studio performance benchmark suite in perf/bench — local runs and modes, the trigger:perf-bench PR label, the Studio Bench workflow_dispatch inputs (run_suite, self_test, backfill_sha, release_tag, ab_from/ab_to) and which combine, and how to read 🔴🟢✅⚪ verdicts. Use when asked to benchmark a PR or commit, compare two commits, backfill or re-run the daily main series, measure a release, add a bench scenario, extend the mock API, or interpret a bench PR comment or a failed Studio Bench run.
+---
+
+# Studio bench (perf/bench)
+
+A built studio measured in Chromium against an in-process mock of the Sanity API: no tokens, no
+network, one clock. The interesting output is an **A/B verdict per metric** from interleaved
+reference/experiment sessions with a cluster bootstrap — 🔴 regression, 🟢 improvement, ✅ neutral,
+⚪ inconclusive (CI too wide within budget; never a coin flip). Absolute numbers are host-relative
+and only comparable with the run's calibration score alongside. `perf/bench/README.md` is the
+full reference; this skill is the operating card. Stored results are read through `sanity-radar`.
+
+## Local
+
+```bash
+pnpm build:bench                                              # required first: packages + bench studio
+pnpm bench help                                               # commands; `pnpm bench run --help` for flags
+pnpm bench scenarios                                          # singleString, arrayI18n, article, recipe, synthetic, syntheticLarge
+pnpm bench run --scenario singleString --sessions 4           # absolute interaction run
+pnpm bench run --mode pageload --scenario singleString        # load vitals + bundle size
+pnpm bench run --mode inp --scenario singleString --sessions 3
+pnpm bench run --mode soak --scenario singleString --minutes 5
+pnpm --filter bench build:reference-config \
+  && pnpm bench run --scenario singleString --reference-dist perf/bench/.reference/dist   # self-test: must be all-neutral
+pnpm bench prepare-backfill --sha <sha>                       # build a historical commit into perf/bench/dist (tarball recipe)
+pnpm bench dev                                                # mock + sanity dev, type into a seeded doc
+pnpm bench:unit                                               # mock contract + stats tests
+```
+
+Flags worth knowing: `--headed`, `--throttle 1` (interaction runs default to 4× CPU throttle),
+`--seed N`, `--budget <s>`, `--json-out <file>`, `--fail-on-verdict`. In a sandbox where the `tsx`
+CLI cannot open its IPC pipe (`listen EPERM … tsx-*/…pipe`), run the CLI directly:
+`node --conditions=monorepo --import tsx perf/bench/cli/index.ts <command>`.
+
+## CI: `.github/workflows/bench.yml`
+
+| Trigger                                                | What runs                                                                                                                             | Result lands in                                                                                              |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Label a PR `trigger:perf-bench` (maintainers)          | PR head vs merge-base A/B, one shard per scenario. The label persists: every later push re-runs the suite until the label is removed. | Sticky PR comment `bench-report`; absolute side stored under the branch (`?branches=main,<branch>` in Radar) |
+| Cron 05:00 UTC daily                                   | Absolute suite on main + soak + INP                                                                                                   | `benchRun` `mode: "absolute"` in Radar (Trends)                                                              |
+| Cron Monday 06:00 UTC                                  | Self-test (build vs itself, `--fail-on-verdict`)                                                                                      | Red job = harness drift                                                                                      |
+| `-f run_suite=true`                                    | Same as the daily cron, on demand                                                                                                     | Radar                                                                                                        |
+| `-f run_suite=true -f backfill_sha=<40-char sha>`      | Replay a historical main commit, store under that sha and its commit date                                                             | Radar (fills a hole in the series)                                                                           |
+| `--ref v6.x.y -f run_suite=true -f release_tag=v6.x.y` | Measure a release commit (`release-latest.yml` does this automatically)                                                               | Radar, `trigger: "release"` → anchors the release marker                                                     |
+| `-f ab_from=<sha> -f ab_to=<sha>`                      | A/B of two arbitrary commits (reference → experiment)                                                                                 | Run summary page + `benchRun` `mode: "ab"` (Radar Comparisons tool)                                          |
+| `-f self_test=true`                                    | Self-test on demand                                                                                                                   | Job status                                                                                                   |
+
+```bash
+gh workflow run bench.yml -R sanity-io/sanity -f ab_from=<sha> -f ab_to=<sha>
+gh run list -R sanity-io/sanity --workflow bench.yml --event workflow_dispatch --limit 5
+gh run watch -R sanity-io/sanity <run-id>; gh run view -R sanity-io/sanity <run-id> --web
+```
+
+Input rules (the workflow validates them): `ab_from`/`ab_to` go together and exclude
+`backfill_sha` and `self_test`; `backfill_sha` requires `run_suite` and excludes `self_test`;
+`release_tag` must point at the measured commit (dispatch at the tag, or pass the tag's sha as
+`backfill_sha` from main). Shas are full 40 characters. Historical builds (backfill, A/B, PR
+reference) install the old commit with `--frozen-lockfile`, pack `sanity` and its workspace deps
+as tarballs, and build HEAD's `perf/bench` harness against them — harness and scenarios are
+always HEAD's; only product code differs. Backfill and A/B fail loudly, the PR reference falls
+back to absolute mode with a warning in the comment.
+
+Radar's run popover copies the A/B command for "this point vs the previous run" (**Copy A/B vs
+previous run**) so the shas never need typing.
+
+## Reading a result
+
+- The PR comment / run summary is deliberately minimal: verdicts, then a link to Radar. A missing scenario is named (`missing-scenarios.json` fails the run) — silence is never "fine".
+- Gates: interaction median with `absMs` 16ms floor (two Event Timing quantisation steps), pageload time-to-editable; INP, vitals, resources, bundle are report-only. Thresholds live in `perf/bench/stats/gate.ts` and are shared with Radar's drift feed.
+- ⚪ on a heavy scenario usually means the budget ran out; re-dispatch or look at `stoppedBy` and `failures` in the stored run.
+- A `hermeticity violation` or `unexpected endpoint` session failure means the studio made a request the mock does not know: extend `perf/bench/mock-api` in the same PR as the studio change.
+
+## Changing the suite
+
+- New scenario: schema in `perf/bench/studio/schemas`, `defineScenario` in `perf/bench/scenarios` (seeded PRNG, never `Math.random`), register in `scenarios/index.ts`, add it to the `bench-interaction` matrix **and** `BENCH_EXPECTED_INTERACTION_SCENARIOS` in `bench.yml`, verify one absolute session passes.
+- Stored document shape: `perf/bench/report/types.ts` → `storeShape.ts`, mirrored by `dev/radar/schemaTypes/benchRun.ts`; bump all three together.
+- Flake rules are in the README (no fixed sleeps, noise widens sampling, seeded PRNG, failed sessions retried and counted, environment drift fails fast). A change that makes a verdict flip on identical builds is a harness bug — the weekly self-test exists to catch it.

--- a/.agents/skills/sanity-radar-investigate/SKILL.md
+++ b/.agents/skills/sanity-radar-investigate/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: sanity-radar-investigate
+description: Investigate a suspected Studio performance regression surfaced by Studio Radar or the bench suite — confirm the signal against host calibration, narrow the commit range, confirm with an A/B dispatch, bisect, and name the culprit or call it noise. Use when handed a Radar "investigation prompt" (starts with "Investigate a suspected performance regression in the sanity-io/sanity monorepo"), a drift flag, a red 🔴 verdict in a bench PR comment, or asked whether commit X, PR Y or release Z regressed a studio metric.
+---
+
+# Investigating a studio performance regression
+
+The output is a verdict with evidence: **culprit commit/PR**, **host or harness artifact**, or
+**noise**. Trend points are host-relative daily samples; only an interleaved A/B run decides.
+Data access and query shapes are in the `sanity-radar` skill (`references/groq-recipes.md`);
+dispatching runs is in `sanity-bench`.
+
+## Rules that keep the verdict honest
+
+- **Never conclude from two absolute points.** Run-to-run noise on main is ~12% at the median, above the gate's 5% threshold. A point-to-point delta is a hypothesis, an A/B verdict is evidence.
+- **Read the host first.** `runner.calibrationMs` (higher = slower) and `runner.cpuModel` per run and per scenario shard. A metric step that coincides with a calibration step, or a CPU model change, is the host until an A/B says otherwise. GitHub rotates runner hardware under the same vCPU shape.
+- **Check the instrument.** A Playwright/Chromium bump moves INP and vitals with no studio change (`runner.browserVersion`). A change under `perf/bench/` (scenario, mock, harness) moves everything in that scenario at once.
+- **⚪ inconclusive means widen, not shrug.** The CI stayed too wide within the budget; re-dispatch, or look at which side had failures (`scenarios[].failures`).
+- **A level step is not a leak.** DOM nodes, listeners or heap moving to a new plateau (and staying) is a behavior change; the soak slope (`soak`) is what detects leaks.
+- **Say what you did not verify.** A shortlist is a shortlist until a dispatch confirms it.
+
+## Procedure
+
+1. **Pin the signal.** From the prompt/flag: series (scenario · metric), the suspicious run's sha and the previous run's sha, the delta. Fetch both runs with calibration/cpuModel/browserVersion, and every other run of the same sha (re-runs exist; if a re-run on a faster host reproduces the value, it is the commit). Confirm the metric moved on the same field in other scenarios or stayed local to one.
+2. **Rule out the host and the harness.** Calibration and CPU model steady across the step → proceed. Otherwise note it and let the A/B decide; do not stop here, a real regression can land on a slow day.
+3. **Narrow the range.** GitHub compare `https://github.com/sanity-io/sanity/compare/<from>...<to>` or the `gitCommit` window query. Shortlist commits that could move this metric: studio runtime under `packages/sanity/src`, dependency bumps (`@sanity/ui`, react, rxjs, styled-components, vite), build config, `perf/bench` itself. Ignore docs/test/CI-only commits unless the harness is the suspect.
+4. **Confirm with an A/B dispatch** (the same harness CI uses, bootstrap-gated verdicts):
+   ```bash
+   gh workflow run bench.yml -R sanity-io/sanity -f ab_from=<full reference sha> -f ab_to=<full experiment sha>
+   gh run list -R sanity-io/sanity --workflow bench.yml --event workflow_dispatch --limit 3   # find the run id
+   gh run watch -R sanity-io/sanity <run-id>
+   gh run view  -R sanity-io/sanity <run-id> --json jobs --jq '.jobs[] | {name, conclusion}'
+   ```
+   ~30 minutes. The verdict table is on the run's summary page (`gh run view --web`), and the comparison is stored as a `mode: "ab"` benchRun (Comparisons tool, or the GROQ recipe). Both builds fail loudly; a failed `build`/`build-reference` job usually means one sha predates the tarball recipe or does not install with `--frozen-lockfile`.
+5. **Bisect if the range is long.** Halve with further dispatches: log₂(N) runs find the commit. Each result is stored, so a session survives context loss — list `mode == "ab"` runs to resume. For regressions a human can _see_ (jank, a slow open) use the Radar Bisect tool instead: it walks the first-parent chain and hands out each commit's `testStudioUrl` preview build.
+6. **Reproduce locally when the mechanism is unclear** (numbers are host-relative; use for profiling, not verdicts):
+   ```bash
+   pnpm build:bench && pnpm bench run --scenario <scenario> --sessions 4 --headed
+   pnpm bench prepare-backfill --sha <sha>   # build a historical commit into perf/bench/dist
+   ```
+   LoAF attribution (`scenarios[].loafAttribution`) and CLS attribution in the stored run name the scripts/elements involved.
+7. **Report.** Culprit sha + PR (or "host"/"noise"), the metric table (reference → experiment, Δ with CI, verdict) copied from the A/B run, the mechanism if known, confidence, and what was not checked. Note whether the change is a deliberate trade (say so, and where the trade is documented) or an unintended regression worth a fix or an upstream issue. For a shipped regression, attribute it to the release that first contained the commit (Releases tool → "Add regression" creates the record).
+
+## Priors from past investigations
+
+- `@sanity/ui` v4 (`bdf98a3448`) doubled DOM nodes and listeners across every scenario: overlays keep children mounted via `<Activity>`. A deliberate level step, not a leak — but it also added an auth round trip at boot by mounting deferred workspace-menu probes.
+- Auth round trips (`boot-cold · auth round trips`, `auth in flight`) grow by whole emulated round trips (~45ms each) — count real requests in `resources.experiment.byClass[endpointClass == "auth"][0].count` (the session-wide ledger), not just the boot window.
+- Runs of one sha often differ by ~20% of calibration across hosts; that is the noise floor for absolute reads.

--- a/.agents/skills/sanity-radar/SKILL.md
+++ b/.agents/skills/sanity-radar/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: sanity-radar
+description: Studio Radar, the repo-health dashboard at radar.sanity.dev (source in dev/radar) — what each tool shows, where the data lives, how to query benchRun / gitCommit / gitTag / bisectSession documents with GROQ (read token required), and how to run, test and change the dashboard code. Use when asked about studio performance trends, drift flags, the bench dataset, release markers, the Bisect or Comparisons tools, "what did the daily bench say", or when editing anything under dev/radar.
+---
+
+# Studio Radar
+
+Radar answers repo-health questions without opening CI logs: is studio performance drifting on
+main, what did a run look like, which commit broke it, what shipped when. It is a Sanity Studio
+(`dev/radar`, deployed at https://radar.sanity.dev) reading a dataset that CI writes. The design
+record is `dev/radar/SPEC.md` — read the section for the view you touch, and update it when
+behavior changes. For regression hunting use `sanity-radar-investigate`; for producing the data
+use `sanity-bench`.
+
+## Tools (URL path = tool name)
+
+| Tool        | Path           | Shows                                                                                                                                                                              |
+| ----------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trends      | `/trends`      | Small multiples per scenario·metric on main: p50 line, p75–p90 band, host calibration (dotted), drift baseline overlay (dashed before / solid after), release ticks. Default view. |
+| Releases    | `/releases`    | Every synced `v*` tag: dist-tags, downloads, changelog links, regressions bisect attributed to it.                                                                                 |
+| Bisect      | `/bisect`      | Guided first-parent bisect over `gitCommit` using each commit's test-studio preview build.                                                                                         |
+| Diagnostics | `/diagnostics` | Paste a studio diagnostics JSON, render it (in-studio twin of `dev/studio-diagnostics-viewer`).                                                                                    |
+| Structure   | `/structure`   | Raw documents.                                                                                                                                                                     |
+| Comparisons | `/comparisons` | Stored `mode: "ab"` runs from A/B dispatches, verdict per metric.                                                                                                                  |
+
+Trends URL state, all shareable: `?range=30|90|all`, `?branches=main,<branch>`,
+`?layers=-band,-calibration` (hide layers), `?tab=<metric group>`, `?max=<series key>` (one chart maximized).
+Clicking a point opens the run popover: value, percentiles, host, release context, links, and
+under "Suspect a regression?" the GitHub compare of the gap, **Copy A/B vs previous run** (the
+`gh workflow run bench.yml … ab_from/ab_to` command) and **Copy investigation prompt** (a
+paste-ready brief for an agent).
+
+## The data
+
+Project `mhfozd0z`, dataset `bench`, **private**: reads need a token with access to the project
+(your CLI token via `sanity debug --secrets`, or a viewer token from sanity.io/manage; the deployed
+studio authenticates through your login). Writes need `RADAR_SANITY_WRITE_TOKEN`, which only CI
+has; never write from a laptop. Ids are built in one place, `@repo/utils/radar-ids`: lowercase,
+dashes, no dots (a dot makes an id a path like `drafts.x`, which the API scopes differently).
+
+| Type            | Written by                                     | Id                                              | Key fields                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --------------- | ---------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `benchRun`      | `bench store` in `.github/workflows/bench.yml` | `bench-run-<sha>-<run id>` / `bench-run-pr-<n>` | `mode` (`absolute` = time-series point, `ab` = investigation record), `trigger` (`cron`/`release`/`backfill`/`dispatch`/`pr`; absent = cron), `git{sha, branch, committedAt, mergeBaseSha, prNumber}`, `runner{calibrationMs, cpuModel, runId…}`, `scenarios[]{scenario, mode, runner{calibrationMs, cpuModel}, metrics[]{label, unit, experiment/reference{summary{median,p75,p90}}, comparison{diff,lo,hi,verdict}}, resources, soak}`, `bundle{initialJsBytes, totalJsBytes}` |
+| `gitCommit`     | `sync-git-metrics.yml` (every push to main)    | `git-commit-<sha>`                              | `sha`, `parentSha` (first-parent chain), `committedAt`, `subject`, `prNumber`, author, `testStudioUrl`                                                                                                                                                                                                                                                                                                                                                                           |
+| `gitTag`        | same, releases and a daily npm floor           | `git-tag-v6-10-1`                               | `tag`, `sha`, `taggedAt`, `major/minor/patch/prerelease`, `npm{distTags, weeklyDownloads, publishedAt}`                                                                                                                                                                                                                                                                                                                                                                          |
+| `bisectSession` | Bisect tool (user-owned, liveEdit)             | `bisect-session-<uuid>`                         | `good/bad{sha}`, `marks[]`, `result{firstBadSha, suspectShas, regression}`                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `driftAck`      | Trends drift feed (user-owned)                 | `drift-ack-<slug of metricKey:branch>`          | `state` (`silenced`/`snoozed`/`fixed`), `baselineValue`, `until`                                                                                                                                                                                                                                                                                                                                                                                                                 |
+
+Rules that every consumer follows (the dashboard's queries are the reference, `tools/*/data.ts`):
+
+- **Project, never fetch `sessions`.** Documents carry per-session sample arrays; a bare `*[_type == "benchRun"]` is megabytes.
+- **Time series = `mode == "absolute"`**, ordered by `coalesce(git.committedAt, startedAt)` (backfill runs have a historical `committedAt` and a recent `startedAt`). PR-branch runs share the type — filter `git.branch == "main"` for the main line.
+- **Same-sha runs are one point.** CI re-measures commits; the charts merge them by median.
+- **Absolute numbers are host-relative.** Always read `runner.calibrationMs` (higher = slower host) and `runner.cpuModel` next to any value; only A/B `comparison.verdict`s are host-independent.
+- `git.sha` is the join key to `gitCommit`; `benchRun.git.commit` is a weak reference that dangles for PR-branch runs.
+
+Ready-made queries: [references/groq-recipes.md](references/groq-recipes.md).
+
+## Working on the dashboard
+
+```bash
+pnpm radar                                  # sanity dev on http://localhost:3399 (needs a Sanity login; reads live data)
+pnpm vitest run --project=radar             # pure modules: trend math, drift, bisect, git parsers
+pnpm build:radar                            # production build (turbo)
+pnpm --filter radar sync-git -- --dry-run   # preview the git-history sync (needs GITHUB_TOKEN)
+```
+
+- **Realtime everywhere**: `useDocumentStore().listenQuery` + `useObservable`, never one-shot `client.fetch`. New cron runs must appear without a reload.
+- **Charts are visx primitives** (`@visx/scale|shape|group|axis|responsive`) inside `@sanity/ui` layout; no chart library.
+- **Debug data sources** (dev server only, toolbar picker; `tools/trends/debugData.ts`) render steady/drift/step/host-correlated/sparse/empty datasets and synthetic release tags — use them to exercise every encoding layer and the drift feed without live data. UI is verified through these, not unit tests.
+- **One source of truth for "enough to care"**: drift thresholds import from `perf/bench/stats/gate.ts`. Don't invent a second statistic; SPEC.md records the baselines that were tried and rejected (step, weekday-matched) and why.
+- Honesty constraint: any surface showing a ms value must make host calibration visible (`CALIBRATION_EXPLAINER` is the one shared wording).
+- Studio conventions from `AGENTS.md` apply (no `forwardRef`, `use-effect-event`, no inline Translate components).
+
+## Operations
+
+- Daily main run: `bench.yml` cron 05:00 UTC; git sync 05:30. A missed day is repaired with a backfill dispatch (see `sanity-bench`). A gap in commits: `gh workflow run sync-git-metrics.yml -f backfill=true`.
+- Release markers only appear for tags whose commit has a `gitCommit` document (main-only by construction); a maintenance release cut from a branch is correctly absent.
+- Cron failures alert the CI Slack channel; a hole in the series with no alert means the store step was skipped, not that the run failed.

--- a/.agents/skills/sanity-radar/references/groq-recipes.md
+++ b/.agents/skills/sanity-radar/references/groq-recipes.md
@@ -1,0 +1,129 @@
+# GROQ recipes for the Radar dataset
+
+Project `mhfozd0z`, dataset `bench`. The dataset is private: every query needs a token with read
+access to the project (`SANITY_AUTH_TOKEN` below — your CLI token from `sanity debug --secrets`
+works). Run any query with:
+
+```bash
+q='<groq>'
+curl -sG "https://mhfozd0z.api.sanity.io/v2025-02-19/data/query/bench" \
+  -H "Authorization: Bearer $SANITY_AUTH_TOKEN" --data-urlencode "query=$q" | jq .result
+```
+
+Every recipe projects; none fetches `sessions`. Ranges are `start`/`end` ISO dates or shas —
+substitute or pass them as `$params` (`--data-urlencode '$sha="…"'`).
+
+## Health of the main-branch series
+
+```groq
+// Latest 10 daily points with host context — read calibration before believing any ms value
+*[_type == "benchRun" && mode == "absolute" && git.branch == "main"]
+  | order(coalesce(git.committedAt, startedAt) desc)[0...10]{
+  _id, startedAt, trigger, releaseTag,
+  "sha": git.sha, "committedAt": git.committedAt,
+  "calibrationMs": runner.calibrationMs, "cpuModel": runner.cpuModel, "runId": runner.runId
+}
+```
+
+```groq
+// Days with a stored main run since $start — diff against a calendar outside GROQ to find gaps
+array::unique(*[_type == "benchRun" && mode == "absolute" && git.branch == "main"
+  && startedAt > $start]{"day": string::split(startedAt, "T")[0]}.day)
+```
+
+## One metric over time
+
+```groq
+// p50/p75/p90 of a metric per run, with the shard's own host calibration
+*[_type == "benchRun" && mode == "absolute" && git.branch == "main"]
+  | order(coalesce(git.committedAt, startedAt) asc){
+  "date": coalesce(git.committedAt, startedAt), "sha": git.sha,
+  "runCalibrationMs": runner.calibrationMs,
+  "shard": scenarios[scenario == $scenario][0]{
+    "calibrationMs": runner.calibrationMs, "cpuModel": runner.cpuModel,
+    "metric": metrics[label == $label][0].experiment.summary{median, p75, p90, n}
+  }
+}
+```
+
+Per-scenario `kind` is `interaction` or `pageload`; `mode` is set only for the extra daily modes
+(`inp`, `soak`). Interaction metric labels are the **field names typed into** (`stringField`,
+`title`, `body`, `simple-en`…), each carrying keystroke latency; pageload labels are
+`<condition> · <metric>` (`boot-cold · time to editable`, `open-doc-warm · LCP`, `boot-cold · auth
+round trips`…); INP scenarios carry `INP` and `INP interactions`. Scenario ids come from
+`pnpm bench scenarios`. Bundle size is top-level per side: `bundle.experiment{initialJsBytes,
+totalJsBytes, chunkCount}`. Soak lives on the soak scenario: `scenarios[mode == "soak"][0].soak`.
+Resources (request counts, DOM nodes, listeners, heap) sit on interaction scenarios:
+`scenarios[kind == "interaction"]{scenario, "r": resources.experiment{requestCount, domNodes, listeners, heapMb}}`.
+
+## Runs for a specific commit
+
+```groq
+// Every run that measured this sha (re-runs land on different hosts — compare calibration)
+*[_type == "benchRun" && git.sha == $sha]{
+  _id, mode, trigger, startedAt, "branch": git.branch,
+  "calibrationMs": runner.calibrationMs, "cpuModel": runner.cpuModel, "runId": runner.runId
+}
+```
+
+## A/B comparisons (investigation records)
+
+```groq
+// Newest first; verdict counts per run
+*[_type == "benchRun" && mode == "ab"] | order(startedAt desc){
+  _id, startedAt,
+  "from": git.mergeBaseSha, "to": git.sha, "runId": runner.runId,
+  "regressions": count(scenarios[].metrics[comparison.verdict == "regression"]),
+  "improvements": count(scenarios[].metrics[comparison.verdict == "improvement"]),
+  "inconclusive": count(scenarios[].metrics[comparison.verdict == "inconclusive"])
+}
+```
+
+```groq
+// The judged metrics of one comparison
+*[_type == "benchRun" && mode == "ab" && _id == $id][0].scenarios[]{
+  scenario, mode,
+  "metrics": metrics[defined(comparison)]{
+    label, unit,
+    "reference": reference.summary.median, "experiment": experiment.summary.median,
+    comparison{diff, lo, hi, verdict}
+  }
+}
+```
+
+## Git history
+
+```groq
+// Commits between two runs' shas, newest first (committedAt window; for the exact first-parent
+// chain walk parentSha from $to until $from)
+*[_type == "gitCommit" && committedAt > *[_type == "gitCommit" && sha == $from][0].committedAt
+  && committedAt <= *[_type == "gitCommit" && sha == $to][0].committedAt]
+  | order(committedAt desc){sha, subject, prNumber, authorLogin, committedAt, testStudioUrl}
+```
+
+```groq
+// Stable releases on main, with what npm currently says about them
+*[_type == "gitTag" && !defined(prerelease) && defined(*[_type == "gitCommit" && sha == ^.sha][0])]
+  | order(taggedAt desc)[0...20]{tag, sha, taggedAt, "distTags": npm.distTags, "downloads": npm.weeklyDownloads}
+```
+
+```groq
+// Which release first shipped a commit: the earliest tag whose commit is at or after it
+*[_type == "gitTag" && !defined(prerelease) && taggedAt >= *[_type == "gitCommit" && sha == $sha][0].committedAt]
+  | order(taggedAt asc)[0]{tag, taggedAt}
+```
+
+(By-date, like the dashboard's release bracket: it says "shipped after", not "contained in".
+Containment needs the first-parent walk.)
+
+## Bisect sessions and acks
+
+```groq
+*[_type == "bisectSession" && defined(result.firstBadSha)] | order(createdAt desc){
+  title, "firstBad": result.firstBadSha, "regression": result.regression, "suspects": result.suspectShas, createdBy
+}
+```
+
+```groq
+*[_type == "driftAck"]{metricKey, branch, state, until, note, ackedBy, ackedAt}
+```

--- a/.claude/skills/sanity-bench
+++ b/.claude/skills/sanity-bench
@@ -1,0 +1,1 @@
+../../.agents/skills/sanity-bench

--- a/.claude/skills/sanity-radar
+++ b/.claude/skills/sanity-radar
@@ -1,0 +1,1 @@
+../../.agents/skills/sanity-radar

--- a/.claude/skills/sanity-radar-investigate
+++ b/.claude/skills/sanity-radar-investigate
@@ -1,0 +1,1 @@
+../../.agents/skills/sanity-radar-investigate

--- a/.github/workflows/sync-git-metrics.yml
+++ b/.github/workflows/sync-git-metrics.yml
@@ -77,6 +77,19 @@ jobs:
 
       - uses: ./.github/actions/setup
 
+      # Migration to the current id scheme (dot-free, dash-case — see
+      # @repo/utils/radar-ids): moves any document still on a legacy
+      # camelCase / dotted id and repoints its commit references. Runs on every
+      # sync, BEFORE it, so the sync never writes a new-id commit next to a
+      # legacy copy of the same sha (type-wide queries would list it twice).
+      # Idempotent: once the dataset is clean this is five empty listings.
+      # Remove the step and dev/radar/scripts/migrateDocumentIds.ts once a run
+      # has reported zero legacy documents.
+      - name: Migrate legacy document ids
+        env:
+          RADAR_SANITY_WRITE_TOKEN: ${{ secrets.RADAR_SANITY_WRITE_TOKEN }}
+        run: pnpm --filter radar migrate-ids
+
       - name: Sync git history to metrics dataset
         env:
           RADAR_SANITY_WRITE_TOKEN: ${{ secrets.RADAR_SANITY_WRITE_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,8 @@ pnpm bench dev                                     # mock + `sanity dev` for int
 
 See `perf/bench/README.md` for A/B comparisons, scenarios, and CI details. (The legacy `dev/efps` suite has been decommissioned; perf/bench replaces it.)
 
+Three skills cover this area: `sanity-bench` (`.agents/skills/sanity-bench/SKILL.md`, running and dispatching the suite, the `trigger:perf-bench` label, dispatch inputs), `sanity-radar` (`.agents/skills/sanity-radar/SKILL.md`, the Studio Radar dashboard in `dev/radar` and how to query its dataset) and `sanity-radar-investigate` (`.agents/skills/sanity-radar-investigate/SKILL.md`, the regression-hunting procedure from a drift flag or investigation prompt to a confirmed culprit).
+
 ### E2E Tests (Token Required)
 
 E2E tests require authentication tokens. Add these to `.env.local` in the repo root:

--- a/dev/radar/SPEC.md
+++ b/dev/radar/SPEC.md
@@ -88,6 +88,13 @@ effect of merged work; secondary: leads scanning health weekly.
    host) and when comparing branches.
 2. **Run detail** (P2) — click-through from a dot: the PR-comment tables
    (absolute variant), soak slope chart, flake telemetry, run metadata.
+   Today's run popover already carries the investigation hand-offs: the
+   GitHub compare of the gap to the previous distinct commit, **Copy A/B vs
+   previous run** (the `gh workflow run bench.yml … ab_from/ab_to` command —
+   GitHub has no URL that prefills dispatch inputs, so it is a command to
+   paste) and **Copy investigation prompt** (the same command inside a
+   paste-ready brief for a coding agent, `investigationPrompt.ts`). The
+   Comparisons tool is where a dispatched comparison lands.
 3. **Drift feed** (P2) — computed client-side, flagging a metric when it
    clears the same `rel`/`absMs` thresholds the gate uses
    (perf/bench/stats/gate.ts — one source of truth for "what matters").

--- a/dev/radar/package.json
+++ b/dev/radar/package.json
@@ -11,6 +11,7 @@
     "build": "sanity build",
     "clean": "rimraf .sanity dist",
     "dev": "sanity dev --port 3399",
+    "migrate-ids": "node --conditions=monorepo --import tsx scripts/migrateDocumentIds.ts",
     "start": "sanity preview --port 3399",
     "sync-git": "node --conditions=monorepo --import tsx scripts/syncGitHistory.ts"
   },

--- a/dev/radar/schemaTypes/bisectSession.ts
+++ b/dev/radar/schemaTypes/bisectSession.ts
@@ -12,7 +12,7 @@ import {defineField, defineType} from 'sanity'
  * only so the sessions list can show the verdict without loading the ~2k
  * commit documents. Undoing a mark clears it again.
  *
- * Id: `bisectSession-<uuid>` — sessions are user-created, not idempotent.
+ * Id: `bisect-session-<uuid>` — sessions are user-created, not idempotent.
  */
 export const bisectSession = defineType({
   name: 'bisectSession',

--- a/dev/radar/schemaTypes/gitCommit.ts
+++ b/dev/radar/schemaTypes/gitCommit.ts
@@ -3,7 +3,7 @@ import {defineField, defineType} from 'sanity'
 
 /**
  * One commit on main, metadata only — written by scripts/syncGitHistory.ts
- * with deterministic id `gitCommit-<sha>`, covering v5.0.0 onward. The
+ * with deterministic id `git-commit-<sha>`, covering v5.0.0 onward. The
  * conventional-commit fields are best-effort parses of the subject, absent
  * where it doesn't conform. Joins are by value: `benchRun.git.sha` ↔ `sha`,
  * time axes on `committedAt`.

--- a/dev/radar/schemaTypes/gitTag.ts
+++ b/dev/radar/schemaTypes/gitTag.ts
@@ -3,7 +3,8 @@ import {defineField, defineType} from 'sanity'
 
 /**
  * One `v*` release tag (major >= 5) — written by scripts/syncGitHistory.ts
- * with deterministic id `gitTag-<tagName>`.
+ * with deterministic id `git-tag-<tag, dots as dashes>` (`git-tag-v6-10-1`; a dotted id
+ * would be a path segment like `drafts.x`, which the API scopes differently).
  *
  * `commit` is a weak reference: ingestion order isn't guaranteed, and tags
  * cut from release branches point at commits that never get a gitCommit

--- a/dev/radar/scripts/backfillBenchRunCommitRefs.ts
+++ b/dev/radar/scripts/backfillBenchRunCommitRefs.ts
@@ -16,6 +16,7 @@ import process from 'node:process'
 import {parseArgs} from 'node:util'
 
 import {readEnv} from '@repo/utils'
+import {gitCommitId} from '@repo/utils/radar-ids'
 import {createClient} from '@sanity/client'
 
 const METRICS_PROJECT_ID = 'mhfozd0z'
@@ -41,7 +42,9 @@ async function main(): Promise<void> {
   const docs = await client.fetch<{_id: string; sha: string | null}[]>(
     '*[_type == "benchRun" && !defined(git.commit)]{_id, "sha": git.sha}',
   )
-  const patchable = docs.filter((doc) => doc.sha && FULL_SHA_RE.test(doc.sha))
+  const patchable = docs.filter(
+    (doc): doc is {_id: string; sha: string} => !!doc.sha && FULL_SHA_RE.test(doc.sha),
+  )
   const skipped = docs.length - patchable.length
   console.log(
     `${docs.length} benchRun doc(s) missing git.commit; ${patchable.length} patchable` +
@@ -50,7 +53,7 @@ async function main(): Promise<void> {
 
   if (values['dry-run']) {
     for (const doc of patchable.slice(0, 5))
-      console.log(`  would patch ${doc._id} -> gitCommit-${doc.sha}`)
+      console.log(`  would patch ${doc._id} -> ${gitCommitId(doc.sha)}`)
     return
   }
   if (patchable.length === 0) return
@@ -61,7 +64,7 @@ async function main(): Promise<void> {
     let transaction = client.transaction()
     for (const doc of patchable.slice(offset, offset + BATCH)) {
       transaction = transaction.patch(doc._id, {
-        set: {'git.commit': {_type: 'reference', _ref: `gitCommit-${doc.sha}`, _weak: true}},
+        set: {'git.commit': {_type: 'reference', _ref: gitCommitId(doc.sha), _weak: true}},
       })
     }
     await transaction.commit()

--- a/dev/radar/scripts/documentIdMigration.test.ts
+++ b/dev/radar/scripts/documentIdMigration.test.ts
@@ -1,0 +1,106 @@
+import {type SanityDocument} from '@sanity/client'
+import {describe, expect, it} from 'vitest'
+
+import {migratedDocument} from './documentIdMigration'
+
+const SHA = 'a'.repeat(40)
+
+function doc(fields: Record<string, unknown> & {_id: string; _type: string}): SanityDocument {
+  return {
+    _rev: 'rev1',
+    _createdAt: '2026-08-01T00:00:00Z',
+    _updatedAt: '2026-08-02T00:00:00Z',
+    ...fields,
+  }
+}
+
+describe('migratedDocument', () => {
+  it('moves a tag to a dot-free id and repoints its weak commit reference', () => {
+    const result = migratedDocument(
+      doc({
+        _id: 'gitTag-v6.10.1',
+        _type: 'gitTag',
+        tag: 'v6.10.1',
+        sha: SHA,
+        commit: {_type: 'reference', _ref: `gitCommit-${SHA}`, _weak: true},
+        major: 6,
+      }),
+    )
+    expect(result?.legacyId).toBe('gitTag-v6.10.1')
+    expect(result?.document).toEqual({
+      _id: 'git-tag-v6-10-1',
+      _type: 'gitTag',
+      tag: 'v6.10.1',
+      sha: SHA,
+      commit: {_type: 'reference', _ref: `git-commit-${SHA}`, _weak: true},
+      major: 6,
+    })
+  })
+
+  it('drops the system fields the API owns', () => {
+    const result = migratedDocument(doc({_id: `gitCommit-${SHA}`, _type: 'gitCommit', sha: SHA}))
+    expect(result?.document).toEqual({_id: `git-commit-${SHA}`, _type: 'gitCommit', sha: SHA})
+  })
+
+  it('rebuilds a run id from its fields (PR runs stay one document per PR)', () => {
+    const main = migratedDocument(
+      doc({
+        _id: `benchRun-${SHA}-424242`,
+        _type: 'benchRun',
+        git: {sha: SHA, branch: 'main', commit: {_type: 'reference', _ref: `gitCommit-${SHA}`}},
+        runner: {runId: '424242', os: 'linux'},
+      }),
+    )
+    expect(main?.document._id).toBe(`bench-run-${SHA}-424242`)
+    expect(main?.document.git).toEqual({
+      sha: SHA,
+      branch: 'main',
+      commit: {_type: 'reference', _ref: `git-commit-${SHA}`, _weak: true},
+    })
+
+    const pr = migratedDocument(
+      doc({_id: 'benchRun-pr-777', _type: 'benchRun', git: {sha: SHA, prNumber: 777}, runner: {}}),
+    )
+    expect(pr?.document._id).toBe('bench-run-pr-777')
+  })
+
+  it('strips a commit reference a run cannot have (no full sha) instead of keeping a legacy one', () => {
+    const local = migratedDocument(
+      doc({
+        _id: 'benchRun-unknown-local',
+        _type: 'benchRun',
+        git: {sha: 'unknown', commit: {_type: 'reference', _ref: 'gitCommit-unknown'}},
+        runner: {},
+      }),
+    )
+    expect(local?.document._id).toBe('bench-run-unknown-local')
+    expect(local?.document.git).toEqual({sha: 'unknown'})
+  })
+
+  it('keeps the uuid of a bisect session and derives an ack id from metric + branch', () => {
+    const uuid = '4bfb578b-c6f2-4df6-9c03-d1d54c216764'
+    expect(
+      migratedDocument(doc({_id: `bisectSession-${uuid}`, _type: 'bisectSession', title: 't'}))
+        ?.document._id,
+    ).toBe(`bisect-session-${uuid}`)
+    expect(
+      migratedDocument(
+        doc({
+          _id: 'driftAck-bundle-initialJs-main',
+          _type: 'driftAck',
+          metricKey: 'bundle:initialJs',
+          branch: 'main',
+        }),
+      )?.document._id,
+    ).toBe('drift-ack-bundle-initialjs-main')
+  })
+
+  it('leaves documents alone when the id is already new or the deriving fields are missing', () => {
+    expect(
+      migratedDocument(doc({_id: `git-commit-${SHA}`, _type: 'gitCommit', sha: SHA})),
+    ).toBeUndefined()
+    expect(migratedDocument(doc({_id: 'gitTag-v6.10.1', _type: 'gitTag'}))).toBeUndefined()
+    expect(migratedDocument(doc({_id: 'benchRun-x', _type: 'benchRun', git: {}}))).toBeUndefined()
+    expect(migratedDocument(doc({_id: 'other-1', _type: 'other'}))).toBeUndefined()
+  })
+})

--- a/dev/radar/scripts/documentIdMigration.ts
+++ b/dev/radar/scripts/documentIdMigration.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure half of the id migration (I/O lives in migrateDocumentIds.ts): given a
+ * document stored under one of the old camelCase / dotted ids
+ * (`gitTag-v6.10.1`, `gitCommit-<sha>`, `benchRun-…`, `bisectSession-<uuid>`,
+ * `driftAck-…`), produce the same document under the id
+ * `@repo/utils/radar-ids` builds today (`git-tag-v6-10-1`, `git-commit-<sha>`,
+ * `bench-run-…`, …), with weak `commit` references repointed at the new commit
+ * ids.
+ */
+import {benchRunId, bisectSessionId, driftAckId, gitCommitId, gitTagId} from '@repo/utils/radar-ids'
+import {type SanityDocument} from '@sanity/client'
+
+const FULL_SHA_RE = /^[0-9a-f]{40}$/
+
+/**
+ * Legacy id prefix per type — anything starting with one of these moves.
+ * Key order is migration order: commits first, so the references the moved
+ * tags and runs point at exist by the time anyone follows them.
+ */
+export const LEGACY_PREFIXES = {
+  gitCommit: 'gitCommit-',
+  gitTag: 'gitTag-',
+  benchRun: 'benchRun-',
+  bisectSession: 'bisectSession-',
+  driftAck: 'driftAck-',
+} as const
+
+export type MigratedType = keyof typeof LEGACY_PREFIXES
+
+export const MIGRATED_TYPES = Object.keys(LEGACY_PREFIXES) as MigratedType[]
+
+export interface Migration {
+  legacyId: string
+  document: Record<string, unknown> & {_id: string; _type: string}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/** Weak reference to a commit document, or nothing when the sha is not a full sha (PR-branch runs). */
+function commitReference(
+  sha: unknown,
+): {commit: {_type: 'reference'; _ref: string; _weak: true}} | Record<never, never> {
+  return typeof sha === 'string' && FULL_SHA_RE.test(sha)
+    ? {commit: {_type: 'reference', _ref: gitCommitId(sha), _weak: true}}
+    : {}
+}
+
+/**
+ * The document as it should exist under its new id, or undefined when the id
+ * is not a legacy one or the fields it derives from are missing (left in
+ * place, reported). System fields the API owns are dropped; the new copy gets
+ * its own `_rev` / `_createdAt` — every type carries its own meaningful
+ * timestamp (`startedAt`, `committedAt`, `taggedAt`, `createdAt`, `ackedAt`).
+ */
+export function migratedDocument(doc: SanityDocument): Migration | undefined {
+  const {_rev: _, _createdAt: __, _updatedAt: ___, _id, _type, ...rest} = doc
+  if (!MIGRATED_TYPES.includes(_type as MigratedType)) return undefined
+  const type = _type as MigratedType
+  if (!_id.startsWith(LEGACY_PREFIXES[type])) return undefined
+
+  const move = (newId: string, patch: Record<string, unknown> = {}): Migration => ({
+    legacyId: _id,
+    document: {...rest, ...patch, _id: newId, _type},
+  })
+
+  switch (type) {
+    case 'gitCommit':
+      return typeof rest.sha === 'string' ? move(gitCommitId(rest.sha)) : undefined
+    case 'gitTag':
+      return typeof rest.tag === 'string'
+        ? move(gitTagId(rest.tag), commitReference(rest.sha))
+        : undefined
+    case 'benchRun': {
+      const git = isRecord(rest.git) ? rest.git : undefined
+      const runner = isRecord(rest.runner) ? rest.runner : undefined
+      if (!git || typeof git.sha !== 'string' || !runner) return undefined
+      // Stored runs carry a weak `git.commit` ref to the legacy commit id;
+      // rebuild it from the sha under the same rule storeShape.ts writes with
+      // (full sha → reference, which dangles by design for PR-branch commits)
+      const {commit: _legacyRef, ...gitRest} = git
+      return move(
+        benchRunId({
+          git: {
+            sha: git.sha,
+            ...(typeof git.prNumber === 'number' ? {prNumber: git.prNumber} : {}),
+          },
+          runner: typeof runner.runId === 'string' ? {runId: runner.runId} : {},
+        }),
+        {git: {...gitRest, ...commitReference(git.sha)}},
+      )
+    }
+    case 'bisectSession':
+      return move(bisectSessionId(_id.slice(LEGACY_PREFIXES.bisectSession.length)))
+    case 'driftAck':
+      return typeof rest.metricKey === 'string' && typeof rest.branch === 'string'
+        ? move(driftAckId(rest.metricKey, rest.branch))
+        : undefined
+    default:
+      return undefined
+  }
+}

--- a/dev/radar/scripts/gitHistory.test.ts
+++ b/dev/radar/scripts/gitHistory.test.ts
@@ -1,9 +1,9 @@
+import {gitCommitId} from '@repo/utils/radar-ids'
 import {describe, expect, it} from 'vitest'
 
 import {
   assembleSyncDocuments,
   commitDocument,
-  commitDocumentId,
   parseCommitRecords,
   parseConventionalSubject,
   parsePrNumber,
@@ -162,7 +162,7 @@ describe('commitDocument', () => {
       subject: 'feat(form)!: add thing (#123)',
     })
     expect(doc).toEqual({
-      _id: `gitCommit-${SHA_A}`,
+      _id: `git-commit-${SHA_A}`,
       _type: 'gitCommit',
       schemaVersion: 1,
       sha: SHA_A,
@@ -206,8 +206,9 @@ describe('tagDocument', () => {
       minor: 10,
       patch: 1,
     })
-    expect(doc._id).toBe('gitTag-v6.10.1')
-    expect(doc.commit).toEqual({_type: 'reference', _ref: commitDocumentId(SHA_A), _weak: true})
+    // No dots: a dotted id is a path the API hides from anonymous reads
+    expect(doc._id).toBe('git-tag-v6-10-1')
+    expect(doc.commit).toEqual({_type: 'reference', _ref: gitCommitId(SHA_A), _weak: true})
     expect(doc).toMatchObject({tag: 'v6.10.1', sha: SHA_A, major: 6, minor: 10, patch: 1})
     expect(doc).not.toHaveProperty('prerelease')
   })

--- a/dev/radar/scripts/gitHistory.ts
+++ b/dev/radar/scripts/gitHistory.ts
@@ -8,6 +8,8 @@
  * throws rather than silently mis-attributing fields.
  */
 
+import {gitCommitId, gitTagId} from '@repo/utils/radar-ids'
+
 /** `git log --format=` value producing one \x1e-terminated record per commit. */
 export const COMMIT_LOG_FORMAT = '%H%x1f%an%x1f%ae%x1f%aI%x1f%cI%x1f%s%x1f%P%x1e'
 
@@ -182,15 +184,11 @@ export function parseTagRefs(raw: string): TagInfo[] {
     })
 }
 
-export function commitDocumentId(sha: string): string {
-  return `gitCommit-${sha}`
-}
-
 export function commitDocument(info: CommitInfo): GitCommitDocument {
   const {commitType, scope, breaking} = parseConventionalSubject(info.subject)
   const prNumber = parsePrNumber(info.subject)
   return {
-    _id: commitDocumentId(info.sha),
+    _id: gitCommitId(info.sha),
     _type: 'gitCommit',
     schemaVersion: 1,
     sha: info.sha,
@@ -209,14 +207,12 @@ export function commitDocument(info: CommitInfo): GitCommitDocument {
 
 export function tagDocument(info: TagInfo): GitTagDocument {
   return {
-    // Dots in ids make path segments (invisible to unauthenticated queries)
-    // — fine here, every reader authenticates
-    _id: `gitTag-${info.tag}`,
+    _id: gitTagId(info.tag),
     _type: 'gitTag',
     schemaVersion: 1,
     tag: info.tag,
     sha: info.sha,
-    commit: {_type: 'reference', _ref: commitDocumentId(info.sha), _weak: true},
+    commit: {_type: 'reference', _ref: gitCommitId(info.sha), _weak: true},
     taggedAt: info.taggedAt,
     major: info.major,
     minor: info.minor,

--- a/dev/radar/scripts/migrateDocumentIds.ts
+++ b/dev/radar/scripts/migrateDocumentIds.ts
@@ -1,0 +1,166 @@
+// oxlint-disable no-console
+/**
+ * One-off migration: move every document written under the old camelCase /
+ * dotted ids to the ids `@repo/utils/radar-ids` builds today, and repoint the
+ * weak `commit` references that named the old commit ids. The mapping itself
+ * is documentIdMigration.ts (pure, unit tested); this file is the I/O.
+ *
+ * Why: a dot in an id makes it a path segment (`drafts.x`), which the API
+ * scopes differently from top-level documents — `gitTag-v6.10.1` sat there by
+ * accident. The other types follow for consistency (see radarIds.ts).
+ *
+ * Idempotent and order-independent: a document that already exists under its
+ * new id is kept and the legacy copy deleted; a rerun finds nothing to move.
+ * sync-git-metrics.yml runs it before every sync (so a new-id commit is never
+ * written next to a legacy copy of the same sha); drop the step and this file
+ * once a run reports zero legacy documents. Locally:
+ *
+ *   pnpm --filter radar migrate-ids -- --dry-run
+ *
+ * --dry-run still needs RADAR_SANITY_WRITE_TOKEN: the dataset is private, so
+ * listing the legacy ids needs a token like any other query.
+ */
+import process from 'node:process'
+import {parseArgs} from 'node:util'
+
+import {readEnv} from '@repo/utils'
+import {gitCommitId} from '@repo/utils/radar-ids'
+import {createClient, type SanityClient, type SanityDocument} from '@sanity/client'
+
+import {
+  LEGACY_PREFIXES,
+  MIGRATED_TYPES,
+  type MigratedType,
+  migratedDocument,
+} from './documentIdMigration'
+
+const METRICS_PROJECT_ID = 'mhfozd0z'
+const METRICS_DATASET = 'bench'
+
+const FULL_SHA_RE = /^[0-9a-f]{40}$/
+
+/** Documents per transaction: benchRun documents carry sample arrays and are large. */
+const BATCH_SIZE: Record<MigratedType, number> = {
+  benchRun: 5,
+  gitCommit: 150,
+  gitTag: 150,
+  bisectSession: 50,
+  driftAck: 50,
+}
+
+async function migrateType(
+  client: SanityClient,
+  type: MigratedType,
+  dryRun: boolean,
+): Promise<{moved: number; skipped: string[]}> {
+  const legacyIds = await client.fetch<string[]>(
+    '*[_type == $type && string::startsWith(_id, $prefix)]._id',
+    {type, prefix: LEGACY_PREFIXES[type]},
+  )
+  console.log(`${type}: ${legacyIds.length} legacy document(s)`)
+  const skipped: string[] = []
+  let moved = 0
+
+  for (let offset = 0; offset < legacyIds.length; offset += BATCH_SIZE[type]) {
+    const ids = legacyIds.slice(offset, offset + BATCH_SIZE[type])
+    const docs = await client.getDocuments<SanityDocument>(ids)
+    let transaction = client.transaction()
+    let queued = 0
+    for (const [index, doc] of docs.entries()) {
+      if (!doc) continue // deleted between listing and fetching — nothing to move
+      const migration = migratedDocument(doc)
+      if (!migration) {
+        skipped.push(ids[index])
+        continue
+      }
+      if (dryRun) {
+        if (moved < 3)
+          console.log(`  would move ${migration.legacyId} -> ${migration.document._id}`)
+      } else {
+        // createIfNotExists: a newer copy the sync already wrote under the new
+        // id wins over the legacy one; the legacy copy goes either way
+        transaction = transaction.createIfNotExists(migration.document).delete(migration.legacyId)
+        queued += 1
+      }
+      moved += 1
+    }
+    // A batch can end up empty (every document skipped, or deleted between
+    // listing and fetching); an empty transaction is a pointless request at
+    // best and an API error at worst
+    if (queued > 0) await transaction.commit()
+    console.log(`  ${Math.min(offset + ids.length, legacyIds.length)}/${legacyIds.length}`)
+  }
+  return {moved, skipped}
+}
+
+/**
+ * Documents already on new ids can still point at legacy commit ids through
+ * their weak `commit` reference (a benchRun stored before this change, then
+ * moved by an earlier partial run; a tag re-synced before deploy). Repoint
+ * them from the sha, which stays the source of truth.
+ */
+async function repairCommitReferences(client: SanityClient, dryRun: boolean): Promise<number> {
+  const stale = await client.fetch<{_id: string; path: string; sha: string | null}[]>(
+    `*[_type in ["benchRun", "gitTag"] && (
+        string::startsWith(git.commit._ref, $legacy) || string::startsWith(commit._ref, $legacy)
+      )]{_id, "path": select(_type == "benchRun" => "git.commit", "commit"), "sha": coalesce(git.sha, sha)}`,
+    {legacy: LEGACY_PREFIXES.gitCommit},
+  )
+  const patchable = stale.filter(
+    (doc): doc is {_id: string; path: string; sha: string} =>
+      !!doc.sha && FULL_SHA_RE.test(doc.sha),
+  )
+  console.log(`commit references: ${patchable.length} stale`)
+  if (dryRun || patchable.length === 0) return patchable.length
+  for (let offset = 0; offset < patchable.length; offset += 300) {
+    let transaction = client.transaction()
+    for (const doc of patchable.slice(offset, offset + 300)) {
+      transaction = transaction.patch(doc._id, {
+        set: {[doc.path]: {_type: 'reference', _ref: gitCommitId(doc.sha), _weak: true}},
+      })
+    }
+    await transaction.commit()
+  }
+  return patchable.length
+}
+
+async function main(): Promise<void> {
+  const {values} = parseArgs({
+    // pnpm forwards a `--` separator verbatim; see syncGitHistory.ts
+    args: process.argv.slice(2).filter((arg) => arg !== '--'),
+    options: {'dry-run': {type: 'boolean', default: false}},
+  })
+  const dryRun = values['dry-run']
+
+  const client = createClient({
+    projectId: METRICS_PROJECT_ID,
+    dataset: METRICS_DATASET,
+    apiVersion: '2025-02-19',
+    token: readEnv('RADAR_SANITY_WRITE_TOKEN'),
+    useCdn: false,
+  })
+
+  let moved = 0
+  const skipped: string[] = []
+  // Commits first (MIGRATED_TYPES order): the moved tags and runs point at the
+  // new commit ids, which should exist by the time anyone follows them
+  for (const type of MIGRATED_TYPES) {
+    const result = await migrateType(client, type, dryRun)
+    moved += result.moved
+    skipped.push(...result.skipped)
+  }
+  const repaired = await repairCommitReferences(client, dryRun)
+
+  console.log(
+    `${dryRun ? 'Would move' : 'Moved'} ${moved} document(s), ${
+      dryRun ? 'would repair' : 'repaired'
+    } ${repaired} reference(s)`,
+  )
+  if (skipped.length > 0) {
+    console.log(`Skipped ${skipped.length} document(s) missing the fields their id derives from:`)
+    for (const id of skipped) console.log(`  ${id}`)
+    process.exitCode = 1
+  }
+}
+
+await main()

--- a/dev/radar/tools/bisect/sessions.ts
+++ b/dev/radar/tools/bisect/sessions.ts
@@ -1,3 +1,4 @@
+import {bisectSessionId} from '@repo/utils/radar-ids'
 import {type Patch} from '@sanity/client'
 import {type SanityClient} from 'sanity'
 
@@ -28,7 +29,7 @@ function endpointLabel(endpoint: {sha: string; label?: string}): string {
 
 export async function createSession(client: SanityClient, input: NewSessionInput): Promise<string> {
   const created = await client.create({
-    _id: `bisectSession-${crypto.randomUUID()}`,
+    _id: bisectSessionId(crypto.randomUUID()),
     _type: 'bisectSession',
     title: `${endpointLabel(input.good)} → ${endpointLabel(input.bad)}`,
     good: input.good,
@@ -66,7 +67,7 @@ export async function reportRegression(
   input: ManualRegressionInput,
 ): Promise<string> {
   const created = await client.create({
-    _id: `bisectSession-${crypto.randomUUID()}`,
+    _id: bisectSessionId(crypto.randomUUID()),
     _type: 'bisectSession',
     title: `${endpointLabel(input.good)} → ${endpointLabel(input.bad)}`,
     good: input.good,

--- a/dev/radar/tools/comparisons/ComparisonsTool.tsx
+++ b/dev/radar/tools/comparisons/ComparisonsTool.tsx
@@ -84,7 +84,10 @@ export function ComparisonsTool() {
             </Text>
             <Card padding={3} radius={2} tone="transparent" border>
               <Text size={1}>
-                <code>gh workflow run bench.yml -f ab_from=&lt;sha&gt; -f ab_to=&lt;sha&gt;</code>
+                <code>
+                  gh workflow run bench.yml -R sanity-io/sanity -f ab_from=&lt;sha&gt; -f
+                  ab_to=&lt;sha&gt;
+                </code>
               </Text>
             </Card>
             {/* A dispatched run takes ~30 minutes to land here; the runs list

--- a/dev/radar/tools/comparisons/ComparisonsTool.tsx
+++ b/dev/radar/tools/comparisons/ComparisonsTool.tsx
@@ -9,7 +9,7 @@ import {useDocumentStore} from 'sanity'
 import {Box} from 'ui5'
 
 import {formatValue} from '../trends/data'
-import {ciRunUrl, commitUrl} from '../trends/links'
+import {ciRunUrl, commitUrl, dispatchRunsUrl} from '../trends/links'
 import {
   type ComparisonMetric,
   type ComparisonRun,
@@ -87,6 +87,21 @@ export function ComparisonsTool() {
                 <code>gh workflow run bench.yml -f ab_from=&lt;sha&gt; -f ab_to=&lt;sha&gt;</code>
               </Text>
             </Card>
+            {/* A dispatched run takes ~30 minutes to land here; the runs list
+                is where to watch it in the meantime */}
+            <Flex>
+              <Button
+                as="a"
+                href={dispatchRunsUrl()}
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Dispatched bench runs on GitHub (opens in a new tab)"
+                mode="ghost"
+                fontSize={1}
+                icon={LaunchIcon}
+                text="Dispatched runs"
+              />
+            </Flex>
           </Stack>
 
           {live.error && (

--- a/dev/radar/tools/trends/RunDetailPopover.tsx
+++ b/dev/radar/tools/trends/RunDetailPopover.tsx
@@ -1,5 +1,6 @@
 import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {CloseIcon} from '@sanity/icons/Close'
+import {CopyIcon} from '@sanity/icons/Copy'
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {RobotIcon} from '@sanity/icons/Robot'
 import {Badge, Button, Flex, Stack, Text, useClickOutsideEvent, useGlobalKeyDown} from '@sanity/ui'
@@ -18,9 +19,40 @@ import {
   type TrendTag,
 } from './data'
 import {buildInvestigationPrompt} from './investigationPrompt'
-import {backlinksFor, compareUrl, sourceFileUrl} from './links'
+import {abDispatchCommand, backlinksFor, compareUrl, sourceFileUrl} from './links'
 
 const FULL_SHA = /^[0-9a-f]{40}$/i
+
+type CopyState = 'idle' | 'copied' | 'failed'
+
+/**
+ * Clipboard write with feedback that lives on the button itself (label + icon
+ * flip) rather than a toast — the popover is small enough that the change is
+ * right under the cursor, and a failure is just as visible. Resets after 2s.
+ */
+function useCopyFeedback(): {state: CopyState; copy: (text: string) => void} {
+  const [state, setState] = useState<CopyState>('idle')
+  const resetTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+  useEffect(() => () => clearTimeout(resetTimer.current), [])
+  const copy = (text: string) => {
+    const finish = (next: 'copied' | 'failed') => {
+      setState(next)
+      clearTimeout(resetTimer.current)
+      resetTimer.current = setTimeout(() => setState('idle'), 2000)
+    }
+    // navigator.clipboard is undefined outside secure contexts, where the
+    // call would throw synchronously instead of rejecting
+    try {
+      navigator.clipboard.writeText(text).then(
+        () => finish('copied'),
+        () => finish('failed'),
+      )
+    } catch {
+      finish('failed')
+    }
+  }
+  return {state, copy}
+}
 
 /**
  * Details for one run, shown in a popover anchored at the clicked point.
@@ -67,30 +99,19 @@ export function RunDetailPopover(props: {
     intent: 'edit',
     params: {id: point.runId, type: 'benchRun'},
   })
-  // Feedback for the copy-prompt button lives on the button itself (label +
-  // icon flip) rather than a toast — the popover is small enough that the
-  // change is right under the cursor, and a failure is just as visible.
-  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
-  const copyResetTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
-  useEffect(() => () => clearTimeout(copyResetTimer.current), [])
-  const handleCopyPrompt = () => {
-    if (!previousPoint) return
-    const finish = (state: 'copied' | 'failed') => {
-      setCopyState(state)
-      clearTimeout(copyResetTimer.current)
-      copyResetTimer.current = setTimeout(() => setCopyState('idle'), 2000)
-    }
-    // navigator.clipboard is undefined outside secure contexts, where the
-    // call would throw synchronously instead of rejecting
-    try {
-      navigator.clipboard.writeText(buildInvestigationPrompt(series, point, previousPoint)).then(
-        () => finish('copied'),
-        () => finish('failed'),
-      )
-    } catch {
-      finish('failed')
-    }
-  }
+  // Two copy affordances share the previous point as `ab_from`: the bare
+  // dispatch command (for someone who already knows what they suspect) and
+  // the full investigation brief for a coding agent. Each keeps its own
+  // feedback state so copying one never relabels the other.
+  const abCopy = useCopyFeedback()
+  const promptCopy = useCopyFeedback()
+  // The bench workflow's ab_from/ab_to inputs require full shas, and GitHub
+  // has no URL that prefills a workflow_dispatch form — so the affordance is
+  // a copyable command, previous point as reference, this point as experiment
+  const abCommand =
+    previousPoint && FULL_SHA.test(previousPoint.sha) && FULL_SHA.test(point.sha)
+      ? abDispatchCommand(previousPoint.sha, point.sha)
+      : undefined
   const backlinks = backlinksFor(point)
   // The scenario source *as it ran for this commit* — pinning to the run's sha
   // (not main) shows exactly the definition that produced this point, since
@@ -372,23 +393,48 @@ export function RunDetailPopover(props: {
                   text="Compare with previous run"
                   aria-label="GitHub compare view of the commits between the previous run's commit and this one (opens in a new tab)"
                 />
+                {/* The bare dispatch command — previous point as reference,
+                    this point as experiment — for a human who knows what they
+                    suspect and just wants the run going. The command doubles
+                    as the tooltip so a denied clipboard is still recoverable. */}
+                {abCommand && (
+                  <Button
+                    mode="ghost"
+                    fontSize={1}
+                    icon={abCopy.state === 'copied' ? CheckmarkIcon : CopyIcon}
+                    tone={abCopy.state === 'copied' ? 'positive' : 'default'}
+                    text={
+                      abCopy.state === 'copied'
+                        ? 'Copied — paste in a terminal'
+                        : abCopy.state === 'failed'
+                          ? 'Copy failed — command in tooltip'
+                          : 'Copy A/B vs previous run'
+                    }
+                    title={abCommand}
+                    aria-label="Copy the gh command dispatching an A/B bench comparison of this commit against the previous run's commit"
+                    onClick={() => abCopy.copy(abCommand)}
+                  />
+                )}
                 {/* A paste-ready brief for a coding agent: the full signal
                     (metric, both commits, delta, backlinks) plus the A/B
                     dispatch / bisect recipe from perf/bench/README.md */}
                 <Button
                   mode="ghost"
                   fontSize={1}
-                  icon={copyState === 'copied' ? CheckmarkIcon : RobotIcon}
-                  tone={copyState === 'copied' ? 'positive' : 'default'}
+                  icon={promptCopy.state === 'copied' ? CheckmarkIcon : RobotIcon}
+                  tone={promptCopy.state === 'copied' ? 'positive' : 'default'}
                   text={
-                    copyState === 'copied'
+                    promptCopy.state === 'copied'
                       ? 'Copied'
-                      : copyState === 'failed'
+                      : promptCopy.state === 'failed'
                         ? 'Copy failed'
                         : 'Copy investigation prompt'
                   }
                   aria-label="Copy an investigation brief for a coding agent to the clipboard"
-                  onClick={handleCopyPrompt}
+                  onClick={() =>
+                    previousPoint &&
+                    promptCopy.copy(buildInvestigationPrompt(series, point, previousPoint))
+                  }
                 />
               </Stack>
             )}

--- a/dev/radar/tools/trends/acks.ts
+++ b/dev/radar/tools/trends/acks.ts
@@ -4,6 +4,7 @@
  * branch and tied to the value at ack time, with a half-life so it can't hide
  * a metric forever.
  */
+import {driftAckId} from '@repo/utils/radar-ids'
 import {type SanityClient} from 'sanity'
 
 export type AckState = 'silenced' | 'snoozed' | 'fixed'
@@ -32,11 +33,6 @@ export const SNOOZE_DAYS = 7
 /** Collapse to an id-safe slug (document ids, DOM ids — keys contain `·`/spaces). */
 export function idSlug(value: string): string {
   return value.replace(/[^a-zA-Z0-9]+/g, '-')
-}
-
-/** Deterministic id so acking a metric/branch updates in place (idempotent). */
-export function ackId(metricKey: string, branch: string): string {
-  return `driftAck-${idSlug(`${metricKey}:${branch}`)}`
 }
 
 /**
@@ -72,7 +68,7 @@ export async function writeAck(
   },
 ): Promise<void> {
   await client.createOrReplace({
-    _id: ackId(input.metricKey, input.branch),
+    _id: driftAckId(input.metricKey, input.branch),
     _type: 'driftAck',
     metricKey: input.metricKey,
     branch: input.branch,
@@ -89,5 +85,5 @@ export async function clearAck(
   metricKey: string,
   branch: string,
 ): Promise<void> {
-  await client.delete(ackId(metricKey, branch))
+  await client.delete(driftAckId(metricKey, branch))
 }

--- a/dev/radar/tools/trends/investigationPrompt.test.ts
+++ b/dev/radar/tools/trends/investigationPrompt.test.ts
@@ -62,7 +62,9 @@ describe('buildInvestigationPrompt', () => {
 
   test('assembles the A/B dispatch command with both full shas', () => {
     const prompt = buildInvestigationPrompt(makeSeries(), makePoint(), previous)
-    expect(prompt).toContain(`gh workflow run bench.yml -f ab_from=${FROM_SHA} -f ab_to=${TO_SHA}`)
+    expect(prompt).toContain(
+      `gh workflow run bench.yml -R sanity-io/sanity -f ab_from=${FROM_SHA} -f ab_to=${TO_SHA}`,
+    )
   })
 
   test('derives the local repro command from the series key', () => {

--- a/dev/radar/tools/trends/investigationPrompt.ts
+++ b/dev/radar/tools/trends/investigationPrompt.ts
@@ -13,7 +13,7 @@ import {
   type TrendSeries,
   type TrendUnit,
 } from './data'
-import {ciRunUrl, commitUrl, compareUrl, prUrl, sourceFileUrl} from './links'
+import {abDispatchCommand, ciRunUrl, commitUrl, compareUrl, prUrl, sourceFileUrl} from './links'
 
 /** Signed delta. The slope units already carry their sign in formatValue. */
 function formatDelta(delta: number, unit: TrendUnit): string {
@@ -91,7 +91,7 @@ export function buildInvestigationPrompt(
     `1. Read the compare range and shortlist commits that could plausibly move this metric (studio runtime code, dependency bumps, build config, or the bench harness/scenario itself).`,
     `2. Confirm with an A/B dispatch — the same harness CI uses, with bootstrap-gated verdicts:
 
-   gh workflow run bench.yml -f ab_from=${previousPoint.sha} -f ab_to=${point.sha}
+   ${abDispatchCommand(previousPoint.sha, point.sha)}
 
    The verdict table lands on that workflow run's summary page, and the comparison is stored as a mode:"ab" benchRun document (Comparisons tool in Studio Radar).`,
     `3. If the range is long, bisect it with further A/B dispatches (log2(N) runs find the culprit commit).`,

--- a/dev/radar/tools/trends/links.test.ts
+++ b/dev/radar/tools/trends/links.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, test} from 'vitest'
+
+import {abDispatchCommand, compareUrl, dispatchRunsUrl} from './links'
+
+const FROM_SHA = 'a'.repeat(40)
+const TO_SHA = 'b'.repeat(40)
+
+describe('abDispatchCommand', () => {
+  test('dispatches bench.yml with the reference as ab_from and the experiment as ab_to', () => {
+    expect(abDispatchCommand(FROM_SHA, TO_SHA)).toBe(
+      `gh workflow run bench.yml -R sanity-io/sanity -f ab_from=${FROM_SHA} -f ab_to=${TO_SHA}`,
+    )
+  })
+
+  test('the dispatched-runs page filters on workflow_dispatch events', () => {
+    expect(dispatchRunsUrl()).toBe(
+      'https://github.com/sanity-io/sanity/actions/workflows/bench.yml?query=event%3Aworkflow_dispatch',
+    )
+  })
+})
+
+describe('compareUrl', () => {
+  test('uses the three-dot range form (commits reachable from to but not from)', () => {
+    expect(compareUrl(FROM_SHA, TO_SHA)).toBe(
+      `https://github.com/sanity-io/sanity/compare/${FROM_SHA}...${TO_SHA}`,
+    )
+  })
+})

--- a/dev/radar/tools/trends/links.ts
+++ b/dev/radar/tools/trends/links.ts
@@ -39,6 +39,21 @@ export function compareUrl(fromSha: string, toSha: string): string {
   return `https://github.com/${REPO}/compare/${fromSha}...${toSha}`
 }
 
+/**
+ * `gh` command dispatching an A/B bench run that compares two commits
+ * (bench.yml `ab_from`/`ab_to` inputs — full shas required). A command to
+ * copy rather than a link: GitHub has no URL that prefills workflow_dispatch
+ * inputs. `-R` pins the repo so the command works from any directory.
+ */
+export function abDispatchCommand(fromSha: string, toSha: string): string {
+  return `gh workflow run bench.yml -R ${REPO} -f ab_from=${fromSha} -f ab_to=${toSha}`
+}
+
+/** The dispatched-runs list, for watching an A/B comparison after dispatching it. */
+export function dispatchRunsUrl(): string {
+  return `https://github.com/${REPO}/actions/workflows/bench.yml?query=event%3Aworkflow_dispatch`
+}
+
 /** Link a scenario's source file on the branch it was measured on (or main). */
 export function sourceFileUrl(path: string, branch = 'main'): string {
   return `https://github.com/${REPO}/blob/${branch}/${path}`

--- a/packages/@repo/utils/package.json
+++ b/packages/@repo/utils/package.json
@@ -6,6 +6,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./radar-ids": "./src/radarIds.ts"
+  },
   "scripts": {},
   "dependencies": {
     "dotenv": "^17.4.2",

--- a/packages/@repo/utils/src/radarIds.ts
+++ b/packages/@repo/utils/src/radarIds.ts
@@ -1,0 +1,59 @@
+/**
+ * Document ids in the Studio Radar dataset (project `mhfozd0z`, dataset
+ * `bench`). One module so every writer agrees — perf/bench stores benchRun
+ * documents, dev/radar's scripts sync git history, dev/radar's tools write
+ * acks and bisect sessions — and so ids follow two rules:
+ *
+ * - **No dots.** A `.` makes an id a path segment (`drafts.x`,
+ *   `versions.r.x`), which the API scopes and permissions differently from
+ *   top-level documents — plain data must never land there by accident, as
+ *   `gitTag-v6.10.1` did.
+ * - **No camelCase.** Lowercase, dash-separated, so ids read the same in
+ *   URLs, logs and queries.
+ *
+ * Ids are deterministic where the document is (commits, tags, acks, runs), so
+ * `createOrReplace` upserts stay idempotent. Browser-safe: no node imports.
+ * Import from `@repo/utils/radar-ids`, not the package index, in browser code.
+ */
+
+/** Collapse to a lowercase id-safe slug: runs of anything but [a-z0-9] become one dash. */
+export function radarIdSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/** `gitCommit` document for a main-branch commit (full 40-char sha). */
+export function gitCommitId(sha: string): string {
+  return `git-commit-${sha.toLowerCase()}`
+}
+
+/** `gitTag` document for a `v*` release tag, e.g. `v6.10.1` → `git-tag-v6-10-1`. */
+export function gitTagId(tag: string): string {
+  return `git-tag-${radarIdSlug(tag)}`
+}
+
+/**
+ * `benchRun` document. A PR run overwrites one document per PR number (latest
+ * push wins — branch comparison wants the newest build, not a pile); main and
+ * A/B runs get one document per run (sha + CI run id) so history accumulates.
+ */
+export function benchRunId(run: {
+  git: {sha: string; prNumber?: number}
+  runner: {runId?: string}
+}): string {
+  return typeof run.git.prNumber === 'number'
+    ? `bench-run-pr-${run.git.prNumber}`
+    : radarIdSlug(`bench-run-${run.git.sha}-${run.runner.runId ?? 'local'}`)
+}
+
+/** `driftAck` document — one per metric per branch, so acking updates in place. */
+export function driftAckId(metricKey: string, branch: string): string {
+  return `drift-ack-${radarIdSlug(`${metricKey}:${branch}`)}`
+}
+
+/** `bisectSession` document — user-created, so a random uuid rather than a derived id. */
+export function bisectSessionId(uuid: string): string {
+  return `bisect-session-${radarIdSlug(uuid)}`
+}

--- a/perf/bench/report/__tests__/storeShape.test.ts
+++ b/perf/bench/report/__tests__/storeShape.test.ts
@@ -151,7 +151,7 @@ describe('toStorableRun', () => {
     const stored = toStorableRun({...RUN, git: {...RUN.git, sha}})
     expect(stored.git.commit).toEqual({
       _type: 'reference',
-      _ref: `gitCommit-${sha}`,
+      _ref: `git-commit-${sha}`,
       _weak: true,
     })
     expect(stored.git.sha).toBe(sha)

--- a/perf/bench/report/__tests__/writeReport.test.ts
+++ b/perf/bench/report/__tests__/writeReport.test.ts
@@ -184,7 +184,7 @@ describe('documentIdForRun', () => {
   // doc per run so the time series accumulates
 
   it('gives a PR run a per-PR id (latest push overwrites)', () => {
-    expect(documentIdForRun(AB_RUN)).toBe('benchRun-pr-777')
+    expect(documentIdForRun(AB_RUN)).toBe('bench-run-pr-777')
   })
 
   it('gives a main run a per-run id (sha + CI run id) so the series accumulates', () => {
@@ -192,7 +192,7 @@ describe('documentIdForRun', () => {
       ...AB_RUN,
       git: {sha: 'abcdef1234567890', branch: 'main'},
     }
-    expect(documentIdForRun(mainRun)).toBe('benchRun-abcdef1234567890-424242')
+    expect(documentIdForRun(mainRun)).toBe('bench-run-abcdef1234567890-424242')
   })
 
   it('falls back to a local suffix without a CI run id', () => {
@@ -201,6 +201,6 @@ describe('documentIdForRun', () => {
       git: {sha: 'abcdef1234567890', branch: 'main'},
       runner: {...AB_RUN.runner, runId: undefined},
     }
-    expect(documentIdForRun(localRun)).toBe('benchRun-abcdef1234567890-local')
+    expect(documentIdForRun(localRun)).toBe('bench-run-abcdef1234567890-local')
   })
 })

--- a/perf/bench/report/storeShape.ts
+++ b/perf/bench/report/storeShape.ts
@@ -1,3 +1,5 @@
+import {gitCommitId} from '@repo/utils/radar-ids'
+
 import {
   type BenchRunDocument,
   type ResourceSide,
@@ -15,8 +17,8 @@ import {
  *   declare either — stored as a keyed `{endpointClass, count}` array
  * - every object in an array gets a `_key`
  * - `git.commit` is added as a weak reference to the run's `gitCommit`
- *   document, derived from the deterministic id `gitCommit-<sha>` — no
- *   lookup. Weak because the target may not exist (PR-branch commits are
+ *   document, derived from the deterministic id (`gitCommitId` in
+ *   `@repo/utils/radar-ids`) — no lookup. Weak because the target may not exist (PR-branch commits are
  *   never synced; a fresh main run can beat the sync). `git.sha` stays the
  *   source of truth.
  *
@@ -30,7 +32,7 @@ export function toStorableRun(document: BenchRunDocument) {
     git: {
       ...document.git,
       ...(isFullSha
-        ? {commit: {_type: 'reference', _ref: `gitCommit-${document.git.sha}`, _weak: true}}
+        ? {commit: {_type: 'reference', _ref: gitCommitId(document.git.sha), _weak: true}}
         : {}),
     },
     scenarios: document.scenarios.map((scenario) => ({

--- a/perf/bench/report/storeToSanity.ts
+++ b/perf/bench/report/storeToSanity.ts
@@ -22,6 +22,7 @@ import process from 'node:process'
 import {fileURLToPath} from 'node:url'
 
 import {readEnv} from '@repo/utils'
+import {benchRunId} from '@repo/utils/radar-ids'
 import {createClient} from '@sanity/client'
 
 import {toStorableRun} from './storeShape'
@@ -33,14 +34,10 @@ const METRICS_DATASET = 'bench'
 
 /**
  * The stored document id decides overwrite-vs-append: a PR run overwrites one
- * doc per PR number (latest push wins — branch comparison wants the newest
- * build, not a pile), while main/cron runs get one doc per run (sha + CI run
- * id) so the time series accumulates.
+ * doc per PR number, main/cron runs get one doc per run — see `benchRunId`.
  */
 export function documentIdForRun(run: BenchRunDocument): string {
-  return typeof run.git.prNumber === 'number'
-    ? `benchRun-pr-${run.git.prNumber}`
-    : `benchRun-${run.git.sha}-${run.runner.runId ?? 'local'}`
+  return benchRunId(run)
 }
 
 export async function storeRun(inputPathArg?: string, options: {ab?: boolean} = {}): Promise<void> {


### PR DESCRIPTION
### Description

Addressing three things that came out of using Radar for hunting regressions:

- "Copy A/B vs previous run" is back in the run popover now that a/b workflow works more reliable.
- Adding three skills: `sanity-radar` (dashboard, data, validated GROQ recipes), `sanity-radar-investigate` (drift flag → confirmed culprit), `sanity-bench` (running and dispatching the suite).
- Migrates to dot-free, dash-case document ids: `gitTag-v6.10.1` is a path to the API, which is best to avoid. All ids now come from one module, `@repo/utils/radar-ids`, so perf/bench and dev/radar cannot drift. Existing documents move via a one-off `migrate_ids` dispatch (idempotent, safe after the sync has already re-created new-id commits).

### Notes for release

N/A – Internal only

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Every sync-git-metrics run mutates the private bench dataset via migrate-ids; logic is idempotent and tested, but bad migration behavior could affect Radar joins or duplicate documents until fixed.
> 
> **Overview**
> Adds **three agent skills** (`sanity-bench`, `sanity-radar`, `sanity-radar-investigate`) plus GROQ recipes, wired from `.agents/skills` through `.claude` symlinks and **AGENTS.md**, so bench dispatch, Radar data, and regression investigation have a single operating guide.
> 
> **Centralizes Studio Radar document ids** in `@repo/utils/radar-ids` (dot-free, dash-case, e.g. `git-tag-v6-10-1`, `git-commit-<sha>`, `bench-run-…`) and updates **perf/bench** store paths and **dev/radar** sync/tools to use them. An **idempotent migration** (`migrate-ids` / `documentIdMigration.ts`) moves legacy camelCase/dotted documents, repoints weak `commit` refs, and runs **before every git-metrics sync** so new and old ids do not duplicate the same sha.
> 
> **Trends investigation UX:** the run popover regains **Copy A/B vs previous run** (shared `abDispatchCommand` with `-R sanity-io/sanity`), separate clipboard feedback from **Copy investigation prompt**, Comparisons gets a **Dispatched runs** GitHub link, and **SPEC.md** documents those hand-offs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5acf2d6723a4329cf98c5407f1f6d3a41cd7fd4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->