### PR TITLE
chore(deps): upgrade react-rx to 7.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,8 +353,8 @@ Import `useEffectEvent` from `use-effect-event`, never from `react`. On React 19
 returns first-render values when the calling component is wrapped in `forwardRef` or `memo`
 ([facebook/react#34818](https://github.com/facebook/react/issues/34818), fixed in 19.3 canaries).
 `eslint/no-restricted-imports` in `.oxlintrc.json` enforces this. The bug reaches any dependency that
-wraps the native hook, so check the implementation before trusting one — `react-rx` is safe on both
-v4 and v5 because `useObservableEvent` builds on the same `use-effect-event` ponyfill.
+wraps the native hook, so check the implementation before trusting one — `react-rx`'s
+`useObservableEvent` builds on the same `use-effect-event` ponyfill.
 
 ### Translate: never define `components` inline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,10 +369,10 @@ Two rules follow:
   `initialValue`, React aborts with "Maximum update depth exceeded"
   (`useDocumentValuesRenderLoop.repro.test.tsx` guards one such case).
 - **Never rely on a synchronous first emission.** `useSyncObservable(obs$, undefined)!` is a
-  first-render crash. Pass the value the observable emits first (`GUARDED`, a store's exported
-  `INITIAL_*_STATE`), or fall back per render with `??` when the initial value depends on the
-  observable's parameters (`useEditState`), since react-rx captures `initialValue` once per hook
-  instance.
+  first-render crash. Pass the value the observable emits first (`GUARDED`, the releases store's
+  exported `INITIAL_RELEASES_STATE`, `useVariantsStore().initialState`), or derive it per render
+  when it depends on the observable's parameters (`useEditState`), since react-rx captures
+  `initialValue` once per hook instance.
 
 ### Translate: never define `components` inline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,8 +353,26 @@ Import `useEffectEvent` from `use-effect-event`, never from `react`. On React 19
 returns first-render values when the calling component is wrapped in `forwardRef` or `memo`
 ([facebook/react#34818](https://github.com/facebook/react/issues/34818), fixed in 19.3 canaries).
 `eslint/no-restricted-imports` in `.oxlintrc.json` enforces this. The bug reaches any dependency that
-wraps the native hook, so check the implementation before trusting one — `react-rx`'s
-`useObservableEvent` builds on the same `use-effect-event` ponyfill.
+wraps the native hook, so check the implementation before trusting one.
+
+### react-rx: stable observables, explicit initial values
+
+`react-rx` v7 never subscribes during render. `useObservable` / `useSyncObservable` render the
+`initialValue` (required — pass `undefined` explicitly when there is nothing better) until the
+subscription started on commit delivers a value, and a synchronous emission arrives one pass later.
+Two rules follow:
+
+- **The observable identity must be stable across renders**: build it with `useMemo`, keep it on a
+  store, or hoist it to module scope, and key memos on primitives (a path string, an id) rather than
+  on arrays or objects recreated every render. An observable rebuilt each render is torn down and
+  re-subscribed each commit; when it synchronously replays a value that differs from the
+  `initialValue`, React aborts with "Maximum update depth exceeded"
+  (`useDocumentValuesRenderLoop.repro.test.tsx` guards one such case).
+- **Never rely on a synchronous first emission.** `useSyncObservable(obs$, undefined)!` is a
+  first-render crash. Pass the value the observable emits first (`GUARDED`, a store's exported
+  `INITIAL_*_STATE`), or fall back per render with `??` when the initial value depends on the
+  observable's parameters (`useEditState`), since react-rx captures `initialValue` once per hook
+  instance.
 
 ### Translate: never define `components` inline
 

--- a/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
+++ b/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
@@ -6,34 +6,9 @@ import {useDocumentPreviewStore, useDocumentValues} from 'sanity'
 import {Flex} from 'ui5'
 
 /**
- * Reproduces a customer-reported stall: document panes that never finish
- * opening while list previews are on screen.
- *
- * The preview rows below call `useDocumentValues(id, ['title'])` with an
- * inline paths array — the natural call shape. The hook memoizes its
- * observable on the array REFERENCE, so every render builds a new observable;
- * react-rx v5 treats each one as a brand-new store whose warm-up replays the
- * cached value synchronously, and the fresh snapshot forces another render —
- * a self-sustaining loop.
- *
- * The pane simulates opening a document at the same time: a heavy subtree
- * mounts in a transition the moment the pane opens. Every loop iteration is
- * an urgent update that restarts the in-flight mount, so the status line
- * stays stuck at "mounting…" for as long as the loop runs. After 15 seconds
- * the loop rows remove themselves — and the mount lands immediately. That is
- * the customer's timeline: the stall lasts exactly as long as the pressure.
- *
- * Once useDocumentValues keys its memo on path CONTENTS instead of the array
- * reference, the rows settle after a couple of renders and the mount
- * completes right away.
- *
- * The cache warmer keeps a stable subscription to the same documents so the
- * preview store replays synchronously on every resubscribe — without it the
- * loop ticks at refetch cadence instead of render speed and looks harmless
- * (in real studios the actual document list plays this role).
- *
- * Unit-level twin:
- * packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
+ * Reproduces a document-pane stall caused by list previews creating a new
+ * observable identity on every render. The cache warmer keeps the preview
+ * values replayable so the loop runs at render speed.
  */
 
 const DOC_IDS = ['render-loop-1', 'render-loop-2', 'render-loop-3', 'render-loop-4']
@@ -60,7 +35,7 @@ function CacheWarmer() {
 function PreviewRow({id}: {id: string}) {
   // oxlint-disable-next-line react/immutability -- deliberate render counter: this repro exists to make the loop measurable
   renderCounts.rows++
-  // The footgun: a fresh array literal on every render
+  // Deliberately inline: stabilizing this array disables the repro.
   const {value, isLoading} = useDocumentValues<{title?: string}>(id, ['title'])
   return (
     <Card border padding={3} radius={2}>

--- a/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
+++ b/dev/test-studio/components/panes/debug/RenderLoopRepro.tsx
@@ -53,7 +53,7 @@ function CacheWarmer() {
       ),
     [previewStore],
   )
-  useObservable(warm$)
+  useObservable(warm$, undefined)
   return null
 }
 

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -213,9 +213,5 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
     workspace.name,
   ])
 
-  // Deferred (per review): keyed on the stable document `_id`/`_type` and
-  // consumed inside a dialog the user opens for a fixed document, so there's
-  // no cross-document tear. react-rx v5's identity-coherent deferral falls
-  // back to the live value if the observable identity changes.
   return useObservable(linkToCanvas$, initialState)
 }

--- a/packages/sanity/src/core/canvas/actions/__tests__/useCanvasCompanionDoc.test.tsx
+++ b/packages/sanity/src/core/canvas/actions/__tests__/useCanvasCompanionDoc.test.tsx
@@ -1,0 +1,71 @@
+import {render} from '@testing-library/react'
+import {Observable, startWith} from 'rxjs'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {
+  type CompanionDocs,
+  INITIAL_COMPANION_DOCS,
+} from '../../store/createCanvasCompanionDocsStore'
+import {useCanvasCompanionDocsStore} from '../../store/useCanvasCompanionDocsStore'
+import {type CompanionDoc} from '../../types'
+import {useCanvasCompanionDoc} from '../useCanvasCompanionDoc'
+
+vi.mock('../../store/useCanvasCompanionDocsStore', () => ({
+  useCanvasCompanionDocsStore: vi.fn(),
+}))
+
+const companion: CompanionDoc = {
+  _id: 'link-1',
+  canvasDocumentId: 'canvas-1',
+  studioDocumentId: 'a',
+  isStudioDocumentEditable: false,
+}
+
+interface Frame {
+  loading: boolean
+  isLinked: boolean
+  isLockedByCanvas: boolean
+}
+
+function Consumer({documentId, frames}: {documentId: string; frames: Frame[]}) {
+  const {loading, isLinked, isLockedByCanvas} = useCanvasCompanionDoc(documentId)
+  frames.push({loading, isLinked, isLockedByCanvas})
+  return null
+}
+
+// Like the store: a warm, replayed lookup delivers the loading state and the result synchronously
+// on subscribe, but react-rx only subscribes on commit.
+function mockLookup(resolved: CompanionDocs) {
+  vi.mocked(useCanvasCompanionDocsStore).mockReturnValue({
+    getCompanionDocs: () =>
+      new Observable<CompanionDocs>((subscriber) => {
+        subscriber.next(resolved)
+      }).pipe(startWith(INITIAL_COMPANION_DOCS)),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+it('is loading in the render that mounts the consumer, never unlinked before the lookup answers', () => {
+  mockLookup({data: [companion], error: null, loading: false})
+  const frames: Frame[] = []
+
+  render(<Consumer documentId="a" frames={frames} />)
+
+  // `LinkToCanvasAction` shows itself when `!isLinked && !loading`: no frame may satisfy that
+  expect(frames[0]).toEqual({loading: true, isLinked: false, isLockedByCanvas: false})
+  expect(frames.some((frame) => !frame.loading && !frame.isLinked)).toBe(false)
+  expect(frames.at(-1)).toEqual({loading: false, isLinked: true, isLockedByCanvas: true})
+})
+
+it('resolves to unlinked once the lookup finds no companion doc', () => {
+  mockLookup({data: [], error: null, loading: false})
+  const frames: Frame[] = []
+
+  render(<Consumer documentId="a" frames={frames} />)
+
+  expect(frames[0]).toMatchObject({loading: true, isLinked: false})
+  expect(frames.at(-1)).toEqual({loading: false, isLinked: false, isLockedByCanvas: false})
+})

--- a/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
+++ b/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
@@ -21,7 +21,7 @@ export const useCanvasCompanionDoc = (documentId: string) => {
   // resets this state, so there's no cross-document tear. react-rx v5's
   // identity-coherent deferral additionally falls back to the live value if
   // the observable identity ever changes.
-  const companionDocs = useObservable(companionDocs$)
+  const companionDocs = useObservable(companionDocs$, undefined)
 
   const companionDoc = useMemo(
     () => companionDocs?.data.find((companion) => companion?.studioDocumentId === documentId),

--- a/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
+++ b/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
@@ -16,11 +16,6 @@ export const useCanvasCompanionDoc = (documentId: string) => {
     () => companionDocsStore.getCompanionDocs(publishedId),
     [publishedId, companionDocsStore],
   )
-  // Deferred (per review): the companion docs stream is keyed on the stable
-  // published id, and the `<DocumentPaneProvider>` remount on navigation
-  // resets this state, so there's no cross-document tear. react-rx v5's
-  // identity-coherent deferral additionally falls back to the live value if
-  // the observable identity ever changes.
   const companionDocs = useObservable(companionDocs$, undefined)
 
   const companionDoc = useMemo(

--- a/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
+++ b/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
@@ -2,6 +2,7 @@ import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 
 import {getPublishedId} from '../../util/draftUtils'
+import {INITIAL_COMPANION_DOCS} from '../store/createCanvasCompanionDocsStore'
 import {useCanvasCompanionDocsStore} from '../store/useCanvasCompanionDocsStore'
 
 /**
@@ -16,16 +17,18 @@ export const useCanvasCompanionDoc = (documentId: string) => {
     () => companionDocsStore.getCompanionDocs(publishedId),
     [publishedId, companionDocsStore],
   )
-  const companionDocs = useObservable(companionDocs$, undefined)
+  // The lookup starts out loading, and the actions that depend on the link state stay hidden while
+  // it is — rendering anything else before the subscription emits would enable them for a moment.
+  const companionDocs = useObservable(companionDocs$, INITIAL_COMPANION_DOCS)
 
   const companionDoc = useMemo(
-    () => companionDocs?.data.find((companion) => companion?.studioDocumentId === documentId),
+    () => companionDocs.data.find((companion) => companion?.studioDocumentId === documentId),
     [companionDocs, documentId],
   )
   return {
     isLinked: Boolean(companionDoc),
     isLockedByCanvas: companionDoc ? !companionDoc.isStudioDocumentEditable : false,
     companionDoc,
-    loading: companionDocs?.loading,
+    loading: companionDocs.loading,
   }
 }

--- a/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
+++ b/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
@@ -21,12 +21,16 @@ import {type CompanionDoc} from '../types'
 export interface CanvasCompanionDocsStore {
   getCompanionDocs: (documentId: string) => Observable<CompanionDocs>
 }
-interface CompanionDocs {
+export interface CompanionDocs {
   data: CompanionDoc[]
   error: null | string
   loading: boolean
 }
-const INITIAL_VALUE: CompanionDocs = {
+/**
+ * What `getCompanionDocs` emits first, while the companion docs are being looked up.
+ * @internal
+ */
+export const INITIAL_COMPANION_DOCS: CompanionDocs = {
   data: [],
   error: null,
   loading: true,
@@ -84,7 +88,7 @@ const getCompanionDocs = memoize(
       mergeMapArray(getCompanionDoc$),
       map((value) => ({error: null, data: value, loading: false})),
       catchError((error) => of({error, data: [], loading: false})),
-      startWith(INITIAL_VALUE),
+      startWith(INITIAL_COMPANION_DOCS),
       // refCount so the listener tears down when the last subscriber leaves.
       // Combined with the credential in the memo key below, a cross-tab
       // re-login's stale-token entry stops listening once the form remounts

--- a/packages/sanity/src/core/comments-v2/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments-v2/hooks/useNotificationTarget.ts
@@ -47,7 +47,7 @@ export function useNotificationTarget(
   // email body, where a briefly stale title is harmless (it can go stale
   // after send anyway). react-rx v5's identity-coherent deferral still falls
   // back to the live value when the previewed document id changes.
-  const previewState = useObservable(previewStateObservable)
+  const previewState = useObservable(previewStateObservable, undefined)
 
   const {snapshot, original} = previewState || {}
   const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string

--- a/packages/sanity/src/core/comments-v2/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments-v2/hooks/useNotificationTarget.ts
@@ -3,10 +3,15 @@ import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {useSchema} from '../../hooks/useSchema'
-import {getPreviewStateObservable} from '../../preview/utils/getPreviewStateObservable'
+import {
+  getPreviewStateObservable,
+  type PreviewState,
+} from '../../preview/utils/getPreviewStateObservable'
 import {useDocumentPreviewStore} from '../../store/datastores'
 import {useWorkspace} from '../../studio/workspace'
 import {type CommentContext} from '../types'
+
+const EMPTY_PREVIEW_STATE: PreviewState = {original: null, snapshot: null}
 
 interface NotificationTargetHookOptions {
   versionId: string
@@ -39,7 +44,7 @@ export function useNotificationTarget(
   const documentPreviewStore = useDocumentPreviewStore()
 
   const previewStateObservable = useMemo(() => {
-    if (!versionId || !schemaType) return of(null)
+    if (!versionId || !schemaType) return of(EMPTY_PREVIEW_STATE)
     const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
     return getPreviewStateObservable(documentPreviewStore, schemaType, versionId, perspectiveStack)
   }, [versionId, documentPreviewStore, schemaType, documentVersionId])
@@ -47,9 +52,7 @@ export function useNotificationTarget(
   // email body, where a briefly stale title is harmless (it can go stale
   // after send anyway). react-rx v5's identity-coherent deferral still falls
   // back to the live value when the previewed document id changes.
-  const previewState = useObservable(previewStateObservable, undefined)
-
-  const {snapshot, original} = previewState || {}
+  const {snapshot, original} = useObservable(previewStateObservable, EMPTY_PREVIEW_STATE)
   const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string
 
   const handleGetNotificationValue = useCallback(

--- a/packages/sanity/src/core/comments-v2/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments-v2/hooks/useNotificationTarget.ts
@@ -48,10 +48,6 @@ export function useNotificationTarget(
     const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
     return getPreviewStateObservable(documentPreviewStore, schemaType, versionId, perspectiveStack)
   }, [versionId, documentPreviewStore, schemaType, documentVersionId])
-  // Deferred (per review): `documentTitle` is only used in the notification
-  // email body, where a briefly stale title is harmless (it can go stale
-  // after send anyway). react-rx v5's identity-coherent deferral still falls
-  // back to the live value when the previewed document id changes.
   const {snapshot, original} = useObservable(previewStateObservable, EMPTY_PREVIEW_STATE)
   const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string
 

--- a/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
@@ -47,7 +47,7 @@ export function useNotificationTarget(
   // email body, where a briefly stale title is harmless (it can go stale
   // after send anyway). react-rx v5's identity-coherent deferral still falls
   // back to the live value when the previewed document id changes.
-  const previewState = useObservable(previewStateObservable)
+  const previewState = useObservable(previewStateObservable, undefined)
 
   const {snapshot, original} = previewState || {}
   const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string

--- a/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
@@ -48,10 +48,6 @@ export function useNotificationTarget(
     const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
     return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspectiveStack)
   }, [documentId, documentPreviewStore, schemaType, documentVersionId])
-  // Deferred (per review): `documentTitle` is only used in the notification
-  // email body, where a briefly stale title is harmless (it can go stale
-  // after send anyway). react-rx v5's identity-coherent deferral still falls
-  // back to the live value when the previewed document id changes.
   const {snapshot, original} = useObservable(previewStateObservable, EMPTY_PREVIEW_STATE)
   const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string
 

--- a/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
@@ -3,10 +3,15 @@ import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {useSchema} from '../../hooks/useSchema'
-import {getPreviewStateObservable} from '../../preview/utils/getPreviewStateObservable'
+import {
+  getPreviewStateObservable,
+  type PreviewState,
+} from '../../preview/utils/getPreviewStateObservable'
 import {useDocumentPreviewStore} from '../../store/datastores'
 import {useWorkspace} from '../../studio/workspace'
 import {type CommentContext} from '../types'
+
+const EMPTY_PREVIEW_STATE: PreviewState = {original: null, snapshot: null}
 
 interface NotificationTargetHookOptions {
   documentId: string
@@ -39,7 +44,7 @@ export function useNotificationTarget(
   const documentPreviewStore = useDocumentPreviewStore()
 
   const previewStateObservable = useMemo(() => {
-    if (!documentId || !schemaType) return of(null)
+    if (!documentId || !schemaType) return of(EMPTY_PREVIEW_STATE)
     const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
     return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspectiveStack)
   }, [documentId, documentPreviewStore, schemaType, documentVersionId])
@@ -47,9 +52,7 @@ export function useNotificationTarget(
   // email body, where a briefly stale title is harmless (it can go stale
   // after send anyway). react-rx v5's identity-coherent deferral still falls
   // back to the live value when the previewed document id changes.
-  const previewState = useObservable(previewStateObservable, undefined)
-
-  const {snapshot, original} = previewState || {}
+  const {snapshot, original} = useObservable(previewStateObservable, EMPTY_PREVIEW_STATE)
   const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string
 
   const handleGetNotificationValue = useCallback(

--- a/packages/sanity/src/core/components/CapabilityGate.test.tsx
+++ b/packages/sanity/src/core/components/CapabilityGate.test.tsx
@@ -4,6 +4,7 @@ import {beforeEach, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../test/testUtils/TestProvider'
 import {useRenderingContextStore} from '../store/datastores'
+import {createRenderingContextStore} from '../store/renderingContext/createRenderingContextStore'
 import {
   type CapabilityRecord,
   type RenderingContextStore,
@@ -18,6 +19,9 @@ const CORE_UI_CONTEXT: StudioRenderingContext = {
   name: 'coreUi',
   metadata: {environment: 'production'},
 }
+const CORE_UI_SEARCH = `?_context=${encodeURIComponent(
+  JSON.stringify({mode: 'core-ui', env: 'production'}),
+)}`
 
 function mockRenderingContextStore(
   renderingContext: StudioRenderingContext,
@@ -27,11 +31,33 @@ function mockRenderingContextStore(
     renderingContext: of(renderingContext),
     capabilities: of(capabilities),
     getRenderingContext: () => renderingContext,
+    getCapabilities: () => capabilities,
   } satisfies RenderingContextStore)
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
+})
+
+it('does not render a local implementation for even one commit while inside core ui', async () => {
+  const wrapper = await createTestProvider()
+  // the real store: it resolves the capabilities as it is created
+  vi.mocked(useRenderingContextStore).mockReturnValue(createRenderingContextStore(CORE_UI_SEARCH))
+  const childRenders: true[] = []
+  function LocalUserMenu() {
+    childRenders.push(true)
+    return <div data-testid="user-menu">User</div>
+  }
+
+  render(
+    <CapabilityGate capability="globalUserMenu" condition="unavailable">
+      <LocalUserMenu />
+    </CapabilityGate>,
+    {wrapper},
+  )
+
+  expect(childRenders).toHaveLength(0)
+  expect(screen.queryByTestId('user-menu')).toBeFalsy()
 })
 
 it('renders the child if the capability is not provided by the rendering context and the condition is "unavailable"', async () => {

--- a/packages/sanity/src/core/components/CapabilityGate.test.tsx
+++ b/packages/sanity/src/core/components/CapabilityGate.test.tsx
@@ -4,9 +4,31 @@ import {beforeEach, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../test/testUtils/TestProvider'
 import {useRenderingContextStore} from '../store/datastores'
+import {
+  type CapabilityRecord,
+  type RenderingContextStore,
+  type StudioRenderingContext,
+} from '../store/renderingContext/types'
 import {CapabilityGate} from './CapabilityGate'
 
 vi.mock('../store/datastores')
+
+const DEFAULT_CONTEXT: StudioRenderingContext = {name: 'default', metadata: {}}
+const CORE_UI_CONTEXT: StudioRenderingContext = {
+  name: 'coreUi',
+  metadata: {environment: 'production'},
+}
+
+function mockRenderingContextStore(
+  renderingContext: StudioRenderingContext,
+  capabilities: CapabilityRecord,
+): void {
+  vi.mocked(useRenderingContextStore).mockReturnValue({
+    renderingContext: of(renderingContext),
+    capabilities: of(capabilities),
+    getRenderingContext: () => renderingContext,
+  } satisfies RenderingContextStore)
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -15,13 +37,7 @@ beforeEach(() => {
 it('renders the child if the capability is not provided by the rendering context and the condition is "unavailable"', async () => {
   const wrapper = await createTestProvider()
 
-  vi.mocked(useRenderingContextStore).mockReturnValue({
-    renderingContext: of({
-      name: 'default',
-      metadata: {},
-    } as const),
-    capabilities: of({}),
-  })
+  mockRenderingContextStore(DEFAULT_CONTEXT, {})
 
   render(
     <CapabilityGate capability="globalUserMenu" condition="unavailable">
@@ -36,17 +52,7 @@ it('renders the child if the capability is not provided by the rendering context
 it('does not render the child if the capability is provided by the rendering context and the condition is "unavailable"', async () => {
   const wrapper = await createTestProvider()
 
-  vi.mocked(useRenderingContextStore).mockReturnValue({
-    renderingContext: of({
-      name: 'coreUi',
-      metadata: {
-        environment: 'production',
-      },
-    } as const),
-    capabilities: of({
-      globalUserMenu: true,
-    }),
-  })
+  mockRenderingContextStore(CORE_UI_CONTEXT, {globalUserMenu: true})
 
   render(
     <CapabilityGate capability="globalUserMenu" condition="unavailable">
@@ -61,17 +67,7 @@ it('does not render the child if the capability is provided by the rendering con
 it('renders the child if the capability is provided by the rendering context and the condition is "available"', async () => {
   const wrapper = await createTestProvider()
 
-  vi.mocked(useRenderingContextStore).mockReturnValue({
-    renderingContext: of({
-      name: 'coreUi',
-      metadata: {
-        environment: 'production',
-      },
-    } as const),
-    capabilities: of({
-      globalUserMenu: true,
-    }),
-  })
+  mockRenderingContextStore(CORE_UI_CONTEXT, {globalUserMenu: true})
 
   render(
     <CapabilityGate capability="globalUserMenu" condition="available">
@@ -86,13 +82,7 @@ it('renders the child if the capability is provided by the rendering context and
 it('does not render the child if the capability is not provided by the rendering context and the condition is "available"', async () => {
   const wrapper = await createTestProvider()
 
-  vi.mocked(useRenderingContextStore).mockReturnValue({
-    renderingContext: of({
-      name: 'default',
-      metadata: {},
-    } as const),
-    capabilities: of({}),
-  })
+  mockRenderingContextStore(DEFAULT_CONTEXT, {})
 
   render(
     <CapabilityGate capability="globalUserMenu" condition="available">

--- a/packages/sanity/src/core/components/CapabilityGate.tsx
+++ b/packages/sanity/src/core/components/CapabilityGate.tsx
@@ -2,12 +2,14 @@ import {type ComponentType, type PropsWithChildren} from 'react'
 import {useSyncObservable} from 'react-rx'
 
 import {useRenderingContextStore} from '../store/datastores'
-import {type Capability} from '../store/renderingContext/types'
+import {type Capability, type CapabilityRecord} from '../store/renderingContext/types'
 
 type Props = PropsWithChildren<{
   capability: Capability
   condition?: 'available' | 'unavailable'
 }>
+
+const EMPTY_CAPABILITIES: CapabilityRecord = {}
 
 /**
  * `CapabilityGate` only renders its children if the current Studio rendering context does not
@@ -24,10 +26,14 @@ export const CapabilityGate: ComponentType<Props> = ({
   capability,
   condition = 'unavailable',
 }) => {
-  const renderingContextStore = useRenderingContextStore()
-  // Kept synchronous: capabilities emit once at boot, so deferring only
-  // delays the gate flipping without any render-load benefit.
-  const renderingContextCapabilities = useSyncObservable(renderingContextStore.capabilities, {})
+  const {capabilities, getCapabilities} = useRenderingContextStore()
+  // Kept synchronous: capabilities emit once at boot, so deferring only delays the gate flipping
+  // without any render-load benefit. The store has already resolved them, so the mounting render
+  // gates correctly too rather than painting the local implementation for a commit.
+  const renderingContextCapabilities = useSyncObservable(
+    capabilities,
+    () => getCapabilities() ?? EMPTY_CAPABILITIES,
+  )
   const renderingContextHasCapability = renderingContextCapabilities[capability] === true
 
   if (condition === 'available' && !renderingContextHasCapability) {

--- a/packages/sanity/src/core/divergence/hooks/useDivergenceController.ts
+++ b/packages/sanity/src/core/divergence/hooks/useDivergenceController.ts
@@ -2,7 +2,7 @@ import {SanityEncoder} from '@sanity/mutate'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {type SanityDocument} from '@sanity/types'
 import {fromString, get} from '@sanity/util/paths'
-import {useContext, useEffect, useState} from 'react'
+import {useContext, useEffect, useMemo, useState} from 'react'
 import {useSyncObservable} from 'react-rx'
 import {
   type Observable,
@@ -100,64 +100,72 @@ export function useDivergenceController(
 
   const [upstreamId, upstreamRevisionId] = sinceRevisionId.split('@')
 
-  const readUpstreamBase: Observable<HydratedSnapshot> = getDocumentAtRevision({
-    client,
-    documentId: upstreamId,
-    revisionId: upstreamRevisionId,
-  }).pipe(
-    switchMap((state) => {
-      if (state?.loading) {
-        return of({
-          isLoading: true,
-        })
-      }
-      return of(state).pipe(
-        filter((revision) => revision !== null),
-        map(({document}) => document),
-        switchMap((document) => {
-          if (!document) {
-            return EMPTY
+  const readUpstreamBase: Observable<HydratedSnapshot> = useMemo(
+    () =>
+      getDocumentAtRevision({
+        client,
+        documentId: upstreamId,
+        revisionId: upstreamRevisionId,
+      }).pipe(
+        switchMap((state) => {
+          if (state?.loading) {
+            return of({
+              isLoading: true,
+            })
           }
+          return of(state).pipe(
+            filter((revision) => revision !== null),
+            map(({document}) => document),
+            switchMap((document) => {
+              if (!document) {
+                return EMPTY
+              }
 
-          return of(get(document, path)).pipe(
-            map((value) => ({value, document})),
-            startWith(undefined),
+              return of(get(document, path)).pipe(
+                map((value) => ({value, document})),
+                startWith(undefined),
+              )
+            }),
+            map((value) => ({isLoading: false, value})),
           )
         }),
-        map((value) => ({isLoading: false, value})),
-      )
-    }),
+      ),
+    [client, path, upstreamId, upstreamRevisionId],
   )
 
   // No `getTargetScopeId(useTargetDocumentState())` here: the version is derived from the divergence's own
   // document id, independent of the selected perspective.
-  const readUpstreamHead: Observable<HydratedSnapshot> = documentStore.pair
-    .editState(getPublishedId(documentId), documentType, getVersionFromId(documentId))
-    .pipe(
-      switchMap((state) => {
-        if (!state.ready) {
-          return of({
-            isLoading: true,
-          })
-        }
-
-        return of(state).pipe(
-          map(selectUpstreamVersion),
-          find((document) => document !== null),
-          switchMap((document) => {
-            if (typeof document === 'undefined') {
-              return EMPTY
+  const readUpstreamHead: Observable<HydratedSnapshot> = useMemo(
+    () =>
+      documentStore.pair
+        .editState(getPublishedId(documentId), documentType, getVersionFromId(documentId))
+        .pipe(
+          switchMap((state) => {
+            if (!state.ready) {
+              return of({
+                isLoading: true,
+              })
             }
 
-            return of(get(document, path)).pipe(
-              map((value) => ({value, document})),
-              startWith(undefined),
+            return of(state).pipe(
+              map(selectUpstreamVersion),
+              find((document) => document !== null),
+              switchMap((document) => {
+                if (typeof document === 'undefined') {
+                  return EMPTY
+                }
+
+                return of(get(document, path)).pipe(
+                  map((value) => ({value, document})),
+                  startWith(undefined),
+                )
+              }),
+              map((value) => ({isLoading: false, value})),
             )
           }),
-          map((value) => ({isLoading: false, value})),
-        )
-      }),
-    )
+        ),
+    [documentId, documentStore.pair, documentType, path],
+  )
 
   // Kept synchronous: `markResolved` / `takeUpstreamValue` build and execute
   // patches from `upstreamHead.value.document` (and gate on `isLoading`), so a

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -743,7 +743,7 @@ function usePreserveIntrinsicBlockSize({
   // (`--intrinsic-block-size`) that preserves layout during activation, so a
   // deferred snapshot lagging the latest ResizeObserver measurement could
   // cause visible layout jumps.
-  const currentSize = useSyncObservable(size)
+  const currentSize = useSyncObservable(size, undefined)
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(([entry]) => {

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -6,12 +6,11 @@ import {useActorRef, useSelector} from '@xstate/react'
 import {
   type ChangeEvent,
   type ComponentType,
-  useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
-import {useSyncObservable} from 'react-rx'
 import {
   combineLatest,
   debounceTime,
@@ -727,9 +726,13 @@ const ManagedVariantRow: ComponentType<{
   )
 }
 
+const INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY = '--intrinsic-block-size'
+
 /**
  * Preserve the intrinsic block size of an element by maintaining an `--intrinsic-block-size`
  * custom property. This custom property must be used by styles to control the element's size.
+ * While inactive the element's natural height is tracked; while active it is pinned to the
+ * last tracked height.
  */
 function usePreserveIntrinsicBlockSize({
   isActive,
@@ -738,41 +741,23 @@ function usePreserveIntrinsicBlockSize({
   isActive: boolean
   element: HTMLElement | null
 }): void {
-  const size = useMemo(() => new Subject<DOMRect | undefined>(), [])
-  // Kept synchronous: this drives an imperative style write
-  // (`--intrinsic-block-size`) that preserves layout during activation, so a
-  // deferred snapshot lagging the latest ResizeObserver measurement could
-  // cause visible layout jumps.
-  const currentSize = useSyncObservable(size, undefined)
+  const measuredHeight = useRef(0)
 
-  useEffect(() => {
-    const resizeObserver = new ResizeObserver(([entry]) => {
-      if (!isActive) {
-        size.next(entry.contentRect)
-      }
-    })
-
-    if (element) {
-      resizeObserver.observe(element)
-    }
-
-    return () => resizeObserver.disconnect()
-  }, [isActive, element, size])
-
-  useEffect(() => {
-    if (!element || !currentSize) {
-      return () => {}
-    }
-
-    const INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY = '--intrinsic-block-size'
-    const cleanUp = () => element.style.removeProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY)
+  useLayoutEffect(() => {
+    if (!element) return undefined
 
     if (isActive) {
-      element?.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${currentSize.height}px`)
-      return cleanUp
+      const height = measuredHeight.current
+      if (!height) return undefined
+      element.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${height}px`)
+      return () => element.style.removeProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY)
     }
 
-    cleanUp()
-    return () => {}
-  }, [element, currentSize, isActive])
+    // Only observe while inactive: the pinned height is the last natural one.
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      measuredHeight.current = entry.contentRect.height
+    })
+    resizeObserver.observe(element)
+    return () => resizeObserver.disconnect()
+  }, [element, isActive])
 }

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -740,42 +740,27 @@ function usePreserveIntrinsicBlockSize({
   isActive: boolean
   element: HTMLElement | null
 }): void {
-  // `isActive` only decides what to do with a measurement; it must not set up
-  // or tear down the ResizeObserver, so the observer reads it through a ref.
-  const isActiveRef = useRef(isActive)
   const heightRef = useRef(0)
 
-  useLayoutEffect(() => {
-    isActiveRef.current = isActive
-
-    if (!element || !heightRef.current) {
+  useEffect(() => {
+    if (!element) {
       return undefined
     }
 
-    const cleanUp = () => {
-      element.style.removeProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY)
-    }
-
-    if (isActive) {
-      element.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${heightRef.current}px`)
-      return cleanUp
-    }
-
-    cleanUp()
-    return undefined
-  }, [element, isActive])
-
-  useEffect(() => {
+    // `observe()` fires an initial callback, so restarting the observer when `isActive`
+    // flips lets the handler apply the transition itself.
     const resizeObserver = new ResizeObserver(([entry]) => {
-      if (!isActiveRef.current) {
+      if (!isActive) {
         heightRef.current = entry.contentRect.height
+      } else if (heightRef.current) {
+        element.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${heightRef.current}px`)
       }
     })
+    resizeObserver.observe(element)
 
-    if (element) {
-      resizeObserver.observe(element)
+    return () => {
+      resizeObserver.disconnect()
+      element.style.removeProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY)
     }
-
-    return () => resizeObserver.disconnect()
-  }, [element])
+  }, [element, isActive])
 }

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -6,6 +6,7 @@ import {useActorRef, useSelector} from '@xstate/react'
 import {
   type ChangeEvent,
   type ComponentType,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -731,8 +732,6 @@ const INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY = '--intrinsic-block-size'
 /**
  * Preserve the intrinsic block size of an element by maintaining an `--intrinsic-block-size`
  * custom property. This custom property must be used by styles to control the element's size.
- * While inactive the element's natural height is tracked; while active it is pinned to the
- * last tracked height.
  */
 function usePreserveIntrinsicBlockSize({
   isActive,
@@ -741,23 +740,42 @@ function usePreserveIntrinsicBlockSize({
   isActive: boolean
   element: HTMLElement | null
 }): void {
-  const measuredHeight = useRef(0)
+  // `isActive` only decides what to do with a measurement; it must not set up
+  // or tear down the ResizeObserver, so the observer reads it through a ref.
+  const isActiveRef = useRef(isActive)
+  const heightRef = useRef(0)
 
   useLayoutEffect(() => {
-    if (!element) return undefined
+    isActiveRef.current = isActive
 
-    if (isActive) {
-      const height = measuredHeight.current
-      if (!height) return undefined
-      element.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${height}px`)
-      return () => element.style.removeProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY)
+    if (!element || !heightRef.current) {
+      return undefined
     }
 
-    // Only observe while inactive: the pinned height is the last natural one.
-    const resizeObserver = new ResizeObserver(([entry]) => {
-      measuredHeight.current = entry.contentRect.height
-    })
-    resizeObserver.observe(element)
-    return () => resizeObserver.disconnect()
+    const cleanUp = () => {
+      element.style.removeProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY)
+    }
+
+    if (isActive) {
+      element.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${heightRef.current}px`)
+      return cleanUp
+    }
+
+    cleanUp()
+    return undefined
   }, [element, isActive])
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (!isActiveRef.current) {
+        heightRef.current = entry.contentRect.height
+      }
+    })
+
+    if (element) {
+      resizeObserver.observe(element)
+    }
+
+    return () => resizeObserver.disconnect()
+  }, [element])
 }

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -743,24 +743,27 @@ function usePreserveIntrinsicBlockSize({
   const heightRef = useRef(0)
 
   useEffect(() => {
-    if (!element) {
+    if (!isActive || !element) {
       return undefined
     }
 
-    // `observe()` fires an initial callback, so restarting the observer when `isActive`
-    // flips lets the handler apply the transition itself.
+    const setHeight = (height: number) => {
+      heightRef.current = height
+      element.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${height}px`)
+    }
+
     const resizeObserver = new ResizeObserver(([entry]) => {
-      if (!isActive) {
-        heightRef.current = entry.contentRect.height
-      } else if (heightRef.current) {
-        element.style.setProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY, `${heightRef.current}px`)
-      }
+      setHeight(entry.contentRect.height)
     })
+
+    if (heightRef.current) {
+      setHeight(heightRef.current)
+    }
     resizeObserver.observe(element)
 
     return () => {
-      resizeObserver.disconnect()
       element.style.removeProperty(INTRINSIC_BLOCK_SIZE_CUSTOM_PROPERTY)
+      resizeObserver.disconnect()
     }
-  }, [element, isActive])
+  }, [isActive, element])
 }

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
@@ -35,6 +35,7 @@ export const DocumentGroupInventoryAction: ComponentType<
       () => versionState.pipe(map(({loading, versions}) => !loading && versions.length !== 0)),
       [versionState],
     ),
+    undefined,
   )
 
   useClickOutsideEvent(

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
@@ -35,7 +35,7 @@ export const DocumentGroupInventoryAction: ComponentType<
       () => versionState.pipe(map(({loading, versions}) => !loading && versions.length !== 0)),
       [versionState],
     ),
-    undefined,
+    false,
   )
 
   useClickOutsideEvent(

--- a/packages/sanity/src/core/field/diff/hooks/useRefValue.ts
+++ b/packages/sanity/src/core/field/diff/hooks/useRefValue.ts
@@ -17,7 +17,7 @@ export function useRefValue<T extends Record<string, any> = Record<string, any>>
   // Kept synchronous: the falsy-ref guard below reads the live `refId`, so a
   // deferred snapshot could return the previously referenced document under a
   // newly selected ref.
-  const value = useSyncObservable(document$)
+  const value = useSyncObservable(document$, undefined)
 
   // Always return undefined in the case of a falsey ref to prevent bug
   // when going from an ID to an undefined state

--- a/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
+++ b/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
@@ -195,6 +195,7 @@ function useCollateDivergencesContext({
           b: subjectHead?._id,
           client,
         }),
+    undefined,
   )
 
   const listenUpstreamHead = useMemo(() => new BehaviorSubject<SanityDocument | null>(null), [])
@@ -270,5 +271,5 @@ function useCollateDivergencesContext({
   // The subscription exists to drive the `context.next` pipeline above; the
   // returned snapshot is not consumed for rendering, so deferring it would
   // only desynchronize the pipeline.
-  return useSyncObservable(listenContext)
+  return useSyncObservable(listenContext, undefined)
 }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -193,7 +193,7 @@ function ImageInputAssetMenuWithReferenceAssetComponent(
   // Kept synchronous: a deferred snapshot could pair the previous asset with a
   // newly selected reference, pointing menu actions (e.g. open in source) at
   // the wrong asset.
-  const asset = useSyncObservable(observable)
+  const asset = useSyncObservable(observable, undefined)
   const assetSourcesWithUpload = getAssetSourcesWithUpload(assetSources)
 
   // Find the first asset source that can handle opening this asset in source

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -92,7 +92,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   const disableNew = inheritedOptions.disableNew ?? schemaType.options?.disableNew === true
   const getClient = source.getClient
 
-  // Plain function: ReferenceInput reads onSearch via useObservableEvent (latest each call).
+  // Plain function: useSearchMachine reads the latest onSearch on each call.
   // oxlint's react-hooks/rules-of-hooks flags passing a useEffectEvent result as a prop.
   const handleSearch = (searchString: string) =>
     from(

--- a/packages/sanity/src/core/form/useComlinkViewHistory.ts
+++ b/packages/sanity/src/core/form/useComlinkViewHistory.ts
@@ -17,7 +17,7 @@ export function useComlinkViewHistory({editState}: {editState: EditStateFor}): v
   const renderingContextStore = useRenderingContextStore()
   // Kept synchronous: capabilities emit once at boot and gate the history
   // recording effect below; deferring only delays it.
-  const capabilities = useSyncObservable(renderingContextStore.capabilities)
+  const capabilities = useSyncObservable(renderingContextStore.capabilities, undefined)
   const {activeWorkspace} = useActiveWorkspace()
   const displayed = editState.version ?? editState.draft ?? editState.published
 

--- a/packages/sanity/src/core/form/useComlinkViewHistory.ts
+++ b/packages/sanity/src/core/form/useComlinkViewHistory.ts
@@ -16,8 +16,12 @@ import {useActiveWorkspace} from '../studio/activeWorkspaceMatcher/useActiveWork
 export function useComlinkViewHistory({editState}: {editState: EditStateFor}): void {
   const renderingContextStore = useRenderingContextStore()
   // Kept synchronous: capabilities emit once at boot and gate the history
-  // recording effect below; deferring only delays it.
-  const capabilities = useSyncObservable(renderingContextStore.capabilities, undefined)
+  // recording effect below; deferring only delays it. The store has already
+  // resolved them, so the effect can record on the mounting commit.
+  const capabilities = useSyncObservable(
+    renderingContextStore.capabilities,
+    renderingContextStore.getCapabilities,
+  )
   const {activeWorkspace} = useActiveWorkspace()
   const displayed = editState.version ?? editState.draft ?? editState.published
 

--- a/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
@@ -1,5 +1,5 @@
 import {act, renderHook, waitFor} from '@testing-library/react'
-import {BehaviorSubject} from 'rxjs'
+import {BehaviorSubject, type Observable, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {type EditStateFor} from '../../store/document/document-pair/editState'
@@ -20,7 +20,9 @@ const initialState: EditStateFor = {
 }
 
 const mockEditState$ = new BehaviorSubject<EditStateFor>(initialState)
-const mockEditStateFn = vi.fn(() => mockEditState$)
+const mockEditStateFn = vi.fn<
+  (publishedId: string, type: string, version?: string) => Observable<EditStateFor>
+>(() => mockEditState$)
 
 const mockDocumentStore = {
   pair: {editState: mockEditStateFn},
@@ -32,7 +34,8 @@ vi.mock('../useSchema', () => ({useSchema: () => ({get: () => undefined})}))
 describe('useEditState', () => {
   beforeEach(() => {
     mockEditState$.next(initialState)
-    mockEditStateFn.mockClear()
+    mockEditStateFn.mockReset()
+    mockEditStateFn.mockImplementation(() => mockEditState$)
   })
 
   it('returns the initial value', () => {
@@ -180,6 +183,48 @@ describe('useEditState', () => {
     await waitFor(() => {
       expect(result.current).toBe(locked)
     })
+  })
+
+  it('derives the new arguments, not the previous document, while a swapped-in stream is silent', () => {
+    const doc2$ = new Subject<EditStateFor>()
+    mockEditStateFn.mockImplementation((publishedId) =>
+      publishedId === 'doc-2' ? doc2$ : mockEditState$,
+    )
+
+    const {result, rerender} = renderHook<EditStateFor, {id: string; version?: string}>(
+      ({id, version}) => useEditState(id, 'book', 'default', version),
+      {initialProps: {id: 'doc-1'}},
+    )
+    expect(result.current).toBe(initialState)
+
+    // react-rx renders its captured initialValue (undefined) for the new identity until it emits
+    rerender({id: 'doc-2', version: 'rel'})
+
+    expect(result.current).not.toBe(initialState)
+    expect(result.current).toMatchObject({
+      id: 'doc-2',
+      type: 'book',
+      ready: false,
+      draft: null,
+      published: null,
+      version: null,
+      liveEdit: true,
+      release: 'rel',
+      scopeId: 'rel',
+    })
+
+    const emitted: EditStateFor = {
+      ...initialState,
+      id: 'doc-2',
+      ready: true,
+      liveEdit: true,
+      release: 'rel',
+      scopeId: 'rel',
+    }
+    act(() => {
+      doc2$.next(emitted)
+    })
+    expect(result.current).toBe(emitted)
   })
 
   it('keeps the result frozen across multiple structurally-equal emissions', () => {

--- a/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
@@ -27,6 +27,7 @@ const mockDocumentStore = {
 }
 
 vi.mock('../../store/datastores', () => ({useDocumentStore: () => mockDocumentStore}))
+vi.mock('../useSchema', () => ({useSchema: () => ({get: () => undefined})}))
 
 describe('useEditState', () => {
   beforeEach(() => {

--- a/packages/sanity/src/core/hooks/useDocumentOperation.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperation.ts
@@ -2,6 +2,7 @@ import {useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
 
 import {useDocumentStore} from '../store/datastores'
+import {GUARDED} from '../store/document/document-pair/operations/helpers'
 import {type OperationsAPI} from '../store/document/document-pair/operations/types'
 import {type DocumentPairTarget} from '../store/document/types'
 import {useDocumentOperationWithComlinkHistory} from './useDocumentOperationWithComlinkHistory'
@@ -30,15 +31,11 @@ export function useDocumentOperation(
     [docTypeName, documentStore.pair, publishedDocId, target],
   )
 
-  /**
-   * We know that since the observable has a startWith operator, it will always emit a value
-   * and that's why the non-null assertion is used here
-   *
-   * Kept synchronous: the operations are imperative emitters bound to the
-   * document id/type they were created for, so a deferred (stale) API could
-   * execute an action against the previously viewed document after navigation.
-   */
-  const api = useSyncObservable(observable, undefined)!
+  // Kept synchronous: the operations are imperative emitters bound to the
+  // document id/type they were created for, so a deferred (stale) API could
+  // execute an action against the previously viewed document after navigation.
+  // `GUARDED` is also what the pair emits first, so nothing can execute before it is ready.
+  const api = useSyncObservable(observable, GUARDED)
 
   return useDocumentOperationWithComlinkHistory({
     api,

--- a/packages/sanity/src/core/hooks/useDocumentOperation.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperation.ts
@@ -38,7 +38,7 @@ export function useDocumentOperation(
    * document id/type they were created for, so a deferred (stale) API could
    * execute an action against the previously viewed document after navigation.
    */
-  const api = useSyncObservable(observable)!
+  const api = useSyncObservable(observable, undefined)!
 
   return useDocumentOperationWithComlinkHistory({
     api,

--- a/packages/sanity/src/core/hooks/useDocumentOperationEvent.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperationEvent.ts
@@ -14,5 +14,5 @@ export function useDocumentOperationEvent(publishedDocId: string, docTypeName: s
   // Kept synchronous: this is an event stream driving effects (toasts,
   // pane-close). Deferring could coalesce a quick success/error sequence into
   // one render and drop an event consumers must react to.
-  return useSyncObservable(observable)
+  return useSyncObservable(observable, undefined)
 }

--- a/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
@@ -41,7 +41,7 @@ export function useDocumentOperationWithComlinkHistory({
   // Kept synchronous: capabilities emit once at boot and gate whether
   // operations are decorated with comlink history capture; deferring only
   // delays the decoration.
-  const capabilities = useSyncObservable(renderingContextStore.capabilities)
+  const capabilities = useSyncObservable(renderingContextStore.capabilities, undefined)
 
   // Used to prevent redundant `edited` events being recorded.
   const [hasRecordedEdit, setHasRecordedEdit] = useState<boolean>(false)

--- a/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
@@ -40,8 +40,12 @@ export function useDocumentOperationWithComlinkHistory({
   const renderingContextStore = useRenderingContextStore()
   // Kept synchronous: capabilities emit once at boot and gate whether
   // operations are decorated with comlink history capture; deferring only
-  // delays the decoration.
-  const capabilities = useSyncObservable(renderingContextStore.capabilities, undefined)
+  // delays the decoration. The store has already resolved them, so the
+  // operations are decorated from the mounting render on.
+  const capabilities = useSyncObservable(
+    renderingContextStore.capabilities,
+    renderingContextStore.getCapabilities,
+  )
 
   // Used to prevent redundant `edited` events being recorded.
   const [hasRecordedEdit, setHasRecordedEdit] = useState<boolean>(false)

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -51,5 +51,5 @@ export function useEditState(
    * We know that since the observable has a startWith operator, it will always emit a value
    * and that's why the non-null assertion is used here
    */
-  return useSyncObservable(observable)!
+  return useSyncObservable(observable, undefined)!
 }

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -3,7 +3,9 @@ import {useSyncObservable} from 'react-rx'
 import {debounce, distinctUntilChanged, merge, share, shareReplay, skip, take, timer} from 'rxjs'
 
 import {useDocumentStore} from '../store/datastores'
-import {type EditStateFor} from '../store/document/document-pair/editState'
+import {type EditStateFor, getInitialEditState} from '../store/document/document-pair/editState'
+import {getIdPair} from '../util/draftUtils'
+import {useSchema} from './useSchema'
 
 // Snapshot refs (draft/published/version) are preserved upstream when content
 // hasn't changed, so ref equality on those + ready + transactionSyncLock catches
@@ -26,6 +28,7 @@ export function useEditState(
     throw new Error('Version cannot be published or draft')
   }
   const documentStore = useDocumentStore()
+  const schema = useSchema()
 
   const observable = useMemo(() => {
     const source = documentStore.pair.editState(publishedDocId, docTypeName, version)
@@ -47,9 +50,14 @@ export function useEditState(
       shareReplay({bufferSize: 1, refCount: true}),
     )
   }, [docTypeName, documentStore.pair, priority, publishedDocId, version])
-  /**
-   * We know that since the observable has a startWith operator, it will always emit a value
-   * and that's why the non-null assertion is used here
-   */
-  return useSyncObservable(observable, undefined)!
+
+  // Rendered until the pipeline emits. Derived per render rather than passed as react-rx's
+  // `initialValue`, which is captured once per hook instance and would carry the previous
+  // document's id through an identity swap.
+  const initialState = useMemo(
+    () => getInitialEditState(schema, getIdPair(publishedDocId, {version}), docTypeName),
+    [docTypeName, publishedDocId, schema, version],
+  )
+
+  return useSyncObservable(observable, undefined) ?? initialState
 }

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -51,13 +51,12 @@ export function useEditState(
     )
   }, [docTypeName, documentStore.pair, priority, publishedDocId, version])
 
-  // Rendered until the pipeline emits. Derived per render rather than passed as react-rx's
-  // `initialValue`, which is captured once per hook instance and would carry the previous
-  // document's id through an identity swap.
-  const initialState = useMemo(
-    () => getInitialEditState(schema, getIdPair(publishedDocId, {version}), docTypeName),
-    [docTypeName, publishedDocId, schema, version],
-  )
-
-  return useSyncObservable(observable, undefined) ?? initialState
+  const editState = useSyncObservable(observable, undefined)
+  return useMemo(() => {
+    if (editState) return editState
+    // Rendered until the pipeline emits. Derived per render rather than passed as react-rx's
+    // `initialValue`, which is captured once per hook instance and would carry the previous
+    // document's id through an identity swap.
+    return getInitialEditState(schema, getIdPair(publishedDocId, {version}), docTypeName)
+  }, [editState, docTypeName, publishedDocId, schema, version])
 }

--- a/packages/sanity/src/core/hooks/useManageFavorite.ts
+++ b/packages/sanity/src/core/hooks/useManageFavorite.ts
@@ -124,7 +124,7 @@ export function useManageFavorite({
   // Kept synchronous: favorite()/unfavorite() push an optimistic SET into
   // this stream so the toggle reflects the click immediately; deferring the
   // state would make the control lag its own interaction.
-  const state = useSyncObservable(stateController.state)
+  const state = useSyncObservable(stateController.state, undefined)
 
   return {
     favorite: useCallback(() => stateController.setState(true), [stateController]),

--- a/packages/sanity/src/core/hooks/useManageFavorite.ts
+++ b/packages/sanity/src/core/hooks/useManageFavorite.ts
@@ -124,13 +124,13 @@ export function useManageFavorite({
   // Kept synchronous: favorite()/unfavorite() push an optimistic SET into
   // this stream so the toggle reflects the click immediately; deferring the
   // state would make the control lag its own interaction.
-  const state = useSyncObservable(stateController.state, undefined)
+  const state = useSyncObservable(stateController.state, INITIAL_STATE)
 
   return {
     favorite: useCallback(() => stateController.setState(true), [stateController]),
     unfavorite: useCallback(() => stateController.setState(false), [stateController]),
-    isFavorited: state?.value,
-    isReady: state?.isReady ?? false,
+    isFavorited: state.value,
+    isReady: state.isReady,
   }
 }
 

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
@@ -41,7 +41,8 @@ describe('isUsingLegacyHttp', () => {
         responseStart: 0,
         secureConnectionStart: 0,
         serverTiming: [],
-        startTime: performance.now() + 1,
+        // Set when the observer fires so startTime is after detectApiNetwork's startedAt.
+        startTime: 0,
         transferSize: 0,
       }
 
@@ -54,7 +55,10 @@ describe('isUsingLegacyHttp', () => {
             this.callback = callback
           }
           observe() {
-            setTimeout(() => this.callback({getEntries: () => [mockEntry]}), 0)
+            setTimeout(() => {
+              mockEntry.startTime = performance.now()
+              this.callback({getEntries: () => [mockEntry]})
+            }, 0)
           }
           disconnect() {
             // noop
@@ -130,7 +134,7 @@ describe('isUsingLegacyHttp', () => {
         responseStart: 40,
         secureConnectionStart: 20,
         serverTiming: [],
-        startTime: performance.now() + 1,
+        startTime: 0,
         transferSize: 304,
       }
       const mockObserve = vi.fn()
@@ -147,6 +151,7 @@ describe('isUsingLegacyHttp', () => {
             mockObserve()
             // Emit the entry async so the fetch can resolve first
             setTimeout(() => {
+              mockEntry.startTime = performance.now()
               this.callback({getEntries: () => [mockEntry]})
             }, 0)
           }
@@ -210,7 +215,7 @@ describe('isUsingLegacyHttp', () => {
         responseStart: 0,
         secureConnectionStart: 0,
         serverTiming: [],
-        startTime: performance.now() + 1,
+        startTime: 0,
         transferSize: 0,
       }
 
@@ -223,7 +228,10 @@ describe('isUsingLegacyHttp', () => {
             this.callback = callback
           }
           observe() {
-            setTimeout(() => this.callback({getEntries: () => [mockEntry]}), 0)
+            setTimeout(() => {
+              mockEntry.startTime = performance.now()
+              this.callback({getEntries: () => [mockEntry]})
+            }, 0)
           }
           disconnect() {
             // noop

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
@@ -41,10 +41,12 @@ describe('isUsingLegacyHttp', () => {
         responseStart: 0,
         secureConnectionStart: 0,
         serverTiming: [],
-        // Set when the observer fires so startTime is after detectApiNetwork's startedAt.
-        startTime: 0,
         transferSize: 0,
       }
+
+      // oxlint-disable-next-line typescript/no-extraneous-class
+      const FakePerformanceResourceTiming = class FakePerformanceResourceTiming {}
+      vi.stubGlobal('PerformanceResourceTiming', FakePerformanceResourceTiming)
 
       vi.mocked(fetch).mockResolvedValue(new Response('pong'))
       vi.stubGlobal(
@@ -56,8 +58,12 @@ describe('isUsingLegacyHttp', () => {
           }
           observe() {
             setTimeout(() => {
-              mockEntry.startTime = performance.now()
-              this.callback({getEntries: () => [mockEntry]})
+              // A fresh entry per delivery, timed after detectApiNetwork's startedAt.
+              const entry = Object.setPrototypeOf(
+                {...mockEntry, startTime: performance.now()},
+                FakePerformanceResourceTiming.prototype,
+              )
+              this.callback({getEntries: () => [entry]})
             }, 0)
           }
           disconnect() {
@@ -65,10 +71,6 @@ describe('isUsingLegacyHttp', () => {
           }
         },
       )
-      // oxlint-disable-next-line typescript/no-extraneous-class
-      const FakePerformanceResourceTiming = class FakePerformanceResourceTiming {}
-      vi.stubGlobal('PerformanceResourceTiming', FakePerformanceResourceTiming)
-      Object.setPrototypeOf(mockEntry, FakePerformanceResourceTiming.prototype)
 
       const client = {
         getUrl: (path: string) => `https://test.api.sanity.io/v2025-02-19${path}`,

--- a/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
+++ b/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
@@ -32,7 +32,7 @@ const OversizedButton = styled(ToolLink)`
 export function ReleasesToolLink(): React.JSX.Element {
   const {t} = useTranslation()
   const {errorCount$} = useReleasesStore()
-  const errorCount = useObservable(errorCount$)
+  const errorCount = useObservable(errorCount$, undefined)
   const hasError = errorCount !== 0
   const {selectedPerspective} = usePerspective()
   const activeToolName = useRouterState(

--- a/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
+++ b/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
@@ -32,7 +32,7 @@ const OversizedButton = styled(ToolLink)`
 export function ReleasesToolLink(): React.JSX.Element {
   const {t} = useTranslation()
   const {errorCount$} = useReleasesStore()
-  const errorCount = useObservable(errorCount$, undefined)
+  const errorCount = useObservable(errorCount$, 0)
   const hasError = errorCount !== 0
   const {selectedPerspective} = usePerspective()
   const activeToolName = useRouterState(

--- a/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
+++ b/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
@@ -14,7 +14,6 @@ import {useAllReleases} from '../../releases/store/useAllReleases'
 import {useReleasesStore} from '../../releases/store/useReleasesStore'
 import {ARCHIVED_RELEASE_STATES} from '../../releases/util/const'
 import {variantAlphaAudience} from '../../variants/__fixtures__/variants.fixture'
-import {INITIAL_VARIANTS_STATE} from '../../variants/store/createVariantsStore'
 import {type VariantStoreState} from '../../variants/store/reducer'
 import {useVariantsStore} from '../../variants/store/useVariantsStore'
 import {getSelectedReleaseId} from '../getSelectedReleaseId'
@@ -38,10 +37,11 @@ const releasesState$ = new BehaviorSubject<MockReleasesState>({
   releases: new Map(),
   state: 'initialising',
 })
-const variantsState$ = new BehaviorSubject<VariantStoreState>({
+const INITIAL_VARIANTS_STATE: VariantStoreState = {
   variants: new Map(),
   state: 'initialising',
-})
+}
+const variantsState$ = new BehaviorSubject<VariantStoreState>(INITIAL_VARIANTS_STATE)
 
 const selectedReleaseName$ = new BehaviorSubject<ReleaseId | undefined>(undefined)
 const selectedVariantName$ = new BehaviorSubject<string | undefined>(undefined)
@@ -50,7 +50,11 @@ vi.mock('../../releases/store/useReleasesStore', () => ({
   useReleasesStore: () => ({state$: releasesState$, dispatch: vi.fn()}),
 }))
 vi.mock('../../variants/store/useVariantsStore', () => ({
-  useVariantsStore: () => ({state$: variantsState$, dispatch: vi.fn()}),
+  useVariantsStore: () => ({
+    state$: variantsState$,
+    initialState: INITIAL_VARIANTS_STATE,
+    dispatch: vi.fn(),
+  }),
 }))
 
 const RELEASE_NAME = 'rASAP' as ReleaseId
@@ -122,8 +126,8 @@ function DeferredActiveReleasesCounterfactual() {
 
 function DeferredAllVariantsCounterfactual() {
   const name = useSyncObservable(selectedVariantName$, undefined)
-  const {state$} = useVariantsStore()
-  const {variants} = useObservable(state$, INITIAL_VARIANTS_STATE)
+  const {state$, initialState} = useVariantsStore()
+  const {variants} = useObservable(state$, initialState)
   variantFrames.push({
     name,
     variantId: getSelectedVariant({selectedVariantName: name, variantsById: variants})?._id,

--- a/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
+++ b/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
@@ -110,7 +110,7 @@ function ReleaseIdProbe() {
 
 /** The real provider fed by the live selection, as wired in the studio. */
 function SyncReleaseHarness() {
-  const name = useSyncObservable(selectedReleaseName$)
+  const name = useSyncObservable(selectedReleaseName$, undefined)
   return (
     <PerspectiveProvider selectedPerspectiveName={name} excludedPerspectives={[]}>
       <ReleaseIdProbe />
@@ -125,7 +125,7 @@ function VariantProbe() {
 }
 
 function SyncVariantHarness() {
-  const name = useSyncObservable(selectedVariantName$)
+  const name = useSyncObservable(selectedVariantName$, undefined)
   return (
     <PerspectiveProvider
       selectedPerspectiveName={undefined}
@@ -143,9 +143,9 @@ function SyncVariantHarness() {
  * live selection and `getSelectedReleaseId` derivation the provider uses.
  */
 function DeferredActiveReleasesCounterfactual() {
-  const name = useSyncObservable(selectedReleaseName$)
+  const name = useSyncObservable(selectedReleaseName$, undefined)
   const {state$} = useReleasesStore()
-  const state = useObservable(state$)!
+  const state = useObservable(state$, undefined)!
   const data = useMemo(
     () =>
       sortReleases(
@@ -164,9 +164,9 @@ function DeferredActiveReleasesCounterfactual() {
  * `getSelectedVariant` derivation `PerspectiveProvider` uses.
  */
 function DeferredAllVariantsCounterfactual() {
-  const name = useSyncObservable(selectedVariantName$)
+  const name = useSyncObservable(selectedVariantName$, undefined)
   const {state$} = useVariantsStore()
-  const {variants} = useObservable(state$)!
+  const {variants} = useObservable(state$, undefined)!
   variantFrames.push({
     name,
     variantId: getSelectedVariant({selectedVariantName: name, variantsById: variants})?._id,
@@ -181,7 +181,7 @@ function DeferredAllVariantsCounterfactual() {
 function MixedSyncDeferredReleasesProbe() {
   const {data: active} = useActiveReleases()
   const {state$} = useReleasesStore()
-  const deferredState = useObservable(state$)!
+  const deferredState = useObservable(state$, undefined)!
   const all = useMemo(
     () => sortReleases(Array.from(deferredState.releases.values())),
     [deferredState.releases],

--- a/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
+++ b/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
@@ -8,11 +8,13 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {createTestProvider} from '../../../../test/testUtils/TestProvider'
 import {activeASAPRelease} from '../../releases/__fixtures__/release.fixture'
 import {sortReleases} from '../../releases/hooks/utils'
+import {INITIAL_RELEASES_STATE} from '../../releases/store/createReleaseStore'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {useAllReleases} from '../../releases/store/useAllReleases'
 import {useReleasesStore} from '../../releases/store/useReleasesStore'
 import {ARCHIVED_RELEASE_STATES} from '../../releases/util/const'
 import {variantAlphaAudience} from '../../variants/__fixtures__/variants.fixture'
+import {INITIAL_VARIANTS_STATE} from '../../variants/store/createVariantsStore'
 import {type VariantStoreState} from '../../variants/store/reducer'
 import {useVariantsStore} from '../../variants/store/useVariantsStore'
 import {getSelectedReleaseId} from '../getSelectedReleaseId'
@@ -104,7 +106,7 @@ function SyncVariantHarness() {
 function DeferredActiveReleasesCounterfactual() {
   const name = useSyncObservable(selectedReleaseName$, undefined)
   const {state$} = useReleasesStore()
-  const state = useObservable(state$, undefined)!
+  const state = useObservable(state$, INITIAL_RELEASES_STATE)
   const data = useMemo(
     () =>
       sortReleases(
@@ -121,7 +123,7 @@ function DeferredActiveReleasesCounterfactual() {
 function DeferredAllVariantsCounterfactual() {
   const name = useSyncObservable(selectedVariantName$, undefined)
   const {state$} = useVariantsStore()
-  const {variants} = useObservable(state$, undefined)!
+  const {variants} = useObservable(state$, INITIAL_VARIANTS_STATE)
   variantFrames.push({
     name,
     variantId: getSelectedVariant({selectedVariantName: name, variantsById: variants})?._id,
@@ -132,7 +134,7 @@ function DeferredAllVariantsCounterfactual() {
 function MixedSyncDeferredReleasesProbe() {
   const {data: active} = useActiveReleases()
   const {state$} = useReleasesStore()
-  const deferredState = useObservable(state$, undefined)!
+  const deferredState = useObservable(state$, INITIAL_RELEASES_STATE)
   const all = useMemo(
     () => sortReleases(Array.from(deferredState.releases.values())),
     [deferredState.releases],

--- a/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
+++ b/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
@@ -22,38 +22,8 @@ import {type ReleaseId} from '../types'
 import {usePerspective} from '../usePerspective'
 
 /**
- * Executable answer to the review follow-up on this PR:
- *
- * > "I'm not sure about the `useAllReleases`, `useActiveReleases` and
- * > `useAllVariants` hooks.. we can defer those, but it's ok to keep them
- * > sync now. We can have a follow up to verify that"
- *
- * Verdict, as proof: it is NOT safe to defer them — not even through
- * react-rx v5's identity-coherent deferred `useObservable`. Their store
- * observables have a stable identity for the lifetime of the workspace, so
- * the identity fallback never engages; deferral simply makes the
- * list lag one render behind urgent updates. The lists are paired with LIVE
- * selection state (the router-driven perspective / variant params feeding
- * `PerspectiveProvider`) and with each other, so that one-render lag is a
- * tear with real consequences:
- *
- * - `selectedReleaseId` resolves `undefined` under a just-selected release
- *   name (callers like reference create-in-place treat that as "no release").
- * - `selectedVariant` resolves `undefined` under a just-selected variant name
- *   (target-document scoping would bind to the wrong variant).
- * - a deferred `useAllReleases` disagrees with the synchronous
- *   `useActiveReleases` about the same store snapshot, producing the
- *   impossible state "active release missing from all releases".
- *
- * Each deferred counterfactual below is the exact hook body with only the
- * read made deferred, so these tests double as regression proofs: if the
- * hooks are ever deferred, the paired sync tests here spell out precisely
- * which coherent frames consumers rely on.
- *
- * The selection values are read synchronously from their own subjects (like
- * the live router state they model), so a single `act` batches "the store
- * learned about the release/variant" and "the user selected it" into one
- * update — the create-then-navigate flow.
+ * These store observables have stable identities, so deferred reads lag behind router-driven
+ * selection instead of switching to a live snapshot.
  */
 
 interface MockReleasesState {
@@ -71,8 +41,6 @@ const variantsState$ = new BehaviorSubject<VariantStoreState>({
   state: 'initialising',
 })
 
-// Live selection state, standing in for the router-driven perspective /
-// variant params. Read synchronously, never deferred — like the real thing.
 const selectedReleaseName$ = new BehaviorSubject<ReleaseId | undefined>(undefined)
 const selectedVariantName$ = new BehaviorSubject<string | undefined>(undefined)
 
@@ -95,9 +63,6 @@ const variantsLoaded: VariantStoreState = {
   state: 'loaded',
 }
 
-// Per-render frames recorded by the probes below. Assertions use
-// contains/not-contains (not exact sequences) so they stay robust to extra
-// renders.
 const releaseFrames: {name: string | undefined; releaseId: string | undefined}[] = []
 const variantFrames: {name: string | undefined; variantId: string | undefined}[] = []
 const crossFrames: {active: string[]; all: string[]}[] = []
@@ -108,7 +73,6 @@ function ReleaseIdProbe() {
   return null
 }
 
-/** The real provider fed by the live selection, as wired in the studio. */
 function SyncReleaseHarness() {
   const name = useSyncObservable(selectedReleaseName$, undefined)
   return (
@@ -137,11 +101,6 @@ function SyncVariantHarness() {
   )
 }
 
-/**
- * `useActiveReleases` body with only the read deferred — what the hook would
- * become if it adopted the deferred `useObservable` — paired with the same
- * live selection and `getSelectedReleaseId` derivation the provider uses.
- */
 function DeferredActiveReleasesCounterfactual() {
   const name = useSyncObservable(selectedReleaseName$, undefined)
   const {state$} = useReleasesStore()
@@ -159,10 +118,6 @@ function DeferredActiveReleasesCounterfactual() {
   return null
 }
 
-/**
- * `useAllVariants` body with only the read deferred, paired with the same
- * `getSelectedVariant` derivation `PerspectiveProvider` uses.
- */
 function DeferredAllVariantsCounterfactual() {
   const name = useSyncObservable(selectedVariantName$, undefined)
   const {state$} = useVariantsStore()
@@ -174,10 +129,6 @@ function DeferredAllVariantsCounterfactual() {
   return null
 }
 
-/**
- * The real synchronous `useActiveReleases` next to what `useAllReleases`
- * would return if deferred. Both read the same store observable.
- */
 function MixedSyncDeferredReleasesProbe() {
   const {data: active} = useActiveReleases()
   const {state$} = useReleasesStore()
@@ -193,7 +144,6 @@ function MixedSyncDeferredReleasesProbe() {
   return null
 }
 
-/** Control: both real (synchronous) hooks over the same store. */
 function SyncReleasesProbe() {
   const {data: active} = useActiveReleases()
   const {data: all} = useAllReleases()
@@ -220,15 +170,12 @@ describe('deferral safety of useActiveReleases / useAllVariants / useAllReleases
       const wrapper = await createTestProvider()
       render(<SyncReleaseHarness />, {wrapper})
 
-      // Model "create release, then navigate to it in the same handler": the
-      // store emits the new release and the selection updates in one batch.
       act(() => {
         releasesState$.next(releasesLoaded)
         selectedReleaseName$.next(RELEASE_NAME)
       })
 
       expect(releaseFrames).toContainEqual({name: RELEASE_NAME, releaseId: RELEASE_NAME})
-      // The frame a deferred list would produce must never be committed.
       expect(releaseFrames).not.toContainEqual({name: RELEASE_NAME, releaseId: undefined})
     })
 
@@ -240,11 +187,7 @@ describe('deferral safety of useActiveReleases / useAllVariants / useAllReleases
         selectedReleaseName$.next(RELEASE_NAME)
       })
 
-      // The tear: the new perspective name paired with the stale (empty)
-      // deferred list — this is the frame the sync test proves never happens.
       expect(releaseFrames).toContainEqual({name: RELEASE_NAME, releaseId: undefined})
-      // It converges afterwards, but consumers have already observed the
-      // torn frame (e.g. reference create-in-place reading "no release").
       expect(releaseFrames[releaseFrames.length - 1]).toEqual({
         name: RELEASE_NAME,
         releaseId: RELEASE_NAME,
@@ -311,10 +254,6 @@ describe('deferral safety of useActiveReleases / useAllVariants / useAllReleases
         releasesState$.next(releasesLoaded)
       })
 
-      // The tear: the sync hook already contains the release while the
-      // deferred read of the very same store snapshot does not. Consumers
-      // pairing the two lists (e.g. document actions gating on membership)
-      // cannot defend against this frame.
       expect(crossFrames).toContainEqual({active: [activeASAPRelease._id], all: []})
       expect(crossFrames[crossFrames.length - 1]).toEqual({
         active: [activeASAPRelease._id],

--- a/packages/sanity/src/core/releases/components/CreateReleaseMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/CreateReleaseMenuItem.tsx
@@ -28,6 +28,7 @@ export const CreateReleaseMenuItem: ComponentType<Props> = ({onCreateRelease}) =
         from(checkWithPermissionGuard(createRelease, createReleaseMetadata(getReleaseDefaults()))),
       [checkWithPermissionGuard, createRelease, createReleaseMetadata],
     ),
+    undefined,
   )
 
   const activeReleases = useActiveReleases()

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -35,7 +35,7 @@ const useVersionIsLinked = (documentId: string, fromRelease: string) => {
   // read can't report linkage for a previous document. react-rx v5's
   // identity-coherent deferral also falls back to the live value if the
   // observable identity changes without a remount.
-  const companionDocs = useObservable(companionDocs$)
+  const companionDocs = useObservable(companionDocs$, undefined)
   return companionDocs?.data.some((companion) => companion?.studioDocumentId === versionId)
 }
 

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -7,6 +7,7 @@ import {memo, type ReactNode, useEffect, useMemo, useRef} from 'react'
 import {useObservable} from 'react-rx'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
+import {INITIAL_COMPANION_DOCS} from '../../../canvas/store/createCanvasCompanionDocsStore'
 import {useCanvasCompanionDocsStore} from '../../../canvas/store/useCanvasCompanionDocsStore'
 import {useReleasesToolAvailable} from '../../../schedules/hooks/useReleasesToolAvailable'
 import {getDraftId, getPublishedId, getVersionId} from '../../../util/draftUtils'
@@ -30,8 +31,8 @@ const useVersionIsLinked = (documentId: string, fromRelease: string) => {
     () => companionDocsStore.getCompanionDocs(documentId),
     [documentId, companionDocsStore],
   )
-  const companionDocs = useObservable(companionDocs$, undefined)
-  return companionDocs?.data.some((companion) => companion?.studioDocumentId === versionId)
+  const companionDocs = useObservable(companionDocs$, INITIAL_COMPANION_DOCS)
+  return companionDocs.data.some((companion) => companion?.studioDocumentId === versionId)
 }
 
 /**

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -30,11 +30,6 @@ const useVersionIsLinked = (documentId: string, fromRelease: string) => {
     () => companionDocsStore.getCompanionDocs(documentId),
     [documentId, companionDocsStore],
   )
-  // Deferred (per review): navigating to another document remounts the
-  // document pane (its `_key` changes), resetting this state, so a deferred
-  // read can't report linkage for a previous document. react-rx v5's
-  // identity-coherent deferral also falls back to the live value if the
-  // observable identity changes without a remount.
   const companionDocs = useObservable(companionDocs$, undefined)
   return companionDocs?.data.some((companion) => companion?.studioDocumentId === versionId)
 }

--- a/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
@@ -33,7 +33,7 @@ const ReleasesMetadataProviderInner = ({children}: {children: React.ReactNode}) 
     [getMetadataStateForSlugs$, listenerReleaseIds],
   )
 
-  const observedResult = useObservable(memoObservable) || DEFAULT_METADATA_STATE
+  const observedResult = useObservable(memoObservable, undefined) || DEFAULT_METADATA_STATE
 
   // patch metadata in local state
   useEffect(

--- a/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
@@ -21,6 +21,13 @@ const DEFAULT_METADATA_STATE: MetadataWrapper = {
   loading: false,
 }
 
+// What the aggregator emits first for a non-empty set of release ids, while their fetch is pending
+const LOADING_METADATA_STATE: MetadataWrapper = {
+  data: null,
+  error: null,
+  loading: true,
+}
+
 const ReleasesMetadataProviderInner = ({children}: {children: React.ReactNode}) => {
   const [listenerReleaseIds, setListenerReleaseIds] = useState<string[]>([])
   const {getMetadataStateForSlugs$} = useReleasesStore()
@@ -33,7 +40,11 @@ const ReleasesMetadataProviderInner = ({children}: {children: React.ReactNode}) 
     [getMetadataStateForSlugs$, listenerReleaseIds],
   )
 
-  const observedResult = useObservable(memoObservable, undefined) || DEFAULT_METADATA_STATE
+  // Until the subscription for the current set of release ids emits (react-rx subscribes on
+  // commit), report what the aggregator emits first for that set: a non-empty set starts loading.
+  const observedResult =
+    useObservable(memoObservable, undefined) ??
+    (listenerReleaseIds.length > 0 ? LOADING_METADATA_STATE : DEFAULT_METADATA_STATE)
 
   // patch metadata in local state
   useEffect(

--- a/packages/sanity/src/core/releases/contexts/__tests__/ReleasesMetadataProvider.test.tsx
+++ b/packages/sanity/src/core/releases/contexts/__tests__/ReleasesMetadataProvider.test.tsx
@@ -1,0 +1,62 @@
+import {act, render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {of, startWith, Subject} from 'rxjs'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {type MetadataWrapper} from '../../store/createReleaseMetadataAggregator'
+import {ReleasesMetadataProvider, useReleasesMetadataProvider} from '../ReleasesMetadataProvider'
+
+const fetch$ = new Subject<MetadataWrapper>()
+const getMetadataStateForSlugs$ = vi.fn((releaseIds: string[]) =>
+  // like the aggregator: a non-empty set of ids starts loading, an empty set is idle
+  releaseIds.length
+    ? fetch$.pipe(startWith({data: null, error: null, loading: true} satisfies MetadataWrapper))
+    : of({data: null, error: null, loading: false} satisfies MetadataWrapper),
+)
+
+vi.mock('../../store/useReleasesStore', () => ({
+  useReleasesStore: () => ({getMetadataStateForSlugs$}),
+}))
+
+interface Frame {
+  loading: boolean
+  data: MetadataWrapper['data']
+}
+
+function Consumer({frames}: {frames: Frame[]}) {
+  const {state, addReleaseIdsToListener} = useReleasesMetadataProvider()
+  frames.push({loading: state.loading, data: state.data})
+  return (
+    <button type="button" onClick={() => addReleaseIdsToListener(['_.releases.r1'])}>
+      listen
+    </button>
+  )
+}
+
+beforeEach(() => {
+  getMetadataStateForSlugs$.mockClear()
+})
+
+it('reports loading from the render that adds the first release id until its metadata arrives', async () => {
+  const frames: Frame[] = []
+  render(
+    <ReleasesMetadataProvider>
+      <Consumer frames={frames} />
+    </ReleasesMetadataProvider>,
+  )
+  expect(frames.at(-1)).toEqual({loading: false, data: null})
+  const idle = frames.length
+
+  await userEvent.click(screen.getByRole('button'))
+
+  expect(getMetadataStateForSlugs$).toHaveBeenLastCalledWith(['_.releases.r1'])
+  // no frame claims the metadata is loaded while the fetch is pending
+  expect(frames.length).toBeGreaterThan(idle)
+  expect(frames.slice(idle).every((frame) => frame.loading)).toBe(true)
+
+  const metadata = {'_.releases.r1': {updatedAt: '2026-09-11T00:00:00Z', documentCount: 2}}
+  act(() => {
+    fetch$.next({data: metadata, error: null, loading: false})
+  })
+  expect(frames.at(-1)).toEqual({loading: false, data: metadata})
+})

--- a/packages/sanity/src/core/releases/store/createReleaseStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseStore.ts
@@ -63,7 +63,11 @@ const QUERY_SORT_ORDER = `order(${SORT_FIELD} ${SORT_ORDER})`
 
 const QUERY = `*[${QUERY_FILTER}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`
 
-const INITIAL_STATE: ReleasesReducerState = {
+/**
+ * What `state$` emits first for a cold store; also the value the hooks render until it emits.
+ * @internal
+ */
+export const INITIAL_RELEASES_STATE: ReleasesReducerState = {
   releases: new Map(),
   state: 'initialising' as const,
 }
@@ -141,8 +145,8 @@ export function createReleaseStore(context: {
 
   const state$ = concat(merge(listFetch$, dispatch$)).pipe(
     filter((action): action is ReleasesReducerAction => typeof action !== 'undefined'),
-    scan((state, action) => releasesReducer(state, action), INITIAL_STATE),
-    startWith(INITIAL_STATE),
+    scan((state, action) => releasesReducer(state, action), INITIAL_RELEASES_STATE),
+    startWith(INITIAL_RELEASES_STATE),
     shareReplay(1),
   )
 

--- a/packages/sanity/src/core/releases/store/useActiveReleases.ts
+++ b/packages/sanity/src/core/releases/store/useActiveReleases.ts
@@ -29,7 +29,7 @@ export function useActiveReleases(): ReleasesState {
   // snapshot could tear the release identity (e.g. reference create-in-place
   // writing `_weak` or opening the wrong version). Executable proof:
   // perspective/__tests__/deferralSafety.test.tsx.
-  const state = useSyncObservable(state$)!
+  const state = useSyncObservable(state$, undefined)!
   const releasesAsArray = useMemo(
     () =>
       sortReleases(

--- a/packages/sanity/src/core/releases/store/useActiveReleases.ts
+++ b/packages/sanity/src/core/releases/store/useActiveReleases.ts
@@ -4,6 +4,7 @@ import {useSyncObservable} from 'react-rx'
 
 import {sortReleases} from '../hooks/utils'
 import {ARCHIVED_RELEASE_STATES} from '../util/const'
+import {INITIAL_RELEASES_STATE} from './createReleaseStore'
 import {type ReleasesReducerAction} from './reducer'
 import {useReleasesStore} from './useReleasesStore'
 
@@ -29,7 +30,7 @@ export function useActiveReleases(): ReleasesState {
   // snapshot could tear the release identity (e.g. reference create-in-place
   // writing `_weak` or opening the wrong version). Executable proof:
   // perspective/__tests__/deferralSafety.test.tsx.
-  const state = useSyncObservable(state$, undefined)!
+  const state = useSyncObservable(state$, INITIAL_RELEASES_STATE)
   const releasesAsArray = useMemo(
     () =>
       sortReleases(

--- a/packages/sanity/src/core/releases/store/useAllReleases.ts
+++ b/packages/sanity/src/core/releases/store/useAllReleases.ts
@@ -21,7 +21,7 @@ export function useAllReleases(): {
   // pair a stale release list with the current selection — or disagree with
   // the synchronous `useActiveReleases` read of the same store. Executable
   // proof: perspective/__tests__/deferralSafety.test.tsx.
-  const {releases, error, state} = useSyncObservable(state$)!
+  const {releases, error, state} = useSyncObservable(state$, undefined)!
 
   return useMemo(
     () => ({

--- a/packages/sanity/src/core/releases/store/useAllReleases.ts
+++ b/packages/sanity/src/core/releases/store/useAllReleases.ts
@@ -3,6 +3,7 @@ import {useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
 
 import {sortReleases} from '../hooks/utils'
+import {INITIAL_RELEASES_STATE} from './createReleaseStore'
 import {useReleasesStore} from './useReleasesStore'
 
 /**
@@ -21,7 +22,7 @@ export function useAllReleases(): {
   // pair a stale release list with the current selection — or disagree with
   // the synchronous `useActiveReleases` read of the same store. Executable
   // proof: perspective/__tests__/deferralSafety.test.tsx.
-  const {releases, error, state} = useSyncObservable(state$, undefined)!
+  const {releases, error, state} = useSyncObservable(state$, INITIAL_RELEASES_STATE)
 
   return useMemo(
     () => ({

--- a/packages/sanity/src/core/scheduled-publishing/hooks/usePreviewState.ts
+++ b/packages/sanity/src/core/scheduled-publishing/hooks/usePreviewState.ts
@@ -22,8 +22,5 @@ export default function usePreviewState(
     [documentPreviewStore, schemaType, documentId],
   )
 
-  // Deferred: react-rx v5's deferral is identity-coherent, so on a document
-  // id change the live snapshot wins and the previous document's preview
-  // never renders under the new id.
   return useObservable(preview$, EMPTY_STATE)
 }

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -127,7 +127,7 @@ export function createLoginComponent({
     // URL change, which triggers a full reload — so `client$` doesn't swap
     // under a mounted login screen. react-rx v5's identity-coherent deferral
     // also falls back to the live value if the client ever does change.
-    const client = useObservable(client$)
+    const client = useObservable(client$, undefined)
 
     const getProviderData = useCallback(async () => {
       let providers = [] as AuthProvider[]

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -123,10 +123,6 @@ export function createLoginComponent({
     const [error, setError] = useState<unknown>(null)
     if (error) throw error
 
-    // Deferred (per review): the only way to change workspace mid-login is a
-    // URL change, which triggers a full reload — so `client$` doesn't swap
-    // under a mounted login screen. react-rx v5's identity-coherent deferral
-    // also falls back to the live value if the client ever does change.
     const client = useObservable(client$, undefined)
 
     const getProviderData = useCallback(async () => {

--- a/packages/sanity/src/core/store/comlink/createComlinkStore.test.ts
+++ b/packages/sanity/src/core/store/comlink/createComlinkStore.test.ts
@@ -1,0 +1,35 @@
+import {createNode} from '@sanity/comlink'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {createComlinkStore} from './createComlinkStore'
+
+const nodeStart = vi.fn(() => vi.fn())
+vi.mock('@sanity/comlink', () => ({
+  createNode: vi.fn(() => ({start: nodeStart})),
+}))
+
+beforeEach(() => {
+  vi.mocked(createNode).mockClear()
+  nodeStart.mockClear()
+})
+
+it('creates the node without starting it, and starts it once on demand', () => {
+  const store = createComlinkStore({capabilities: {comlink: true}})
+
+  expect(createNode).toHaveBeenCalledTimes(1)
+  expect(store.node).toBeDefined()
+  expect(nodeStart).not.toHaveBeenCalled()
+
+  // every consumer asks for a start; the node is only started once
+  store.start()
+  store.start()
+  expect(nodeStart).toHaveBeenCalledTimes(1)
+})
+
+it('creates no node when the rendering context does not provide comlink', () => {
+  const store = createComlinkStore({capabilities: {}})
+
+  expect(createNode).not.toHaveBeenCalled()
+  expect(store.node).toBeUndefined()
+  expect(() => store.start()).not.toThrow()
+})

--- a/packages/sanity/src/core/store/comlink/createComlinkStore.ts
+++ b/packages/sanity/src/core/store/comlink/createComlinkStore.ts
@@ -15,14 +15,18 @@ interface Options {
 const SDK_CHANNEL_NAME = 'dashboard/channels/sdk'
 const SDK_NODE_NAME = 'dashboard/nodes/sdk'
 
+function noop() {}
+
 /**
- * Create a Comlink node if Comlink is provided by the Studio rendering context.
+ * Create a Comlink node if Comlink is provided by the Studio rendering context. The node is not
+ * started here — the store is created during render — but by the first `start()` call, which
+ * `useComlinkStore` makes once the consumer has committed.
  *
  * @internal
  */
 export function createComlinkStore({capabilities}: Options): ComlinkStore {
   if (!capabilities.comlink) {
-    return {}
+    return {start: noop}
   }
 
   const node = createNode<FrameMessages, WindowMessages>({
@@ -30,9 +34,14 @@ export function createComlinkStore({capabilities}: Options): ComlinkStore {
     connectTo: SDK_CHANNEL_NAME,
   })
 
-  node.start()
+  let started = false
 
   return {
     node,
+    start: () => {
+      if (started) return
+      started = true
+      node.start()
+    },
   }
 }

--- a/packages/sanity/src/core/store/comlink/types.ts
+++ b/packages/sanity/src/core/store/comlink/types.ts
@@ -3,4 +3,10 @@ import {type FrameMessages, type WindowMessages} from '@sanity/message-protocol'
 
 export interface ComlinkStore {
   node?: Node<FrameMessages, WindowMessages>
+  /**
+   * Starts the node the first time it is called; later calls do nothing. Rendering must not start
+   * it: `useComlinkStore` calls this from an effect, so a render React abandons never leaves a
+   * started node behind. Messages posted before the start are queued by the node until then.
+   */
+  start: () => void
 }

--- a/packages/sanity/src/core/store/comlink/useComlinkStore.test.tsx
+++ b/packages/sanity/src/core/store/comlink/useComlinkStore.test.tsx
@@ -1,0 +1,53 @@
+import {createNode} from '@sanity/comlink'
+import {render} from '@testing-library/react'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {useComlinkStore} from '../datastores'
+import type * as RenderingContextStoreModule from '../renderingContext/createRenderingContextStore'
+import {ResourceCacheProvider} from '../ResourceCacheProvider'
+
+const CORE_UI_SEARCH = `?_context=${encodeURIComponent(
+  JSON.stringify({mode: 'core-ui', env: 'test'}),
+)}`
+
+const nodeStart = vi.fn(() => vi.fn())
+vi.mock('@sanity/comlink', () => ({
+  createNode: vi.fn(() => ({start: nodeStart})),
+}))
+
+// The studio is rendered inside core ui, which provides comlink
+vi.mock('../renderingContext/createRenderingContextStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof RenderingContextStoreModule>()
+  return {
+    ...actual,
+    createRenderingContextStore: () => actual.createRenderingContextStore(CORE_UI_SEARCH),
+  }
+})
+
+beforeEach(() => {
+  vi.mocked(createNode).mockClear()
+  nodeStart.mockClear()
+})
+
+it('creates the comlink node for the mounting render but starts it only on commit', () => {
+  const startsSeenWhileRendering: number[] = []
+  function Consumer() {
+    const {node} = useComlinkStore()
+    startsSeenWhileRendering.push(nodeStart.mock.calls.length)
+    return <span data-node={node ? 'yes' : 'no'} />
+  }
+
+  const {container} = render(
+    <ResourceCacheProvider>
+      <Consumer />
+      <Consumer />
+    </ResourceCacheProvider>,
+  )
+
+  // the capabilities are resolved up front, so the node exists from the first render on...
+  expect(container.querySelectorAll('[data-node="yes"]')).toHaveLength(2)
+  expect(createNode).toHaveBeenCalledTimes(1)
+  // ...but no render — a render React may abandon — started it; the commit did, once for both consumers
+  expect(startsSeenWhileRendering.every((count) => count === 0)).toBe(true)
+  expect(nodeStart).toHaveBeenCalledTimes(1)
+})

--- a/packages/sanity/src/core/store/datastores.ts
+++ b/packages/sanity/src/core/store/datastores.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {useToast} from '@sanity/ui/toast'
-import {useCallback, useMemo} from 'react'
+import {useCallback, useEffect, useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
 
 import {useClient} from '../hooks/useClient'
@@ -448,19 +448,19 @@ export function useRenderingContextStore(): RenderingContextStore {
 export function useComlinkStore(): ComlinkStore {
   const resourceCache = useResourceCache()
   const renderingContext = useRenderingContextStore()
-  // Kept synchronous: `createComlinkStore` starts the comlink node when
-  // `capabilities.comlink` flips true, so a deferred snapshot would delay
-  // comlink initialization. Capabilities emit once at boot; there is nothing
-  // to gain from deferring them. The store has already resolved them, so the
-  // comlink store is created for the actual capabilities right away instead
-  // of once for `{}` and again after the first emission.
+  // Kept synchronous: the comlink node is created when `capabilities.comlink`
+  // is true, so a deferred snapshot would delay comlink initialization.
+  // Capabilities emit once at boot; there is nothing to gain from deferring
+  // them. The store has already resolved them, so the comlink store is created
+  // for the actual capabilities right away instead of once for `{}` and again
+  // after the first emission.
   const capabilities = useSyncObservable(
     renderingContext.capabilities,
     () => renderingContext.getCapabilities() ?? EMPTY_CAPABILITIES,
   )
 
-  return useMemo(() => {
-    const comlinkStore =
+  const comlinkStore = useMemo(() => {
+    const store =
       resourceCache.get<ComlinkStore>({
         dependencies: [capabilities],
         namespace: 'ComlinkStore',
@@ -469,9 +469,18 @@ export function useComlinkStore(): ComlinkStore {
     resourceCache.set({
       dependencies: [capabilities],
       namespace: 'ComlinkStore',
-      value: comlinkStore,
+      value: store,
     })
 
-    return comlinkStore
+    return store
   }, [capabilities, resourceCache])
+
+  // The store is created during render, which React may abandon; the node is
+  // only started once a consumer commits. Starting is idempotent, so every
+  // consumer may ask for it.
+  useEffect(() => {
+    comlinkStore.start()
+  }, [comlinkStore])
+
+  return comlinkStore
 }

--- a/packages/sanity/src/core/store/datastores.ts
+++ b/packages/sanity/src/core/store/datastores.ts
@@ -44,13 +44,15 @@ import {createPresenceStore, type PresenceStore} from './presence/presence-store
 import {createProjectStore} from './project/projectStore'
 import {type ProjectStore} from './project/types'
 import {createRenderingContextStore} from './renderingContext/createRenderingContextStore'
-import {type RenderingContextStore} from './renderingContext/types'
+import {type CapabilityRecord, type RenderingContextStore} from './renderingContext/types'
 import {useResourceCache} from './ResourceCacheProvider'
 import {createUserStore, type UserStore} from './user/userStore'
 
 /**
  * Latencies below this value will not be logged
  */
+const EMPTY_CAPABILITIES: CapabilityRecord = {}
+
 const IGNORE_LATENCY_BELOW_MS = 1000
 
 /** Minimum time between slow commit toast notifications */
@@ -449,8 +451,13 @@ export function useComlinkStore(): ComlinkStore {
   // Kept synchronous: `createComlinkStore` starts the comlink node when
   // `capabilities.comlink` flips true, so a deferred snapshot would delay
   // comlink initialization. Capabilities emit once at boot; there is nothing
-  // to gain from deferring them.
-  const capabilities = useSyncObservable(renderingContext.capabilities, {})
+  // to gain from deferring them. The store has already resolved them, so the
+  // comlink store is created for the actual capabilities right away instead
+  // of once for `{}` and again after the first emission.
+  const capabilities = useSyncObservable(
+    renderingContext.capabilities,
+    () => renderingContext.getCapabilities() ?? EMPTY_CAPABILITIES,
+  )
 
   return useMemo(() => {
     const comlinkStore =

--- a/packages/sanity/src/core/store/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/document/document-pair/editState.ts
@@ -89,6 +89,35 @@ function classifyRelease(
   return getReleaseIdFromReleaseDocumentId(releaseRef)
 }
 
+/**
+ * The edit state before any snapshot has arrived. `editState` emits it first, and `useEditState`
+ * renders it until the pipeline emits.
+ *
+ * @internal
+ */
+export function getInitialEditState(
+  schema: Schema,
+  idPair: IdPair,
+  typeName: string,
+): EditStateFor {
+  const liveEditSchemaType = isLiveEditEnabled(schema, typeName)
+  const scopeId = idPair.versionId ? getVersionFromId(idPair.versionId) : undefined
+
+  return {
+    id: idPair.publishedId,
+    type: typeName,
+    draft: null,
+    published: null,
+    version: null,
+    liveEdit: typeof idPair.versionId !== 'undefined' || liveEditSchemaType,
+    liveEditSchemaType,
+    ready: false,
+    transactionSyncLock: null,
+    release: scopeId,
+    scopeId,
+  }
+}
+
 // How long to keep the pipeline alive after the last subscriber unsubscribes.
 // Subscriber churn (e.g. a React commit that unsubscribes every consumer before
 // the replacements subscribe) can momentarily drop the refcount to zero. A bare
@@ -115,9 +144,8 @@ export const editState = memoize(
     idPair: IdPair,
     typeName: string,
   ): Observable<EditStateFor> => {
-    const liveEditSchemaType = isLiveEditEnabled(ctx.schema, typeName)
-    const liveEdit = typeof idPair.versionId !== 'undefined' || liveEditSchemaType
-    const scopeId = idPair.versionId ? getVersionFromId(idPair.versionId) : undefined
+    const initialState = getInitialEditState(ctx.schema, idPair, typeName)
+    const {liveEdit, liveEditSchemaType, scopeId} = initialState
 
     return snapshotPair(ctx.client, idPair, typeName, undefined, ctx.extraOptions).pipe(
       switchMap((versions) =>
@@ -168,19 +196,7 @@ export const editState = memoize(
           scopeId,
         }),
       ),
-      startWith({
-        id: idPair.publishedId,
-        type: typeName,
-        draft: null,
-        published: null,
-        version: null,
-        liveEdit,
-        liveEditSchemaType,
-        ready: false,
-        transactionSyncLock: null,
-        release: scopeId,
-        scopeId,
-      }),
+      startWith(initialState),
       // Unlike `publishReplay(1) + refCount()`, this resets the replay subject
       // when the pipeline is torn down, so a later cold subscriber won't get a
       // stale `ready: true` replayed before the cold-start emissions (and an

--- a/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
+++ b/packages/sanity/src/core/store/document/hooks/__tests__/useDocumentValuesRenderLoop.repro.test.tsx
@@ -1,26 +1,4 @@
-/**
- * Regression guard for a render loop reported from the field (customer
- * profile showed ~60 update passes/second, sustained, studio-wide slowdown).
- *
- * `useDocumentValues(documentId, paths)` used to memoize its observable on
- * the `paths` ARRAY REFERENCE. A caller passing an inline literal — the
- * natural call shape, e.g. `useDocumentValues(id, ['title'])` — busted the
- * memo every render: each render built a new observable (the preview store's
- * observePaths returns a fresh pipeline per call), react-rx treated it as a
- * brand-new external store whose warm-up replays the cached value
- * synchronously, and the fresh snapshot forced another render — around again
- * forever (~22k renders in 500ms before the fix; the hook now keys the memo
- * on path CONTENTS via useShallowUnique).
- *
- * Version-linked: under react-rx v4 (studio before 6.9.0) the unfixed inline case
- * rendered exactly twice and settled — the footgun was latent. Under v5
- * (adopted in 6.9.0 via #13799 + #13814) each new identity's deferred pass
- * re-rendered and minted another identity, closing the loop (verified by
- * swapping the react-rx resolution to 4.2.5 and re-running).
- *
- * Mounted via a raw createRoot with IS_REACT_ACT_ENVIRONMENT disabled: act
- * would flush and mask the loop's scheduling.
- */
+/** Uses a raw root because `act` masks the scheduling that caused the original loop. */
 import {createRoot, type Root} from 'react-dom/client'
 import {BehaviorSubject} from 'rxjs'
 import {map} from 'rxjs/operators'
@@ -32,11 +10,8 @@ declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean | undefined
 }
 
-// Mirrors the real preview store's shape: the underlying value is cached and
-// replays synchronously to new subscribers, but every observePaths() call
-// returns a NEW observable identity (createPathObserver builds a fresh
-// pipeline per call)
 const cachedValue$ = new BehaviorSubject<Record<string, unknown>>({title: 'hello'})
+// Each call must return a new observable identity to reproduce the original bug.
 const observePaths = vi.fn(() => cachedValue$.pipe(map((value) => value)))
 const mockPreviewStore = {observePaths}
 vi.mock('../../../datastores', () => ({
@@ -48,7 +23,6 @@ const counters = {inline: 0, stable: 0}
 function InlineProbe() {
   // oxlint-disable-next-line react/immutability -- deliberate render counter: this guard exists to make a loop measurable
   counters.inline++
-  // The footgun call shape: fresh array literal every render
   const {value} = useDocumentValues<{title?: string}>('doc-inline', ['title'])
   return <div data-testid="inline">{value?.title}</div>
 }

--- a/packages/sanity/src/core/store/document/hooks/useDocumentValues.ts
+++ b/packages/sanity/src/core/store/document/hooks/useDocumentValues.ts
@@ -12,11 +12,6 @@ export function useDocumentValues<T = Record<string, unknown>>(
 ): LoadableState<T | undefined> {
   const documentPreviewStore = useDocumentPreviewStore()
 
-  // Consumers routinely pass `paths` as an inline literal. Keying the memo on
-  // the array reference would rebuild the observable on every render, which
-  // react-rx v5 turns into a self-sustaining render loop (each new identity's
-  // deferred pass re-renders, minting another identity — see
-  // __tests__/useDocumentValuesRenderLoop.repro.test.tsx). Key on contents.
   const stablePaths = useShallowUnique(paths)
 
   const documentValues$ = useMemo(

--- a/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.test.ts
@@ -34,4 +34,13 @@ describe('capabilities', () => {
     const {capabilities} = createRenderingContextStore()
     expect(await firstValueFrom(capabilities)).toEqual({})
   })
+
+  it('resolves the capabilities synchronously when the store is created', () => {
+    expect(createRenderingContextStore().getCapabilities()).toEqual({})
+    expect(createRenderingContextStore(CORE_UI_SEARCH).getCapabilities()).toEqual({
+      globalUserMenu: true,
+      globalWorkspaceControl: true,
+      comlink: true,
+    })
+  })
 })

--- a/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.test.ts
@@ -3,6 +3,10 @@ import {describe, expect, it} from 'vitest'
 
 import {createRenderingContextStore} from './createRenderingContextStore'
 
+const CORE_UI_SEARCH = `?_context=${encodeURIComponent(
+  JSON.stringify({mode: 'core-ui', env: 'test'}),
+)}`
+
 describe('renderingContext', () => {
   it('emits rendering context', async () => {
     const {renderingContext} = createRenderingContextStore()
@@ -10,6 +14,17 @@ describe('renderingContext', () => {
     expect(await firstValueFrom(renderingContext)).toEqual({
       name: 'default',
       metadata: {},
+    })
+  })
+
+  it('resolves the rendering context synchronously when the store is created', () => {
+    expect(createRenderingContextStore().getRenderingContext()).toEqual({
+      name: 'default',
+      metadata: {},
+    })
+    expect(createRenderingContextStore(CORE_UI_SEARCH).getRenderingContext()).toEqual({
+      name: 'coreUi',
+      metadata: {environment: 'test'},
     })
   })
 })

--- a/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.ts
+++ b/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.ts
@@ -3,7 +3,11 @@ import {of, shareReplay} from 'rxjs'
 import {coreUiRenderingContext} from './coreUiRenderingContext'
 import {defaultRenderingContext} from './defaultRenderingContext'
 import {listCapabilities} from './listCapabilities'
-import {type RenderingContextStore, type StudioRenderingContext} from './types'
+import {
+  type CapabilityRecord,
+  type RenderingContextStore,
+  type StudioRenderingContext,
+} from './types'
 
 /**
  * Rendering Context Store provides information about where Studio is being rendered, and which
@@ -27,16 +31,21 @@ export function createRenderingContextStore(urlSearch?: string): RenderingContex
   const capabilities = renderingContext.pipe(listCapabilities(), shareReplay(1))
 
   // The context is static for the lifetime of the page and the pipeline resolves it synchronously
-  // (the source completes right away), so connect it once here and keep the result: consumers read
-  // it during render, where nothing may subscribe.
+  // (the source completes right away), so connect both streams once here and keep the results:
+  // consumers read them during render, where nothing may subscribe.
   let resolvedRenderingContext: StudioRenderingContext | undefined
   renderingContext.subscribe((value) => {
     resolvedRenderingContext = value
+  })
+  let resolvedCapabilities: CapabilityRecord | undefined
+  capabilities.subscribe((value) => {
+    resolvedCapabilities = value
   })
 
   return {
     renderingContext,
     capabilities,
     getRenderingContext: () => resolvedRenderingContext,
+    getCapabilities: () => resolvedCapabilities,
   }
 }

--- a/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.ts
+++ b/packages/sanity/src/core/store/renderingContext/createRenderingContextStore.ts
@@ -3,7 +3,7 @@ import {of, shareReplay} from 'rxjs'
 import {coreUiRenderingContext} from './coreUiRenderingContext'
 import {defaultRenderingContext} from './defaultRenderingContext'
 import {listCapabilities} from './listCapabilities'
-import {type RenderingContextStore} from './types'
+import {type RenderingContextStore, type StudioRenderingContext} from './types'
 
 /**
  * Rendering Context Store provides information about where Studio is being rendered, and which
@@ -12,19 +12,31 @@ import {type RenderingContextStore} from './types'
  * This can be used to adapt parts of the Studio UI that are provided by the rendering context,
  * such as the global user menu.
  *
+ * @param urlSearch - The URL query string to resolve the rendering context from; defaults to the
+ * one captured when the studio booted.
+ *
  * @internal
  */
-export function createRenderingContextStore(): RenderingContextStore {
+export function createRenderingContextStore(urlSearch?: string): RenderingContextStore {
   const renderingContext = of(undefined).pipe(
-    coreUiRenderingContext(),
+    coreUiRenderingContext(urlSearch),
     defaultRenderingContext(),
     shareReplay(1),
   )
 
   const capabilities = renderingContext.pipe(listCapabilities(), shareReplay(1))
 
+  // The context is static for the lifetime of the page and the pipeline resolves it synchronously
+  // (the source completes right away), so connect it once here and keep the result: consumers read
+  // it during render, where nothing may subscribe.
+  let resolvedRenderingContext: StudioRenderingContext | undefined
+  renderingContext.subscribe((value) => {
+    resolvedRenderingContext = value
+  })
+
   return {
     renderingContext,
     capabilities,
+    getRenderingContext: () => resolvedRenderingContext,
   }
 }

--- a/packages/sanity/src/core/store/renderingContext/types.ts
+++ b/packages/sanity/src/core/store/renderingContext/types.ts
@@ -52,6 +52,12 @@ export type CapabilityRecord = Partial<Record<Capability, boolean>>
 export type RenderingContextStore = {
   renderingContext: Observable<StudioRenderingContext>
   capabilities: Observable<CapabilityRecord>
+  /**
+   * The rendering context the store resolved when it was created — the value `renderingContext`
+   * replays — for reading during render, where nothing may subscribe. `undefined` only while the
+   * context is unresolved, which the store's own synchronous pipeline never is.
+   */
+  getRenderingContext: () => StudioRenderingContext | undefined
 }
 
 /**

--- a/packages/sanity/src/core/store/renderingContext/types.ts
+++ b/packages/sanity/src/core/store/renderingContext/types.ts
@@ -58,6 +58,11 @@ export type RenderingContextStore = {
    * context is unresolved, which the store's own synchronous pipeline never is.
    */
   getRenderingContext: () => StudioRenderingContext | undefined
+  /**
+   * The capabilities of that rendering context — the value `capabilities` replays — for reading
+   * during render, on the same terms as `getRenderingContext`.
+   */
+  getCapabilities: () => CapabilityRecord | undefined
 }
 
 /**

--- a/packages/sanity/src/core/store/renderingContext/useRenderingContext.test.tsx
+++ b/packages/sanity/src/core/store/renderingContext/useRenderingContext.test.tsx
@@ -1,0 +1,55 @@
+import {render} from '@testing-library/react'
+import {of, shareReplay} from 'rxjs'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {useRenderingContextStore} from '../datastores'
+import {coreUiRenderingContext} from './coreUiRenderingContext'
+import {defaultRenderingContext} from './defaultRenderingContext'
+import {listCapabilities} from './listCapabilities'
+import {type RenderingContextStore, type StudioRenderingContext} from './types'
+import {useRenderingContext} from './useRenderingContext'
+
+vi.mock('../datastores')
+
+const CORE_UI_SEARCH = `?_context=${encodeURIComponent(
+  JSON.stringify({mode: 'core-ui', env: 'test'}),
+)}`
+
+// The same pipeline as `createRenderingContextStore`, for a given URL query string
+function createStore(urlSearch: string): RenderingContextStore {
+  const renderingContext = of(undefined).pipe(
+    coreUiRenderingContext(urlSearch),
+    defaultRenderingContext(),
+    shareReplay(1),
+  )
+  return {renderingContext, capabilities: renderingContext.pipe(listCapabilities(), shareReplay(1))}
+}
+
+function Consumer({frames}: {frames: (StudioRenderingContext | undefined)[]}) {
+  frames.push(useRenderingContext())
+  return null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+it('resolves the core ui rendering context in the render that mounts the consumer', () => {
+  vi.mocked(useRenderingContextStore).mockReturnValue(createStore(CORE_UI_SEARCH))
+  const frames: (StudioRenderingContext | undefined)[] = []
+
+  render(<Consumer frames={frames} />)
+
+  // no frame — and so no effect of the first commit — sees the context unresolved
+  expect(frames[0]).toEqual({name: 'coreUi', metadata: {environment: 'test'}})
+  expect(frames.every((frame) => frame?.name === 'coreUi')).toBe(true)
+})
+
+it('resolves the default rendering context in the render that mounts the consumer', () => {
+  vi.mocked(useRenderingContextStore).mockReturnValue(createStore(''))
+  const frames: (StudioRenderingContext | undefined)[] = []
+
+  render(<Consumer frames={frames} />)
+
+  expect(frames[0]).toEqual({name: 'default', metadata: {}})
+})

--- a/packages/sanity/src/core/store/renderingContext/useRenderingContext.test.tsx
+++ b/packages/sanity/src/core/store/renderingContext/useRenderingContext.test.tsx
@@ -1,12 +1,9 @@
 import {render} from '@testing-library/react'
-import {of, shareReplay} from 'rxjs'
 import {beforeEach, expect, it, vi} from 'vitest'
 
 import {useRenderingContextStore} from '../datastores'
-import {coreUiRenderingContext} from './coreUiRenderingContext'
-import {defaultRenderingContext} from './defaultRenderingContext'
-import {listCapabilities} from './listCapabilities'
-import {type RenderingContextStore, type StudioRenderingContext} from './types'
+import {createRenderingContextStore} from './createRenderingContextStore'
+import {type StudioRenderingContext} from './types'
 import {useRenderingContext} from './useRenderingContext'
 
 vi.mock('../datastores')
@@ -14,16 +11,6 @@ vi.mock('../datastores')
 const CORE_UI_SEARCH = `?_context=${encodeURIComponent(
   JSON.stringify({mode: 'core-ui', env: 'test'}),
 )}`
-
-// The same pipeline as `createRenderingContextStore`, for a given URL query string
-function createStore(urlSearch: string): RenderingContextStore {
-  const renderingContext = of(undefined).pipe(
-    coreUiRenderingContext(urlSearch),
-    defaultRenderingContext(),
-    shareReplay(1),
-  )
-  return {renderingContext, capabilities: renderingContext.pipe(listCapabilities(), shareReplay(1))}
-}
 
 function Consumer({frames}: {frames: (StudioRenderingContext | undefined)[]}) {
   frames.push(useRenderingContext())
@@ -35,7 +22,7 @@ beforeEach(() => {
 })
 
 it('resolves the core ui rendering context in the render that mounts the consumer', () => {
-  vi.mocked(useRenderingContextStore).mockReturnValue(createStore(CORE_UI_SEARCH))
+  vi.mocked(useRenderingContextStore).mockReturnValue(createRenderingContextStore(CORE_UI_SEARCH))
   const frames: (StudioRenderingContext | undefined)[] = []
 
   render(<Consumer frames={frames} />)
@@ -46,7 +33,7 @@ it('resolves the core ui rendering context in the render that mounts the consume
 })
 
 it('resolves the default rendering context in the render that mounts the consumer', () => {
-  vi.mocked(useRenderingContextStore).mockReturnValue(createStore(''))
+  vi.mocked(useRenderingContextStore).mockReturnValue(createRenderingContextStore(''))
   const frames: (StudioRenderingContext | undefined)[] = []
 
   render(<Consumer frames={frames} />)

--- a/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
+++ b/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
@@ -7,5 +7,5 @@ export function useRenderingContext() {
 
   // Kept synchronous: the rendering context emits once at boot; deferring
   // only delays consumers reacting to it.
-  return useSyncObservable(renderingContextStore.renderingContext)
+  return useSyncObservable(renderingContextStore.renderingContext, undefined)
 }

--- a/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
+++ b/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
@@ -1,11 +1,32 @@
 import {useSyncObservable} from 'react-rx'
+import {type Observable} from 'rxjs'
 
 import {useRenderingContextStore} from '../datastores'
+import {type StudioRenderingContext} from './types'
 
-export function useRenderingContext() {
-  const renderingContextStore = useRenderingContextStore()
+/**
+ * The rendering context is resolved synchronously from the URL captured at boot and replayed to
+ * every subscriber, so the render that mounts a consumer can read it directly. react-rx only
+ * subscribes on commit and renders the initial value until then, while consumers act on the
+ * context in the effects of that very commit (`useFeedbackAvailable` skips its probe inside the
+ * dashboard), so the initial value has to be the resolved context rather than `undefined`.
+ */
+function readRenderingContext(
+  renderingContext$: Observable<StudioRenderingContext>,
+): StudioRenderingContext | undefined {
+  let renderingContext: StudioRenderingContext | undefined
+  renderingContext$
+    .subscribe((value) => {
+      renderingContext = value
+    })
+    .unsubscribe()
+  return renderingContext
+}
+
+export function useRenderingContext(): StudioRenderingContext | undefined {
+  const {renderingContext} = useRenderingContextStore()
 
   // Kept synchronous: the rendering context emits once at boot; deferring
   // only delays consumers reacting to it.
-  return useSyncObservable(renderingContextStore.renderingContext, undefined)
+  return useSyncObservable(renderingContext, () => readRenderingContext(renderingContext))
 }

--- a/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
+++ b/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
@@ -1,32 +1,15 @@
 import {useSyncObservable} from 'react-rx'
-import {type Observable} from 'rxjs'
 
 import {useRenderingContextStore} from '../datastores'
 import {type StudioRenderingContext} from './types'
 
-/**
- * The rendering context is resolved synchronously from the URL captured at boot and replayed to
- * every subscriber, so the render that mounts a consumer can read it directly. react-rx only
- * subscribes on commit and renders the initial value until then, while consumers act on the
- * context in the effects of that very commit (`useFeedbackAvailable` skips its probe inside the
- * dashboard), so the initial value has to be the resolved context rather than `undefined`.
- */
-function readRenderingContext(
-  renderingContext$: Observable<StudioRenderingContext>,
-): StudioRenderingContext | undefined {
-  let renderingContext: StudioRenderingContext | undefined
-  renderingContext$
-    .subscribe((value) => {
-      renderingContext = value
-    })
-    .unsubscribe()
-  return renderingContext
-}
-
 export function useRenderingContext(): StudioRenderingContext | undefined {
-  const {renderingContext} = useRenderingContextStore()
+  const {renderingContext, getRenderingContext} = useRenderingContextStore()
 
-  // Kept synchronous: the rendering context emits once at boot; deferring
-  // only delays consumers reacting to it.
-  return useSyncObservable(renderingContext, () => readRenderingContext(renderingContext))
+  // Kept synchronous: the rendering context emits once at boot; deferring only delays consumers
+  // reacting to it. react-rx subscribes on commit and renders the initial value until then, while
+  // consumers act on the context in the effects of that very commit (`useFeedbackAvailable` skips
+  // its probe inside the dashboard), so the initial value is the context the store has already
+  // resolved rather than `undefined`.
+  return useSyncObservable(renderingContext, getRenderingContext)
 }

--- a/packages/sanity/src/core/studio/components/navbar/resources/useCanDeployStudio.ts
+++ b/packages/sanity/src/core/studio/components/navbar/resources/useCanDeployStudio.ts
@@ -1,8 +1,11 @@
+import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {map, of} from 'rxjs'
 
 import {useProjectStore} from '../../../../store/datastores'
 import {hasDeployStudioGrant} from '../../../manifest/canDeployStudio'
+
+const DISABLED$ = of(false)
 
 /**
  * A hook that returns whether the current user can deploy the studio.
@@ -12,10 +15,11 @@ import {hasDeployStudioGrant} from '../../../manifest/canDeployStudio'
 export function useCanDeployStudio(enabled: boolean = true): boolean {
   const projectStore = useProjectStore()
 
-  const result$ = projectStore.getGrants().pipe(map(hasDeployStudioGrant))
-
   // If the hook is disabled, don't subscribe to the observable
-  const canDeploy$ = enabled ? result$ : of(false)
+  const canDeploy$ = useMemo(
+    () => (enabled ? projectStore.getGrants().pipe(map(hasDeployStudioGrant)) : DISABLED$),
+    [enabled, projectStore],
+  )
 
   return useObservable(canDeploy$, false)
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/ReferencePreviewTitle.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/ReferencePreviewTitle.tsx
@@ -25,9 +25,6 @@ export function ReferencePreviewTitle({
     () => getPreviewStateObservable(documentPreviewStore, schemaType, documentId),
     [documentId, documentPreviewStore, schemaType],
   )
-  // Deferred: react-rx v5's deferral is identity-coherent, so on a document
-  // id change the live snapshot wins and the previous document's title never
-  // renders for the new id.
   const {snapshot, original, isLoading} = useObservable(observable, INITIAL_PREVIEW_STATE)
 
   if (isLoading) {

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -80,9 +80,6 @@ export function SearchResultItemPreview({
     [documentId, documentType],
   )
 
-  // Deferred: react-rx v5's deferral is identity-coherent, so on a document
-  // id change the live snapshot wins and the previous document's title/media
-  // never renders next to the new document's version badges.
   const {isLoading, snapshot, original} = useObservable(observable, INITIAL_PREVIEW_STATE)
 
   const {versions} = useDocumentVersions({documentId})

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuthCard.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuthCard.tsx
@@ -29,7 +29,7 @@ export function WorkspaceAuthCard({workspace, onSelect}: WorkspaceAuthCardProps)
       }),
     [workspace.apiHost, workspace.dataset, workspace.projectId],
   )
-  const probe = useObservable(probe$)
+  const probe = useObservable(probe$, undefined)
 
   const state: 'loading' | 'logged-in' | 'logged-out' | 'no-access' = !probe
     ? 'loading'

--- a/packages/sanity/src/core/studio/networkCheck/useNetworkProtocolCheck.tsx
+++ b/packages/sanity/src/core/studio/networkCheck/useNetworkProtocolCheck.tsx
@@ -47,7 +47,7 @@ export function useNetworkProtocolCheck(): undefined {
     () => (isWarningSnoozed ? of(undefined) : isUsingLegacyHttp(client)),
     [client, isWarningSnoozed],
   )
-  const isOnLegacyHttp = useObservable(isOnLegacyHttp$)
+  const isOnLegacyHttp = useObservable(isOnLegacyHttp$, undefined)
 
   const handleSnooze = useCallback(
     () => setWarningSnoozedAt(new Date().toISOString()),

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -134,5 +134,5 @@ export function useUnclaimedProjectCopy(enabled: boolean): UnclaimedProjectCopy 
     )
   }, [client, enabled, localCopyUrl])
 
-  return useObservable(copy$)
+  return useObservable(copy$, undefined)
 }

--- a/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
+++ b/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
@@ -63,7 +63,7 @@ export function useDocumentPreviewValues(options: PreviewHookOptions): PreviewHo
   // Deferred: react-rx v5's deferral is identity-coherent, so on a document
   // id change the live snapshot wins and the previous document's title/media
   // never pairs with the new identity.
-  const previewState = useObservable(previewStateObservable)
+  const previewState = useObservable(previewStateObservable, undefined)
 
   const isLoading = previewState?.isLoading ?? true
 

--- a/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
+++ b/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
@@ -60,9 +60,6 @@ export function useDocumentPreviewValues(options: PreviewHookOptions): PreviewHo
     perspectiveStack,
     variant,
   ])
-  // Deferred: react-rx v5's deferral is identity-coherent, so on a document
-  // id change the live snapshot wins and the previous document's title/media
-  // never pairs with the new identity.
   const previewState = useObservable(previewStateObservable, undefined)
 
   const isLoading = previewState?.isLoading ?? true

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -79,8 +79,6 @@ describe('createHookFromObservableFactory', () => {
     await waitFor(() =>
       expect(renderTimeline[renderTimeline.length - 1]).toEqual([{value: 'hello, world'}, false]),
     )
-    // One factory call per distinct arg — react-rx@4.2.5 fixed a useObservable cache
-    // leak that previously caused duplicate subscriptions (and thus double calls).
     expect(observableFactory).toHaveBeenCalledTimes(1)
 
     const timelineLengthBeforeArgChange = renderTimeline.length
@@ -137,7 +135,6 @@ describe('createHookFromObservableFactory', () => {
     // Wait for the initial render cycle to settle with the resolved value
     await waitFor(() => expect(syncRenders).toBeGreaterThan(1))
     await waitFor(() => expect(deferRenders).toBeGreaterThan(0))
-    // One factory call per distinct arg (see react-rx@4.2.5 cache-leak fix note above).
     expect(observableFactory).toHaveBeenCalledTimes(1)
     // Deferred child should render fewer or equal times than the sync parent
     expect(deferRenders).toBeLessThanOrEqual(syncRenders)

--- a/packages/sanity/src/core/util/createHookFromObservableFactory.ts
+++ b/packages/sanity/src/core/util/createHookFromObservableFactory.ts
@@ -65,22 +65,11 @@ export function createHookFromObservableFactory<T, TArg = void>(
         ),
       [arg],
     )
-    // react-rx v5 defers updates and keeps the deferral identity-coherent: on
-    // an identity change (e.g. a new document id) it falls back to the new
-    // observable's live value — which synchronously resets to the loading
-    // tuple — so the previous arg's value never renders as loaded state for
-    // the new one.
     const result = useObservable(observable, initialResult)
-    // Throw from the live snapshot so errors reach the error boundary as soon
-    // as the observable errors, instead of after the deferred value catches
-    // up. Both hooks share one store subscription per observable, so this
-    // sync read costs no extra subscription.
+    // Read errors synchronously so they reach the boundary before the deferred result catches up.
     const liveResult = useSyncObservable(observable, initialResult)
 
     if (liveResult.type === 'error') throw liveResult.error
-    // Unreachable within an identity (the deferred value lags the live one,
-    // which threw above) and across identities (the identity-coherent
-    // deferral falls back to the live value), but it narrows the type.
     if (result.type === 'error') throw result.error
 
     return result.tuple

--- a/packages/sanity/src/core/util/useLoadable.ts
+++ b/packages/sanity/src/core/util/useLoadable.ts
@@ -48,10 +48,6 @@ export function useLoadable<T>(
       : {isLoading: false, value: initialValue, error: null}
 
   const loadableObservable = useMemo(() => value$.pipe(asLoadable()), [value$])
-  // Deferred: react-rx v5's deferral is identity-coherent, so when callers
-  // key `value$` on identities like a document id the live loadable wins on
-  // an identity change — the previous identity's loaded value never returns
-  // under the new one.
   return useObservable(loadableObservable, initial)
 }
 

--- a/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
@@ -17,6 +17,7 @@ const mockDispatch = vi.fn()
 vi.mock('../useVariantsStore', () => ({
   useVariantsStore: () => ({
     state$: mockState$,
+    initialState,
     dispatch: mockDispatch,
   }),
 }))

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -26,17 +26,17 @@ const QUERY_PROJECTION = `{
 
 const QUERY = `*[${QUERY_FILTER}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`
 
-/**
- * What `state$` emits first for a cold store; also the value the hooks render until it emits.
- * @internal
- */
-export const INITIAL_VARIANTS_STATE: VariantStoreState = {
+const INITIAL_STATE: VariantStoreState = {
   variants: new Map(),
   state: 'initialising' as const,
 }
 
 export interface VariantStore {
   state$: Observable<VariantStoreState>
+  /**
+   * What `state$` emits first; hooks render it until the subscription started on commit emits.
+   */
+  initialState: VariantStoreState
   dispatch: Dispatch<VariantStoreAction>
 }
 
@@ -62,6 +62,7 @@ export function createVariantsStore(context: {
 
     return {
       state$: of(disabledState),
+      initialState: disabledState,
       dispatch: () => {
         // noop
       },
@@ -99,13 +100,14 @@ export function createVariantsStore(context: {
   )
 
   const state$ = merge(listFetch$, dispatch$).pipe(
-    scan((state, action) => variantStoreReducer(state, action), INITIAL_VARIANTS_STATE),
-    startWith(INITIAL_VARIANTS_STATE),
+    scan((state, action) => variantStoreReducer(state, action), INITIAL_STATE),
+    startWith(INITIAL_STATE),
     shareReplay(1),
   )
 
   return {
     state$,
+    initialState: INITIAL_STATE,
     dispatch,
   }
 }

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -26,7 +26,11 @@ const QUERY_PROJECTION = `{
 
 const QUERY = `*[${QUERY_FILTER}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`
 
-const INITIAL_STATE: VariantStoreState = {
+/**
+ * What `state$` emits first for a cold store; also the value the hooks render until it emits.
+ * @internal
+ */
+export const INITIAL_VARIANTS_STATE: VariantStoreState = {
   variants: new Map(),
   state: 'initialising' as const,
 }
@@ -95,8 +99,8 @@ export function createVariantsStore(context: {
   )
 
   const state$ = merge(listFetch$, dispatch$).pipe(
-    scan((state, action) => variantStoreReducer(state, action), INITIAL_STATE),
-    startWith(INITIAL_STATE),
+    scan((state, action) => variantStoreReducer(state, action), INITIAL_VARIANTS_STATE),
+    startWith(INITIAL_VARIANTS_STATE),
     shareReplay(1),
   )
 

--- a/packages/sanity/src/core/variants/store/useAllVariants.ts
+++ b/packages/sanity/src/core/variants/store/useAllVariants.ts
@@ -2,7 +2,6 @@ import {useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
 
 import {type SystemVariant} from '../types'
-import {INITIAL_VARIANTS_STATE} from './createVariantsStore'
 import {useVariantsStore} from './useVariantsStore'
 
 /**
@@ -15,12 +14,12 @@ export function useAllVariants(): {
   error?: Error
   loading: boolean
 } {
-  const {state$} = useVariantsStore()
+  const {state$, initialState} = useVariantsStore()
   // Kept synchronous: variant resolution feeds `useTargetDocumentState`'s
   // target scope, so a deferred snapshot could bind the form checkout to the
   // wrong variant after navigation. Executable proof:
   // perspective/__tests__/deferralSafety.test.tsx.
-  const {variants, error, state} = useSyncObservable(state$, INITIAL_VARIANTS_STATE)
+  const {variants, error, state} = useSyncObservable(state$, initialState)
 
   return useMemo(
     () => ({

--- a/packages/sanity/src/core/variants/store/useAllVariants.ts
+++ b/packages/sanity/src/core/variants/store/useAllVariants.ts
@@ -19,7 +19,7 @@ export function useAllVariants(): {
   // target scope, so a deferred snapshot could bind the form checkout to the
   // wrong variant after navigation. Executable proof:
   // perspective/__tests__/deferralSafety.test.tsx.
-  const {variants, error, state} = useSyncObservable(state$)!
+  const {variants, error, state} = useSyncObservable(state$, undefined)!
 
   return useMemo(
     () => ({

--- a/packages/sanity/src/core/variants/store/useAllVariants.ts
+++ b/packages/sanity/src/core/variants/store/useAllVariants.ts
@@ -2,6 +2,7 @@ import {useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
 
 import {type SystemVariant} from '../types'
+import {INITIAL_VARIANTS_STATE} from './createVariantsStore'
 import {useVariantsStore} from './useVariantsStore'
 
 /**
@@ -19,7 +20,7 @@ export function useAllVariants(): {
   // target scope, so a deferred snapshot could bind the form checkout to the
   // wrong variant after navigation. Executable proof:
   // perspective/__tests__/deferralSafety.test.tsx.
-  const {variants, error, state} = useSyncObservable(state$, undefined)!
+  const {variants, error, state} = useSyncObservable(state$, INITIAL_VARIANTS_STATE)
 
   return useMemo(
     () => ({

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
@@ -134,7 +134,7 @@ export function VideoPreview(props: VideoAssetInputProps) {
   )
   // Kept synchronous: a deferred snapshot could pair the previous asset with a
   // newly selected reference, pointing open-in-source at the wrong asset.
-  const resolvedAsset = useSyncObservable(observable)
+  const resolvedAsset = useSyncObservable(observable, undefined)
 
   const openInSourceResult = useMemo(() => {
     if (resolvedAsset) {

--- a/packages/sanity/src/presentation/editor/usePreviewState.ts
+++ b/packages/sanity/src/presentation/editor/usePreviewState.ts
@@ -36,8 +36,5 @@ export default function usePreviewState(documentId: string, schemaType?: SchemaT
     [documentPreviewStore, schemaType, documentId, perspectiveStack, selectedVariantName],
   )
 
-  // Deferred: react-rx v5's deferral is identity-coherent, so on a document
-  // id change the live snapshot wins and the previous document's preview
-  // never renders under the new identity.
   return useObservable(preview$, EMPTY_STATE)
 }

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/LinkToExistingPreview.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/LinkToExistingPreview.tsx
@@ -54,10 +54,6 @@ export function LinkToExistingPreview(props: LinkToExistingPreviewProps) {
     )
   }, [props.documentPreviewStore, schemaType, value._id])
 
-  // Deferred: react-rx v5's deferral is identity-coherent, so when this
-  // component is reused for a new document id the live snapshot wins and the
-  // previous document's title/media never renders beside the new document's
-  // version badge.
   const {snapshot, original, isLoading} = useObservable(
     previewStateObservable,
     INITIAL_PREVIEW_STATE,

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -82,10 +82,6 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
     selectedVariantName,
   ])
 
-  // Deferred: react-rx v5's deferral is identity-coherent, so when a
-  // (recycled) list item switches to a new document id the live snapshot for
-  // the new id wins and the previous document's title/media never renders
-  // next to the new document's version badges.
   const {
     snapshot,
     original,

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -14,6 +14,8 @@ import {AskToEditRequestSent} from './__telemetry__/RequestPermissionDialog.tele
 import {type AccessRequest} from './useRoleRequestsStatus'
 
 const MAX_NOTE_LENGTH = 150
+// Requested until the project's roles say an editor role exists.
+const ADMIN_ROLE = 'administrator' as const
 
 const DialogBody = styled(Box)`
   box-sizing: border-box;
@@ -61,7 +63,7 @@ export function RequestPermissionDialog({
   const [hasBeenDenied, setHasBeenDenied] = useState<boolean>(false)
 
   const requestedRole$: Observable<'administrator' | 'editor'> = useMemo(() => {
-    const adminRole = 'administrator' as const
+    const adminRole = ADMIN_ROLE
     if (!projectId || !client) return of(adminRole)
     return client.observable
       .request<(Role & {appliesToUsers?: boolean})[]>({url: `/projects/${projectId}/roles`})
@@ -80,7 +82,7 @@ export function RequestPermissionDialog({
   // Kept synchronous: `onSubmit` reads this value into the request body, so a
   // deferred snapshot could submit the stale startWith('administrator') role
   // after the observable has already resolved to 'editor'.
-  const requestedRole = useSyncObservable(requestedRole$, undefined)
+  const requestedRole = useSyncObservable(requestedRole$, ADMIN_ROLE)
 
   const onSubmit = () => {
     setIsSubmitting(true)

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -80,7 +80,7 @@ export function RequestPermissionDialog({
   // Kept synchronous: `onSubmit` reads this value into the request body, so a
   // deferred snapshot could submit the stale startWith('administrator') role
   // after the observable has already resolved to 'editor'.
-  const requestedRole = useSyncObservable(requestedRole$)
+  const requestedRole = useSyncObservable(requestedRole$, undefined)
 
   const onSubmit = () => {
     setIsSubmitting(true)

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
@@ -39,7 +39,13 @@ const ReferenceChangedBannerComponent: ComponentType = () => {
   const {params, groupIndex, routerPanesState, replaceCurrent, BackLink} = usePaneRouter()
   const {paneDataItems} = useResolvedPanesList()
   const routerReferenceId = routerPanesState.at(groupIndex)?.at(0)?.id
-  const parentPath = params?.parentRefPath ? pathFromString(params.parentRefPath) : null
+  const parentRefPath = params?.parentRefPath
+  // Keyed on the string: a fresh path array per render would rebuild (and resubscribe) the
+  // observable below on every render.
+  const parentPath = useMemo(
+    () => (parentRefPath ? pathFromString(parentRefPath) : null),
+    [parentRefPath],
+  )
   const {t} = useTranslation(structureLocaleNamespace)
 
   const parentPaneData = paneDataItems.find(

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.test.tsx
@@ -1,0 +1,66 @@
+import {act, render, screen} from '@testing-library/react'
+import {useTranslation} from 'sanity'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {structureLocaleNamespace, structureUsEnglishLocaleBundle} from '../../../../../i18n'
+import {useDocumentPane} from '../../../useDocumentPane'
+import {DocumentGroupInventoryHint} from './DocumentGroupInventoryHint'
+
+vi.mock('../../../useDocumentPane', () => ({
+  useDocumentPane: vi.fn(),
+}))
+
+const SESSION_COUNT_KEY = 'studio.document-group-inventory.hint.session-count'
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+  vi.mocked(useDocumentPane).mockReturnValue({
+    setIsDocumentGroupInventoryActive: vi.fn(),
+  } as unknown as ReturnType<typeof useDocumentPane>)
+})
+
+function LocaleProbe() {
+  useTranslation(structureLocaleNamespace)
+  return <span data-testid="locale-loaded" />
+}
+
+// `useTranslation` suspends until the structure namespace is loaded. In the studio it has long
+// been loaded when a document header renders, so load it here too: the hint's mounting render is
+// then synchronous, and what it paints before the status resolves is observable.
+async function createWrapper(): Promise<Awaited<ReturnType<typeof createTestProvider>>> {
+  const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+  const {unmount} = render(<LocaleProbe />, {wrapper})
+  await screen.findByTestId('locale-loaded')
+  unmount()
+  return wrapper
+}
+
+// the status is read from storage asynchronously, so it is unresolved in the mounting render
+async function letStatusResolve() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+it('does not show a dismissed hint while its status is still being read', async () => {
+  localStorage.setItem(SESSION_COUNT_KEY, '-1') // suppressed by the user
+  const wrapper = await createWrapper()
+
+  render(<DocumentGroupInventoryHint />, {wrapper})
+  expect(screen.queryByRole('button')).toBeNull()
+
+  await letStatusResolve()
+  expect(screen.queryByRole('button')).toBeNull()
+})
+
+it('shows the hint once its status resolves as active', async () => {
+  const wrapper = await createWrapper()
+
+  render(<DocumentGroupInventoryHint />, {wrapper})
+  expect(screen.queryByRole('button')).toBeNull()
+
+  await letStatusResolve()
+  expect(screen.getByRole('button')).toBeTruthy()
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
@@ -16,7 +16,10 @@ export const DocumentGroupInventoryHint: ComponentType = () => {
   const {t} = useTranslation(structureLocaleNamespace)
   const {setIsDocumentGroupInventoryActive} = useDocumentPane()
   const telemetry = useTelemetry()
-  const status = useObservable(useMemo(() => hintStatus(browserStorageAdapter), []))
+  const status = useObservable(
+    useMemo(() => hintStatus(browserStorageAdapter), []),
+    undefined,
+  )
 
   if (status === 'inactive') {
     return null

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
@@ -21,7 +21,9 @@ export const DocumentGroupInventoryHint: ComponentType = () => {
     undefined,
   )
 
-  if (status === 'inactive') {
+  // The status is read from storage asynchronously; a hint the user has already dismissed must
+  // not flash while it is unresolved.
+  if (status !== 'active') {
     return null
   }
 

--- a/packages/sanity/src/structure/panes/document/usePreviewUrl.ts
+++ b/packages/sanity/src/structure/panes/document/usePreviewUrl.ts
@@ -37,5 +37,5 @@ export function usePreviewUrl(value: Partial<SanityDocument> | undefined): strin
     )
   }, [resolveProductionUrl, subject])
 
-  return useObservable(resolvedUrlObservable)
+  return useObservable(resolvedUrlObservable, undefined)
 }

--- a/packages/sanity/src/structure/useStructureToolSetting.test.tsx
+++ b/packages/sanity/src/structure/useStructureToolSetting.test.tsx
@@ -1,0 +1,82 @@
+import {render} from '@testing-library/react'
+import {merge, NEVER, of} from 'rxjs'
+import {beforeEach, expect, it, vi} from 'vitest'
+
+import {useStructureToolSetting} from './useStructureToolSetting'
+
+// Like the SWR-wrapped key-value store: the locally cached value (or `null`) arrives synchronously
+// on subscribe, and the stream then stays open for the server.
+const stored = new Map<string, string>()
+const setKey = vi.fn(async (key: string, value: unknown) => {
+  stored.set(key, value as string)
+})
+// Stable like the real store (it comes from the resource cache): a fresh object per render would
+// rebuild `value$` on every render.
+const keyValueStore = {
+  getKey: (key: string) => merge(of(stored.get(key) ?? null), NEVER),
+  setKey,
+}
+vi.mock('sanity', () => ({
+  useKeyValueStore: () => keyValueStore,
+}))
+
+interface Frame {
+  key: string
+  value: string | undefined
+}
+
+function Consumer({
+  settingKey,
+  defaultValue,
+  frames,
+}: {
+  settingKey: string
+  defaultValue: string
+  frames: Frame[]
+}) {
+  const [value] = useStructureToolSetting<string>('layout', settingKey, defaultValue)
+  frames.push({key: settingKey, value})
+  return null
+}
+
+beforeEach(() => {
+  stored.clear()
+  setKey.mockClear()
+})
+
+it('renders only the current key’s setting when the key and its default change', () => {
+  stored.set('studio.structure-tool.layout.author', 'detail')
+  stored.set('studio.structure-tool.layout.book', 'compact')
+  const frames: Frame[] = []
+  const {rerender} = render(<Consumer settingKey="author" defaultValue="default" frames={frames} />)
+  expect(frames.at(-1)).toEqual({key: 'author', value: 'detail'})
+
+  rerender(<Consumer settingKey="book" defaultValue="media" frames={frames} />)
+
+  // no render of the new key shows the previous key's setting, nor the default it mounted with
+  const bookFrames = frames.filter((frame) => frame.key === 'book').map((frame) => frame.value)
+  expect(bookFrames).not.toContain('detail')
+  expect(bookFrames).not.toContain('default')
+  expect(bookFrames.at(-1)).toBe('compact')
+})
+
+it('renders the current default while a key without a stored setting loads', () => {
+  stored.set('studio.structure-tool.layout.author', 'detail')
+  const frames: Frame[] = []
+  const {rerender} = render(<Consumer settingKey="author" defaultValue="default" frames={frames} />)
+
+  rerender(<Consumer settingKey="movie" defaultValue="media" frames={frames} />)
+
+  const movieFrames = frames.filter((frame) => frame.key === 'movie').map((frame) => frame.value)
+  expect(movieFrames.every((value) => value === 'media')).toBe(true)
+})
+
+it('follows a changed default for a key without a stored setting', () => {
+  const frames: Frame[] = []
+  const {rerender} = render(<Consumer settingKey="author" defaultValue="default" frames={frames} />)
+  const before = frames.length
+
+  rerender(<Consumer settingKey="author" defaultValue="media" frames={frames} />)
+
+  expect(frames.slice(before).every((frame) => frame.value === 'media')).toBe(true)
+})

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -24,11 +24,7 @@ export function useStructureToolSetting<ValueType>(
     )
   }, [defaultValue, keyValueStore, keyValueStoreKey])
 
-  // Keep the immediate store value for write-side equality checks so a stale
-  // deferred snapshot cannot skip (or redundantly issue) a setKey while the
-  // store has already moved on. The rendered value is deferred by react-rx v5
-  // (identity-coherent, and sharing the same store subscription as the sync
-  // read), so a storage key change never renders the previous key's value.
+  // Use the live value for write-side equality; rendering can remain deferred.
   const observedValue = useSyncObservable(value$, defaultValue) as ValueType
   const value = useObservable(value$, defaultValue) as ValueType
   const set = useCallback(

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -24,9 +24,13 @@ export function useStructureToolSetting<ValueType>(
     )
   }, [defaultValue, keyValueStore, keyValueStoreKey])
 
+  // react-rx captures an initial value once per hook instance, but this instance outlives its key
+  // (`PaneContainer` is reused across panes) and `defaultValue` differs per key. Until the
+  // subscription for the current `value$` emits, fall back per render to the current default, so a
+  // key change never renders the previous key's default — nor its value — for a commit.
   // Use the live value for write-side equality; rendering can remain deferred.
-  const observedValue = useSyncObservable(value$, defaultValue) as ValueType
-  const value = useObservable(value$, defaultValue) as ValueType
+  const observedValue = (useSyncObservable(value$, undefined) ?? defaultValue) as ValueType
+  const value = (useObservable(value$, undefined) ?? defaultValue) as ValueType
   const set = useCallback(
     async (newValue: ValueType | null) => {
       if (newValue !== observedValue) {

--- a/perf/bench/README.md
+++ b/perf/bench/README.md
@@ -46,7 +46,7 @@ runner (tsx CLI, runs from HEAD)
 
 ### Settle mode (render-loop detector)
 
-`--mode settle` targets the render-loop bug class (per-render observable identity churn — react-rx v5 turned it into self-sustaining loops, e.g. `useDocumentValues` with an inline `paths` array, fixed in #14241): open the scenario, wait for readiness, then measure **time to quiescence** — and whether the page ever gets there. No typing. Activity signals, all on the page clock:
+`--mode settle` targets the render-loop bug class (per-render observable identity churn, e.g. `useDocumentValues` with an inline `paths` array, fixed in #14241): open the scenario, wait for readiness, then measure **time to quiescence** — and whether the page ever gets there. No typing. Activity signals, all on the page clock:
 
 - **React commits** (primary): a settle-only init script (`instrumentation/settle.ts`) installs a minimal React DevTools hook stub before React loads; production react-dom reports every commit to it, so a loop is visible even when each frame is cheap. This script is injected by settle sessions ONLY — `instrumentation/index.ts` stays byte-identical for every other mode, by design.
 - **Long Animation Frames** with script attribution (expensive loops name their culprit).

--- a/perf/bench/runner/session/settle.ts
+++ b/perf/bench/runner/session/settle.ts
@@ -15,7 +15,7 @@ import {foldLoafAttribution} from './pageLoad'
  * Settle session: open the scenario, wait for readiness, then measure how
  * long the page takes to go quiet — and whether it ever does. No typing:
  * the mode targets the render-loop bug class (per-render observable
- * identity churn, react-rx v5), whose direct symptom is a page that never
+ * identity churn), whose direct symptom is a page that never
  * reaches quiescence after opening a document. Staying read-only also
  * sidesteps the read-only-interruption machinery entirely.
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ catalogs:
       specifier: ^19.3.0
       version: 19.3.0
     react-rx:
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^7.0.0
+      version: 7.0.0
     rimraf:
       specifier: ^6.1.3
       version: 6.1.3
@@ -595,7 +595,7 @@ importers:
         version: 19.3.0(react@19.3.0)
       react-rx:
         specifier: 'catalog:'
-        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
+        version: 7.0.0(react@19.3.0)(rxjs@7.8.2)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -971,7 +971,7 @@ importers:
         version: 4.0.0(react@19.3.0)
       react-rx:
         specifier: 'catalog:'
-        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
+        version: 7.0.0(react@19.3.0)(rxjs@7.8.2)
       refractor:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1883,7 +1883,7 @@ importers:
         version: 7.3.0
       react-rx:
         specifier: 'catalog:'
-        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
+        version: 7.0.0(react@19.3.0)(rxjs@7.8.2)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -2231,7 +2231,7 @@ importers:
         version: 4.0.0(react@19.3.0)
       react-rx:
         specifier: 'catalog:'
-        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
+        version: 7.0.0(react@19.3.0)(rxjs@7.8.2)
       refractor:
         specifier: ^5.0.0
         version: 5.0.0
@@ -13214,8 +13214,8 @@ packages:
       react: ^18.3 || >=19.0.0-0
       rxjs: ^7
 
-  react-rx@6.1.0:
-    resolution: {integrity: sha512-49/nd9p0id/DCFzNUwVVuKrDb94Imh79eiz/NlUvPRDSiGt3NPIna8aXXgplikkTN/3wsrjJTX9gyJgubNlelg==}
+  react-rx@7.0.0:
+    resolution: {integrity: sha512-FJgX1VXGzbeQsH68XvaL8giJDdY5e4CVMTFLvfYtPm7XxLj9aIH4Iqgw8S7PKR7BCT03IjFYWR5zkbE/MCn2iA==}
     engines: {node: '>=22.12'}
     peerDependencies:
       react: ^19.2
@@ -26818,11 +26818,10 @@ snapshots:
       rxjs: 7.8.2
       use-effect-event: 2.0.4(react@19.3.0)
 
-  react-rx@6.1.0(react@19.3.0)(rxjs@7.8.2):
+  react-rx@7.0.0(react@19.3.0)(rxjs@7.8.2):
     dependencies:
       react: 19.3.0
       rxjs: 7.8.2
-      use-effect-event: 2.0.4(react@19.3.0)
 
   react-select@5.10.2(@types/react@19.3.0)(react-dom@19.3.0)(react@19.3.0)(supports-color@8.1.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ catalogs:
       specifier: ^19.3.0
       version: 19.3.0
     react-rx:
-      specifier: ^6.0.1
-      version: 6.0.1
+      specifier: ^6.1.0
+      version: 6.1.0
     rimraf:
       specifier: ^6.1.3
       version: 6.1.3
@@ -595,7 +595,7 @@ importers:
         version: 19.3.0(react@19.3.0)
       react-rx:
         specifier: 'catalog:'
-        version: 6.0.1(react@19.3.0)(rxjs@7.8.2)
+        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -971,7 +971,7 @@ importers:
         version: 4.0.0(react@19.3.0)
       react-rx:
         specifier: 'catalog:'
-        version: 6.0.1(react@19.3.0)(rxjs@7.8.2)
+        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
       refractor:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1883,7 +1883,7 @@ importers:
         version: 7.3.0
       react-rx:
         specifier: 'catalog:'
-        version: 6.0.1(react@19.3.0)(rxjs@7.8.2)
+        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -2231,7 +2231,7 @@ importers:
         version: 4.0.0(react@19.3.0)
       react-rx:
         specifier: 'catalog:'
-        version: 6.0.1(react@19.3.0)(rxjs@7.8.2)
+        version: 6.1.0(react@19.3.0)(rxjs@7.8.2)
       refractor:
         specifier: ^5.0.0
         version: 5.0.0
@@ -13214,8 +13214,8 @@ packages:
       react: ^18.3 || >=19.0.0-0
       rxjs: ^7
 
-  react-rx@6.0.1:
-    resolution: {integrity: sha512-akApBgNmDXi7WcjkOHNBvgSNdwocpHoivPdau8ZUQ2is+cnCKJb3AMAh/dhtgdh2VxelUCJPI6Az1ZsshotOLQ==}
+  react-rx@6.1.0:
+    resolution: {integrity: sha512-49/nd9p0id/DCFzNUwVVuKrDb94Imh79eiz/NlUvPRDSiGt3NPIna8aXXgplikkTN/3wsrjJTX9gyJgubNlelg==}
     engines: {node: '>=22.12'}
     peerDependencies:
       react: ^19.2
@@ -26818,7 +26818,7 @@ snapshots:
       rxjs: 7.8.2
       use-effect-event: 2.0.4(react@19.3.0)
 
-  react-rx@6.0.1(react@19.3.0)(rxjs@7.8.2):
+  react-rx@6.1.0(react@19.3.0)(rxjs@7.8.2):
     dependencies:
       react: 19.3.0
       rxjs: 7.8.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalog:
   react: ^19.3.0
   react-dom: ^19.3.0
   react-is: ^19.3.0
-  react-rx: ^6.0.1
+  react-rx: ^6.1.0
   rimraf: ^6.1.3
   storybook: ^10.6.0
   styled-components: ^6.5.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalog:
   react: ^19.3.0
   react-dom: ^19.3.0
   react-is: ^19.3.0
-  react-rx: ^6.1.0
+  react-rx: ^7.0.0
   rimraf: ^6.1.3
   storybook: ^10.6.0
   styled-components: ^6.5.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Upgrade `react-rx` to 7.0.0 (sanity-io/react-rx#611), via the 6.1.0 step that marked the v7-incompatible overloads as deprecated (sanity-io/react-rx#584).

react-rx 7 never subscribes during render. `useObservable` / `useSyncObservable` render the required `initialValue` until the subscription started on commit emits, and an observable rebuilt on every render is torn down and re-subscribed each commit — which loops when the source synchronously replays a value that differs from the `initialValue` (v6's render-phase warm-up let that converge). The studio relied on both v6 behaviors, so this PR:

- Removes the `useSyncObservable(obs$, undefined)!` assertions that depended on a synchronous first emission. `useDocumentOperation` renders `GUARDED` (what the pair emits first), `useActiveReleases` / `useAllReleases` / `useAllVariants` render the stores' now-exported `INITIAL_RELEASES_STATE` / `INITIAL_VARIANTS_STATE`, and `useEditState` derives `getInitialEditState(...)` (extracted from the pipeline's `startWith`) while the stream is silent — per render rather than as react-rx's `initialValue`, because that is captured once per hook instance and would carry the previous document's id through an identity swap (covered by a new test). `useStructureToolSetting` gets the same per-render fallback to its current `defaultValue`: its instance outlives its key (`PaneContainer` is reused across panes with different defaults), so a key or default change no longer renders the default the hook mounted with for a commit.
- Memoizes three observables that were rebuilt on every render and would now loop: `useDivergenceController`'s upstream base/head streams, `useCanDeployStudio` (`of(false)` and the grants pipeline), and `ReferenceChangedBanner`'s `parentPath` array (keyed on the router string).
- Audits every `useObservable` / `useSyncObservable` / `useObservablePromise` call site (140 + 6) for identity stability, memo deps that churn, and the same-component `use()` deadlock — everything else already followed the v7 rules.
- Passes explicit initial values everywhere (the 6.1 step; review follow-ups replaced `undefined` with the stream's first value in `RequestPermissionDialog`, `ReleasesToolLink`, `useManageFavorite`, `DocumentGroupInventoryAction` and `useCanvasCompanionDoc` — the latter renders the store's exported `INITIAL_COMPANION_DOCS`, so `LinkToCanvasAction` stays hidden while the lookup for an already linked document is pending instead of enabling itself for a commit), removes stale v5 / `useObservableEvent` commentary (no call site used the removed hook), and documents the v7 rules in `AGENTS.md`.
- Fixes the first-commit effects the lost warm-up exposed: the rendering-context store resolves its synchronous pipeline once on creation and exposes `getRenderingContext()` / `getCapabilities()`, which `useRenderingContext`, `CapabilityGate`, `useComlinkStore` and the comlink history hooks use as their initial values, so `ResourcesButton` / `useFeedbackAvailable` see `coreUi` on the mounting commit and skip the feedback tunnel probe inside the dashboard, capability-gated UI is right from the first commit (no local user menu painted for a commit inside the dashboard — that one was a pre-existing flash, since v6 never warmed up an observable given an initial value), and the comlink store is created once for the real capabilities; `DocumentGroupInventoryHint` gates on a resolved `'active'` status instead of hiding only for `'inactive'`, so a dismissed hint is not painted while its storage reads are pending; `ReleasesMetadataProvider` derives its pre-emission fallback from the current listener set (a non-empty set is loading, matching the aggregator's first emission) instead of the static empty state, so the releases overview does not report a finished, empty fetch for the pass in which the first release id is added.
- Starts the comlink node on commit: `createComlinkStore` used to call `node.start()` on creation, inside `useComlinkStore`'s `useMemo` — a render-phase side effect that, with the capabilities resolved up front, moved to the mounting render. The store now exposes an idempotent `start()` that `useComlinkStore` calls from an effect, so a render React abandons leaves only an unstarted node in the resource cache, and the first committed consumer starts it once (the node queues messages posted before that).

Also in this PR:

- `usePreserveIntrinsicBlockSize` in `DocumentGroupInventory.tsx` drops its `Subject` + `useSyncObservable` for a single effect that runs only while active and drives `--intrinsic-block-size` from a ResizeObserver directly.
- Dependencies: the branch is rebased onto `main`, which has since moved to `vite` 8.3.0 / React 19.3.0 and dropped the `vite>rolldown` and `@sanity/ui>react-is` overrides itself, so the only workspace change left here is `react-rx ^6.0.1 → ^7.0.0` (and `use-effect-event` is no longer pulled in through react-rx).

### What to review

- `pnpm-workspace.yaml` / lockfile resolve `react-rx` 7.0.0 (on `minimumReleaseAgeExclude`); the lockfile diff against `main` is the react-rx bump only.
- Initial values now match what each pipeline emits first, so the first pass is the same "loading" state a cold store showed on v6; a warm store shows it for one extra pass.
- `useEditState` now reads `useSchema()` (for `liveEditSchemaType`); its unit test mocks it and covers the identity-swap fallback. `useStructureToolSetting` applies the same fallback pattern; write-side equality is unchanged.
- The three memoization fixes are behavior-preserving on v6 and required on v7.
- `RenderingContextStore` (`@internal`, returned by the public `useRenderingContextStore`) gains `getRenderingContext()` and `getCapabilities()`; `createRenderingContextStore` connects its `of()`-sourced pipelines once (they complete immediately) and accepts an optional `urlSearch` for tests. Nothing subscribes during render.
- `ComlinkStore` gains `start()`; the node is never stopped, as before (one node for the app lifetime).
- `useCanvasCompanionDoc`'s `loading` is now `boolean` (was `boolean | undefined`); its consumers only branch on it.

### Testing

- `pnpm build`
- On the rebased branch: `pnpm check:oxlint` (type-aware + typeCheck) and `pnpm check:format` pass; `TZ=America/Los_Angeles pnpm vitest run --project=sanity`: 604 files passed, 14 skipped; 5,668 tests passed, 2 expected failures, 98 skipped, 6 todo; no type errors. Before the fixes the equivalent full run on 7.0.0 had 14 files / 137 tests failing, all from the sync-first-emission assertions.
- Static audit scripts over all react-rx call sites (identity of the observable argument, and the declarations behind each `useMemo` dependency) — findings are the three memoization fixes above.
- `createRenderingContextStore.test.ts` covers the synchronous resolution of the context and its capabilities (default and `core-ui`); `useRenderingContext.test.tsx` asserts the mounting render already holds the `coreUi` / `default` context (both cases render `undefined` on the pre-fix head); `CapabilityGate.test.tsx` asserts the child of an `unavailable` gate never renders inside core ui, not even for the mounting commit (it renders once on the pre-fix head); `createComlinkStore.test.ts` and `useComlinkStore.test.tsx` assert the node is created but not started by any render and started exactly once on commit for two consumers (the pre-fix head starts it during the mounting render); `DocumentGroupInventoryHint.test.tsx` asserts nothing is painted before the status resolves, for a dismissed hint and for a fresh session, and that the hint appears once active (both cases paint the button on the pre-fix head — the test loads the `structure` locale namespace first, since `useTranslation` otherwise suspends the cold mount and masks the flash); `ReleasesMetadataProvider.test.tsx` asserts every frame from adding the first release id until its fetch resolves reports `loading: true` (the pre-fix head reports `loading: false` for the first pass); `useCanvasCompanionDoc.test.tsx` asserts the mounting render is loading and that no frame is ever both not loading and unlinked before the lookup answers (the pre-fix head mounts with `loading: undefined`); `useStructureToolSetting.test.tsx` asserts a key + default change renders neither the previous key's setting nor the mount-time default and settles on the new key's stored value, that an unstored key renders only its current default, and that a default change is followed (all three fail on the pre-fix head, which renders `['default', 'compact', 'compact']` for the new key).
- Dev studio smoke test against project `ppsg7ml5`: structure tool, Author list, document form load and document switch (`useEditState` / `useDocumentOperation`), perspective menu with releases (`useActiveReleases`), Releases tool, setting a reference and opening its child pane (`ReferenceChangedBanner`), Variants tool and Variant menu (`useAllVariants`) all render; no error toast, error boundary, or "Maximum update depth exceeded", and the `sanity dev` log shows no browser `console.error`.

[studio-smoke-test-react-rx-7.mp4](https://cursor.com/agents/bc-ecba6160-9aa0-437c-8149-2c038b1efeb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio-smoke-test-react-rx-7.mp4)

[Author document form loaded on react-rx 7](https://cursor.com/agents/bc-ecba6160-9aa0-437c-8149-2c038b1efeb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio-author-form-react-rx-7.webp)

[Perspective menu listing releases on react-rx 7](https://cursor.com/agents/bc-ecba6160-9aa0-437c-8149-2c038b1efeb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio-perspective-menu-react-rx-7.webp)

### Notes for release

N/A – Internal dependency maintenance

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecba6160-9aa0-437c-8149-2c038b1efeb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecba6160-9aa0-437c-8149-2c038b1efeb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

