### PR TITLE
chore: migrate grid in src

### DIFF
--- a/packages/sanity/src/insert-menu/InsertMenu.tsx
+++ b/packages/sanity/src/insert-menu/InsertMenu.tsx
@@ -3,13 +3,13 @@ import {SearchIcon} from '@sanity/icons/Search'
 import {ThLargeIcon} from '@sanity/icons/ThLarge'
 import {UlistIcon} from '@sanity/icons/Ulist'
 import {type InsertMenuOptions, type SchemaType} from '@sanity/types'
-import {Button, Flex, Grid, Stack, Tab, TabList, Text, TextInput} from '@sanity/ui'
+import {Button, Flex, Stack, Tab, TabList, Text, TextInput} from '@sanity/ui'
 import {Menu, MenuItem, type MenuItemProps} from '@sanity/ui/menu'
 import {Tooltip} from '@sanity/ui/tooltip'
 import startCase from 'lodash-es/startCase.js'
 import {useReducer, useState, type ChangeEvent, type CSSProperties} from 'react'
 import {isValidElementType} from 'react-is'
-import {Box} from 'ui5'
+import {Grid, Box} from 'ui5'
 
 import {getSchemaTypeIcon} from './getSchemaTypeIcon'
 
@@ -165,7 +165,7 @@ export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
               </Text>
             </Box>
           ) : !selectedView ? null : selectedView.name === 'grid' ? (
-            <Grid autoRows="auto" flex={1} gap={1} style={gridStyle}>
+            <Grid gridAutoRows="auto" flexBasis="0%" flexGrow={1} gap={1} style={gridStyle}>
               {filteredSchemaTypes.map((schemaType) => (
                 <GridMenuItem
                   key={schemaType.name}

--- a/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
+++ b/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
@@ -8,14 +8,14 @@ import {
   enablePreviewAccessSharing,
 } from '@sanity/preview-url-secret/toggle-preview-access-sharing'
 import {setSecretSearchParams} from '@sanity/preview-url-secret/without-secret-search-params'
-import {Card, Grid, Spinner, Stack, Switch, Text} from '@sanity/ui'
+import {Card, Spinner, Stack, Switch, Text} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
 import {useToast} from '@sanity/ui/toast'
 import {AnimatePresence, motion} from 'motion/react'
 import {lazy, Suspense, useCallback, useEffect, useMemo, useState} from 'react'
 import {useClient, useCurrentUser, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Grid, Box} from 'ui5'
 
 import {Button} from '../../ui-components/button/Button'
 import {MenuButton} from '../../ui-components/menuButton/MenuButton'
@@ -213,10 +213,10 @@ export function SharePreviewMenu(props: SharePreviewMenuProps): React.JSX.Elemen
             <>
               <label style={{cursor: 'pointer'}}>
                 <Grid
-                  gridTemplateColumns={2}
-                  gridTemplateRows={2}
-                  gapX={3}
-                  gapY={1}
+                  gridTemplateColumns="repeat(2, minmax(0, 1fr))"
+                  gridTemplateRows="repeat(2, minmax(0, 1fr))"
+                  columnGap={3}
+                  rowGap={1}
                   style={{
                     justifyContent: 'center',
                     alignItems: 'center',

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/AddIncomingReference.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/AddIncomingReference.tsx
@@ -1,6 +1,6 @@
 import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import {type SanityDocumentLike} from '@sanity/types'
-import {Grid, Stack, Text} from '@sanity/ui'
+import {Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {useCallback, useMemo} from 'react'
 import {map, type Observable} from 'rxjs'
@@ -22,7 +22,7 @@ import {
   useSource,
   useTranslation,
 } from 'sanity'
-import {Box} from 'ui5'
+import {Grid, Box} from 'ui5'
 
 import {structureLocaleNamespace} from '../../i18n'
 import {CreateNewIncomingReference} from './CreateNewIncomingReference'

--- a/packages/sanity/src/ui-components/__tests__/CardTones.stories.tsx
+++ b/packages/sanity/src/ui-components/__tests__/CardTones.stories.tsx
@@ -1,5 +1,6 @@
-import {Badge, Card, type CardTone, Grid, Stack, Text} from '@sanity/ui'
+import {Badge, Card, type CardTone, Stack, Text} from '@sanity/ui'
 import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {Grid} from 'ui5'
 
 const TONES: CardTone[] = [
   'default',
@@ -28,7 +29,7 @@ type Story = StoryObj<typeof meta>
 
 export const AllTones: Story = {
   render: () => (
-    <Grid gap={3} gridTemplateColumns={2} padding={4}>
+    <Grid gap={3} gridTemplateColumns="repeat(2, minmax(0, 1fr))" padding={4}>
       {TONES.map((tone) => (
         <Card key={tone} border padding={4} radius={2} tone={tone}>
           <Stack gap={3}>

--- a/packages/sanity/src/ui-components/button/__tests__/Button.stories.tsx
+++ b/packages/sanity/src/ui-components/button/__tests__/Button.stories.tsx
@@ -1,7 +1,8 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {PublishIcon} from '@sanity/icons/Publish'
-import {type ButtonTone, Flex, Grid, Stack, Text} from '@sanity/ui'
+import {type ButtonTone, Flex, Stack, Text} from '@sanity/ui'
 import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {Grid} from 'ui5'
 
 import {Button} from '../Button'
 
@@ -42,7 +43,11 @@ export const AllVariants: Story = {
           <Text muted size={1} weight="medium">
             mode="{mode}"
           </Text>
-          <Grid gap={2} gridTemplateColumns={TONES.length} style={{justifyItems: 'start'}}>
+          <Grid
+            gap={2}
+            gridTemplateColumns={`repeat(${TONES.length}, minmax(0, 1fr))`}
+            style={{justifyItems: 'start'}}
+          >
             {TONES.map((tone) => (
               <Button key={tone} mode={mode} tone={tone} text={tone} />
             ))}

--- a/packages/sanity/src/ui-components/confirmPopover/ConfirmPopover.tsx
+++ b/packages/sanity/src/ui-components/confirmPopover/ConfirmPopover.tsx
@@ -2,7 +2,6 @@
 import {
   Button as UIButton,
   Flex,
-  Grid,
   Text,
   useClickOutsideEvent,
   useGlobalKeyDown,
@@ -11,7 +10,7 @@ import {
 import {Popover as UIPopover, type PopoverProps as UIPopoverProps} from '@sanity/ui/popover'
 import {type ComponentType, type ReactNode, useCallback, useRef} from 'react'
 import {useTranslation} from 'react-i18next'
-import {Box} from 'ui5'
+import {Grid, Box} from 'ui5'
 
 export interface ConfirmPopoverProps {
   cancelButtonIcon?: ReactNode | ComponentType
@@ -105,7 +104,7 @@ function ConfirmPopoverContent({
         <Text size={1}>{message}</Text>
       </Box>
       <Box paddingX={4} paddingY={3} style={{borderTop: '1px solid var(--card-border-color)'}}>
-        <Grid gridTemplateColumns={2} gap={2}>
+        <Grid gridTemplateColumns="repeat(2, minmax(0, 1fr))" gap={2}>
           <UIButton
             data-testid="confirm-popover-cancel-button"
             icon={cancelButtonIcon}

--- a/packages/sanity/src/ui-components/popover/__tests__/Popover.stories.tsx
+++ b/packages/sanity/src/ui-components/popover/__tests__/Popover.stories.tsx
@@ -1,5 +1,6 @@
-import {Box, Flex, Grid, Stack, Text} from '@sanity/ui'
+import {Box, Flex, Stack, Text} from '@sanity/ui'
 import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {Grid} from 'ui5'
 
 import {Button} from '../../button/Button'
 import {Popover} from '../Popover'
@@ -66,7 +67,7 @@ function PlacementCell(props: {placement: 'top' | 'right' | 'bottom' | 'left'}) 
  */
 export const Placements: Story = {
   render: () => (
-    <Grid gap={6} gridTemplateColumns={2} paddingX={4} paddingY={6}>
+    <Grid gap={6} gridTemplateColumns="repeat(2, minmax(0, 1fr))" paddingX={4} paddingY={6}>
       {(['top', 'right', 'bottom', 'left'] as const).map((placement) => (
         <PlacementCell key={placement} placement={placement} />
       ))}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR migrates the Grid component from `@sanity/ui` v4 to v5 in the `packages/sanity/src` directory. It updates Grid across 6 files containing 30 JSX or styled-component instances.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop updates look correct.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I did manual QA focusing on the share preview in Presentation and confirmation popover in Review Changes.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Layout-only import and prop renames with no auth, data, or API changes; visual regressions are the main concern in affected menus and popovers.
> 
> **Overview**
> This PR continues the **@sanity/ui → ui5** migration by moving **`Grid`** off `@sanity/ui` in `packages/sanity/src` and updating call sites to the ui5 prop API.
> 
> Imports now pull `Grid` from `ui5` (often alongside existing `Box` imports) in studio flows such as **insert menu** grid view, **Presentation share preview** toggle layout, **incoming references** autocomplete row, and **confirm popover** action buttons, plus related Storybook layouts.
> 
> Prop updates are consistent across files: numeric shorthands like `gridTemplateColumns={2}` become CSS strings such as `repeat(2, minmax(0, 1fr))`, `gapX`/`gapY` become `columnGap`/`rowGap`, `autoRows` becomes `gridAutoRows`, and flex sizing uses `flexBasis`/`flexGrow` instead of `flex={1}` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad9975816de0689fcdc3ef2d869481d8788795a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->