### PR TITLE
fix(examples): stop importing ui5 in ecommerce studio

### DIFF
--- a/examples/studios/ecommerce-studio/package.json
+++ b/examples/studios/ecommerce-studio/package.json
@@ -33,8 +33,7 @@
     "react-barcode": "^1.6.1",
     "react-dom": "catalog:",
     "sanity": "workspace:*",
-    "styled-components": "catalog:",
-    "ui5": "catalog:"
+    "styled-components": "catalog:"
   },
   "devDependencies": {
     "rimraf": "catalog:"

--- a/examples/studios/ecommerce-studio/plugins/barcode-input/BarcodeInput.tsx
+++ b/examples/studios/ecommerce-studio/plugins/barcode-input/BarcodeInput.tsx
@@ -1,11 +1,10 @@
 // Copied from `@sanity/cli` (templates/ecommerce/plugins/barcode-input/BarcodeInput.js)
 
-import {Text} from '@sanity/ui'
+import {Box, Text} from '@sanity/ui'
 import {useState} from 'react'
 import Barcode from 'react-barcode'
 import {type FieldMember, MemberField, type ObjectInputProps} from 'sanity'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
 
 const BarcodeRoot = styled(Box)`
   svg {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`ui5` is the pinned npm alias for the `@sanity/ui` v5 prerelease (`pnpm-workspace.yaml` maps it to `npm:@sanity/ui@5.0.0-alpha.8`), so it only resolves inside this monorepo. Example studios are templates users copy into their own projects, where that alias does not exist — the barcode input's `Box` import would break on the way out. `@sanity/ui` exports the same component, so the fix is a one-line import move.

Follow-up: [#14682](https://github.com/sanity-io/sanity/pull/14682) adds the lint gate that keeps this from coming back. It is stacked on this branch, because the gate fails while this violation is still present.

### What to review

Two files in `examples/studios/ecommerce-studio`. `styled(Box)` still works — `@sanity/ui`'s `Box` is the component this file used before the ui5 migration touched it.

No lockfile change: the workspace globs in `pnpm-workspace.yaml` are `examples/*`, which matches `examples/studios` and `examples/functions`, not the individual studios, so `ecommerce-studio` is not a workspace project and has no importer entry. Confirmed with `pnpm install --lockfile-only` leaving `pnpm-lock.yaml` untouched.

### Testing

`examples/**` is excluded from CI (`ignorePatterns` in `.oxlintrc.json`, SGH-461) and this studio has no build or test script beyond `sanity dev`, so there is no automated check to run against it. Verified by inspection that `Box` is exported from `@sanity/ui` and that no other `ui5` reference remains in `examples/`. The gate in #14682 was confirmed to flag exactly the import this PR removes.

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c53a514-8a00-4b0f-8026-3e1096d221a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c53a514-8a00-4b0f-8026-3e1096d221a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

