### PR TITLE
fix(validation): keep inherited rules and runtime context consistent

### DIFF
--- a/packages/@sanity/validation/src/inferFromSchemaType.ts
+++ b/packages/@sanity/validation/src/inferFromSchemaType.ts
@@ -1,6 +1,6 @@
 import {type Schema, type SchemaType, type SchemaValidationValue} from '@sanity/types'
 
-import {normalizeValidationRules} from './util/normalizeValidationRules'
+import {compileValidationRules} from './util/normalizeValidationRules'
 
 // NOTE: this overload is for TS API compatibility with a previous implementation
 export function inferFromSchemaType(
@@ -28,7 +28,7 @@ function traverse(typeDef: SchemaType, visited: Set<SchemaType>) {
   // Only normalize validation at schema-compile time when it doesn't rely on runtime context.
   // Context-aware validation functions must be evaluated during validation, where context exists.
   if (!usesValidationContext) {
-    typeDef.validation = normalizeValidationRules(typeDef)
+    typeDef.validation = compileValidationRules(typeDef)
   }
 
   if ('fields' in typeDef) {

--- a/packages/@sanity/validation/src/inferFromSchemaType.ts
+++ b/packages/@sanity/validation/src/inferFromSchemaType.ts
@@ -53,13 +53,13 @@ function traverse(typeDef: SchemaType, visited: Set<SchemaType>) {
 }
 
 /**
- * Checks if a validation function uses the context parameter.
+ * Checks if a validation function may use the context parameter.
  *
  * Functions with 2+ parameters like `(rule, context) => ...` need runtime context
  * (e.g., `context.hidden`, `context.document`) and cannot be pre-evaluated at schema compile time.
  *
- * Functions with 1 parameter like `(rule) => rule.required()` don't need context
- * and can be normalized immediately for better performance.
+ * Simple functions with only a rule parameter can be normalized immediately.
+ * Unrecognized signatures are deferred because their arity may hide context usage.
  *
  * @internal
  */
@@ -73,8 +73,12 @@ export function hasValidationContext(validation: SchemaValidationValue | undefin
   // Check declared parameter count first (most common case)
   if (validation.length >= 2) return true
 
-  // Function.length doesn't count rest parameters, so check the signature for patterns like
-  // `(rule, ...args)` which would have length === 1 but still expects context
+  // Default and rest parameters do not contribute to Function.length. Only compile
+  // recognizable zero/one-parameter signatures; wrappers and unknown forms stay at runtime.
   const signature = Function.prototype.toString.call(validation)
-  return /\(\s*\w+\s*,\s*\.\.\./.test(signature)
+  if (/\barguments\b|\[native code\]/.test(signature)) return true
+
+  const simpleArrow = /^\s*(?:[\w$]+|\(\s*(?:[\w$]+\s*)?\))\s*=>/
+  const simpleFunction = /^\s*(?:function(?:\s+[\w$]+)?|[\w$]+)\s*\(\s*(?:[\w$]+\s*)?\)\s*\{/
+  return !simpleArrow.test(signature) && !simpleFunction.test(signature)
 }

--- a/packages/@sanity/validation/src/util/getTypeChain.ts
+++ b/packages/@sanity/validation/src/util/getTypeChain.ts
@@ -1,0 +1,14 @@
+import {type SchemaType} from '@sanity/types'
+
+export function getTypeChain(
+  type: SchemaType | undefined,
+  visited: Set<SchemaType> = new Set(),
+): SchemaType[] {
+  if (!type) return []
+  if (visited.has(type)) return []
+
+  visited.add(type)
+
+  const next = type.type ? getTypeChain(type.type, visited) : []
+  return [...next, type]
+}

--- a/packages/@sanity/validation/src/util/normalizeValidationRules.ts
+++ b/packages/@sanity/validation/src/util/normalizeValidationRules.ts
@@ -11,6 +11,9 @@ import {dequal as isEqual} from 'dequal/lite'
 import {markInternalValidator} from '../internalValidators'
 import {Rule as RuleClass} from '../Rule'
 import {slugStructureValidator, slugUniquenessValidator} from '../validators/slugValidator'
+import {getTypeChain} from './getTypeChain'
+
+export {getTypeChain} from './getTypeChain'
 
 const ruleConstraintTypes: {[P in Lowercase<RuleTypeConstraint>]: true} = {
   array: true,
@@ -39,26 +42,7 @@ export function compileValidationRules(type: SchemaType): Rule[] {
   return rules
 }
 
-export function getTypeChain(
-  type: SchemaType | undefined,
-  visited: Set<SchemaType> = new Set(),
-): SchemaType[] {
-  if (!type) return []
-  if (visited.has(type)) return []
-
-  visited.add(type)
-
-  const next = type.type ? getTypeChain(type.type, visited) : []
-  return [...next, type]
-}
-
-function baseRuleReducer(inputRule: Rule, type: SchemaType) {
-  let baseRule = inputRule
-
-  if (isRuleConstraint(type.jsonType)) {
-    baseRule = baseRule.type(type.jsonType)
-  }
-
+function baseRuleReducer(baseRule: Rule, type: SchemaType) {
   if (type.name === 'datetime') return baseRule.type('Date')
   if (type.name === 'date') return baseRule.type('Date')
   if (type.name === 'url') return baseRule.uri()
@@ -151,6 +135,7 @@ export function normalizeValidationRules(
     return omitLeakedDefaultUri(rules, typeDef)
   }
 
+  const initialRule = new RuleClass(typeDef)
   let baseRule =
     // using an object + Object.values to de-dupe the type chain by type name
     Object.values(
@@ -158,7 +143,10 @@ export function normalizeValidationRules(
         acc[type.name] = type
         return acc
       }, {}),
-    ).reduce(baseRuleReducer, new RuleClass(typeDef))
+    ).reduce(
+      baseRuleReducer,
+      isRuleConstraint(typeDef.jsonType) ? initialRule.type(typeDef.jsonType) : initialRule,
+    )
 
   const options = typeDef.options
   const list =

--- a/packages/@sanity/validation/src/util/normalizeValidationRules.ts
+++ b/packages/@sanity/validation/src/util/normalizeValidationRules.ts
@@ -3,6 +3,7 @@ import {
   type RuleSpec,
   type RuleTypeConstraint,
   type SchemaType,
+  type SchemaValidationValue,
   type ValidationContext,
 } from '@sanity/types'
 import {dequal as isEqual} from 'dequal/lite'
@@ -23,6 +24,21 @@ const ruleConstraintTypes: {[P in Lowercase<RuleTypeConstraint>]: true} = {
 const isRuleConstraint = (typeString: string): typeString is Lowercase<RuleTypeConstraint> =>
   typeString in ruleConstraintTypes
 
+const compiledValidations = new WeakMap<
+  object,
+  {type: SchemaType; definition: SchemaValidationValue | undefined; rules: Rule[]}
+>()
+
+export function compileValidationRules(type: SchemaType): Rule[] {
+  const inherited = Array.isArray(type.validation)
+    ? compiledValidations.get(type.validation)
+    : undefined
+  const definition = inherited ? inherited.definition : type.validation
+  const rules = normalizeValidationRules(type)
+  compiledValidations.set(rules, {type, definition, rules})
+  return rules
+}
+
 export function getTypeChain(
   type: SchemaType | undefined,
   visited: Set<SchemaType> = new Set(),
@@ -41,22 +57,6 @@ function baseRuleReducer(inputRule: Rule, type: SchemaType) {
 
   if (isRuleConstraint(type.jsonType)) {
     baseRule = baseRule.type(type.jsonType)
-  }
-
-  const typeOptionsList =
-    // if type.options is truthy
-    type?.options &&
-    // and type.options is an object (non-null from the previous)
-    typeof type.options === 'object' &&
-    // and if `list` is in options
-    'list' in type.options &&
-    // then finally access the list
-    type.options.list
-
-  if (Array.isArray(typeOptionsList)) {
-    baseRule = baseRule.valid(
-      typeOptionsList.map((option) => extractValueFromListOption(option, type)),
-    )
   }
 
   if (type.name === 'datetime') return baseRule.type('Date')
@@ -126,6 +126,16 @@ export function normalizeValidationRules(
     return []
   }
 
+  const compiled = Array.isArray(typeDef.validation)
+    ? compiledValidations.get(typeDef.validation)
+    : undefined
+  if (compiled) {
+    if (compiled.type === typeDef) return compiled.rules
+    // Derived fields inherit compiled rules, but their options can differ. Rebuild
+    // from the authored definition instead of reusing the ancestor's constraints.
+    return normalizeValidationRules({...typeDef, validation: compiled.definition}, context)
+  }
+
   const validation = typeDef.validation
 
   if (Array.isArray(validation)) {
@@ -141,7 +151,7 @@ export function normalizeValidationRules(
     return omitLeakedDefaultUri(rules, typeDef)
   }
 
-  const baseRule =
+  let baseRule =
     // using an object + Object.values to de-dupe the type chain by type name
     Object.values(
       getTypeChain(typeDef).reduce<Record<string, SchemaType>>((acc, type) => {
@@ -149,6 +159,13 @@ export function normalizeValidationRules(
         return acc
       }, {}),
     ).reduce(baseRuleReducer, new RuleClass(typeDef))
+
+  const options = typeDef.options
+  const list =
+    options && typeof options === 'object' && 'list' in options ? options.list : undefined
+  if (Array.isArray(list)) {
+    baseRule = baseRule.valid(list.map((option) => extractValueFromListOption(option, typeDef)))
+  }
 
   if (validation && typeof validation === 'object') {
     return [validation]

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -692,25 +692,21 @@ function validateItemObservable({
         .flatMap((fieldResults) => Object.entries(fieldResults))
         .flatMap(([name, validation]) => {
           const fieldType = fieldTypes[name]
-          return normalizeValidationRules({...fieldType, validation})
+          const nestedValue = isRecord(value) ? value[name] : undefined
+          const fieldContext = {
+            ...restOfContext,
+            parent: value,
+            path: path.concat(name),
+            type: fieldType,
+            environment,
+            hidden: resolveHiddenForType(fieldType, nestedValue, value, path.concat(name), hidden),
+          }
+          return normalizeValidationRules({...fieldType, validation}, fieldContext)
             .map(addUnknownFieldsValidator)
             .map((subRule) => {
-              const nestedValue = isRecord(value) ? value[name] : undefined
-              const nestedHidden = resolveHiddenForType(
-                fieldType,
-                nestedValue,
-                value,
-                path.concat(name),
-                hidden,
-              )
               return defer(() =>
                 validateRule(subRule, nestedValue, {
-                  ...restOfContext,
-                  parent: value,
-                  path: path.concat(name),
-                  type: fieldType,
-                  environment,
-                  hidden: nestedHidden,
+                  ...fieldContext,
                   __internal: {
                     ...__internal,
                     customValidation,

--- a/packages/@sanity/validation/src/validators/dateValidator.ts
+++ b/packages/@sanity/validation/src/validators/dateValidator.ts
@@ -1,7 +1,8 @@
-import {type Validators} from '@sanity/types'
+import {type SchemaType, type Validators} from '@sanity/types'
 import * as legacyDateFormat from '@sanity/util/legacyDateFormat'
 
 import {validationMarkerCodes} from '../codes'
+import {getTypeChain} from '../util/getTypeChain'
 import {genericValidators} from './genericValidator'
 
 function isRecord(obj: unknown): obj is Record<string, unknown> {
@@ -18,18 +19,17 @@ interface DateTimeOptions {
   timeFormat?: string
 }
 
-const getFormattedDate = (type = '', value: Date, options?: DateTimeOptions) => {
+const getFormattedDate = (type: SchemaType, value: Date, options?: DateTimeOptions) => {
+  const dateOnly = getTypeChain(type).some((candidate) => candidate.name === 'date')
   const dateFormat = options?.dateFormat || legacyDateFormat.DEFAULT_DATE_FORMAT
   const timeFormat = options?.timeFormat || legacyDateFormat.DEFAULT_TIME_FORMAT
 
   // adding the time information in the date only case causes timezone information to be kept
   // instead of it being assumed to be UTC. This was a problem because midnight UTC is the previous
   // day in many other timezones resulting in the date displayed to be the previous day.
-  return legacyDateFormat.format(
-    value,
-    type === 'date' ? dateFormat : `${dateFormat} ${timeFormat}`,
-    {useUTC: type === 'date'},
-  )
+  return legacyDateFormat.format(value, dateOnly ? dateFormat : `${dateFormat} ${timeFormat}`, {
+    useUTC: dateOnly,
+  })
 }
 
 function parseDate(date: unknown): Date | null
@@ -92,7 +92,7 @@ export const dateValidators: Validators = {
         // validator is available as `providedMinDate`. This because the formatted date is likely
         // what the developer wants to present to the user
         i18n.t('validation:date.minimum', {
-          minDate: getFormattedDate(type.name, minDateVal, dateTimeOptions),
+          minDate: getFormattedDate(type, minDateVal, dateTimeOptions),
           providedMinDate: minDate,
         }),
     }
@@ -127,7 +127,7 @@ export const dateValidators: Validators = {
         // validator is available as `providedMaxDate`. This because the formatted date is likely
         // what the developer wants to present to the user
         i18n.t('validation:date.maximum', {
-          maxDate: getFormattedDate(type.name, maxDateVal, dateTimeOptions),
+          maxDate: getFormattedDate(type, maxDateVal, dateTimeOptions),
           providedMaxDate: maxDate,
         }),
     }

--- a/packages/@sanity/validation/test/compiledValidation.test.ts
+++ b/packages/@sanity/validation/test/compiledValidation.test.ts
@@ -22,6 +22,118 @@ function createSchema(types: SchemaTypeDefinition[], compiled: boolean) {
 }
 
 describe.each([false, true])('validation with compiled schema=%s', (compiled) => {
+  it.each(['date', 'datetime'])('keeps %s validation through multiple aliases', async (type) => {
+    const schema = createSchema(
+      [
+        {name: 'eventDate', type},
+        {name: 'nestedDate', type: 'eventDate'},
+        {name: 'article', type: 'document', fields: [{name: 'date', type: 'nestedDate'}]},
+      ],
+      compiled,
+    )
+    const invalid = await validateDocument({schema, document: {...document, date: 'not a date'}})
+    expect(invalid.markers).toEqual([
+      expect.objectContaining({code: validationMarkerCodes.dateInvalidFormat}),
+    ])
+    await expect(
+      validateDocument({schema, document: {...document, date: '2027-01-01'}}),
+    ).resolves.toMatchObject({status: 'passed', markers: []})
+  })
+
+  it('preserves URL scheme overrides across inherited validation arrays', async () => {
+    const schema = createSchema(
+      [
+        {
+          name: 'contactUrl',
+          type: 'url',
+          validation: (rule: Rule) => [rule.uri({scheme: ['mailto']}), rule.required()],
+        },
+        {name: 'article', type: 'document', fields: [{name: 'contact', type: 'contactUrl'}]},
+      ],
+      compiled,
+    )
+    await expect(
+      validateDocument({schema, document: {...document, contact: 'mailto:test@example.com'}}),
+    ).resolves.toMatchObject({status: 'passed', markers: []})
+    const invalid = await validateDocument({
+      schema,
+      document: {...document, contact: 'https://example.com'},
+    })
+    expect(invalid.status).toBe('failed')
+  })
+
+  it('keeps inherited weak references', async () => {
+    const schema = createSchema(
+      [
+        {name: 'articleReference', type: 'reference', to: [{type: 'article'}], weak: true},
+        {
+          name: 'article',
+          type: 'document',
+          fields: [{name: 'related', type: 'articleReference'}],
+        },
+      ],
+      compiled,
+    )
+    const getDocumentExists = vi.fn(async () => false)
+    await expect(
+      validateDocument({
+        schema,
+        getDocumentExists,
+        document: {...document, related: {_type: 'reference', _ref: 'missing'}},
+      }),
+    ).resolves.toMatchObject({status: 'passed', markers: []})
+    expect(getDocumentExists).not.toHaveBeenCalled()
+  })
+
+  it.each(['image', 'file'])('keeps inherited %s asset requirements', async (type) => {
+    const schema = createSchema(
+      [
+        {name: 'media', type, validation: (rule: Rule) => rule.assetRequired()},
+        {name: 'article', type: 'document', fields: [{name: 'media', type: 'media'}]},
+      ],
+      compiled,
+    )
+    const result = await validateDocument({
+      schema,
+      document: {...document, media: {_type: 'media'}},
+    })
+    expect(result.markers).toEqual([
+      expect.objectContaining({
+        code: validationMarkerCodes.assetRequired,
+        details: {assetType: type},
+      }),
+    ])
+  })
+
+  it('uses the date field’s formatting options for inherited bounds', async () => {
+    const schema = createSchema(
+      [
+        {
+          name: 'eventDate',
+          type: 'date',
+          options: {dateFormat: 'YYYY-MM-DD'},
+          validation: (rule: Rule) => rule.min('2026-12-31'),
+        },
+        {
+          name: 'article',
+          type: 'document',
+          fields: [{name: 'date', type: 'eventDate', options: {dateFormat: 'DD/MM/YYYY'}}],
+        },
+      ],
+      compiled,
+    )
+    const result = await validateDocument({schema, document: {...document, date: '2026-01-01'}})
+    expect(result.markers).toEqual([
+      expect.objectContaining({
+        code: validationMarkerCodes.dateMinimum,
+        message: expect.stringContaining('31/12/2026'),
+      }),
+    ])
+    await expect(
+      validateDocument({schema, document: {...document, date: '2027-01-01'}}),
+    ).resolves.toMatchObject({status: 'passed', markers: []})
+  })
+
   it('passes child context to Rule.fields builders', async () => {
     const contexts: Array<ValidationContext | undefined> = []
     const schema = createSchema(

--- a/packages/@sanity/validation/test/compiledValidation.test.ts
+++ b/packages/@sanity/validation/test/compiledValidation.test.ts
@@ -1,0 +1,153 @@
+import {Schema} from '@sanity/schema'
+import {builtinTypes} from '@sanity/schema/_internal'
+import {type Rule, type SchemaTypeDefinition} from '@sanity/types'
+import {describe, expect, it, vi} from 'vitest'
+
+import {validateDocument, validationMarkerCodes} from '../src'
+import {inferFromSchema} from '../src/_internal'
+
+const document = {
+  _id: 'article-id',
+  _type: 'article',
+  _rev: 'revision',
+  _createdAt: '2026-01-01T00:00:00.000Z',
+  _updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function createSchema(types: SchemaTypeDefinition[], compiled: boolean) {
+  const parent = Schema.compile({name: 'builtin', types: builtinTypes})
+  if (compiled) inferFromSchema(parent)
+  const schema = Schema.compile({name: 'test', parent, types})
+  return compiled ? inferFromSchema(schema) : schema
+}
+
+describe.each([false, true])('validation with compiled schema=%s', (compiled) => {
+  it.each(['string', 'color', 'nestedColor'])(
+    'uses the field list on %s without requiring an explicit validation function',
+    async (type) => {
+      const schema = createSchema(
+        [
+          {name: 'color', type: 'string', options: {list: ['red']}},
+          {name: 'nestedColor', type: 'color'},
+          {
+            name: 'article',
+            type: 'document',
+            fields: [{name: 'color', type, options: {list: ['blue']}}],
+          },
+        ],
+        compiled,
+      )
+
+      await Promise.all(
+        ['red', 'green', 'blue'].map(async (color) => {
+          const result = await validateDocument({schema, document: {...document, color}})
+          expect(result.status).toBe(color === 'blue' ? 'passed' : 'failed')
+        }),
+      )
+    },
+  )
+
+  it('removes an inherited list when field options replace it', async () => {
+    const schema = createSchema(
+      [
+        {name: 'color', type: 'string', options: {list: ['red']}},
+        {name: 'nestedColor', type: 'color'},
+        {
+          name: 'article',
+          type: 'document',
+          fields: [{name: 'color', type: 'nestedColor', options: {}}],
+        },
+      ],
+      compiled,
+    )
+    await expect(
+      validateDocument({schema, document: {...document, color: 'green'}}),
+    ).resolves.toMatchObject({status: 'passed', markers: []})
+  })
+
+  it('keeps inherited explicit validation when rebuilding the field list', async () => {
+    const schema = createSchema(
+      [
+        {
+          name: 'color',
+          type: 'string',
+          options: {list: ['red']},
+          validation: (rule: Rule) => [rule.required(), rule.min(3)],
+        },
+        {
+          name: 'article',
+          type: 'document',
+          fields: [{name: 'color', type: 'color', options: {list: ['blue', 'a']}}],
+        },
+      ],
+      compiled,
+    )
+
+    const missing = await validateDocument({schema, document})
+    expect(missing.markers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({code: validationMarkerCodes.valueRequired}),
+      ]),
+    )
+    const short = await validateDocument({schema, document: {...document, color: 'a'}})
+    expect(short.status).toBe('failed')
+    await expect(
+      validateDocument({schema, document: {...document, color: 'blue'}}),
+    ).resolves.toMatchObject({status: 'passed', markers: []})
+  })
+
+  it('allows a field validation function to replace inherited validation', async () => {
+    const schema = createSchema(
+      [
+        {name: 'name', type: 'string', validation: (rule: Rule) => rule.min(5)},
+        {
+          name: 'article',
+          type: 'document',
+          fields: [{name: 'name', type: 'name', validation: (rule: Rule) => rule.min(2)}],
+        },
+      ],
+      compiled,
+    )
+    await expect(
+      validateDocument({schema, document: {...document, name: 'abc'}}),
+    ).resolves.toMatchObject({status: 'passed', markers: []})
+  })
+
+  it('preserves explicit valid constraints alongside inferred list constraints', async () => {
+    const schema = createSchema(
+      [
+        {
+          name: 'color',
+          type: 'string',
+          options: {list: ['red']},
+          validation: (rule: Rule) => rule.valid(['red', 'blue']),
+        },
+        {
+          name: 'article',
+          type: 'document',
+          fields: [{name: 'color', type: 'color', options: {list: ['blue', 'green']}}],
+        },
+      ],
+      compiled,
+    )
+    await Promise.all(
+      ['red', 'green', 'blue'].map(async (color) => {
+        const result = await validateDocument({schema, document: {...document, color}})
+        expect(result.status).toBe(color === 'blue' ? 'passed' : 'failed')
+      }),
+    )
+  })
+})
+
+it('reuses compiled static rules for the same field across repeated inference and validation', async () => {
+  const validation = vi.fn((rule: Rule) => rule.min(3))
+  const schema = createSchema(
+    [{name: 'article', type: 'document', fields: [{name: 'name', type: 'string', validation}]}],
+    true,
+  )
+  const callsAfterCompilation = validation.mock.calls.length
+  inferFromSchema(schema)
+  await validateDocument({schema, document: {...document, name: 'abc'}})
+  await validateDocument({schema, document: {...document, name: 'def'}})
+  expect(validation).toHaveBeenCalledTimes(callsAfterCompilation)
+})

--- a/packages/@sanity/validation/test/compiledValidation.test.ts
+++ b/packages/@sanity/validation/test/compiledValidation.test.ts
@@ -22,6 +22,52 @@ function createSchema(types: SchemaTypeDefinition[], compiled: boolean) {
 }
 
 describe.each([false, true])('validation with compiled schema=%s', (compiled) => {
+  it('passes child context to Rule.fields builders', async () => {
+    const contexts: Array<ValidationContext | undefined> = []
+    const schema = createSchema(
+      [
+        {
+          name: 'article',
+          type: 'document',
+          fields: [
+            {name: 'requireValue', type: 'boolean'},
+            {
+              name: 'details',
+              type: 'object',
+              fields: [{name: 'title', type: 'string', hidden: true}],
+              validation: (rule: Rule) =>
+                rule.fields({
+                  title: (fieldRule, context) => {
+                    contexts.push(context)
+                    return context?.document?.requireValue
+                      ? fieldRule.required()
+                      : fieldRule.optional()
+                  },
+                }),
+            },
+          ],
+        },
+      ],
+      compiled,
+    )
+    const result = await validateDocument({
+      schema,
+      document: {...document, requireValue: true, details: {}},
+    })
+    expect(
+      result.markers.filter((marker) => marker.code === validationMarkerCodes.valueRequired),
+    ).toEqual([expect.objectContaining({path: ['details', 'title']})])
+    expect(contexts).toEqual([
+      expect.objectContaining({
+        document: expect.objectContaining({requireValue: true}),
+        parent: {},
+        path: ['details', 'title'],
+        hidden: true,
+        type: expect.objectContaining({name: 'string'}),
+      }),
+    ])
+  })
+
   it.each([
     [
       'default context',

--- a/packages/@sanity/validation/test/compiledValidation.test.ts
+++ b/packages/@sanity/validation/test/compiledValidation.test.ts
@@ -1,6 +1,6 @@
 import {Schema} from '@sanity/schema'
 import {builtinTypes} from '@sanity/schema/_internal'
-import {type Rule, type SchemaTypeDefinition} from '@sanity/types'
+import {type Rule, type SchemaTypeDefinition, type ValidationContext} from '@sanity/types'
 import {describe, expect, it, vi} from 'vitest'
 
 import {validateDocument, validationMarkerCodes} from '../src'
@@ -22,6 +22,59 @@ function createSchema(types: SchemaTypeDefinition[], compiled: boolean) {
 }
 
 describe.each([false, true])('validation with compiled schema=%s', (compiled) => {
+  it.each([
+    [
+      'default context',
+      (rule: Rule, context: Partial<ValidationContext> = {}) =>
+        context.document?.requireValue ? rule.required() : rule.optional(),
+    ],
+    [
+      'default destructured context',
+      (rule: Rule, {document: currentDocument}: Partial<ValidationContext> = {}) =>
+        currentDocument?.requireValue ? rule.required() : rule.optional(),
+    ],
+    [
+      'rest parameters',
+      (...[rule, context]: [Rule, ValidationContext?]) =>
+        context?.document?.requireValue ? rule.required() : rule.optional(),
+    ],
+    [
+      'bound function',
+      function (this: {enabled: boolean}, rule: Rule, context: Partial<ValidationContext> = {}) {
+        return this.enabled && context.document?.requireValue ? rule.required() : rule.optional()
+      }.bind({enabled: true}),
+    ],
+    [
+      'wrapped function',
+      vi.fn((rule: Rule, context: Partial<ValidationContext> = {}) =>
+        context.document?.requireValue ? rule.required() : rule.optional(),
+      ),
+    ],
+  ])('evaluates %s using the current document', async (_name, validation) => {
+    const schema = createSchema(
+      [
+        {name: 'title', type: 'string', validation},
+        {
+          name: 'article',
+          type: 'document',
+          fields: [
+            {name: 'requireValue', type: 'boolean'},
+            {name: 'title', type: 'title'},
+          ],
+        },
+      ],
+      compiled,
+    )
+    for (const requireValue of [false, true, false]) {
+      // Run sequentially to exercise changing context against the same compiled schema.
+      // oxlint-disable-next-line no-await-in-loop -- each validation checks the next document state
+      const result = await validateDocument({schema, document: {...document, requireValue}})
+      expect(
+        result.markers.filter((marker) => marker.code === validationMarkerCodes.valueRequired),
+      ).toHaveLength(requireValue ? 1 : 0)
+    }
+  })
+
   it.each(['string', 'color', 'nestedColor'])(
     'uses the field list on %s without requiring an explicit validation function',
     async (type) => {
@@ -140,14 +193,19 @@ describe.each([false, true])('validation with compiled schema=%s', (compiled) =>
 })
 
 it('reuses compiled static rules for the same field across repeated inference and validation', async () => {
-  const validation = vi.fn((rule: Rule) => rule.min(3))
+  const onCompile = vi.fn()
+  const validation = (rule: Rule) => {
+    onCompile()
+    return rule.min(3)
+  }
   const schema = createSchema(
     [{name: 'article', type: 'document', fields: [{name: 'name', type: 'string', validation}]}],
     true,
   )
-  const callsAfterCompilation = validation.mock.calls.length
+  const callsAfterCompilation = onCompile.mock.calls.length
+  expect(callsAfterCompilation).toBeGreaterThan(0)
   inferFromSchema(schema)
   await validateDocument({schema, document: {...document, name: 'abc'}})
   await validateDocument({schema, document: {...document, name: 'def'}})
-  expect(validation).toHaveBeenCalledTimes(callsAfterCompilation)
+  expect(onCompile).toHaveBeenCalledTimes(callsAfterCompilation)
 })

--- a/packages/sanity/src/core/studio/components/navbar/search/datastores/recentSearches.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/datastores/recentSearches.test.tsx
@@ -4,6 +4,7 @@ import {act, renderHook} from '@testing-library/react'
 import {afterEach, beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {useSchema} from '../../../../../hooks/useSchema'
 import {type SearchTerms} from '../../../../../search/common/types'
 import {filterDefinitions} from '../definitions/defaultFilters'
 import {createFieldDefinitions} from '../definitions/fields'
@@ -65,7 +66,9 @@ const constructRecentSearchesStore = async () => {
 
   return renderHook(
     () => {
-      return useRecentSearchesStore()
+      const store = useRecentSearchesStore()
+      const schema = useSchema()
+      return {...store, schema}
     },
     {wrapper: TestWrapper},
   )
@@ -278,7 +281,9 @@ describe('search-store', () => {
       const recentTerms = result.current.getRecentSearches()
 
       expect(recentTerms.length).toEqual(1)
-      expect(recentTerms[0]).toMatchObject(searchTerms)
+      expect(recentTerms[0]).toMatchObject({query: searchTerms.query})
+      expect(recentTerms[0]?.types).toHaveLength(1)
+      expect(recentTerms[0]?.types[0]).toBe(result.current.schema.get('article'))
     })
 
     it('should remove duplicate terms', async () => {


### PR DESCRIPTION
### Issue

Fixes [AIGRO-5488](https://linear.app/sanity/issue/AIGRO-5488).

A follow-up to a customer's slug-alias report found more cases where inherited validation loses field options or runtime context. List overrides, defaulted context parameters, nested field builders, and date aliases all reproduce before the recent extraction into `@sanity/validation`.

### What to review

The stack separates the four fixes and a search-test update. Inherited rules now use the final field options, context-dependent builders receive the current document, and date aliases keep date validation. The search test checks that restored searches use the resolved Studio schema.

### Walkthrough

<img width="960" height="549" alt="shapiro fix-latent-schema-validation" src="https://github.com/user-attachments/assets/31263616-d020-4304-8f48-097ea494cdbf" />

### Testing

Both schema-compilation paths have regression coverage. A local mock-backed Studio verifies that each error appears and clears after editing, including toggling conditional requirements off and on.

The application suites pass with four workers: 7,015 tests across 729 files, including the complete validation suite. Build, formatting, lint/type checks, exports, and dependency checks pass. The unrestricted run also exposes a timing-sensitive network test and an unrelated E2E reporter path assertion; the network test passes in the lower-concurrency run, and the reporter failure reproduces in the earlier checkout. BugBot found no bugs in the stack ending at `578f03139b`.

### Notes for release

Fix validation for type aliases with option lists and date constraints. Ensure context-dependent validation and nested field rules receive the current document and field context.

---
