### PR TITLE
fix: key client-capturing memo caches by credential

### DIFF
--- a/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
+++ b/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
@@ -84,10 +84,20 @@ const getCompanionDocs = memoize(
       map((value) => ({error: null, data: value, loading: false})),
       catchError((error) => of({error, data: [], loading: false})),
       startWith(INITIAL_VALUE),
-      shareReplay(1),
+      // refCount so the listener tears down when the last subscriber leaves.
+      // Combined with the credential in the memo key below, a cross-tab
+      // re-login's stale-token entry stops listening once the form remounts
+      // onto the new client — a plain `shareReplay(1)` would keep the
+      // stale-token listener connected forever and it would 401.
+      shareReplay({bufferSize: 1, refCount: true}),
     )
   },
-  (publishedId, client) => `${publishedId}-${client.config().dataset}-${client.config().projectId}`,
+  // `token` is part of the key: this captures `client` and fetches/listens
+  // through it, so a cross-tab re-login (new token) gets a fresh entry rather
+  // than replaying the stale-token client. See the memoizeKeyGen comment for
+  // the full explanation.
+  (publishedId, client) =>
+    `${publishedId}-${client.config().dataset}-${client.config().projectId}-${client.config().token ?? ''}`,
 )
 
 /**

--- a/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
+++ b/packages/sanity/src/core/canvas/store/createCanvasCompanionDocsStore.ts
@@ -14,6 +14,7 @@ import {mergeMapArray} from 'rxjs-mergemap-array'
 
 import {type DocumentPreviewStore} from '../../preview/documentPreviewStore'
 import {memoize} from '../../store/document/utils/createMemoizer'
+import {createMemoKey, getClientCredentialSegments} from '../../store/document/utils/memoKey'
 import {getPublishedId} from '../../util/draftUtils'
 import {type CompanionDoc} from '../types'
 
@@ -92,12 +93,10 @@ const getCompanionDocs = memoize(
       shareReplay({bufferSize: 1, refCount: true}),
     )
   },
-  // `token` is part of the key: this captures `client` and fetches/listens
-  // through it, so a cross-tab re-login (new token) gets a fresh entry rather
-  // than replaying the stale-token client. See the memoizeKeyGen comment for
-  // the full explanation.
-  (publishedId, client) =>
-    `${publishedId}-${client.config().dataset}-${client.config().projectId}-${client.config().token ?? ''}`,
+  // Keyed by the credential: this captures `client` and fetches/listens through
+  // it, so a cross-tab re-login (new token) gets a fresh entry rather than
+  // replaying the stale-token client. See getClientCredentialSegments.
+  (publishedId, client) => createMemoKey([publishedId, ...getClientCredentialSegments(client)]),
 )
 
 /**

--- a/packages/sanity/src/core/store/document/document-pair/getOperationStoreKey.ts
+++ b/packages/sanity/src/core/store/document/document-pair/getOperationStoreKey.ts
@@ -2,12 +2,19 @@ import {type SanityClient} from '@sanity/client'
 
 export function getOperationStoreKey(client: SanityClient): string {
   const config = client.config()
-  const {projectId, dataset} = config
+  const {projectId, dataset, token} = config
   if (!projectId) {
     throw new Error('Client is missing projectId')
   }
   if (!dataset) {
     throw new Error('Client is missing dataset')
   }
-  return `${projectId}-${dataset}`
+  // Include the token so an operation is routed to the pipeline built on the
+  // same credential. This key only needs to agree between the emitter and the
+  // pipeline (both call this function) — it does not have to equal the
+  // operationEvents memo key. Once operationEvents is memoized per token, a
+  // re-login runs a second pipeline; without the token here one emitted
+  // operation would match both the fresh and the stale-token pipeline while
+  // both are briefly subscribed and execute the mutation twice.
+  return `${projectId}-${dataset}-${token ?? ''}`
 }

--- a/packages/sanity/src/core/store/document/document-pair/getOperationStoreKey.ts
+++ b/packages/sanity/src/core/store/document/document-pair/getOperationStoreKey.ts
@@ -1,5 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 
+import {createMemoKey} from '../utils/memoKey'
+
 export function getOperationStoreKey(client: SanityClient): string {
   const config = client.config()
   const {projectId, dataset, token} = config
@@ -16,5 +18,5 @@ export function getOperationStoreKey(client: SanityClient): string {
   // re-login runs a second pipeline; without the token here one emitted
   // operation would match both the fresh and the stale-token pipeline while
   // both are briefly subscribed and execute the mutation twice.
-  return `${projectId}-${dataset}-${token ?? ''}`
+  return createMemoKey([projectId, dataset, token])
 }

--- a/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.test.ts
@@ -1,0 +1,43 @@
+import {type SanityClient} from '@sanity/client'
+import {describe, expect, test} from 'vitest'
+
+import {memoizeKeyGen} from './memoizeKeyGen'
+
+function createClient(config: {token?: string; projectId?: string; dataset?: string} = {}) {
+  return {config: () => ({projectId: 'p', dataset: 'd', ...config})} as unknown as SanityClient
+}
+
+const idPair = {publishedId: 'doc', draftId: 'drafts.doc'}
+
+describe('memoizeKeyGen', () => {
+  test('clients with the same token share a key (so sibling clients reuse one pair)', () => {
+    const a = createClient({token: 'token-1'})
+    const b = createClient({token: 'token-1'})
+    expect(memoizeKeyGen(a, idPair, 'type')).toBe(memoizeKeyGen(b, idPair, 'type'))
+  })
+
+  test('a new token yields a different key (re-auth gets a fresh pair)', () => {
+    const before = createClient({token: 'token-OLD'})
+    const after = createClient({token: 'token-NEW'})
+    expect(memoizeKeyGen(before, idPair, 'type')).not.toBe(memoizeKeyGen(after, idPair, 'type'))
+  })
+
+  test('cookie clients (no token) share a key', () => {
+    expect(memoizeKeyGen(createClient(), idPair, 'type')).toBe(
+      memoizeKeyGen(createClient(), idPair, 'type'),
+    )
+  })
+
+  test('still distinguishes project, dataset, document, version and type', () => {
+    const client = createClient({token: 't'})
+    const keys = [
+      memoizeKeyGen(client, idPair, 'type'),
+      memoizeKeyGen(client, idPair, 'other'),
+      memoizeKeyGen(client, {...idPair, versionId: 'versions.r1.doc'}, 'type'),
+      memoizeKeyGen(client, {publishedId: 'doc2', draftId: 'drafts.doc2'}, 'type'),
+      memoizeKeyGen(createClient({token: 't', dataset: 'd2'}), idPair, 'type'),
+      memoizeKeyGen(createClient({token: 't', projectId: 'p2'}), idPair, 'type'),
+    ]
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})

--- a/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.ts
+++ b/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.ts
@@ -2,7 +2,13 @@ import {type SanityClient} from '@sanity/client'
 
 import {type IdPair} from '../types'
 
+// The key must include the token: the pair captures its client and keeps a
+// listener open, so keying by project/dataset alone would replay a stale-token
+// pair after a re-login and 401 on `/data/listen`. Key by token
+// value, not client instance — sibling clients sharing a token reuse one pair,
+// and only a real credential change makes a new one (instance-keying churns on
+// every re-render). Token stays in memory (never logged).
 export function memoizeKeyGen(client: SanityClient, idPair: IdPair, typeName: string) {
   const config = client.config()
-  return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${idPair.versionId ?? ''}-${typeName}`
+  return `${config.token ?? ''}-${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${idPair.versionId ?? ''}-${typeName}`
 }

--- a/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.ts
+++ b/packages/sanity/src/core/store/document/document-pair/memoizeKeyGen.ts
@@ -1,14 +1,16 @@
 import {type SanityClient} from '@sanity/client'
 
 import {type IdPair} from '../types'
+import {createMemoKey, getClientCredentialSegments} from '../utils/memoKey'
 
-// The key must include the token: the pair captures its client and keeps a
+// The key must include the credential: the pair captures its client and keeps a
 // listener open, so keying by project/dataset alone would replay a stale-token
-// pair after a re-login and 401 on `/data/listen`. Key by token
-// value, not client instance — sibling clients sharing a token reuse one pair,
-// and only a real credential change makes a new one (instance-keying churns on
-// every re-render). Token stays in memory (never logged).
+// pair after a re-login and 401 on `/data/listen`. See getClientCredentialSegments.
 export function memoizeKeyGen(client: SanityClient, idPair: IdPair, typeName: string) {
-  const config = client.config()
-  return `${config.token ?? ''}-${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${idPair.versionId ?? ''}-${typeName}`
+  return createMemoKey([
+    ...getClientCredentialSegments(client),
+    idPair.publishedId,
+    idPair.versionId,
+    typeName,
+  ])
 }

--- a/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
@@ -210,7 +210,11 @@ export const operationEvents = memoize(
   },
   (ctx) => {
     const config = ctx.client.config()
-    // we only want one of these per dataset+projectid
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}`
+    // One per dataset+projectid, but ALSO per credential: this captures
+    // `ctx.client` and drives commits/mutations through it, so a cross-tab
+    // re-login (new token) must get a fresh entry rather than replaying the
+    // stale-token client. See the memoizeKeyGen comment for the full
+    // explanation.
+    return `${config.token ?? ''}-${config.dataset ?? ''}-${config.projectId ?? ''}`
   },
 )

--- a/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
@@ -21,6 +21,7 @@ import {type HistoryStore} from '../../history/createHistoryStore'
 import {type DocumentStoreExtraOptions} from '../getPairListener'
 import {type IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
+import {createMemoKey, getClientCredentialSegments} from '../utils/memoKey'
 import {consistencyStatus} from './consistencyStatus'
 import {getOperationStoreKey} from './getOperationStoreKey'
 import {operationArgs} from './operationArgs'
@@ -208,13 +209,10 @@ export const operationEvents = memoize(
     // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
     return merge(result$, autoCommit$.pipe(mergeMapTo(EMPTY)))
   },
-  (ctx) => {
-    const config = ctx.client.config()
-    // One per dataset+projectid, but ALSO per credential: this captures
-    // `ctx.client` and drives commits/mutations through it, so a cross-tab
-    // re-login (new token) must get a fresh entry rather than replaying the
-    // stale-token client. See the memoizeKeyGen comment for the full
-    // explanation.
-    return `${config.token ?? ''}-${config.dataset ?? ''}-${config.projectId ?? ''}`
-  },
+  (ctx) =>
+    // Per credential (token+dataset+projectId): this captures `ctx.client` and
+    // drives commits/mutations through it, so a cross-tab re-login (new token)
+    // must get a fresh entry rather than replaying the stale-token client. See
+    // getClientCredentialSegments.
+    createMemoKey(getClientCredentialSegments(ctx.client)),
 )

--- a/packages/sanity/src/core/store/document/utils/memoKey.test.ts
+++ b/packages/sanity/src/core/store/document/utils/memoKey.test.ts
@@ -1,0 +1,52 @@
+import {type SanityClient} from '@sanity/client'
+import {describe, expect, it} from 'vitest'
+
+import {createMemoKey, getClientCredentialSegments} from './memoKey'
+
+const client = (config: {token?: string; dataset?: string; projectId?: string}) =>
+  ({config: () => config}) as unknown as SanityClient
+
+describe('createMemoKey', () => {
+  it('does not collide when a segment contains the values of adjacent segments', () => {
+    // A plain `-` join would make both of these `a-b-c`.
+    expect(createMemoKey(['a-b', 'c'])).not.toBe(createMemoKey(['a', 'b-c']))
+  })
+
+  it('does not collide when a dash-bearing dataset abuts another segment', () => {
+    // `test-dataset` + `ppsg` vs `test` + `dataset-ppsg`.
+    expect(createMemoKey(['', 'test-dataset', 'ppsg'])).not.toBe(
+      createMemoKey(['', 'test', 'dataset-ppsg']),
+    )
+  })
+
+  it('is stable for equal segment lists', () => {
+    expect(createMemoKey(['t', 'd', 'p'])).toBe(createMemoKey(['t', 'd', 'p']))
+  })
+
+  it('treats undefined as an empty segment', () => {
+    expect(createMemoKey(['t', undefined, 'p'])).toBe(createMemoKey(['t', '', 'p']))
+  })
+})
+
+describe('getClientCredentialSegments', () => {
+  it('returns [token, dataset, projectId], defaulting missing values to empty strings', () => {
+    expect(
+      getClientCredentialSegments(client({token: 'sk', dataset: 'd', projectId: 'p'})),
+    ).toEqual(['sk', 'd', 'p'])
+    expect(getClientCredentialSegments(client({dataset: 'd', projectId: 'p'}))).toEqual([
+      '',
+      'd',
+      'p',
+    ])
+  })
+
+  it('changes the credential key when only the token differs', () => {
+    const a = createMemoKey(
+      getClientCredentialSegments(client({token: 'old', dataset: 'd', projectId: 'p'})),
+    )
+    const b = createMemoKey(
+      getClientCredentialSegments(client({token: 'new', dataset: 'd', projectId: 'p'})),
+    )
+    expect(a).not.toBe(b)
+  })
+})

--- a/packages/sanity/src/core/store/document/utils/memoKey.ts
+++ b/packages/sanity/src/core/store/document/utils/memoKey.ts
@@ -1,0 +1,32 @@
+import {type SanityClient} from '@sanity/client'
+
+/**
+ * Segments identifying the credentialed client an observable is built with:
+ * `[token, dataset, projectId]`. Any module-level {@link memoize} of a
+ * client-capturing observable MUST include these in its key — keying by
+ * project/dataset alone replays a stale-token client after a cross-tab
+ * re-login and 401s. Keyed by the token *value* (not the client instance) so
+ * sibling clients sharing a token reuse one entry and only a real credential
+ * change makes a new one.
+ *
+ * @internal
+ */
+export function getClientCredentialSegments(client: SanityClient): [string, string, string] {
+  const {token, dataset, projectId} = client.config()
+  return [token ?? '', dataset ?? '', projectId ?? '']
+}
+
+/**
+ * Builds a memo cache key from an ordered list of segments. Segments are joined
+ * via `JSON.stringify` rather than a `-` (or any single delimiter): the raw
+ * values routinely contain dashes (dataset names like `test-dataset`, document
+ * ids, type names), so a plain join lets distinct tuples collide into the same
+ * string (`['a-b','c']` and `['a','b-c']` both become `a-b-c`) and reuse the
+ * wrong cached observable. The result is an opaque cache key — never parsed or
+ * shown to users.
+ *
+ * @internal
+ */
+export function createMemoKey(segments: readonly (string | undefined)[]): string {
+  return JSON.stringify(segments.map((segment) => segment ?? ''))
+}

--- a/packages/sanity/src/core/store/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/grants/documentPairPermissions.ts
@@ -14,6 +14,7 @@ import {useGrantsStore} from '../datastores'
 import {snapshotPair} from '../document/document-pair/snapshotPair'
 import {type DocumentStoreExtraOptions} from '../document/getPairListener'
 import {memoize} from '../document/utils/createMemoizer'
+import {createMemoKey, getClientCredentialSegments} from '../document/utils/memoKey'
 import {useCurrentUser} from '../user/hooks'
 import {type GrantsStore, type PermissionCheckResult} from './types'
 
@@ -289,11 +290,10 @@ export const getDocumentPairPermissions = memoize(
     permission,
     userId,
   }: DocumentPairPermissionsOptions): string => {
-    // `token` is part of the key: this captures `client` and issues grants
+    // Keyed by the credential: this captures `client` and issues grants
     // requests through it, so a re-login must build a fresh entry instead of
-    // replaying the stale-token client, which would 401 (see the memoizeKeyGen
-    // comment).
-    const {dataset = '', projectId = '', token = ''} = client.config()
+    // replaying the stale-token client, which would 401 (see
+    // getClientCredentialSegments).
     // `liveEdit` is derived from the schema and branches the resulting permission
     // observable, so it must be part of the key: workspaces sharing a
     // project/dataset can define the same `type` with a different `liveEdit`.
@@ -302,17 +302,15 @@ export const getDocumentPairPermissions = memoize(
     // (id, version) to `getIdPair(id, {version})`, a pure function of
     // (getPublishedId(id), version). The raw `version` string is kept as-is;
     // never call getIdPair here (it throws on version 'drafts'|'published').
-    return [
-      token,
-      dataset,
-      projectId,
+    return createMemoKey([
+      ...getClientCredentialSegments(client),
       getPublishedId(id),
-      version ?? '',
-      userId ?? '',
+      version,
+      userId,
       type,
       permission,
-      liveEdit,
-    ].join('-')
+      String(liveEdit),
+    ])
   },
 )
 

--- a/packages/sanity/src/core/store/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/grants/documentPairPermissions.ts
@@ -289,7 +289,11 @@ export const getDocumentPairPermissions = memoize(
     permission,
     userId,
   }: DocumentPairPermissionsOptions): string => {
-    const {dataset = '', projectId = ''} = client.config()
+    // `token` is part of the key: this captures `client` and issues grants
+    // requests through it, so a re-login must build a fresh entry instead of
+    // replaying the stale-token client, which would 401 (see the memoizeKeyGen
+    // comment).
+    const {dataset = '', projectId = '', token = ''} = client.config()
     // `liveEdit` is derived from the schema and branches the resulting permission
     // observable, so it must be part of the key: workspaces sharing a
     // project/dataset can define the same `type` with a different `liveEdit`.
@@ -299,6 +303,7 @@ export const getDocumentPairPermissions = memoize(
     // (getPublishedId(id), version). The raw `version` string is kept as-is;
     // never call getIdPair here (it throws on version 'drafts'|'published').
     return [
+      token,
       dataset,
       projectId,
       getPublishedId(id),

--- a/packages/sanity/src/core/store/project/projectStore.test.ts
+++ b/packages/sanity/src/core/store/project/projectStore.test.ts
@@ -17,18 +17,18 @@ const createMockProjectData = (organizationId: string): ProjectData =>
 interface MockClientOptions {
   projectId: string
   requestImplementation: () => ReturnType<SanityClient['observable']['request']>
+  token?: string
 }
 
-const createMockClient = ({projectId, requestImplementation}: MockClientOptions) => {
+const createMockClient = ({projectId, requestImplementation, token}: MockClientOptions) => {
+  const request = vi.fn(requestImplementation)
   const client = {
-    config: () => ({projectId, dataset: 'test-dataset'}),
+    config: () => ({projectId, dataset: 'test-dataset', token}),
     withConfig: () => client,
-    observable: {
-      request: vi.fn(requestImplementation),
-    },
+    observable: {request},
   }
 
-  return client as unknown as SanityClient
+  return client as unknown as SanityClient & {observable: {request: typeof request}}
 }
 
 describe('createProjectStore getOrganizationId', () => {
@@ -139,5 +139,52 @@ describe('createProjectStore getOrganizationId', () => {
     expect(emitted).toEqual([null])
 
     subscription.unsubscribe()
+  })
+})
+
+describe('createProjectStore memoization keyed by credential', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('a new-token client re-requests instead of replaying the old token’s result', async () => {
+    // Two clients, same project/dataset, different tokens — as after a re-auth.
+    // The memoized org request must NOT replay the first client's observable to
+    // the second; otherwise the second (new-token) store would surface the old
+    // token's data and, worse, keep polling on the old token.
+    const oldClient = createMockClient({
+      projectId: 'p',
+      token: 'token-OLD',
+      requestImplementation: () => of(createMockProjectData('org-OLD')),
+    })
+    const newClient = createMockClient({
+      projectId: 'p',
+      token: 'token-NEW',
+      requestImplementation: () => of(createMockProjectData('org-NEW')),
+    })
+
+    const emittedA: Array<string | null> = []
+    const emittedB: Array<string | null> = []
+
+    const storeA = createProjectStore({client: oldClient})
+    const subA = storeA.getOrganizationId().subscribe((v) => emittedA.push(v))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(emittedA).toEqual(['org-OLD'])
+
+    const storeB = createProjectStore({client: newClient})
+    const subB = storeB.getOrganizationId().subscribe((v) => emittedB.push(v))
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The new-token store resolved via the new client's own request, not a
+    // replay of the old one.
+    expect(emittedB).toEqual(['org-NEW'])
+    expect(newClient.observable.request).toHaveBeenCalledTimes(1)
+
+    subA.unsubscribe()
+    subB.unsubscribe()
   })
 })

--- a/packages/sanity/src/core/store/project/projectStore.ts
+++ b/packages/sanity/src/core/store/project/projectStore.ts
@@ -14,19 +14,19 @@ import {
 } from 'rxjs'
 
 import {memoize} from '../document/utils/createMemoizer'
+import {createMemoKey, getClientCredentialSegments} from '../document/utils/memoKey'
 import {type ProjectData, type ProjectGrants, type ProjectStore} from './types'
 
 const REFETCH_INTERVAL = 5 * 60 * 1000 // 5 minutes
 
 // Memo key for the per-client request observables below. Must include the
-// token, not just project/dataset — these poll `/projects` on a captured
-// client, so a stale-token entry would keep 401ing after a re-login (see the
-// memoizeKeyGen comment). The old entry goes idle when its last
+// credential, not just project/dataset — these poll `/projects` on a captured
+// client, so a stale-token entry would keep 401ing after a re-login (see
+// getClientCredentialSegments). The old entry goes idle when its last
 // subscriber leaves, but the memoizer never evicts, so its key and token string
 // are retained for the life of the page. Token stays in-memory (never logged).
 function projectRequestKey(client: SanityClient): string {
-  const config = client.config()
-  return `${config.projectId}-${config.dataset}-${config.token ?? ''}`
+  return createMemoKey(getClientCredentialSegments(client))
 }
 
 /**

--- a/packages/sanity/src/core/store/project/projectStore.ts
+++ b/packages/sanity/src/core/store/project/projectStore.ts
@@ -18,53 +18,61 @@ import {type ProjectData, type ProjectGrants, type ProjectStore} from './types'
 
 const REFETCH_INTERVAL = 5 * 60 * 1000 // 5 minutes
 
+// Memo key for the per-client request observables below. Must include the
+// token, not just project/dataset — these poll `/projects` on a captured
+// client, so a stale-token entry would keep 401ing after a re-login (see the
+// memoizeKeyGen comment). The old entry goes idle when its last
+// subscriber leaves, but the memoizer never evicts, so its key and token string
+// are retained for the life of the page. Token stays in-memory (never logged).
+function projectRequestKey(client: SanityClient): string {
+  const config = client.config()
+  return `${config.projectId}-${config.dataset}-${config.token ?? ''}`
+}
+
 /**
  * This value will be cached for 5 minutes, after that internal the cache will be refreshed.
  * If you need to be 100% sure the organizationId is up to date, you can call the `/projects/${projectId}` endpoint directly.
  */
-const getProjectOrg = memoize(
-  (client: SanityClient) => {
-    return client.observable
-      .request<ProjectData>({
-        url: `/projects/${client.config().projectId}`,
-        tag: 'get-project-org',
-        query: {
-          includeMembers: 'false',
-          includeFeatures: 'false',
-          includeOrganization: 'true',
-        },
-      })
-      .pipe(
-        catchError(() => {
-          return of(null)
-        }),
-        repeat({delay: REFETCH_INTERVAL}),
-        // A transient refetch failure emits `null`. Retain the last known
-        // project data so a failed refetch does not clobber a previously-good
-        // organization id (which would strip org_id from telemetry events
-        // flushed during the refetch window). See SAPP-3824.
-        scan<ProjectData | null, ProjectData | null>((lastKnown, next) => next ?? lastKnown, null),
-        distinctUntilChanged(),
-        share({
-          connector: () => new ReplaySubject(1),
-          resetOnComplete: true,
-          // delay unsubscriptions a little to keep the observable active
-          // during React effect setup and teardown due to rapidly changing deps
-          resetOnRefCountZero: () => timer(1000),
-        }),
-      )
-  },
-  (client) => `${client.config().projectId}-${client.config().dataset}`,
-)
+const getProjectOrg = memoize((client: SanityClient) => {
+  return client.observable
+    .request<ProjectData>({
+      url: `/projects/${client.config().projectId}`,
+      tag: 'get-project-org',
+      query: {
+        includeMembers: 'false',
+        includeFeatures: 'false',
+        includeOrganization: 'true',
+      },
+    })
+    .pipe(
+      catchError(() => {
+        return of(null)
+      }),
+      repeat({delay: REFETCH_INTERVAL}),
+      // A transient refetch failure emits `null`. Retain the last known
+      // project data so a failed refetch does not clobber a previously-good
+      // organization id (which would strip org_id from telemetry events
+      // flushed during the refetch window). See SAPP-3824.
+      scan<ProjectData | null, ProjectData | null>((lastKnown, next) => next ?? lastKnown, null),
+      distinctUntilChanged(),
+      share({
+        connector: () => new ReplaySubject(1),
+        resetOnComplete: true,
+        // delay unsubscriptions a little to keep the observable active
+        // during React effect setup and teardown due to rapidly changing deps
+        resetOnRefCountZero: () => timer(1000),
+      }),
+    )
+}, projectRequestKey)
 
 const getOrganizationId = memoize(
   (client: SanityClient) => getProjectOrg(client).pipe(map((res) => res?.organizationId ?? null)),
-  (client) => `${client.config().projectId}-${client.config().dataset}`,
+  projectRequestKey,
 )
 
 const getOrganizationData = memoize(
   (client: SanityClient) => getProjectOrg(client).pipe(map((res) => res?.organization ?? null)),
-  (client) => `${client.config().projectId}-${client.config().dataset}`,
+  projectRequestKey,
 )
 
 /**
@@ -73,9 +81,10 @@ const getOrganizationData = memoize(
  * project store (e.g. the schema/manifest upload gate) hit the same cached
  * observable instead of issuing a duplicate `/grants` request.
  *
- * Keyed by `projectId-dataset`, matching the other memoized requests in this
- * module, so a client for a different project/dataset never reuses another's
- * grants.
+ * Keyed by project/dataset **and credential** (see `projectRequestKey`),
+ * matching the other memoized requests in this module, so a client for a
+ * different project/dataset — or a new post-re-auth token — never reuses
+ * another's grants.
  *
  * @internal
  */
@@ -87,7 +96,7 @@ export const getProjectGrants = memoize(
         tag: 'get-grants',
       })
       .pipe(shareReplay(1)),
-  (client) => `${client.config().projectId}-${client.config().dataset}`,
+  projectRequestKey,
 )
 
 /** @internal */


### PR DESCRIPTION
### Description
Currently, client instance memo keys includes projectId and dataset (plus, in some cases, a handful of extra relevant properties). However, we have a few instances where the token is not included in the memo key, causing client instances to keep being used after their token is invalidated (e.g. after token expiry or logout).

In some cases, this could trigger a logout right after logging in in a different tab, since another tab would issue a request using a stale client, with an invalid token, and respond to the 401 by logging out again.

This PR fixes the issue by including the token in the memo key in places where it was missing.

As a result, when the auth store now emit a new client after a login, downstream react hooks will invalidate (because they'll receive a new client instance which invalidates hooks and effects which again will request a new client via the memoized functions.

### What to review
- All instances covered?
- Verify that the logged out after logging in again-bug is gone.
- Review revealed that the way we generated memo keys were (in theory) prone to collision, so included a separate commit to address that too.

### Testing
Unit tests included

### Notes for release
Fixes an issue where signing in could immediately sign you out if multiple Studio tabs were open.

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes auth-sensitive memoization across document operations, permissions, listeners, and project polling; incorrect keying could still cause duplicate commits or stale grants, but the change is narrowly scoped with tests.
> 
> **Overview**
> Fixes stale-auth bugs by including the Sanity client **credential (`token`)** in memo/cache keys anywhere a memoized observable or pipeline **captures** a `SanityClient` and keeps issuing requests or listeners through it.
> 
> After re-login (especially cross-tab), keys that only used `projectId`/`dataset` could replay caches built on an invalid token—leading to **401s**, accidental **logouts**, **duplicate mutations** (operation store key vs `operationEvents`), or continued polling on the old credential. Keys use the **token value** (empty for cookie clients), not client instance identity, so sibling clients with the same token still share one cache entry.
> 
> **Touches:** `memoizeKeyGen` (document pairs/listeners), `operationEvents` + `getOperationStoreKey`, Canvas companion docs store, document pair permissions grants cache, and project store memoization via shared `projectRequestKey` (org/grants polling). Adds **`memoizeKeyGen` unit tests** and a **project store test** that a new-token client re-fetches instead of replaying the old token’s observable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30fe8742573b3e2ffc388e793b9730ac319f3589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->