### PR TITLE
fix(studio): stabilize custom spinners in safari

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/SearchHeader.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SearchHeader.tsx
@@ -25,6 +25,8 @@ const rotate = keyframes`
 
 const AnimatedSpinnerIcon = styled(SpinnerIcon)`
   animation: ${rotate} 500ms linear infinite;
+  height: round(1em, 2px);
+  width: round(1em, 2px);
 `
 
 const FilterDiv = styled.div`

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -65,16 +65,21 @@ const fadeIn = keyframes`
   }
 `
 
-const AnimatedSpinnerIcon = styled(SpinnerIcon)`
+const SizedSpinnerIcon = styled(SpinnerIcon)`
+  height: round(1em, 2px);
+  width: round(1em, 2px);
+`
+
+const AnimatedSpinnerIcon = styled(SizedSpinnerIcon)`
   animation: ${rotate} 500ms linear infinite;
 `
 
-const SubtleSpinnerIcon = styled(SpinnerIcon)`
+const SubtleSpinnerIcon = styled(SizedSpinnerIcon)`
   animation: ${rotate} 1500ms linear infinite;
   opacity: 0.4;
 `
 
-const DelayedSubtleSpinnerIcon = styled(SpinnerIcon)`
+const DelayedSubtleSpinnerIcon = styled(SizedSpinnerIcon)`
   animation:
     ${rotate} 1500ms linear infinite,
     ${fadeIn} 1000ms linear;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Custom `SpinnerIcon` animations in Studio bypass the shared `@sanity/ui` spinner primitive and therefore miss the Safari wobble fix from sanity-io/ui#2897. Apply the same rounded square dimensions to the global-search spinner and all three document-list variants.

<!-- before-and-after:start -->
### Before / after (WebKit)

#### Before

[webkit_global_search_spinner_before.mp4](https://cursor.com/agents/bc-be98f047-c8eb-43bb-b59e-bd9e4dda7593/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebkit_global_search_spinner_before.mp4)

#### After

[webkit_global_search_spinner_after.mp4](https://cursor.com/agents/bc-be98f047-c8eb-43bb-b59e-bd9e4dda7593/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebkit_global_search_spinner_after.mp4)

The cloud VM is Linux, so this uses Playwright WebKit—the Safari rendering engine—rather than the macOS Safari application. The low recording cadence makes the baseline wobble look like positional jitter; the fixed spinner remains centered.
<!-- before-and-after:end -->

### What to review

Confirm the `round(1em, 2px)` dimensions match the upstream fix and that the shared document-list base preserves each variant's animation and opacity.

### Testing

- `pnpm exec oxfmt --check` on both changed files
- `pnpm exec oxlint --disable-nested-config --quiet` on both changed files
- `pnpm --filter sanity build`
- `pnpm vitest run --project=sanity packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx`
- Manual before/after in headed Playwright WebKit against the real global-search loading state

### Notes for release

Loading spinners in global search and document lists no longer wobble in Safari.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be98f047-c8eb-43bb-b59e-bd9e4dda7593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be98f047-c8eb-43bb-b59e-bd9e4dda7593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

