### PR TITLE
fix: key document pair memoization by credential

### DIFF
--- a/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.test.ts
@@ -1,0 +1,49 @@
+import {type SanityClient} from '@sanity/client'
+import {describe, expect, test} from 'vitest'
+
+import {memoizeKeyGen} from './memoizeKeyGen'
+
+function createClient(config: {token?: string; projectId?: string; dataset?: string}) {
+  return {config: () => ({projectId: 'p', dataset: 'd', ...config})} as unknown as SanityClient
+}
+
+const idPair = {publishedId: 'doc', draftId: 'drafts.doc'}
+
+describe('memoizeKeyGen', () => {
+  test('clients with the same token share a key', () => {
+    const a = createClient({token: 'token-1'})
+    const b = createClient({token: 'token-1'})
+    expect(memoizeKeyGen(a, idPair, 'type')).toBe(memoizeKeyGen(b, idPair, 'type'))
+  })
+
+  test('a client with a different token gets a different key', () => {
+    const before = createClient({token: 'token-1'})
+    const after = createClient({token: 'token-2'})
+    expect(memoizeKeyGen(before, idPair, 'type')).not.toBe(memoizeKeyGen(after, idPair, 'type'))
+  })
+
+  test('cookie clients (no token) share a key', () => {
+    expect(memoizeKeyGen(createClient({}), idPair, 'type')).toBe(
+      memoizeKeyGen(createClient({}), idPair, 'type'),
+    )
+  })
+
+  test('the key does not contain the token', () => {
+    expect(memoizeKeyGen(createClient({token: 'sk-secret'}), idPair, 'type')).not.toContain(
+      'sk-secret',
+    )
+  })
+
+  test('the key still distinguishes project, dataset, document and version', () => {
+    const client = createClient({token: 'token-1'})
+    const keys = [
+      memoizeKeyGen(client, idPair, 'type'),
+      memoizeKeyGen(client, idPair, 'other'),
+      memoizeKeyGen(client, {...idPair, versionId: 'versions.r1.doc'}, 'type'),
+      memoizeKeyGen(client, {publishedId: 'doc2', draftId: 'drafts.doc2'}, 'type'),
+      memoizeKeyGen(createClient({token: 'token-1', dataset: 'd2'}), idPair, 'type'),
+      memoizeKeyGen(createClient({token: 'token-1', projectId: 'p2'}), idPair, 'type'),
+    ]
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})

--- a/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.ts
+++ b/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.ts
@@ -2,7 +2,28 @@ import {type SanityClient} from '@sanity/client'
 
 import {type IdPair} from '../types'
 
+// Pair streams are memoized for the life of the page, so the key has to
+// change when the credentials do: after a re-auth the auth store hands out a
+// new client with a new token, and a pair built on the old one would keep
+// listening (and failing) with the stale token while every other store has
+// moved on. Clients carrying the same token still share a pair — the studio
+// builds several (different api versions) per source. Cookie clients (no
+// token) all share: the cookie is browser-global, so a reconnect picks up the
+// current session on its own. Mapped to a counter so the key never contains
+// the token; the map only ever holds one entry per token seen on this page.
+const credentialIds = new Map<string, number>()
+
+function getCredentialId(client: SanityClient): number {
+  const token = client.config().token ?? ''
+  let id = credentialIds.get(token)
+  if (id === undefined) {
+    id = credentialIds.size
+    credentialIds.set(token, id)
+  }
+  return id
+}
+
 export function memoizeKeyGen(client: SanityClient, idPair: IdPair, typeName: string) {
   const config = client.config()
-  return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${idPair.versionId ?? ''}-${typeName}`
+  return `${getCredentialId(client)}-${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${idPair.versionId ?? ''}-${typeName}`
 }


### PR DESCRIPTION
### Description

Returning to a Studio tab left open in the background could crash the Structure Tool.

Document pairs are memoized for the life of the page on a key built from project, dataset, document id and type, not the client. This is fine when a studio had one client per page, but since the auth store started emitting a new client on token refresh (#12679), a re-auth in another tab leaves the idle tab rebuilding its stores on the new client while the cache hands back the pair built with the *old* one. That stale listener reconnects with the expired token, 401s, and (terminal on 4xx since @sanity/client v7.23.1) crashes the tool.

As of this PR, client memo also includes token value, so the several clients a source builds still share one listener, and cookie clients (no token) all share since the cookie is browser-global.

### What to review

`memoizeKeyGen.ts` only, in `packages/sanity`. Confirm the token→id map: same token shares, new token separates, cookie clients share, token never in the key string.

### Testing

`memoizeKeyGen.test.ts` unit tests updated to verify key stability across tokens, cookie sharing, token absent from key, and that project/dataset/document/version still yields a new key.

### Notes for release

Fixed a bug where returning to a Studio tab left open in the background could take down the Structure Tool after the session had been refreshed in another tab.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes long-lived document pair caching and real-time listener error handling in the core document store; behavior is heavily unit-tested but affects auth refresh and connection recovery paths.
> 
> **Overview**
> Fixes Structure Tool crashes when a background Studio tab keeps a memoized document pair on **stale credentials** after auth refresh elsewhere, and adds a safety net when a listener still hits a terminal `ConnectionFailedError`.
> 
> **Document pair memo keys** now include a per-token credential id (mapped to a counter so the key string never embeds the secret). Clients with the same token still share a pair; a new token after re-auth gets a fresh pair. Tokenless cookie clients continue to share one id.
> 
> **Document pair listeners** pipe through a new `reconnectOnRejectedConnection` operator: on client-abandoned 4xx listener failures it emits `reconnect` (read-only UX), resubscribes with capped exponential backoff (1s→30s), resets backoff after `welcome`/`welcomeback`, and leaves other errors unchanged. Unit tests cover key generation, the operator, and `getPairListener` integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ed25e14bae32447a12d9e85a64a76828ac7d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->