### PR TITLE
fix(radar): make drift detection noise-aware

### DIFF
--- a/dev/radar/SPEC.md
+++ b/dev/radar/SPEC.md
@@ -96,12 +96,54 @@ effect of merged work; secondary: leads scanning health weekly.
    paste-ready brief for a coding agent, `investigationPrompt.ts`). The
    Comparisons tool is where a dispatched comparison lands.
 3. **Drift feed** (P2) — computed client-side, flagging a metric when it
-   clears the same `rel`/`absMs` thresholds the gate uses
-   (perf/bench/stats/gate.ts — one source of truth for "what matters").
+   clears the gate's floors (perf/bench/stats/gate.ts — one source of truth
+   for "what matters": 16ms and 5% for ms metrics) **and** moves by at least
+   2.5 standard errors of its own run-to-run noise.
 
    One baseline: the median of the last 7 runs vs the median of the prior 21.
    Smoothing both sides is what makes it trustworthy — one noisy run barely
    moves a median of 7, so a flag means a sustained shift.
+
+   The noise test is what makes the feed reviewable. Per-run noise on keystroke
+   latency is 11–22% and on load metrics 5–20% (48 stored runs, Aug 2026), so
+   the gate's fixed 5% floor alone flagged 68% of all 7-vs-21 windows on the
+   stored history — and a pure-noise simulation with the same spread flagged
+   57%. The noise is estimated per series from the points being compared
+   (robust MAD of consecutive differences and of the prior window's residuals,
+   whichever is larger, so both scatter and slow wander count). With it, the
+   same history flags 6% of keystroke windows (simulated pure noise: 1%), and
+   the load metrics that still flag are real sustained level shifts. What the
+   noise estimate sees: run-to-run scatter (consecutive differences, across
+   both windows and across the recent window alone) and slow wander inside
+   the prior window (residuals around its median). What it deliberately does
+   not treat as noise: a ramp inside the recent window, which is a level
+   change in progress.
+
+   Stated plainly, the feed catches **sustained level shifts, not steady
+   slopes**. A regression that creeps in a few percent per run is absorbed as
+   wander: +14% spread evenly over 21 runs comes out neutral (z ≈ 2.5 against
+   a 2.5 threshold). Catching slopes needs a trend test, which is a different
+   detector with its own false-alarm budget — not on the board today.
+
+   The summary numbers above are the whole record; the replay scripts that
+   produced them are not checked in (they ran against the bench dataset while
+   it was still publicly readable, with a Python model of the rule that the
+   shipped TypeScript was then checked against on the live history).
+
+   Drift stays on **measured values** — no host-speed correction. Keystroke
+   latency does track runner calibration (log-log slope 1.08, R² 0.35 on the
+   stored history; INP 0.90; load metrics only 0.28), and dividing it out
+   would take the keystroke false-alarm rate at z = 2.5 from 6% to 2%. It was
+   still left out, on the same grounds as the earlier host-normalization work
+   (`metrics-host-normalization-reference`: a controlled CPU-throttle sweep
+   fitting a sensitivity exponent per metric, kept strictly to a labelled
+   display lens): a correction is a model estimate with error bars, and the
+   review feed, badges and acks must not flag or unflag on a model. Calibration
+   is drawn as context so a reader can see when the host moved with the metric.
+   An implemented variant (a `scalesWithHost` series flag, adjustment applied
+   inside the window comparison, "host-adjusted" labels) exists as an unmerged
+   local branch and is not part of this repository's history; the decision
+   above is what to revisit first if it ever comes back.
 
    Windows are counted in **runs, not days**, and the UI says so ("vs prior 21
    runs"): the cron aims for one run a day, but the history has gaps and
@@ -119,6 +161,14 @@ effect of merged work; secondary: leads scanning health weekly.
    throttled or failed re-run can't drag the point. The merged point keeps a real
    run's identity so click-through opens an actual document.
 
+   Median for the window statistic too — measured, not assumed. Keystroke noise
+   is Gaussian (sd/MAD ratio 0.8–1.25, excess kurtosis ≈ 0), where a mean would
+   be ~20% more efficient; but the load metrics are heavy-tailed (auth-in-flight
+   kurtosis 12; syntheticLarge LCP bimodal between ~6s and ~25s), and there the
+   median fires on real shifts while the mean fires on the tail. Under the
+   noise-aware rule the median fires no more often than the mean anywhere, and it
+   is the statistic the plotted point, the badge and the PR gate already use.
+
    Honesty cost, stated plainly: re-runs of one commit often land on hosts of
    different speed (sha `7147d045`'s two runs differ by 21% of calibration), so a
    merged point averages across hosts. The **calibration strip is deliberately
@@ -130,7 +180,9 @@ effect of merged work; secondary: leads scanning health weekly.
    size, because run-to-run noise (~12% median) is well over the 5% threshold.
    Two baselines would also be impossible to tell apart in the UI while one of
    them fired constantly. Catching a single-run jump needs a more precise
-   measurement (more sessions per run), not different arithmetic.
+   measurement (more sessions per run), not different arithmetic — the noise
+   test above makes the 7-vs-21 comparison honest about its noise, it does not
+   make a single run less noisy.
 
    A weekday-matched variant (compare against the last 4 runs on the _same
    weekday_, to control for day-of-week CI runner load) was rejected too: the

--- a/dev/radar/SPEC.md
+++ b/dev/radar/SPEC.md
@@ -96,11 +96,12 @@ effect of merged work; secondary: leads scanning health weekly.
    paste-ready brief for a coding agent, `investigationPrompt.ts`). The
    Comparisons tool is where a dispatched comparison lands.
 3. **Drift feed** (P2) — computed client-side, flagging a metric when it
-   clears the gate's floors (perf/bench/stats/gate.ts — one source of truth
-   for "what matters": the larger of 16ms and 5% of the baseline for ms
-   metrics, so a baseline of 0 is judged on the absolute floor alone and a
-   tripwire count going 0 → 4 flags) **and** moves by at least 2.5 standard
-   errors of its own run-to-run noise. A move from a zero baseline is shown
+   clears the floors (the larger of 16ms and 5% of the baseline for ms
+   metrics — the gate's interaction pair from perf/bench/stats/gate.ts, applied
+   to load metrics as well since drift cannot tell the two apart by unit and
+   the gate's looser pageload pair of 100ms/8% is a subset; at a baseline of 0
+   the absolute floor alone decides, so a tripwire count going 0 → 4 flags)
+   **and** moves by at least 2.5 standard errors of its own run-to-run noise. A move from a zero baseline is shown
    as its absolute size ("+4"), since a percentage of nothing has no meaning.
 
    One baseline: the median of the last 7 runs vs the median of the prior 21.
@@ -109,7 +110,7 @@ effect of merged work; secondary: leads scanning health weekly.
 
    The noise test is what makes the feed reviewable. Per-run noise on keystroke
    latency is 11–22% and on load metrics 5–20% (48 stored runs, Aug 2026), so
-   the gate's fixed 5% floor alone flagged 68% of all 7-vs-21 windows on the
+   the fixed 5% floor alone flagged 68% of all 7-vs-21 windows on the
    stored history — and a pure-noise simulation with the same spread flagged
    57%. The noise is estimated per series from the points being compared
    (robust MAD of consecutive differences and of the prior window's residuals,

--- a/dev/radar/SPEC.md
+++ b/dev/radar/SPEC.md
@@ -97,8 +97,11 @@ effect of merged work; secondary: leads scanning health weekly.
    Comparisons tool is where a dispatched comparison lands.
 3. **Drift feed** (P2) — computed client-side, flagging a metric when it
    clears the gate's floors (perf/bench/stats/gate.ts — one source of truth
-   for "what matters": 16ms and 5% for ms metrics) **and** moves by at least
-   2.5 standard errors of its own run-to-run noise.
+   for "what matters": the larger of 16ms and 5% of the baseline for ms
+   metrics, so a baseline of 0 is judged on the absolute floor alone and a
+   tripwire count going 0 → 4 flags) **and** moves by at least 2.5 standard
+   errors of its own run-to-run noise. A move from a zero baseline is shown
+   as its absolute size ("+4"), since a percentage of nothing has no meaning.
 
    One baseline: the median of the last 7 runs vs the median of the prior 21.
    Smoothing both sides is what makes it trustworthy — one noisy run barely

--- a/dev/radar/tools/trends/DriftFeed.tsx
+++ b/dev/radar/tools/trends/DriftFeed.tsx
@@ -8,14 +8,9 @@ import {Box} from 'ui5'
 
 import {idSlug, SNOOZE_DAYS} from './acks'
 import {formatValue} from './data'
-import {baselineDetail, type DriftResult, noiseLabel} from './drift'
+import {baselineDetail, deltaLabel, type DriftResult, noiseLabel} from './drift'
 import {backlinksFor} from './links'
 import {type DriftState} from './useDriftState'
-
-function pct(fraction: number): string {
-  const sign = fraction > 0 ? '+' : ''
-  return `${sign}${(fraction * 100).toFixed(0)}%`
-}
 
 function DriftRow(props: {
   entry: DriftResult
@@ -40,7 +35,7 @@ function DriftRow(props: {
           ({entry.branch})
         </Text>
       )}
-      <Text size={1}>{pct(worst.deltaFraction)}</Text>
+      <Text size={1}>{deltaLabel(worst, entry.unit)}</Text>
       <Text size={0} muted>
         {formatValue(worst.baseline, entry.unit)} → {formatValue(worst.recent, entry.unit)}
         {' · '}

--- a/dev/radar/tools/trends/DriftFeed.tsx
+++ b/dev/radar/tools/trends/DriftFeed.tsx
@@ -8,7 +8,7 @@ import {Box} from 'ui5'
 
 import {idSlug, SNOOZE_DAYS} from './acks'
 import {formatValue} from './data'
-import {baselineDetail, type DriftResult} from './drift'
+import {baselineDetail, type DriftResult, noiseLabel} from './drift'
 import {backlinksFor} from './links'
 import {type DriftState} from './useDriftState'
 
@@ -45,6 +45,8 @@ function DriftRow(props: {
         {formatValue(worst.baseline, entry.unit)} → {formatValue(worst.recent, entry.unit)}
         {' · '}
         {baselineDetail(worst)}
+        {' · '}
+        {noiseLabel(worst)}
       </Text>
       {backlinksFor(entry.latest).map((link) => (
         <Box
@@ -91,10 +93,11 @@ function DriftRow(props: {
 }
 
 /**
- * "Changes to review" — metrics that drifted past the gate thresholds.
- * Regressions first; entries can be silenced / snoozed / marked fixed
- * (shared driftAck docs, realtime, half-lived). Acked entries collapse into
- * a reveal footer. Renders nothing when everything is steady and unacked.
+ * "Changes to review" — metrics whose recent window moved past the gate's
+ * floors *and* past their own noise (see drift.ts). Regressions first;
+ * entries can be silenced / snoozed / marked fixed (shared driftAck docs,
+ * realtime, half-lived). Acked entries collapse into a reveal footer.
+ * Renders nothing when everything is steady and unacked.
  */
 export function DriftFeed(props: {
   drift: DriftState

--- a/dev/radar/tools/trends/TrendsTool.tsx
+++ b/dev/radar/tools/trends/TrendsTool.tsx
@@ -63,7 +63,7 @@ import {
   vitalSections,
 } from './data'
 import {DEBUG_SOURCES, type DebugSource, generateDebugRuns, generateDebugTags} from './debugData'
-import {type DriftResult, worstBySeries} from './drift'
+import {deltaLabel, type DriftResult, worstBySeries} from './drift'
 import {DriftFeed} from './DriftFeed'
 import {type LayerState, useLayerState} from './layers'
 import {sourceFileUrl, webVitalDocUrl} from './links'
@@ -328,12 +328,10 @@ function chartDomId(seriesKey: string): string {
 }
 
 function driftBadge(entry: DriftResult): {tone: 'caution' | 'positive'; label: string} {
-  const worst = entry.baseline
-  const sign = worst.deltaFraction > 0 ? '+' : ''
   const arrow = entry.direction === 'regression' ? '↑' : '↓'
   return {
     tone: entry.direction === 'regression' ? 'caution' : 'positive',
-    label: `${arrow} ${sign}${(worst.deltaFraction * 100).toFixed(0)}%`,
+    label: `${arrow} ${deltaLabel(entry.baseline, entry.unit)}`,
   }
 }
 

--- a/dev/radar/tools/trends/drift.test.ts
+++ b/dev/radar/tools/trends/drift.test.ts
@@ -7,6 +7,8 @@ import {
   computeDrift,
   type DriftBaseline,
   type DriftResult,
+  NOISE_Z,
+  noiseLabel,
   worstBySeries,
 } from './drift'
 
@@ -41,30 +43,30 @@ function series(values: number[], overrides: Partial<TrendSeries> = {}): TrendSe
 }
 
 test('flat series does not fire', () => {
-  const drift = computeDrift([series(Array.from({length: 30}, () => 32))])
+  const drift = computeDrift([series(Array.from({length: 30}, () => 320))])
   expect(flagged(drift)).toHaveLength(0)
   // But a baseline is still computed, so the chart can draw the reference
   expect(drift).toHaveLength(1)
   expect(drift[0].direction).toBe('neutral')
 })
 
-// Prior ~32, last 7 jump to ~40 (25% > 5% and > 3ms)
+// Prior ~320, last 7 jump to ~400 (25% > 5%, 80ms > 16ms, and a flat prior has no noise)
 test('regression fires', () => {
-  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
+  const values = [...Array.from({length: 21}, () => 320), ...Array.from({length: 9}, () => 400)]
   const drift = computeDrift([series(values)])
   expect(flagged(drift)).toHaveLength(1)
   expect(drift[0].direction).toBe('regression')
 })
 
 test('improvement fires as improvement', () => {
-  const values = [...Array.from({length: 21}, () => 40), ...Array.from({length: 9}, () => 30)]
+  const values = [...Array.from({length: 21}, () => 400), ...Array.from({length: 9}, () => 300)]
   const drift = computeDrift([series(values)])
   expect(drift[0].direction).toBe('improvement')
 })
 
-// Below the relative floor: 32 → 33 is ~3% < 5%
+// Below the relative floor: 320 → 330 is ~3% < 5%
 test('sub-threshold move stays quiet', () => {
-  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 33)]
+  const values = [...Array.from({length: 21}, () => 320), ...Array.from({length: 9}, () => 330)]
   const drift = computeDrift([series(values)])
   expect(flagged(drift)).toHaveLength(0)
   expect(drift[0].direction).toBe('neutral')
@@ -111,22 +113,22 @@ test('context series is ignored', () => {
 // Too little history means no comparison exists at all — distinct from a
 // computed-but-quiet one, and the charts get no overlay either
 test('short history yields no baseline at all', () => {
-  expect(computeDrift([series([32, 33, 40])])).toHaveLength(0)
-  expect(computeDrift([series([32, 40])])).toHaveLength(0)
+  expect(computeDrift([series([320, 330, 400])])).toHaveLength(0)
+  expect(computeDrift([series([320, 400])])).toHaveLength(0)
 })
 
 // The whole point of neutral entries: a quiet chart still gets its reference
 // lines, so the overlay does not blink in and out as metrics cross the threshold.
 test('a quiet series still carries drawable windows', () => {
-  const drift = computeDrift([series(Array.from({length: 30}, () => 32))])
+  const drift = computeDrift([series(Array.from({length: 30}, () => 320))])
   expect(drift[0].direction).toBe('neutral')
   expect(drift[0].baseline.recentPointsMs).toHaveLength(7)
   expect(drift[0].baseline.baselinePointsMs).toHaveLength(21)
 })
 
 test('regressions sort first', () => {
-  const reg = series([...Array(21).fill(32), ...Array(9).fill(42)], {key: 'reg', title: 'reg'})
-  const imp = series([...Array(21).fill(42), ...Array(9).fill(30)], {key: 'imp', title: 'imp'})
+  const reg = series([...Array(21).fill(320), ...Array(9).fill(420)], {key: 'reg', title: 'reg'})
+  const imp = series([...Array(21).fill(420), ...Array(9).fill(300)], {key: 'imp', title: 'imp'})
   const drift = computeDrift([imp, reg])
   expect(drift[0].direction).toBe('regression')
 })
@@ -135,10 +137,10 @@ test('regressions sort first', () => {
 // a two-way "is it a regression" comparator answered improvement-vs-neutral
 // inconsistently, which makes Array.sort's output unspecified
 test('sorts regression, improvement, neutral in every input order', () => {
-  const reg = series([...Array(21).fill(32), ...Array(9).fill(42)], {key: 'reg', title: 'reg'})
-  const imp = series([...Array(21).fill(42), ...Array(9).fill(30)], {key: 'imp', title: 'imp'})
+  const reg = series([...Array(21).fill(320), ...Array(9).fill(420)], {key: 'reg', title: 'reg'})
+  const imp = series([...Array(21).fill(420), ...Array(9).fill(300)], {key: 'imp', title: 'imp'})
   const quiet = series(
-    Array.from({length: 30}, () => 32),
+    Array.from({length: 30}, () => 320),
     {key: 'quiet', title: 'quiet'},
   )
   for (const input of [
@@ -158,6 +160,9 @@ function baseline(overrides: Partial<DriftBaseline> = {}): DriftBaseline {
     delta: 8,
     deltaFraction: 0.25,
     direction: 'regression',
+    noiseSigma: 0,
+    standardError: 0,
+    zScore: Infinity,
     recentPointsMs: [START],
     baselinePointsMs: [START - DAY],
     ...overrides,
@@ -209,7 +214,7 @@ test('worstBySeries keeps the larger move within the same direction', () => {
 // The chart overlay draws these windows, so they must be exactly the windows
 // the medians came from — otherwise the picture and the percentage disagree.
 test('baseline carries its two window timestamps', () => {
-  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
+  const values = [...Array.from({length: 21}, () => 320), ...Array.from({length: 9}, () => 400)]
   const [entry] = computeDrift([series(values)])
   const {baseline: fired} = entry
 
@@ -235,7 +240,7 @@ function medianOf(list: number[]): number {
 // A window that doesn't contain the runs producing its median would draw the
 // rule in the wrong place; recomputing the median from the window guards that.
 test('window timestamps reproduce the reported medians', () => {
-  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
+  const values = [...Array.from({length: 21}, () => 320), ...Array.from({length: 9}, () => 400)]
   const trend = series(values)
   const points = trend.lines[0].points
   const valueAt = (ms: number) => points.find((point) => point.date.getTime() === ms)!.value
@@ -249,7 +254,7 @@ test('window timestamps reproduce the reported medians', () => {
 // silently leave the other behind. Both are stated in runs (never days) because
 // the cron misses days and sometimes runs twice.
 test('baseline labels match the windows the math uses', () => {
-  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
+  const values = [...Array.from({length: 21}, () => 320), ...Array.from({length: 9}, () => 400)]
   const {baseline: fired} = computeDrift([series(values)])[0]
 
   expect(baselineLabel(fired)).toContain(`${fired.baselinePointsMs.length} runs`)
@@ -264,7 +269,7 @@ test('baseline labels match the windows the math uses', () => {
 // size, and the label must count the runs it actually has — "vs prior 21 runs"
 // over 5 runs of evidence would overstate it fourfold
 test('labels count the actual window on short history', () => {
-  const values = [...Array.from({length: 5}, () => 32), ...Array.from({length: 7}, () => 40)]
+  const values = [...Array.from({length: 5}, () => 320), ...Array.from({length: 7}, () => 400)]
   const {baseline: fired} = computeDrift([series(values)])[0]
 
   expect(fired.baselinePointsMs).toHaveLength(5)
@@ -303,4 +308,83 @@ test('worstBySeries prefers a regression over a larger neutral', () => {
   })
   expect(worstBySeries([bigNeutral, smallRegression]).get('test')?.direction).toBe('regression')
   expect(worstBySeries([smallRegression, bigNeutral]).get('test')?.direction).toBe('regression')
+})
+
+// --- the noise test -----------------------------------------------------------
+
+/** 21 prior + 7 recent, alternating high/low so the series carries real noise. */
+function noisy(priorLevel: number, recentLevel: number, spread: number): number[] {
+  const wobble = (index: number) => (index % 2 === 0 ? -spread : spread)
+  return [
+    ...Array.from({length: 21}, (_, index) => priorLevel + wobble(index)),
+    ...Array.from({length: 7}, (_, index) => recentLevel + wobble(index)),
+  ]
+}
+
+// The same +9% move (350 → 380, 30ms > 16ms) flags on a quiet series and stays
+// neutral on a series whose runs scatter ±100ms: the move is well inside what
+// that series does on its own. This is the difference between a review feed
+// and an alarm that is always on.
+test('a move inside the series own noise stays neutral', () => {
+  const quiet = computeDrift([series([...Array(21).fill(350), ...Array(7).fill(380)])])
+  expect(quiet[0].direction).toBe('regression')
+
+  const scattered = computeDrift([series(noisy(350, 380, 100))])
+  expect(scattered[0].direction).toBe('neutral')
+  // Still clears both gate floors — only the noise test held it back
+  expect(Math.abs(scattered[0].baseline.delta)).toBeGreaterThanOrEqual(16)
+  expect(Math.abs(scattered[0].baseline.deltaFraction)).toBeGreaterThanOrEqual(0.05)
+  expect(scattered[0].baseline.zScore).toBeLessThan(NOISE_Z)
+})
+
+// ...but a move that is large relative to that same scatter still fires
+test('a move well outside the noise fires', () => {
+  const drift = computeDrift([series(noisy(350, 800, 100))])
+  expect(drift[0].direction).toBe('regression')
+  expect(drift[0].baseline.zScore).toBeGreaterThanOrEqual(NOISE_Z)
+})
+
+// A flat prior has no noise at all: the standard error is 0 and any move past
+// the floors is real by definition — the label says so rather than dividing by 0
+test('a series that never varied reports infinite noise clearance', () => {
+  const drift = computeDrift([series([...Array(21).fill(320), ...Array(9).fill(400)])])
+  expect(drift[0].baseline.noiseSigma).toBe(0)
+  expect(drift[0].baseline.zScore).toBe(Infinity)
+  expect(noiseLabel(drift[0].baseline)).toBe('∞× noise')
+  // And a flat series that did not move is 0, not NaN
+  const flat = computeDrift([series(Array.from({length: 30}, () => 320))])
+  expect(flat[0].baseline.zScore).toBe(0)
+})
+
+test('noise label states the move as a multiple of the noise', () => {
+  const drift = computeDrift([series(noisy(350, 380, 100))])
+  expect(noiseLabel(drift[0].baseline)).toMatch(/^\d+\.\d× noise$/)
+})
+
+// A slow wander (each step small, the level drifting) must count as noise too:
+// consecutive differences alone would call this series quiet and flag the
+// window difference the wander produces.
+test('slow wander inside the prior window raises the noise estimate', () => {
+  // Prior 21 ramp 300 → 400 in 5ms steps; recent 7 sit at the top of the ramp
+  const ramp = Array.from({length: 21}, (_, index) => 300 + index * 5)
+  const drift = computeDrift([series([...ramp, ...Array(7).fill(400)])])
+  // Consecutive differences see 5ms steps (σ ≈ 5.2); the prior window's
+  // residuals around its median of 350 have a MAD of 25 (σ ≈ 37), and win
+  expect(drift[0].baseline.noiseSigma).toBeCloseTo(1.4826 * 25, 1)
+  // 350 → 400 is +14%, but against that wander it is z ≈ 2.47: a steady slope
+  // is absorbed as noise — the feed catches level shifts, not ramps (SPEC.md)
+  expect(drift[0].baseline.zScore).toBeLessThan(NOISE_Z)
+  expect(drift[0].direction).toBe('neutral')
+})
+
+// Scatter that only starts in the recent window: a flat prior, then seven
+// runs alternating 300/500 (a host change that made a stable series jittery).
+// The whole-window step MAD ignores 7 steps out of 27 and the prior residuals
+// are zero, so without the recent-window step estimate this reads as an
+// infinitely significant "improvement" to 300.
+test('scatter confined to the recent window counts as noise', () => {
+  const recent = [300, 500, 300, 500, 300, 500, 300]
+  const drift = computeDrift([series([...Array(21).fill(400), ...recent])])
+  expect(drift[0].baseline.noiseSigma).toBeGreaterThan(100)
+  expect(drift[0].direction).toBe('neutral')
 })

--- a/dev/radar/tools/trends/drift.test.ts
+++ b/dev/radar/tools/trends/drift.test.ts
@@ -5,6 +5,7 @@ import {
   baselineDetail,
   baselineLabel,
   computeDrift,
+  deltaLabel,
   type DriftBaseline,
   type DriftResult,
   NOISE_Z,
@@ -325,7 +326,7 @@ function noisy(priorLevel: number, recentLevel: number, spread: number): number[
 // neutral on a series whose runs scatter ±100ms: the move is well inside what
 // that series does on its own. This is the difference between a review feed
 // and an alarm that is always on.
-test('a move inside the series own noise stays neutral', () => {
+test("a move inside the series' own noise stays neutral", () => {
   const quiet = computeDrift([series([...Array(21).fill(350), ...Array(7).fill(380)])])
   expect(quiet[0].direction).toBe('regression')
 
@@ -387,4 +388,44 @@ test('scatter confined to the recent window counts as noise', () => {
   const drift = computeDrift([series([...Array(21).fill(400), ...recent])])
   expect(drift[0].baseline.noiseSigma).toBeGreaterThan(100)
   expect(drift[0].direction).toBe('neutral')
+})
+
+// --- zero baselines --------------------------------------------------------------
+
+// A tripwire count that has always been 0 has no relative scale. The gate's
+// rule is max(absolute, relative × baseline), so at 0 the absolute floor alone
+// decides — an earlier `baseline !== 0` guard made such series unflaggable,
+// which is exactly wrong for "sessions not settled".
+test('a move away from a zero baseline flags on the absolute floor', () => {
+  const drift = computeDrift([series([...Array(21).fill(0), ...Array(7).fill(4)], {unit: 'count'})])
+  expect(drift[0].direction).toBe('regression')
+  expect(drift[0].baseline.deltaFraction).toBe(Infinity)
+  // No percentage of nothing — the label falls back to the absolute move
+  expect(deltaLabel(drift[0].baseline, 'count')).toBe('+4')
+  // ...and it outranks a finite regression in the feed
+  const finite = series([...Array(21).fill(320), ...Array(9).fill(400)], {key: 'finite'})
+  const [first] = computeDrift([
+    finite,
+    series([...Array(21).fill(0), ...Array(7).fill(4)], {unit: 'count', key: 'zero'}),
+  ])
+  expect(first.seriesKey).toBe('zero')
+})
+
+test('a zero baseline that stays at zero is neutral, not NaN', () => {
+  const drift = computeDrift([
+    series(
+      Array.from({length: 30}, () => 0),
+      {unit: 'count'},
+    ),
+  ])
+  expect(drift[0].direction).toBe('neutral')
+  expect(drift[0].baseline.deltaFraction).toBe(0)
+  expect(deltaLabel(drift[0].baseline, 'count')).toBe('0%')
+})
+
+test('deltaLabel shows a signed percentage for finite baselines', () => {
+  const up = computeDrift([series([...Array(21).fill(320), ...Array(9).fill(400)])])
+  expect(deltaLabel(up[0].baseline, 'ms')).toBe('+25%')
+  const down = computeDrift([series([...Array(21).fill(400), ...Array(9).fill(300)])])
+  expect(deltaLabel(down[0].baseline, 'ms')).toBe('−25%')
 })

--- a/dev/radar/tools/trends/drift.ts
+++ b/dev/radar/tools/trends/drift.ts
@@ -2,27 +2,23 @@
  * Drift detection: "did any metric move enough to care?"
  *
  * One baseline: the median of the last 7 runs against the median of the 21
- * before them. Smoothing both sides is what makes it trustworthy — a single
- * noisy run barely moves a median of 7, so a flag means a sustained shift.
+ * before them (one point per commit — `buildSeries` merges re-runs). A move
+ * counts when it passes all three of:
  *
- * Windows are counted in **runs, not days**: the cron aims for one run a day but
- * the history has gaps and same-day doubles, so a day-based label would be a
- * guess. `buildSeries` has already merged re-runs of the same commit into one
- * point (see `mergeRunsPerCommit`), so a window of 21 is 21 commits — and the
- * spans the chart overlay draws line up with the plotted points exactly.
+ * 1. the gate's absolute floor for the unit (perf/bench/stats/gate.ts; 16ms
+ *    for ms — two Event Timing quantisation steps);
+ * 2. the gate's relative floor, 5% of the baseline; and
+ * 3. a noise test: at least NOISE_Z standard errors of the window comparison,
+ *    with the noise estimated from the series itself (`noiseSigma`).
  *
- * A second, faster "step" baseline (latest run vs a median of recent runs, to
- * catch a jump the day it lands) was considered and rejected: measured against
- * the stored history it would fire on 74–92% of runs at every window size,
- * because run-to-run noise on these metrics (~12% median) is well over the 5%
- * threshold. A detector that fires four runs out of five is not a signal, and
- * no windowing fixes it. Detecting a single-run jump needs a more precise
- * measurement (more sessions per run), not different arithmetic.
- *
- * "Enough to care" reuses the bench gate's thresholds (perf/bench/stats/
- * gate.ts) so the dashboard and the PR gate share one definition of a
- * meaningful change: the delta must clear BOTH an absolute floor and a
- * relative fraction of the baseline.
+ * The third test is what makes the feed reviewable: run-to-run noise on these
+ * metrics (11–22% on keystroke latency) is well over the 5% floor, so the
+ * floors alone flagged ~68% of all windows on the stored history — about what
+ * pure noise would. Windows are run-counted, not day-counted; the statistic is
+ * the median (matching the plotted point and the gate); host speed is not
+ * corrected for. The derivation, the measurements behind each of those
+ * choices and the alternatives that were rejected are in SPEC.md, "Drift
+ * feed" — this header only repeats the numbers the constants below depend on.
  */
 import {type TrendPoint, type TrendSeries, type TrendUnit} from './data'
 
@@ -31,12 +27,11 @@ interface DriftThreshold {
   relative: number
 }
 
-/** Mirrors INTERACTION_THRESHOLDS / PAGELOAD_THRESHOLDS by unit. */
+/** Mirrors the gate's floors by unit (INTERACTION_THRESHOLDS for ms). */
 function thresholdFor(unit: TrendUnit): DriftThreshold {
-  // ms metrics split into keystroke-latency (tight) vs load (loose); we can't
-  // tell them apart by unit alone, so use the stricter interaction floor for
-  // ms — a load metric that clears 8% will clear it comfortably anyway.
-  if (unit === 'ms') return {absolute: 3, relative: 0.05}
+  // 16ms = two Event Timing quantisation steps (8ms granularity), the gate's
+  // interaction floor. Load metrics are far above it, so one floor serves both.
+  if (unit === 'ms') return {absolute: 16, relative: 0.05}
   if (unit === 'megabytes') return {absolute: 1, relative: 0.05}
   if (unit === 'bytes') return {absolute: 10 * 1024, relative: 0.05}
   // CLS is unitless and small (good ≤ 0.1) — a whole-unit absolute floor would
@@ -50,11 +45,72 @@ function thresholdFor(unit: TrendUnit): DriftThreshold {
 const RECENT_RUNS = 7
 const BASELINE_RUNS = 21
 
+/**
+ * How many standard errors the window difference must clear. 2.5 is a nominal
+ * ~1% two-sided false-alarm rate per series; with ~50 series on the board that
+ * is about one spurious flag standing at any time. z = 2 left two to three
+ * (and 24% of keystroke windows firing on the stored history); z = 3 starts
+ * hiding real 10% shifts on the noisier series.
+ */
+export const NOISE_Z = 2.5
+
+/**
+ * Standard error of a sample median relative to a sample mean under Gaussian
+ * noise (√(π/2)). The noise test uses medians, so their wider spread has to
+ * be priced in or the test is too eager.
+ */
+const MEDIAN_EFFICIENCY = Math.sqrt(Math.PI / 2)
+
+/** 1.4826 × MAD estimates σ for Gaussian noise; robust to a few outliers. */
+const MAD_TO_SIGMA = 1.4826
+
 function median(values: number[]): number | null {
   if (values.length === 0) return null
   const sorted = [...values].sort((a, b) => a - b)
   const mid = Math.floor(sorted.length / 2)
   return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+function medianAbsoluteDeviation(values: number[], center: number): number {
+  return median(values.map((value) => Math.abs(value - center))) ?? 0
+}
+
+/**
+ * Per-run noise (σ) of a series, in its own unit, from the points the window
+ * comparison uses. Three robust estimates, take the largest:
+ *
+ * - MAD of consecutive differences across both windows (÷√2, since a
+ *   difference of two iid samples has √2 the spread of one). Catches
+ *   run-to-run scatter; a single step change inside the window is one outlier
+ *   and does not inflate it.
+ * - The same over the recent window alone. Seven of 27 steps cannot move the
+ *   whole-window MAD, so scatter that only starts in the recent window — a
+ *   host change that makes a stable series jittery — is invisible to it, and
+ *   a flat prior would otherwise make any recent wobble look infinitely
+ *   significant.
+ * - MAD of the prior window's residuals around its own median. Catches slow
+ *   wander — host image changes, gradual regressions — that consecutive
+ *   differences understate because each step is small. Deliberately NOT
+ *   computed for the recent window: a ramp inside the last 7 runs is a level
+ *   change in progress, not noise.
+ *
+ * Under iid Gaussian noise the estimates agree; taking the max means whichever
+ * kind of noise a series has, the threshold rises to meet it. Zero for a
+ * perfectly repeatable series (counts that never move), so any move past the
+ * floors flags — correct: a count that has never varied and now did is a real
+ * change.
+ */
+function noiseSigma(
+  windowValues: number[],
+  recentValues: number[],
+  priorValues: number[],
+  priorMedian: number,
+): number {
+  const stepsOf = (values: number[]) => values.slice(1).map((value, index) => value - values[index])
+  const sigmaFromSteps = (values: number[]) =>
+    (MAD_TO_SIGMA * medianAbsoluteDeviation(stepsOf(values), 0)) / Math.SQRT2
+  const fromResiduals = MAD_TO_SIGMA * medianAbsoluteDeviation(priorValues, priorMedian)
+  return Math.max(sigmaFromSteps(windowValues), sigmaFromSteps(recentValues), fromResiduals)
 }
 
 export type DriftDirection = 'regression' | 'improvement' | 'neutral'
@@ -65,6 +121,15 @@ export interface DriftBaseline {
   delta: number
   deltaFraction: number
   direction: DriftDirection
+  /**
+   * Per-run noise of the series in its unit (see `noiseSigma`), and the
+   * standard error of `delta` it implies. `zScore` is |delta| / standardError
+   * — how many times its own noise the series moved; the noise test is
+   * `zScore >= NOISE_Z`. Infinity when the series has no noise at all.
+   */
+  noiseSigma: number
+  standardError: number
+  zScore: number
   /**
    * Run timestamps of the window whose median is `recent`, and of the window
    * whose median is `baseline` — what the chart overlay draws so the badge's
@@ -91,6 +156,16 @@ export function baselineDetail(baseline: DriftBaseline): string {
   return `median of the last ${baseline.recentPointsMs.length} runs vs the prior ${baseline.baselinePointsMs.length} runs`
 }
 
+/**
+ * The move as a multiple of the series' own noise — the third test, stated so
+ * a reader can see why a 6% move flagged on one chart and a 9% move did not on
+ * another. "∞× noise" for a series that has never varied.
+ */
+export function noiseLabel(baseline: DriftBaseline): string {
+  if (!Number.isFinite(baseline.zScore)) return '∞× noise'
+  return `${baseline.zScore.toFixed(1)}× noise`
+}
+
 export interface DriftResult {
   seriesKey: string
   title: string
@@ -110,6 +185,7 @@ export interface DriftResult {
 function classify(
   recent: number,
   baseline: number,
+  standardError: number,
   threshold: DriftThreshold,
   goal: TrendSeries['goal'],
 ): DriftDirection {
@@ -117,33 +193,13 @@ function classify(
   const cleared =
     Math.abs(delta) >= threshold.absolute &&
     baseline !== 0 &&
-    Math.abs(delta) / Math.abs(baseline) >= threshold.relative
+    Math.abs(delta) / Math.abs(baseline) >= threshold.relative &&
+    // standardError is 0 for a series that never varies: any move that
+    // cleared the floors is then real by definition
+    Math.abs(delta) >= NOISE_Z * standardError
   if (!cleared || goal === 'context') return 'neutral'
   // Lower is better: a rise is a regression
   return delta > 0 ? 'regression' : 'improvement'
-}
-
-function makeBaseline(
-  recentPoints: TrendPoint[],
-  baselinePoints: TrendPoint[],
-  recent: number,
-  baselineValue: number,
-  threshold: DriftThreshold,
-  goal: TrendSeries['goal'],
-): DriftBaseline {
-  // A sub-threshold move is still a real comparison worth drawing — the charts
-  // show the overlay on every series, and `direction: 'neutral'` is what keeps
-  // it out of the review feed and the tab counts.
-  const direction = classify(recent, baselineValue, threshold, goal)
-  return {
-    recent,
-    baseline: baselineValue,
-    delta: recent - baselineValue,
-    deltaFraction: baselineValue === 0 ? 0 : (recent - baselineValue) / Math.abs(baselineValue),
-    direction,
-    recentPointsMs: recentPoints.map((point) => point.date.getTime()),
-    baselinePointsMs: baselinePoints.map((point) => point.date.getTime()),
-  }
 }
 
 /** Points sorted oldest→newest, most recent last. */
@@ -157,12 +213,36 @@ function computeBaseline(
   if (points.length < 10) return null // need a meaningful prior window
   // Slice the points (not the values) so the same windows that produce the
   // medians also carry their timestamps to the chart overlay
-  const recentPoints = points.slice(-RECENT_RUNS)
-  const priorPoints = points.slice(-(RECENT_RUNS + BASELINE_RUNS), -RECENT_RUNS)
-  const recent = median(recentPoints.map((point) => point.value))
-  const prior = median(priorPoints.map((point) => point.value))
+  const windowPoints = points.slice(-(RECENT_RUNS + BASELINE_RUNS))
+  const values = windowPoints.map((point) => point.value)
+  const recentPoints = windowPoints.slice(-RECENT_RUNS)
+  const priorPoints = windowPoints.slice(0, -RECENT_RUNS)
+  const recentValues = values.slice(-RECENT_RUNS)
+  const priorValues = values.slice(0, -RECENT_RUNS)
+  const recent = median(recentValues)
+  const prior = median(priorValues)
   if (recent === null || prior === null) return null
-  return makeBaseline(recentPoints, priorPoints, recent, prior, threshold, goal)
+
+  const sigma = noiseSigma(values, recentValues, priorValues, prior)
+  const standardError =
+    sigma * MEDIAN_EFFICIENCY * Math.sqrt(1 / recentValues.length + 1 / priorValues.length)
+  const delta = recent - prior
+  // A sub-threshold move is still a real comparison worth drawing — the charts
+  // show the overlay on every series, and `direction: 'neutral'` is what keeps
+  // it out of the review feed and the tab counts.
+  const direction = classify(recent, prior, standardError, threshold, goal)
+  return {
+    recent,
+    baseline: prior,
+    delta,
+    deltaFraction: prior === 0 ? 0 : delta / Math.abs(prior),
+    direction,
+    noiseSigma: sigma,
+    standardError,
+    zScore: standardError === 0 ? (delta === 0 ? 0 : Infinity) : Math.abs(delta) / standardError,
+    recentPointsMs: recentPoints.map((point) => point.date.getTime()),
+    baselinePointsMs: priorPoints.map((point) => point.date.getTime()),
+  }
 }
 
 /**

--- a/dev/radar/tools/trends/drift.ts
+++ b/dev/radar/tools/trends/drift.ts
@@ -20,7 +20,7 @@
  * choices and the alternatives that were rejected are in SPEC.md, "Drift
  * feed" — this header only repeats the numbers the constants below depend on.
  */
-import {type TrendPoint, type TrendSeries, type TrendUnit} from './data'
+import {formatValue, type TrendPoint, type TrendSeries, type TrendUnit} from './data'
 
 interface DriftThreshold {
   absolute: number
@@ -119,6 +119,12 @@ export interface DriftBaseline {
   recent: number
   baseline: number
   delta: number
+  /**
+   * `delta` as a fraction of the baseline. ±Infinity when the baseline is 0
+   * and the series moved (a move from nothing has no finite relative size, and
+   * it should sort first, not last) — display through `deltaLabel`, which
+   * falls back to the absolute move in that case.
+   */
   deltaFraction: number
   direction: DriftDirection
   /**
@@ -157,6 +163,19 @@ export function baselineDetail(baseline: DriftBaseline): string {
 }
 
 /**
+ * The move for badges and feed rows: a signed percentage of the baseline, or
+ * the signed absolute move when the baseline was 0 and a percentage has no
+ * meaning ("+4" for a tripwire count that went 0 → 4).
+ */
+export function deltaLabel(baseline: DriftBaseline, unit: TrendUnit): string {
+  const sign = baseline.delta > 0 ? '+' : baseline.delta < 0 ? '−' : ''
+  if (!Number.isFinite(baseline.deltaFraction)) {
+    return `${sign}${formatValue(Math.abs(baseline.delta), unit)}`
+  }
+  return `${sign}${Math.abs(baseline.deltaFraction * 100).toFixed(0)}%`
+}
+
+/**
  * The move as a multiple of the series' own noise — the third test, stated so
  * a reader can see why a 6% move flagged on one chart and a 9% move did not on
  * another. "∞× noise" for a series that has never varied.
@@ -190,10 +209,15 @@ function classify(
   goal: TrendSeries['goal'],
 ): DriftDirection {
   const delta = recent - baseline
+  // The gate's rule (gate.ts): the minimum effect is the larger of the absolute
+  // floor and the relative floor of the baseline. Written that way rather than
+  // as two checks so a baseline of 0 is handled: a tripwire count ("sessions
+  // not settled") sitting at 0 has no relative scale, and a move to 4 must
+  // flag on the absolute floor alone — an earlier `baseline !== 0` guard made
+  // such series unflaggable.
+  const minimumEffect = Math.max(threshold.absolute, threshold.relative * Math.abs(baseline))
   const cleared =
-    Math.abs(delta) >= threshold.absolute &&
-    baseline !== 0 &&
-    Math.abs(delta) / Math.abs(baseline) >= threshold.relative &&
+    Math.abs(delta) >= minimumEffect &&
     // standardError is 0 for a series that never varies: any move that
     // cleared the floors is then real by definition
     Math.abs(delta) >= NOISE_Z * standardError
@@ -235,7 +259,8 @@ function computeBaseline(
     recent,
     baseline: prior,
     delta,
-    deltaFraction: prior === 0 ? 0 : delta / Math.abs(prior),
+    deltaFraction:
+      prior === 0 ? (delta === 0 ? 0 : Math.sign(delta) * Infinity) : delta / Math.abs(prior),
     direction,
     noiseSigma: sigma,
     standardError,

--- a/dev/radar/tools/trends/drift.ts
+++ b/dev/radar/tools/trends/drift.ts
@@ -5,9 +5,12 @@
  * before them (one point per commit — `buildSeries` merges re-runs). A move
  * counts when it passes all three of:
  *
- * 1. the gate's absolute floor for the unit (perf/bench/stats/gate.ts; 16ms
- *    for ms — two Event Timing quantisation steps);
- * 2. the gate's relative floor, 5% of the baseline; and
+ * 1. an absolute floor per unit — for ms the gate's interaction floor of 16ms
+ *    (perf/bench/stats/gate.ts; two Event Timing quantisation steps);
+ * 2. a relative floor of 5% of the baseline — the gate's interaction figure,
+ *    applied to every ms series (the gate's looser pageload pair, 100ms and
+ *    8%, is not used: drift cannot tell load from keystroke metrics by unit,
+ *    and a load metric that clears 8% clears 5%); and
  * 3. a noise test: at least NOISE_Z standard errors of the window comparison,
  *    with the noise estimated from the series itself (`noiseSigma`).
  *
@@ -27,7 +30,12 @@ interface DriftThreshold {
   relative: number
 }
 
-/** Mirrors the gate's floors by unit (INTERACTION_THRESHOLDS for ms). */
+/**
+ * Floors by unit. For ms this is the gate's INTERACTION_THRESHOLDS (16ms, 5%),
+ * applied to load metrics too — the gate's PAGELOAD_THRESHOLDS (100ms, 8%) are
+ * deliberately not mirrored, since drift cannot tell the two kinds apart by
+ * unit and the tighter pair is a superset. The other units are drift's own.
+ */
 function thresholdFor(unit: TrendUnit): DriftThreshold {
   // 16ms = two Event Timing quantisation steps (8ms granularity), the gate's
   // interaction floor. Load metrics are far above it, so one floor serves both.


### PR DESCRIPTION
### Description

The trend charts currently flags a metric when the median of the last 7 runs moved 5% against the prior 21. Run-to-run noise on e.g. keystroke latency is 11–22%, so on the stored history this fired on 68% of windows. Pure noise with the same spread fires on 57%, causing trend charts to be less informative.

A move now has to be at least 2.5 standard errors of the series' own noise, estimated from the points in the two windows. Same history: 6% of keystroke windows fire (pure noise: 1%), and the load metrics that still fire are real level shifts. On the day this was written, the live feed went from 20 flagged series to 4.

Also fixes an ms floor from 3ms to 16ms. 3ms is below one 8ms Event Timing step and did not match the gate it claimed to mirror.

Note: this detects level shifts, not slow slopes. A +14% spread over 21 runs stays neutral.

### What to review

- `drift.ts`: `noiseSigma`, the standard error for a difference of medians, and the three-part `classify`.
- `SPEC.md`, Drift feed section: the derivation and decisions.
- `DriftFeed.tsx` shows a "N× noise" label per row. Client-side only, no data changes.

### Testing

- Existing drift tests rescaled to clear the 16ms floor.
- New tests cover: a move inside the series' scatter stays neutral while the same move on a quiet series fires, zero-noise series give ∞ not NaN, a ramp in the prior window is absorbed as wander, and scatter that starts in the recent window counts as noise.

### Notes for release

N/A – Internal only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Client-side Radar trends logic and docs only; no API or persisted data changes, with broad vitest coverage for the new classifier.
> 
> **Overview**
> Radar’s **drift feed** no longer flags on gate floors alone. A 7-vs-21-run median shift must also clear **≥2.5 standard errors** of per-series noise (`noiseSigma` from MAD of step differences and prior-window residuals), which cut false positives on stored history from ~68% of windows to ~6% on keystroke metrics.
> 
> **`drift.ts`** aligns ms floors with the bench gate (**16ms**, not 3ms, plus 5% via `max(absolute, relative × baseline)`), fixes **zero-baseline** count metrics (e.g. 0→4 flags and shows **+4** via `deltaLabel`), and exposes **`noiseLabel`** / z-score on each finding. **`DriftFeed`** and chart badges use those helpers instead of raw percentages.
> 
> **`SPEC.md`** documents the noise rule, level-shift vs slope limits, median choice, and explicit no host-normalization for drift.
> 
> Tests are rescaled for 16ms and add coverage for noise gating, wander/ramp behavior, and zero baselines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2337f62e785cab17c3d3a80f216f831ee2df8394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->