### PR TITLE
fix(studio): preserve light-dark in auto-update bundle css

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,10 @@ pnpm analyze:sanity
 
 The report is written to `packages/sanity/lib/analyze-data.md` (gitignored with `lib/`). The flag is opt-in because analysis adds work to the package build; it is declared in `packages/sanity/turbo.json` so turbo-cached builds are invalidated when it changes. Wiring is `@sanity/tsdown-config`'s `bundleAnalyzer` option (`true` selects markdown).
 
+### Auto-updating studio CSS (Lightning CSS `light-dark()`)
+
+The CDN / auto-update bundle Vite config lives in `@repo/package.bundle` (`createDefaultConfig`). Vite 8 minifies that CSS with Lightning CSS against `baseline-widely-available` (Chrome 111 / Safari 16.4), which down-transpiles `light-dark()` into `--lightningcss-light` / `--lightningcss-dark` toggled only by `prefers-color-scheme`. That breaks Studio theme colors when OS appearance ≠ Studio theme (ui5 sets `color-scheme` independently). The shared config excludes `Features.LightDark` so the function is left native — same workaround as Tailwind; see [lightningcss#873](https://github.com/parcel-bundler/lightningcss/issues/873). Do not re-enable that polyfill. The `sanity build` / `sanity preview` Vite config lives in `sanity-io/cli`, not this repo.
+
 ### Studio performance benchmarks (perf/bench — No Auth Required)
 
 The `perf/bench` suite benchmarks a built studio against a **local mock** of the Sanity API — fully hermetic, no tokens, no network:

--- a/packages/@repo/package.bundle/package.json
+++ b/packages/@repo/package.bundle/package.json
@@ -15,6 +15,7 @@
     "@sanity/vanilla-extract-vite-plugin": "catalog:",
     "@types/lodash-es": "^4.17.12",
     "@vitejs/plugin-react": "catalog:",
+    "lightningcss": "^1.33.0",
     "lodash-es": "^4.18.1",
     "oxc-transform-react": "catalog:",
     "vite": "catalog:",

--- a/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
+++ b/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
@@ -1,3 +1,4 @@
+import {Features, transform} from 'lightningcss'
 import {describe, expect, it} from 'vitest'
 
 import {cleanupCssOutputPlugin, createDefaultConfig} from '../package.bundle'
@@ -6,6 +7,57 @@ describe('createDefaultConfig()', () => {
   it('injects the provided version as the __PKG_VERSION__ define', () => {
     const config = createDefaultConfig({version: '9.9.9-test.1'})
     expect(config.define?.['__PKG_VERSION__']).toBe('"9.9.9-test.1"')
+  })
+
+  it('excludes the Lightning CSS light-dark polyfill', () => {
+    const config = createDefaultConfig({version: '9.9.9-test.1'})
+    expect(config.css?.lightningcss?.exclude).toBe(Features.LightDark)
+  })
+})
+
+/**
+ * Vite 8's default CSS minify target (`baseline-widely-available`): Chrome 111,
+ * Edge 111, Firefox 114, Safari 16.4. Those browsers predate native `light-dark()`.
+ */
+const VITE_BASELINE_WIDELY_AVAILABLE_TARGETS = {
+  chrome: 111 << 16,
+  edge: 111 << 16,
+  firefox: 114 << 16,
+  safari: (16 << 16) | (4 << 8),
+  ios_saf: (16 << 16) | (4 << 8),
+}
+
+const LIGHT_DARK_CSS = '.x{color:light-dark(white,black)}'
+
+describe('Lightning CSS light-dark minify', () => {
+  it('rewrites light-dark() when the polyfill is left enabled', () => {
+    const {code} = transform({
+      filename: 'theme.css',
+      code: Buffer.from(LIGHT_DARK_CSS),
+      minify: true,
+      targets: VITE_BASELINE_WIDELY_AVAILABLE_TARGETS,
+    })
+    const css = code.toString()
+
+    expect(css).toContain('--lightningcss-light')
+    expect(css).toContain('--lightningcss-dark')
+    expect(css).not.toContain('light-dark(')
+  })
+
+  it('preserves light-dark() when the bundle config exclude is applied', () => {
+    const config = createDefaultConfig({version: '9.9.9-test.1'})
+    const {code} = transform({
+      filename: 'theme.css',
+      code: Buffer.from(LIGHT_DARK_CSS),
+      minify: true,
+      targets: VITE_BASELINE_WIDELY_AVAILABLE_TARGETS,
+      exclude: config.css?.lightningcss?.exclude,
+    })
+    const css = code.toString()
+
+    expect(css).toContain('light-dark(')
+    expect(css).not.toContain('--lightningcss-light')
+    expect(css).not.toContain('--lightningcss-dark')
   })
 })
 

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -1,5 +1,6 @@
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import viteReact from '@vitejs/plugin-react'
+import {Features} from 'lightningcss'
 import escapeRegExp from 'lodash-es/escapeRegExp.js'
 import {esmExternalRequirePlugin, type Plugin, type UserConfig} from 'vite'
 
@@ -18,6 +19,18 @@ export interface DefaultConfigOptions {
 export function createDefaultConfig({version}: DefaultConfigOptions): UserConfig {
   return {
     appType: 'custom',
+    // Vite 8 minifies CSS with Lightning CSS against `baseline-widely-available`
+    // (Chrome 111 / Safari 16.4). That target still down-transpiles `light-dark()`
+    // into `--lightningcss-light` / `--lightningcss-dark` toggled only by
+    // `prefers-color-scheme`, so Studio theme colors follow the OS instead of
+    // `color-scheme` when the two disagree. Disable the polyfill — same as
+    // Tailwind — rather than raising `build.cssTarget` (that would change other
+    // CSS lowering). See https://github.com/parcel-bundler/lightningcss/issues/873
+    css: {
+      lightningcss: {
+        exclude: Features.LightDark,
+      },
+    },
     define: {
       '__SANITY_STAGING__': process.env.SANITY_INTERNAL_ENV === 'staging',
       '__PKG_VERSION__': JSON.stringify(version),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1192,6 +1192,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.1.1(@rolldown/plugin-babel@0.2.3)(oxc-transform-react@0.149.0)(vite@8.2.2)
+      lightningcss:
+        specifier: ^1.33.0
+        version: 1.33.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

After the comments UI landed on `@sanity/ui` v5 (`light-dark()` tokens), production / auto-updating Studios show poor contrast when OS appearance ≠ Studio theme (system dark + Studio light, or vice versa). `pnpm dev` is fine; the Vite 8 production minify is not.

Vite 8 minifies CDN CSS with Lightning CSS against `baseline-widely-available` (Chrome 111 / Safari 16.4). That target still down-transpiles `light-dark()` into `--lightningcss-light` / `--lightningcss-dark` toggled only by `prefers-color-scheme`, so ui5 colors follow the OS instead of Studio's `color-scheme`. Same Lightning CSS bug Tailwind already disabled: https://github.com/parcel-bundler/lightningcss/issues/873

This repo owns the auto-update bundle Vite config (`@repo/package.bundle`). The `sanity build` / `sanity preview` config lives in `sanity-io/cli` and needs the same exclude there.

**Why not raise `build.cssTarget` to baseline 2024** (already the JS browserslist): Vite minify overwrites `css.lightningcss.targets` with `build.cssTarget`, and raising that would change other CSS lowering (oklch, prefixes, nesting). `exclude: Features.LightDark` is the targeted fix Cody asked for.

### What to review

- `packages/@repo/package.bundle/src/package.bundle.ts` — `css.lightningcss.exclude: Features.LightDark` only; no other build settings
- Tests in `package.bundle.test.ts` that replay Vite's minify targets with and without the exclude

### Testing

Added unit tests that call Lightning CSS `transform()` with Vite 8's default minify targets (`chrome111` / `safari16.4`):

- without the exclude, `light-dark()` becomes `--lightningcss-light` / `--lightningcss-dark`
- with the bundle config exclude, `light-dark()` is preserved

No browser test: the failure is in emitted CSS, not a rendered component.

### Notes for release

Auto-updating Studios no longer let OS light/dark appearance override the Studio theme. Theme colors from `@sanity/ui` v5 `light-dark()` tokens stay tied to the Studio theme (via `color-scheme`), including when the OS is set to the opposite appearance.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b91aaa70-4c56-46b5-8db3-addeee3a433b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b91aaa70-4c56-46b5-8db3-addeee3a433b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

