### PR TITLE
fix(core): terminate document listener on 401

### DIFF
--- a/packages/sanity/src/core/store/document/getPairListener.test.ts
+++ b/packages/sanity/src/core/store/document/getPairListener.test.ts
@@ -1,5 +1,5 @@
-import {type SanityClient} from '@sanity/client'
-import {from, lastValueFrom, of, Subject, throwError} from 'rxjs'
+import {ConnectionFailedError, type SanityClient} from '@sanity/client'
+import {defer, from, lastValueFrom, type Observable, of, Subject, throwError} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {type StoreRequestErrorHandler} from '../requestErrorHandler'
@@ -406,6 +406,74 @@ describe('getPairListener', () => {
       // welcomeback means resume succeeded — no snapshot fetch needed
       expect(getDocuments.mock.calls.length).toBe(fetchCountAfterWelcome)
 
+      sub.unsubscribe()
+    })
+  })
+
+  describe('listener connection failures', () => {
+    // A listener connection the client gives up on errors the stream with a
+    // `ConnectionFailedError` carrying the HTTP status.
+    function rejectedConnection(status: number) {
+      return throwError(() => new ConnectionFailedError('EventSource connection failed', {status}))
+    }
+
+    function createFailingClient(connectImpl: () => Observable<unknown>) {
+      const connect = vi.fn(connectImpl)
+      const mockClient = {
+        observable: {
+          listen: vi.fn(() => defer(connect)),
+          getDocuments: vi.fn(() => of([publishedDoc, draftDoc])),
+        },
+        withConfig: vi.fn(function (this: unknown) {
+          return this
+        }),
+      } as unknown as SanityClient
+      return {client: mockClient, connect}
+    }
+
+    test('a 401 completes the stream — no error rethrow, no retry', async () => {
+      const {client: mockClient, connect} = createFailingClient(() => rejectedConnection(401))
+
+      const errors: unknown[] = []
+      let completed = false
+      const sub = getPairListener(mockClient, idPair).subscribe({
+        error: (e) => errors.push(e),
+        complete: () => {
+          completed = true
+        },
+      })
+      await nextTick()
+
+      // The listen endpoint only 401s on an invalid/expired session, so the
+      // connection is terminal: the stream completes (not errors — an errored
+      // stream would be rethrown by `useSyncObservable` and crash the tool)
+      // and is not retried. Recovery is driven by the studio's request handler
+      // on ordinary requests, not by this stream.
+      expect(errors).toEqual([])
+      expect(completed).toBe(true)
+      expect(connect).toHaveBeenCalledTimes(1)
+
+      sub.unsubscribe()
+    })
+
+    test('other listener errors still propagate', async () => {
+      const error = new Error('channel error')
+      const {client: mockClient} = createFailingClient(() => throwError(() => error))
+      const errors: unknown[] = []
+      const sub = getPairListener(mockClient, idPair).subscribe({error: (e) => errors.push(e)})
+      await nextTick()
+      // Non-session errors are not swallowed and still surface to the caller.
+      expect(errors).toEqual([error])
+      sub.unsubscribe()
+    })
+
+    test('a non-401 rejected connection also propagates (listen only 401s in practice)', async () => {
+      const {client: mockClient} = createFailingClient(() => rejectedConnection(500))
+      const errors: unknown[] = []
+      const sub = getPairListener(mockClient, idPair).subscribe({error: (e) => errors.push(e)})
+      await nextTick()
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toBeInstanceOf(ConnectionFailedError)
       sub.unsubscribe()
     })
   })

--- a/packages/sanity/src/core/store/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/document/getPairListener.ts
@@ -1,11 +1,12 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from '@sanity/types'
 import groupBy from 'lodash-es/groupBy.js'
-import {defer, merge, type Observable, of, throwError} from 'rxjs'
+import {defer, EMPTY, merge, type Observable, of, throwError} from 'rxjs'
 import {catchError, concatMap, filter, map, mergeMap, scan, share} from 'rxjs/operators'
 
 import {shareReplayLatest} from '../../preview/utils/shareReplayLatest'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../releases/util/releasesClient'
+import {isConnectionSessionError} from '../../util/apiErrors'
 import {getVersionFromId} from '../../util/draftUtils'
 import {type StoreRequestErrorHandler} from '../requestErrorHandler'
 import {debug} from './debug'
@@ -271,6 +272,19 @@ export function getPairListener(
         // this will retry immediately
         return caught$
       }
+
+      // A listener 401 is a dead session (see isConnectionSessionError), so
+      // complete the stream rather than rethrow — an errored stream is rethrown
+      // by `useSyncObservable` during render and crashes the tool. Forced logout
+      // is not triggered here; it's owned by the request handler, which 401s on
+      // the ordinary HTTP requests a mounted pane also fires (users, grants, …).
+      // The pane keeps its last value (or stays loading if it never got a
+      // snapshot) until that logout lands.
+      if (isConnectionSessionError(err)) {
+        debug('Listener connection rejected (HTTP 401), terminating (invalid session)')
+        return EMPTY
+      }
+
       return throwError(() => err)
     }),
   )

--- a/packages/sanity/src/core/util/apiErrors.ts
+++ b/packages/sanity/src/core/util/apiErrors.ts
@@ -1,8 +1,27 @@
-import {type HttpError, isHttpError} from '@sanity/client'
+import {type ConnectionFailedError, type HttpError, isHttpError} from '@sanity/client'
 
 /** @internal */
 export function isUnauthorizedError(err: unknown): err is HttpError {
   return isHttpError(err) && err.statusCode === 401
+}
+
+/**
+ * Whether `err` is a listener/live-events connection the client rejected with a
+ * 401. Unlike a data request, the `listen` endpoint never answers 403: access
+ * is applied by filtering events, so a rejected connection can only be an
+ * invalid or expired session. The rejection is a `ConnectionFailedError`
+ * carrying only `status` (no response body, so no `errorCode`), matched by name
+ * to survive duplicate `@sanity/client` copies.
+ *
+ * @internal
+ */
+export function isConnectionSessionError(err: unknown): err is ConnectionFailedError {
+  return (
+    err instanceof Error &&
+    err.name === 'ConnectionFailedError' &&
+    'status' in err &&
+    err.status === 401
+  )
 }
 
 /**


### PR DESCRIPTION
### Description
A rejected listener connection (e.g. listen endpoint returns 401) should complete the stream instead of rethrowing or reconnecting forever. Recovery happens in auth store, where a new client will be emitted upon login, which will, in turn, flow down to React, causing a new client instance to be returned from useClient(), and finally re-establishing listener connections. Note that the listen request is unlikely to return 401 when set up initially, but it could happen during a reconnect e.g. after token expiry.

### What to review
Does the changes make sense? Am I overlooking something?

### Testing

Unit test verifying that the stream ends after 401 is included

### Notes for release
Fixes an issue where an expired session could crash the Studio with an "EventSource connection failed" error.

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes real-time document listener behavior on session expiry during reconnect; mitigated by not handling logout here and by tests, but affects how open panes behave until auth recovery.
> 
> **Overview**
> When the document pair **live listener** reconnects with an **invalid or expired session** (`ConnectionFailedError` with HTTP **401**), the observable now **completes cleanly** instead of erroring the stream.
> 
> A new **`isConnectionSessionError`** helper in `apiErrors` identifies that case (listen rejections carry status only, not API `errorCode`). **`getPairListener`** maps it to Rx **`EMPTY`** so **`useSyncObservable`** does not throw during render; the pane keeps its last snapshot until the normal request path handles logout. **Non-401** listener failures still propagate.
> 
> Unit tests cover 401 completion (no retry), generic errors, and non-401 `ConnectionFailedError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bfda044f50b22330341c4ffae5cebf072fa7da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->