### PR TITLE
fix(core): resolve the duplicate-variant link to a real tool-scoped route

### DIFF
--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
@@ -9,10 +9,12 @@ import {VariantDialog} from './VariantDialog'
 interface CreateVariantDialogProps {
   onCancel: () => void
   onSubmit: (createdVariantId: string) => void
+  /** See `VariantForm`'s prop of the same name. */
+  withinVariantsTool: boolean
 }
 
 export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.Element {
-  const {onCancel, onSubmit} = props
+  const {onCancel, onSubmit, withinVariantsTool} = props
   const {t} = useTranslation(variantsLocaleNamespace)
   const {createVariant} = useVariantOperations()
   const initialValue = useMemo(() => getVariantDefaults(), [])
@@ -35,6 +37,7 @@ export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.
       initialValue={initialValue}
       onCancel={onCancel}
       onSubmit={handleSubmit}
+      withinVariantsTool={withinVariantsTool}
     />
   )
 }

--- a/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
@@ -10,6 +10,8 @@ interface EditVariantDialogProps {
   onCancel: () => void
   onSubmit: () => void
   variant: SystemVariant
+  /** See `VariantForm`'s prop of the same name. */
+  withinVariantsTool: boolean
 }
 
 function toEditableVariant(variant: SystemVariant): EditableSystemVariant {
@@ -23,7 +25,7 @@ function toEditableVariant(variant: SystemVariant): EditableSystemVariant {
 }
 
 export function EditVariantDialog(props: EditVariantDialogProps): React.JSX.Element {
-  const {onCancel, onSubmit, variant: initialVariant} = props
+  const {onCancel, onSubmit, variant: initialVariant, withinVariantsTool} = props
   const {t} = useTranslation(variantsLocaleNamespace)
   const {updateVariant} = useVariantOperations()
   const initialValue = useMemo(() => toEditableVariant(initialVariant), [initialVariant])
@@ -47,6 +49,7 @@ export function EditVariantDialog(props: EditVariantDialogProps): React.JSX.Elem
       onCancel={onCancel}
       onSubmit={handleSubmit}
       renderCancelButton
+      withinVariantsTool={withinVariantsTool}
     />
   )
 }

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -25,6 +25,8 @@ interface VariantDialogProps {
   onCancel: () => void
   onSubmit: (variant: EditableSystemVariant) => Promise<void>
   renderCancelButton?: boolean
+  /** See `VariantForm`'s prop of the same name. */
+  withinVariantsTool: boolean
 }
 
 export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
@@ -38,6 +40,7 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
     onCancel,
     onSubmit,
     renderCancelButton = false,
+    withinVariantsTool,
   } = props
   const toast = useToast()
   const {t} = useTranslation(variantsLocaleNamespace)
@@ -114,6 +117,7 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
               onPriorityValidityChange={setPriorityInvalid}
               showValidation={showValidation}
               value={variant}
+              withinVariantsTool={withinVariantsTool}
             />
           </Box>
           <Flex gap={2} justifyContent="flex-end" paddingTop={5}>

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -161,14 +161,21 @@ function getPortableTextDescriptionValue(description?: PortableTextBlock[]): str
   return toPlainText(description)
 }
 
-function DuplicateVariantLink(props: {children?: ReactNode; variantId?: string}) {
-  return (
-    <StateLink
-      state={{tool: VARIANTS_TOOL_NAME, [VARIANTS_TOOL_NAME]: {variantId: props.variantId}}}
-    >
-      {props.children}
-    </StateLink>
-  )
+function DuplicateVariantLink(props: {
+  children?: ReactNode
+  variantId?: string
+  withinVariantsTool: boolean
+}) {
+  // The router state's own shape depends on where this link renders, and that can't be
+  // detected at runtime: inside the variants tool, `RouteScope` has already stripped the
+  // `tool` key out of the local state view, so a bare `{variantId}` is what resolves. Anywhere
+  // else (e.g. the perspective bar's "Add variant" menu) there is no such scope, and the link
+  // has to name the tool explicitly. Callers know which case they're in; this doesn't guess.
+  const state = props.withinVariantsTool
+    ? {variantId: props.variantId}
+    : {tool: VARIANTS_TOOL_NAME, [VARIANTS_TOOL_NAME]: {variantId: props.variantId}}
+
+  return <StateLink state={state}>{props.children}</StateLink>
 }
 
 const DUPLICATE_MESSAGE_COMPONENTS = {VariantLink: DuplicateVariantLink}
@@ -191,6 +198,13 @@ export function VariantForm(props: {
   onPriorityValidityChange: (invalid: boolean) => void
   showValidation?: boolean
   value: EditableSystemVariant
+  /**
+   * Whether this form is rendered inside the variants tool's own route scope (the overview or a
+   * variant's detail page) as opposed to elsewhere (e.g. the perspective bar's "Add variant"
+   * menu). Determines how the duplicate-variant link resolves its target — see
+   * `DuplicateVariantLink` above.
+   */
+  withinVariantsTool: boolean
 }) {
   const {
     duplicateConditionsOf,
@@ -200,6 +214,7 @@ export function VariantForm(props: {
     onPriorityValidityChange,
     showValidation = false,
     value,
+    withinVariantsTool,
   } = props
   const {t} = useTranslation(variantsLocaleNamespace)
   const {data: variants} = useAllVariants()
@@ -379,7 +394,10 @@ export function VariantForm(props: {
                 t={t}
                 i18nKey="dialog.create.variant-title.duplicate"
                 components={DUPLICATE_MESSAGE_COMPONENTS}
-                componentProps={{variantId: getVariantId(duplicateTitleVariant._id)}}
+                componentProps={{
+                  variantId: getVariantId(duplicateTitleVariant._id),
+                  withinVariantsTool,
+                }}
                 values={{title: getVariantTitle(duplicateTitleVariant)}}
               />
             ) : (
@@ -576,7 +594,10 @@ export function VariantForm(props: {
               t={t}
               i18nKey="dialog.create.conditions.duplicate"
               components={DUPLICATE_MESSAGE_COMPONENTS}
-              componentProps={{variantId: getVariantId(duplicateConditionsVariant._id)}}
+              componentProps={{
+                variantId: getVariantId(duplicateConditionsVariant._id),
+                withinVariantsTool,
+              }}
               values={{title: getVariantTitle(duplicateConditionsVariant)}}
             />
           </TextWithTone>

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -25,6 +25,7 @@ import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {Translate} from '../../../i18n/Translate'
 import {useVariantConditions} from '../../hooks/useVariantConditions'
 import {type VariantsLocaleResourceKeys, variantsLocaleNamespace} from '../../i18n'
+import {VARIANTS_TOOL_NAME} from '../../plugin'
 import {useAllVariants} from '../../store/useAllVariants'
 import {getVariantId, getVariantTitle} from '../../tool/util'
 import {type EditableSystemVariant, type SystemVariant} from '../../types'
@@ -161,7 +162,13 @@ function getPortableTextDescriptionValue(description?: PortableTextBlock[]): str
 }
 
 function DuplicateVariantLink(props: {children?: ReactNode; variantId?: string}) {
-  return <StateLink state={{variantId: props.variantId}}>{props.children}</StateLink>
+  return (
+    <StateLink
+      state={{tool: VARIANTS_TOOL_NAME, [VARIANTS_TOOL_NAME]: {variantId: props.variantId}}}
+    >
+      {props.children}
+    </StateLink>
+  )
 }
 
 const DUPLICATE_MESSAGE_COMPONENTS = {VariantLink: DuplicateVariantLink}

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -31,20 +31,24 @@ vi.mock('@sanity/ui/toast', async (importOriginal) => ({
   useToast: vi.fn(() => toastMock),
 }))
 
-// The test router has no `variantId` route, so resolve duplicate-error links to plain anchors.
+// The test router has no real `variants` tool route registered, so resolve the tool-scoped
+// duplicate-error state to plain anchors instead of exercising real route resolution.
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),
   StateLink: function MockStateLink({
     ref,
     state,
     ...rest
-  }: {state?: {variantId?: string}} & HTMLProps<HTMLAnchorElement>) {
+  }: {
+    state?: {tool?: string; variants?: {variantId?: string}}
+  } & HTMLProps<HTMLAnchorElement>) {
+    const variantId = state?.tool === 'variants' ? state.variants?.variantId : undefined
     return (
       // oxlint-disable-next-line jsx_a11y/anchor-has-content
       <a
         {...rest}
         ref={ref as Ref<HTMLAnchorElement>}
-        href={state?.variantId ? `/variants/${state.variantId}` : '/variants'}
+        href={variantId ? `/variants/${variantId}` : '/variants'}
       />
     )
   },

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -31,24 +31,20 @@ vi.mock('@sanity/ui/toast', async (importOriginal) => ({
   useToast: vi.fn(() => toastMock),
 }))
 
-// The test router has no real `variants` tool route registered, so resolve the tool-scoped
-// duplicate-error state to plain anchors instead of exercising real route resolution.
+// The test router has no `variantId` route, so resolve duplicate-error links to plain anchors.
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),
   StateLink: function MockStateLink({
     ref,
     state,
     ...rest
-  }: {
-    state?: {tool?: string; variants?: {variantId?: string}}
-  } & HTMLProps<HTMLAnchorElement>) {
-    const variantId = state?.tool === 'variants' ? state.variants?.variantId : undefined
+  }: {state?: {variantId?: string}} & HTMLProps<HTMLAnchorElement>) {
     return (
       // oxlint-disable-next-line jsx_a11y/anchor-has-content
       <a
         {...rest}
         ref={ref as Ref<HTMLAnchorElement>}
-        href={variantId ? `/variants/${variantId}` : '/variants'}
+        href={state?.variantId ? `/variants/${state.variantId}` : '/variants'}
       />
     )
   },
@@ -79,9 +75,12 @@ describe('CreateVariantDialog', () => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} />, {
-      wrapper,
-    })
+    const result = render(
+      <CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} withinVariantsTool />,
+      {
+        wrapper,
+      },
+    )
     await screen.findByRole('dialog', {name: 'Create variant definition'})
     return result
   }
@@ -561,9 +560,12 @@ describe('CreateVariantDialog mapped conditions', () => {
       },
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} />, {
-      wrapper,
-    })
+    const result = render(
+      <CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} withinVariantsTool />,
+      {
+        wrapper,
+      },
+    )
     await screen.findByRole('dialog', {name: 'Create variant definition'})
     return result
   }

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
@@ -63,6 +63,7 @@ describe('VariantDialog', () => {
         onCancel={onCancel}
         onSubmit={onSubmit}
         renderCancelButton={props?.renderCancelButton}
+        withinVariantsTool
       />,
       {wrapper},
     )

--- a/packages/sanity/src/core/variants/plugin/index.tsx
+++ b/packages/sanity/src/core/variants/plugin/index.tsx
@@ -20,7 +20,10 @@ export const VARIANTS_NAME = 'sanity/variants'
 
 const VARIANTS_INTENT = 'variant'
 
-const VARIANTS_TOOL_NAME = 'variants'
+/**
+ * @internal
+ */
+export const VARIANTS_TOOL_NAME = 'variants'
 
 /**
  * @internal

--- a/packages/sanity/src/core/variants/tool/detail/VariantActionRail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantActionRail.tsx
@@ -55,6 +55,7 @@ export function VariantActionRail({
           onCancel={() => setEditDialogOpen(false)}
           onSubmit={() => setEditDialogOpen(false)}
           variant={variant}
+          withinVariantsTool
         />
       )}
     </>

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -65,6 +65,7 @@ export function VariantMenuButton({
           onCancel={() => setIsEditDialogOpen(false)}
           onSubmit={() => setIsEditDialogOpen(false)}
           variant={variant}
+          withinVariantsTool
         />
       )}
       {isDeleteDialogOpen && (

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -197,6 +197,7 @@ export function VariantsOverview(): React.JSX.Element {
         <CreateVariantDialog
           onCancel={() => setIsCreateVariantDialogOpen(false)}
           onSubmit={handleOnCreateVariant}
+          withinVariantsTool
         />
       )}
     </Flex>


### PR DESCRIPTION
## What's broken

`DuplicateVariantLink` (in `VariantForm.tsx`, the "already exists, see X" warning shown when a new variant's title or conditions collide with an existing one) builds its router state without accounting for where it renders. Today this link only ever renders while already inside the Variants tool (e.g. "New variant definition" on the overview page), where a bare `{variantId}` happens to resolve against that tool's own `/:variantId` route — so it's never been exercised from anywhere else. That changes with the in-flight perspective-bar redesign (#14185 adds an "Add variant" entry to the perspective bar's variant dropdown, reachable from any tool). Opening the create-variant dialog from there and triggering the duplicate warning throws immediately, and React's top-level `ErrorBoundary` catches it, taking the whole Studio down to an error screen.

## Two false starts before landing on the actual fix

**Attempt 1** used a bare, unregistered state key (`state={{variantId: props.variantId}}`) — wrong outside the variants tool because there's no ambient tool context to resolve it against.

**Attempt 2** tried to detect the render context at runtime via `useRouterState((state) => state.tool)`, branching between a bare and a tool-scoped shape depending on whether that read equalled `'variants'`. This looked plausible and passed the existing tests, but was still wrong: `RouteScope` (`packages/sanity/src/router/RouteScope.tsx`) rescopes the router for every tool's own subtree, stripping the `tool` key out of the *local* state view it hands to that subtree. So `state.tool` reads as `undefined` from **within any tool**, not only from outside all tools. The runtime check always took the "outside" branch, meaning a duplicate link rendered from *inside* the Variants tool (the only place this link has ever actually rendered) still resolved to the tool-scoped shape and threw `Unable to find matching route for state` — this is the bug the prompter (Faheem) caught live in both the PR preview and the SAPP-4125 preview build, after attempt 2 had already been pushed and reported as fixed.

## The actual fix

The correct signal isn't available at runtime at all — `RouteScope` makes "am I inside the variants tool" indistinguishable from "am I outside every tool" by the time this component renders. Callers, however, know their own render context statically (each call site is either inside the tool's own route tree or isn't). So `withinVariantsTool: boolean` is now a required, explicitly-threaded prop from each dialog's call site down through `CreateVariantDialog`/`EditVariantDialog` → `VariantDialog` → `VariantForm` → `DuplicateVariantLink`, instead of guessed at runtime:

```tsx
function DuplicateVariantLink(props: {
  children?: ReactNode
  variantId?: string
  withinVariantsTool: boolean
}) {
  const state = props.withinVariantsTool
    ? {variantId: props.variantId}
    : {tool: VARIANTS_TOOL_NAME, [VARIANTS_TOOL_NAME]: {variantId: props.variantId}}

  return <StateLink state={state}>{props.children}</StateLink>
}
```

`VARIANTS_TOOL_NAME` is exported from `packages/sanity/src/core/variants/plugin/index.tsx` so the `false` branch can reference it. Every call site on `main` today is `withinVariantsTool` (the overview page's "New variant definition", and "Edit definition" from both the detail-page action rail and the overview row menu) — there is no `false` call site yet on this branch, since the perspective bar's "Add variant" entry only exists on the not-yet-merged #14185. The prop is required (no default) precisely so a future caller — like that one — has to declare its context explicitly rather than inherit a guess.

## Why the existing test didn't catch either wrong attempt

`CreateVariantDialog.test.tsx` mocks `sanity/router` entirely. Its mock was updated alongside attempt 2 to read the tool-scoped shape unconditionally (`state.tool === 'variants' ? state.variants?.variantId : undefined`), which happened to still pass only because the test harness's `state.tool` is also `undefined` — coincidentally matching attempt 2's (wrong) runtime branch rather than validating the real router's behavior. The mock now reads the bare `{variantId}` shape the corrected component actually sends when `withinVariantsTool` is true (every render this branch can currently exercise), and both `CreateVariantDialog` test renders pass `withinVariantsTool` explicitly.

## Verification

- `pnpm build` — clean.
- `pnpm vitest run --project=sanity packages/sanity/src/core/variants/` — 317/318 passing. The one failure (`disables add condition until the last row is complete`) is a pre-existing, unrelated combobox-typing flake in the same file, confirmed reproducible on the unmodified branch commit before this change.
- Live-verified against this branch's own `pnpm dev` studio: created a variant definition with conditions matching an existing one ("Loyal customers en us"), triggering the duplicate-conditions warning from inside the Variants tool (the only context this branch's plugin wiring exposes today). Before the fix, this crashed the Studio. After the fix, the warning renders and its link resolves to the real duplicate's detail route (`/test/variants/:variantId`) and navigates there cleanly, with no console errors.
- The `withinVariantsTool={false}` branch (the perspective-bar "Add variant" entry from #14185) was separately live-verified against a branch with #14185 merged in, in both the "duplicate title" and the perspective-bar "Add variant → duplicate conditions" flows — the exact scenario originally reported as broken.

## Scope note

Found while reviewing #14185 (perspective-bar dropdown redesign) but is independent of it — this bug lives entirely in already-merged code on `main` and is worth fixing regardless of when that PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk2fstZS9JyFC5qngCBNkm
