### PR TITLE
chore(lint): gate ui5 imports out of example studios

### DIFF
--- a/.oxlintrc.examples.json
+++ b/.oxlintrc.examples.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  // `examples/**` is in the root config's `ignorePatterns` because it is out of scope for type
+  // checking (SGH-461), and `options.typeCheck` cannot be scoped per override — so this restriction
+  // cannot live in `.oxlintrc.json`. `check:oxlint` runs this config over `examples` as a second
+  // pass. Only the import restriction is enabled; examples stay ungated for every other rule.
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "ui5",
+            "message": "The ui5 alias is only available to first-party monorepo code. Example studios must import from @sanity/ui."
+          }
+        ],
+        "patterns": [
+          {
+            "group": ["ui5/*"],
+            "message": "The ui5 alias is only available to first-party monorepo code. Example studios must import from @sanity/ui."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,15 +41,15 @@ pnpm check:oxlint
 
 These checks run on every PR and **must pass**:
 
-| Check            | Command               | Notes                                                                                                                                                            |
-| ---------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Format**       | `pnpm check:format`   | Uses oxfmt. Fix with `pnpm chore:format:fix`                                                                                                                     |
-| **Oxlint**       | `pnpm check:oxlint`   | Rust linter with type-aware rules and TypeScript type checking via tsgolint (`options.typeCheck`). Fix with `pnpm chore:oxlint:fix`                              |
-| **Unit Tests**   | `pnpm test`           | Vitest, sharded in CI                                                                                                                                            |
-| **Export Tests** | `pnpm test:exports`   | Ensures ESM/CJS/DTS work                                                                                                                                         |
-| **Dep Check**    | `pnpm depcheck`       | Finds unused/missing deps                                                                                                                                        |
-| **Zizmor**       | `pnpm lint:workflows` | Audits `.github/workflows/` for security issues. Fails CI on high-severity findings. Local run needs [`zizmor`](https://docs.zizmor.sh/installation/) on `PATH`. |
-| **PR Title**     | Conventional commits  | e.g., `feat(scope): description`                                                                                                                                 |
+| Check            | Command               | Notes                                                                                                                                                                                                                    |
+| ---------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Format**       | `pnpm check:format`   | Uses oxfmt. Fix with `pnpm chore:format:fix`                                                                                                                                                                             |
+| **Oxlint**       | `pnpm check:oxlint`   | Rust linter with type-aware rules and TypeScript type checking via tsgolint (`options.typeCheck`). Runs `.oxlintrc.json` over the repo, then `.oxlintrc.examples.json` over `examples`. Fix with `pnpm chore:oxlint:fix` |
+| **Unit Tests**   | `pnpm test`           | Vitest, sharded in CI                                                                                                                                                                                                    |
+| **Export Tests** | `pnpm test:exports`   | Ensures ESM/CJS/DTS work                                                                                                                                                                                                 |
+| **Dep Check**    | `pnpm depcheck`       | Finds unused/missing deps                                                                                                                                                                                                |
+| **Zizmor**       | `pnpm lint:workflows` | Audits `.github/workflows/` for security issues. Fails CI on high-severity findings. Local run needs [`zizmor`](https://docs.zizmor.sh/installation/) on `PATH`.                                                         |
+| **PR Title**     | Conventional commits  | e.g., `feat(scope): description`                                                                                                                                                                                         |
 
 ### Before Committing
 
@@ -334,6 +334,8 @@ pnpm lint:fix          # Auto-fix issues (oxfmt + oxlint --fix)
 All packages use **ESM** (`"type": "module"`). TypeScript strict mode is enabled.
 
 Rules that the linter already enforces (restricted imports, type-aware rules, React Compiler rules, i18n rules, module boundaries) are not repeated in this guide — run `pnpm lint` and follow the reported messages, which explain the expected pattern.
+
+`examples/**` is in the root config's `ignorePatterns` (out of scope for type checking, SGH-461), so rules that must still reach example studios live in `.oxlintrc.examples.json`, which `check:oxlint` runs as a second pass. It cannot be an override in `.oxlintrc.json`: `options.typeCheck` is global and has no per-override form, so un-ignoring `examples` would flood the run with type errors. Keep that config scoped to restrictions that genuinely matter for code users copy into their own projects — examples are otherwise deliberately ungated.
 
 ### Do Not Weaken the Linter
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check": "npm-run-all build --parallel check:*",
     "check:deps": "knip --dependencies",
     "check:format": "oxfmt --check .",
-    "check:oxlint": "oxlint --disable-nested-config --quiet",
+    "check:oxlint": "oxlint --disable-nested-config --quiet && oxlint --config .oxlintrc.examples.json --disable-nested-config --quiet examples",
     "check:test": "pnpm test -- --silent",
     "chore:format:fix": "pnpm format",
     "chore:normalize-versions": "tsx scripts/normalizeDependencyVersions.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follows [#14681](https://github.com/sanity-io/sanity/pull/14681), which removed the one `ui5` import from the ecommerce example. This adds the gate so it cannot come back. **Stacked on that branch** — the gate fails while the violation is still present, so this cannot be based on `main` until #14681 merges.

The rule belongs in `.oxlintrc.json`, but it cannot go there. `examples/**` sits in that config's `ignorePatterns` because examples are out of scope for type checking (SGH-461), and `options.typeCheck` is global with no per-override form — `OxlintOverride` accepts only `env`, `excludeFiles`, `files`, `globals`, `jsPlugins`, `plugins`, and `rules`. I tried un-ignoring `examples` to confirm: the main run then reports hundreds of pre-existing `TS2307` / `TS7031` errors across `examples/functions`. So the rule lives in a second, narrowly scoped config that `check:oxlint` runs over `examples` as a follow-up pass. Same script, same CI step, no new workflow job.

Why not other approaches: a standalone Node scanner (an earlier revision of this work) duplicates what `no-restricted-imports` already does; nested config is off repo-wide via `--disable-nested-config`; and paying down SGH-461 so examples can join the root config is a much larger change than this gate warrants.

### What to review

`.oxlintrc.examples.json` — it enables only `eslint/no-restricted-imports` and sets `correctness` to `off`, so examples stay deliberately ungated for everything else instead of being pulled into the full rule set. It restricts both the `ui5` package root and the `ui5/*` pattern; the latter is how a stylesheet import such as `ui5/styles.css` would otherwise slip through.

The trade-off to weigh: `check:oxlint` is now two oxlint invocations, and a failure in the main pass short-circuits before the examples pass runs.

`AGENTS.md` records the arrangement and the `typeCheck` constraint so the two-config setup is not rediscovered later.

### Testing

- CI `Lint PR / oxlint` passes on this branch, and its single `Oxlint files` step runs both passes (visible in the job log as `oxlint --disable-nested-config --quiet && oxlint --config .oxlintrc.examples.json --disable-nested-config --quiet examples`)
- Locally, reintroducing the exact import #14681 removed makes the examples pass fail with the intended message, confirming the gate would have caught it
- A `ui5` import in `dev/radar` is untouched by the examples pass, so first-party code is unaffected
- `pnpm check:format`

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c53a514-8a00-4b0f-8026-3e1096d221a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c53a514-8a00-4b0f-8026-3e1096d221a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

