### PR TITLE
fix(core): reconnect document pair listener on rejected connection

### DIFF
--- a/packages/sanity/src/core/store/document/getPairListener.test.ts
+++ b/packages/sanity/src/core/store/document/getPairListener.test.ts
@@ -1,5 +1,5 @@
-import {type SanityClient} from '@sanity/client'
-import {from, lastValueFrom, of, Subject, throwError} from 'rxjs'
+import {ConnectionFailedError, type SanityClient} from '@sanity/client'
+import {defer, from, lastValueFrom, type Observable, of, Subject, throwError} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type StoreRequestErrorHandler} from '../requestErrorHandler'
@@ -405,6 +405,123 @@ describe('getPairListener', () => {
 
       // welcomeback means resume succeeded — no snapshot fetch needed
       expect(getDocuments.mock.calls.length).toBe(fetchCountAfterWelcome)
+
+      sub.unsubscribe()
+    })
+  })
+
+  describe('listener connection failures', () => {
+    // The client gives up on a listener whose connection is rejected with a
+    // 4xx it does not retry itself (anything but 408/429), erroring the stream
+    // with a `ConnectionFailedError` carrying the status.
+    function rejectedConnection(status: number) {
+      return throwError(() => new ConnectionFailedError('EventSource connection failed', {status}))
+    }
+
+    // `client.observable.listen()` is cold: every subscription opens a new
+    // EventSource. Mirror that with `defer`, and count connection attempts.
+    function createFailingClient(attempts: Array<() => Observable<unknown>>) {
+      let attempt = 0
+      const connect = vi.fn((): Observable<unknown> => {
+        const next = attempts[Math.min(attempt, attempts.length - 1)]
+        attempt++
+        return next()
+      })
+      const mockClient = {
+        observable: {
+          listen: vi.fn(() => defer(connect)),
+          getDocuments: vi.fn(() => of([publishedDoc, draftDoc])),
+        },
+        withConfig: vi.fn(function (this: unknown) {
+          return this
+        }),
+      } as unknown as SanityClient
+      return {client: mockClient, connect}
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    test('a rejected connection signals reconnect and re-establishes the listener after a delay', async () => {
+      const attempt2$ = new Subject<ListenerEvent>()
+      const {client: mockClient, connect} = createFailingClient([
+        () => rejectedConnection(401),
+        () => attempt2$,
+      ])
+
+      const events: ListenerEvent[] = []
+      const errors: unknown[] = []
+      const sub = getPairListener(mockClient, idPair).subscribe({
+        next: (e) => events.push(e),
+        error: (e) => errors.push(e),
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Not an error for the document streams: the pair reports a lost
+      // connection (the form goes read-only) and waits to reconnect.
+      expect(errors).toEqual([])
+      expect(events.some((e) => e.type === 'reconnect')).toBe(true)
+      expect(connect).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(999)
+      expect(connect).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(connect).toHaveBeenCalledTimes(2)
+
+      // The fresh connection's welcome resyncs the pair from snapshots.
+      attempt2$.next({type: 'welcome', listenerName: 'test'})
+      await vi.advanceTimersByTimeAsync(0)
+      expect(events.filter((e) => e.type === 'snapshot')).toHaveLength(2)
+      expect(errors).toEqual([])
+
+      sub.unsubscribe()
+      attempt2$.complete()
+    })
+
+    // The backoff schedule itself is covered in
+    // `reconnectOnRejectedConnection.test.ts`; here we only verify the pair
+    // reconnects, resyncs, and resets after a successful connection.
+    test('a reconnected listener resyncs and resets its backoff', async () => {
+      const reconnected$ = new Subject<ListenerEvent>()
+      const {client: mockClient, connect} = createFailingClient([
+        () => rejectedConnection(403), // reject once
+        () => reconnected$, // then connect and stay open
+      ])
+
+      const events: ListenerEvent[] = []
+      const sub = getPairListener(mockClient, idPair).subscribe((e) => events.push(e))
+
+      // Reconnects after the base delay and resyncs from the welcome.
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(connect).toHaveBeenCalledTimes(2)
+      reconnected$.next({type: 'welcome', listenerName: 'test'})
+      await vi.advanceTimersByTimeAsync(0)
+      expect(events.filter((e) => e.type === 'snapshot')).toHaveLength(2)
+
+      // A later rejection starts over at the base delay (backoff reset).
+      reconnected$.error(new ConnectionFailedError('EventSource connection failed', {status: 403}))
+      await vi.advanceTimersByTimeAsync(999)
+      expect(connect).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(connect).toHaveBeenCalledTimes(3)
+
+      sub.unsubscribe()
+    })
+
+    test('other listener errors still propagate', async () => {
+      const error = new Error('channel error')
+      const {client: mockClient, connect} = createFailingClient([() => throwError(() => error)])
+
+      const errors: unknown[] = []
+      const sub = getPairListener(mockClient, idPair).subscribe({error: (e) => errors.push(e)})
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      expect(errors).toEqual([error])
+      expect(connect).toHaveBeenCalledTimes(1)
 
       sub.unsubscribe()
     })

--- a/packages/sanity/src/core/store/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/document/getPairListener.ts
@@ -19,6 +19,7 @@ import {
   type WelcomeEvent,
 } from './types'
 import {dedupeListenerEvents} from './utils/dedupeListenerEvents'
+import {reconnectOnRejectedConnection} from './utils/reconnectOnRejectedConnection'
 import {OutOfSyncError, sequentializeListenerEvents} from './utils/sequentializeListenerEvents'
 
 interface Snapshots {
@@ -155,6 +156,7 @@ export function getPairListener(
         },
       ) as Observable<WelcomeEvent | MutationEvent | ReconnectEvent | WelcomeBackEvent | ResetEvent>
     ).pipe(
+      reconnectOnRejectedConnection(),
       dedupeListenerEvents(),
       map((event): WelcomeEvent | MutationEvent | ReconnectEvent | WelcomeBackEvent | ResetEvent =>
         event.type === 'mutation'

--- a/packages/sanity/src/core/store/document/utils/reconnectOnRejectedConnection.test.ts
+++ b/packages/sanity/src/core/store/document/utils/reconnectOnRejectedConnection.test.ts
@@ -1,0 +1,117 @@
+import {ConnectionFailedError} from '@sanity/client'
+import {defer, type Observable, of, Subject, throwError} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {reconnectOnRejectedConnection} from './reconnectOnRejectedConnection'
+
+type Event = {type: string}
+
+const rejected = () =>
+  throwError(() => new ConnectionFailedError('EventSource connection failed', {status: 401}))
+
+// A cold source, like `client.observable.listen()`: each subscription connects
+// anew, running the next scripted attempt.
+function coldSource(attempts: Array<() => Observable<Event>>) {
+  let attempt = 0
+  const connect = vi.fn((): Observable<Event> => {
+    const next = attempts[Math.min(attempt, attempts.length - 1)]
+    attempt++
+    return next()
+  })
+  return {source$: defer(connect), connect}
+}
+
+describe('reconnectOnRejectedConnection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('emits reconnect and resubscribes the source with capped exponential backoff', async () => {
+    const {source$, connect} = coldSource([rejected])
+    const events: Event[] = []
+    const sub = source$.pipe(reconnectOnRejectedConnection()).subscribe((e) => events.push(e))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(events).toEqual([{type: 'reconnect'}])
+    expect(connect).toHaveBeenCalledTimes(1)
+
+    // 1s, 2s, 4s, ... up to 30s between attempts
+    for (const [delay, attempts] of [
+      [1_000, 2],
+      [2_000, 3],
+      [4_000, 4],
+      [8_000, 5],
+      [16_000, 6],
+      [30_000, 7],
+      [30_000, 8],
+    ] as const) {
+      await vi.advanceTimersByTimeAsync(delay - 1)
+      expect(connect).toHaveBeenCalledTimes(attempts - 1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(connect).toHaveBeenCalledTimes(attempts)
+    }
+
+    sub.unsubscribe()
+  })
+
+  test('resets the backoff once a connection succeeds (welcome)', async () => {
+    const welcomed$ = new Subject<Event>()
+    const {source$, connect} = coldSource([
+      rejected, // reject once
+      () => welcomed$, // then connect and stay open
+    ])
+    const sub = source$.pipe(reconnectOnRejectedConnection()).subscribe()
+
+    // First rejection retries after the base delay and connects.
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(connect).toHaveBeenCalledTimes(2)
+    welcomed$.next({type: 'welcome'})
+
+    // A later rejection starts over at the base delay, not the escalated one.
+    welcomed$.error(new ConnectionFailedError('EventSource connection failed', {status: 401}))
+    await vi.advanceTimersByTimeAsync(999)
+    expect(connect).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(connect).toHaveBeenCalledTimes(3)
+
+    sub.unsubscribe()
+  })
+
+  test('the backoff counter is per subscription, not shared', async () => {
+    // Two subscriptions to the *same* piped observable over an always-rejecting
+    // source. The counter lives in the operator's `defer`, so each subscription
+    // gets its own; a shared counter would make the second escalate off the
+    // first's progress.
+    const {source$, connect} = coldSource([rejected])
+    const reconnecting$ = source$.pipe(reconnectOnRejectedConnection())
+
+    // First subscription: connects at 0s, then retries at 1s and 3s. Its next
+    // delay would be 4s.
+    const first = reconnecting$.subscribe()
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(connect).toHaveBeenCalledTimes(3)
+
+    // Second subscription at t=3s: connects immediately, first retry at t=4s
+    // (base delay). With a shared counter it would instead wait 8s.
+    const second = reconnecting$.subscribe()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(connect).toHaveBeenCalledTimes(4)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(connect).toHaveBeenCalledTimes(5)
+
+    first.unsubscribe()
+    second.unsubscribe()
+  })
+
+  test('passes non-connection errors through', () => {
+    const error = new Error('channel error')
+    const errors: unknown[] = []
+    throwError(() => error)
+      .pipe(reconnectOnRejectedConnection())
+      .subscribe({error: (e) => errors.push(e)})
+    expect(errors).toEqual([error])
+  })
+})

--- a/packages/sanity/src/core/store/document/utils/reconnectOnRejectedConnection.ts
+++ b/packages/sanity/src/core/store/document/utils/reconnectOnRejectedConnection.ts
@@ -1,0 +1,81 @@
+import {concat, defer, of, type OperatorFunction, throwError, timer} from 'rxjs'
+import {catchError, retry, tap} from 'rxjs/operators'
+
+import {debug} from '../debug'
+import {type ReconnectEvent} from '../types'
+
+const RECONNECT: ReconnectEvent = {type: 'reconnect'}
+
+// Doubles per consecutive rejection up to the cap, so a listener that keeps
+// being rejected does not hammer the API. Reset once a connection succeeds
+// (a `welcome`), so an isolated blip after a long healthy stretch waits the
+// base delay, not the escalated one.
+const BASE_DELAY_MS = 1_000
+const MAX_DELAY_MS = 30_000
+
+/**
+ * Whether `err` is a listener connection the client gave up on: an EventSource
+ * connection rejected with a 4xx the client does not retry itself (anything
+ * but 408/429). Network drops and 5xx never surface here — the client turns
+ * those into `reconnect` events and reconnects on its own. Matched by name
+ * rather than `instanceof`, so it also holds across duplicate client copies.
+ */
+function isRejectedConnection(err: unknown): err is Error & {status?: number} {
+  return err instanceof Error && err.name === 'ConnectionFailedError'
+}
+
+/**
+ * Re-establishes a listener the client gave up on, instead of letting the
+ * failure error the document event streams.
+ *
+ * The listener does not go through the studio request handler (it is an
+ * EventSource, not a request), so a rejected connection — typically a 401
+ * from credentials that expired while the tab was idle — would otherwise
+ * error every stream derived from the pair and take the whole tool down.
+ * Instead, signal a `reconnect` so the form goes read-only like on any other
+ * connection loss, and retry with backoff. A fresh connection replays
+ * `welcome`, which refetches the snapshots and resyncs the pair.
+ *
+ * `retry` (not `catchError`'s `caught`) does the resubscription, so it stays
+ * flat: `caught` nests a new subscriber chain per retry, and the retry count
+ * here is unbounded (a persistent 403 loops forever at the cap), so a
+ * long-lived tab would grow the chain until delivery overflows the stack —
+ * the exact crash this operator exists to prevent. The backoff can't ride on
+ * `retry`'s own count, though: it must reset on `welcome`, and `resetOnSuccess`
+ * resets on *any* upstream value including the `reconnect` this emits (which
+ * would stop the backoff ever growing). So the count is tracked explicitly and
+ * reset on `welcome`, with `resetOnSuccess` left off.
+ */
+export function reconnectOnRejectedConnection<T extends {type: string}>(): OperatorFunction<
+  T,
+  T | ReconnectEvent
+> {
+  return (source) =>
+    // `defer` so the counter is per subscription, not shared across them.
+    defer(() => {
+      let consecutiveRejections = 0
+      return source.pipe(
+        tap((event) => {
+          if (event.type === 'welcome' || event.type === 'welcomeback') consecutiveRejections = 0
+        }),
+        // Surface the rejection as a `reconnect` event, then rethrow so `retry`
+        // resubscribes after the backoff.
+        catchError((err: unknown) => {
+          if (!isRejectedConnection(err)) throw err
+          return concat(
+            of(RECONNECT),
+            throwError(() => err),
+          )
+        }),
+        retry({
+          delay: (err: unknown) => {
+            if (!isRejectedConnection(err)) throw err
+            consecutiveRejections += 1
+            const delay = Math.min(BASE_DELAY_MS * 2 ** (consecutiveRejections - 1), MAX_DELAY_MS)
+            debug('Listener connection rejected (HTTP %s), reconnecting in %dms', err.status, delay)
+            return timer(delay)
+          },
+        }),
+      )
+    })
+}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes real-time document listening and reconnection behavior for auth/expired-session style failures; mistakes could cause reconnect loops or missed errors, but behavior is heavily tested and scoped to `ConnectionFailedError`.
> 
> **Overview**
> When the Sanity client aborts an EventSource listener with a non-retryable **4xx** (`ConnectionFailedError`), the document pair listener no longer tears down the whole editor stream. A new **`reconnectOnRejectedConnection`** RxJS operator is piped into `getPairListener` before deduplication.
> 
> On that failure it emits **`reconnect`** (same signal as a normal connection loss, so the form can go read-only), then resubscribes to `client.observable.listen()` with **capped exponential backoff** (1s → 30s). Backoff resets after **`welcome`** / **`welcomeback`**; other errors still propagate. The operator uses **`retry`** with an explicit rejection counter (not nested `catchError`) so long-lived tabs do not stack subscriber chains.
> 
> Unit tests cover backoff, per-subscription counters, and non-connection errors; `getPairListener` tests cover reconnect, snapshot resync on a new `welcome`, and unchanged behavior for unrelated listener errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570f0daad31746678b62ad09c6bffcb81bfc1bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->