### PR TITLE
perf(preview): keep one observable per useValuePreview across value edits

### DIFF
--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -189,6 +189,28 @@ describe('createPathObserver', () => {
     })
   })
 
+  describe('values without a document id', () => {
+    it('previews an array item in place, even when it carries an own undefined _id', () => {
+      const observeFields = vi.fn()
+      const observePaths = createPathObserver({observeFields})
+
+      const {values, unsubscribe} = collectEmissions(
+        observePaths(
+          // the shape `{_id: document._id, ...item}` produces for an item that only has a `_key`
+          {_id: undefined, _key: 'item-1', _type: 'item', title: 'In place'} as never,
+          ['title', '_createdAt', '_updatedAt'],
+        ),
+      )
+
+      // nothing to look up: the missing document fields resolve locally to `undefined`
+      expect(observeFields).not.toHaveBeenCalled()
+      expect(values).toHaveLength(1)
+      expect(values[0]).toMatchObject({title: 'In place', _createdAt: undefined})
+
+      unsubscribe()
+    })
+  })
+
   describe('primitive arrays in preview paths', () => {
     it('resolves numeric segments and length on string arrays without wiping index 0', () => {
       const observeFields = vi.fn()

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -1,4 +1,4 @@
-import {firstValueFrom, of, Subject} from 'rxjs'
+import {firstValueFrom, of, ReplaySubject, Subject} from 'rxjs'
 import {take, tap} from 'rxjs/operators'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -262,6 +262,77 @@ describe('observeFields', () => {
       .subscribe()
       .unsubscribe()
     expect(syncValue).toBe(null)
+  })
+
+  describe('subscriber swaps', () => {
+    const SETTLE_TIME = 200
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    function setup() {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      // The real channel replays the listener's `connected` event to every new subscriber
+      const channel = new ReplaySubject<InvalidationChannelEvent>(1)
+      channel.next({type: 'connected'})
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+      return {
+        get fetchCount() {
+          return fetchCount
+        },
+        observe,
+      }
+    }
+
+    it('does not refetch when a subscriber is replaced right away', async () => {
+      const harness = setup()
+      const values: unknown[] = []
+
+      const first = harness.observe('foo', ['title']).subscribe((value) => values.push(value))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+      expect(harness.fetchCount).toBe(1)
+
+      // e.g. a preview pipeline torn down and rebuilt for a new document value
+      first.unsubscribe()
+      const second = harness.observe('foo', ['title']).subscribe((value) => values.push(value))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+
+      expect(harness.fetchCount).toBe(1)
+      expect(values).toHaveLength(2)
+      second.unsubscribe()
+    })
+
+    it('refetches for a subscriber that arrives after the grace period', async () => {
+      const harness = setup()
+
+      const first = harness.observe('foo', ['title']).subscribe(() => {})
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+      first.unsubscribe()
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      const second = harness.observe('foo', ['title']).subscribe(() => {})
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+
+      expect(harness.fetchCount).toBe(2)
+      second.unsubscribe()
+    })
   })
 
   describe('invalidation filter with perspective', () => {

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -1,4 +1,4 @@
-import {type SchemaType} from '@sanity/types'
+import {type SchemaType, type SortOrdering} from '@sanity/types'
 import {act, render} from '@testing-library/react'
 import {Observable, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -144,6 +144,69 @@ describe('useValuePreview', () => {
       second.next({snapshot: {title: 'two'}})
     })
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'two'})
+  })
+
+  it('resets to loading in the render that changes the schema type, until the new preview arrives', () => {
+    const asArticle = new Subject<{snapshot: {title: string}}>()
+    const articleType = {name: 'article', jsonType: 'object', preview: {}} as unknown as SchemaType
+    observeForPreview.mockImplementation((value: {title: string}, type: SchemaType) =>
+      type === articleType
+        ? asArticle
+        : new Observable((subscriber) => {
+            subscriber.next({snapshot: {title: value.title}})
+          }),
+    )
+    const frames: Frame[] = []
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(<Harness value={value} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+    const settled = frames.length
+
+    // the same document prepared through another schema type is another preview: the previous
+    // one must not linger, not even in the render that first receives the new type
+    rerender(<Harness value={value} schemaType={articleType} frames={frames} />)
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('one')
+    expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
+
+    act(() => {
+      asArticle.next({snapshot: {title: 'one, as an article'}})
+    })
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one, as an article'})
+  })
+
+  it('resets to loading in the render that changes the ordering, until the new preview arrives', () => {
+    const byDate: SortOrdering = {
+      name: 'byDate',
+      title: 'By date',
+      by: [{field: 'date', direction: 'asc'}],
+    }
+    const orderedByDate = new Subject<{snapshot: {title: string}}>()
+    observeForPreview.mockImplementation(
+      (
+        value: {title: string},
+        _type: unknown,
+        options: {viewOptions: {ordering?: SortOrdering}},
+      ) =>
+        options.viewOptions.ordering === byDate
+          ? orderedByDate
+          : new Observable((subscriber) => {
+              subscriber.next({snapshot: {title: value.title}})
+            }),
+    )
+    const frames: Frame[] = []
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(<Harness value={value} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+    const settled = frames.length
+
+    rerender(<Harness value={value} ordering={byDate} frames={frames} />)
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('one')
+    expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
+
+    act(() => {
+      orderedByDate.next({snapshot: {title: 'one · 2026'}})
+    })
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one · 2026'})
   })
 
   it('keeps the preview when a draft or version of the same document is materialized', () => {

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -137,9 +137,12 @@ describe('useValuePreview', () => {
     const frames: Frame[] = []
     const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+    const settled = frames.length
 
-    // the new document's preview is still pending: the previous title must not linger
+    // the new document's preview is still pending: the previous title must not linger, not even
+    // in the render that first receives the new value (before any effect has run)
     rerender(<Harness value={{_id: 'b', title: 'two'}} frames={frames} />)
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('one')
     expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
 
     act(() => {
@@ -174,9 +177,11 @@ describe('useValuePreview', () => {
     const version = {_id: 'versions.r1.a', title: 'in release'}
     const {rerender} = render(<Harness value={version} frames={frames} />)
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'in release'})
+    const settled = frames.length
 
     // the same version, now marked for unpublishing: it previews the published document instead
     rerender(<Harness value={{...version, _system: {delete: true}}} frames={frames} />)
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('in release')
     expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
     expect(observeForPreview).toHaveBeenLastCalledWith(
       {_id: 'a'},
@@ -268,6 +273,30 @@ describe('useValuePreview', () => {
       />,
     )
     expect(frames.length).toBe(before + 3)
+  })
+
+  it('compares element media by identity without walking it', () => {
+    // A self-referencing prop would overflow a deep compare that walked into the element
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    const makeMedia = () => <span data-owner={cyclic} />
+    observeForPreview.mockImplementation(
+      (value: {title: string; version: number}) =>
+        new Observable((subscriber) => {
+          subscriber.next({snapshot: {title: value.title, media: makeMedia()}})
+        }),
+    )
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness value={{_id: 'a', title: 'one', version: 1}} frames={frames} />,
+    )
+    const before = frames.length
+
+    // a new element instance is new media, so the consumer re-renders (rerender + store update)
+    rerender(<Harness value={{_id: 'a', title: 'one', version: 2}} frames={frames} />)
+
+    expect(frames.length).toBe(before + 2)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
   })
 
   it('surfaces a preview error once, even when the value is rebuilt on every render', () => {

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -12,9 +12,11 @@ vi.mock('../../store/datastores', () => ({
   useDocumentPreviewStore: () => ({observeForPreview}),
 }))
 // Stable like the real context value: a fresh array per render would rebuild the observable.
-const perspective = {perspectiveStack: ['drafts'], selectedVariantName: undefined}
+const DEFAULT_PERSPECTIVE = {perspectiveStack: ['drafts'], selectedVariantName: undefined}
+let currentPerspective: {perspectiveStack: string[]; selectedVariantName: string | undefined} =
+  DEFAULT_PERSPECTIVE
 vi.mock('../../perspective/usePerspective', () => ({
-  usePerspective: () => perspective,
+  usePerspective: () => currentPerspective,
 }))
 
 const schemaType = {name: 'book', jsonType: 'object', preview: {}} as unknown as SchemaType
@@ -36,6 +38,7 @@ describe('useValuePreview', () => {
   beforeEach(() => {
     subscriptions.active = 0
     subscriptions.total = 0
+    currentPerspective = DEFAULT_PERSPECTIVE
     observeForPreview.mockReset()
     observeForPreview.mockImplementation(
       (value: {title: string}) =>
@@ -153,6 +156,76 @@ describe('useValuePreview', () => {
 
     expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(false)
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one in release'})
+  })
+
+  it('keeps the preview when a draft of a cross-dataset document is materialized', () => {
+    const frames: Frame[] = []
+    const reference = {_projectId: 'p1', _dataset: 'd1'}
+    const {rerender} = render(
+      <Harness value={{...reference, _ref: 'x', title: 'one'}} frames={frames} />,
+    )
+    const settled = frames.length
+
+    rerender(
+      <Harness value={{...reference, _ref: 'drafts.x', title: 'one edited'}} frames={frames} />,
+    )
+    rerender(
+      <Harness
+        value={{...reference, _ref: 'versions.r1.x', title: 'in release'}}
+        frames={frames}
+      />,
+    )
+
+    expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(false)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'in release'})
+
+    // the same document in another dataset is a different target
+    rerender(
+      <Harness
+        value={{...reference, _dataset: 'd2', _ref: 'x', title: 'elsewhere'}}
+        frames={frames}
+      />,
+    )
+    expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(true)
+  })
+
+  it('does not resubscribe a version preview when the global perspective or variant changes', () => {
+    const frames: Frame[] = []
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(
+      <Harness value={value} frames={frames} perspectiveStack={['r1', 'drafts']} />,
+    )
+    const settled = frames.length
+
+    // the caller previews a specific version, so the global selection does not take part
+    currentPerspective = {perspectiveStack: ['r2', 'drafts'], selectedVariantName: 'variant'}
+    rerender(<Harness value={value} frames={frames} perspectiveStack={['r1', 'drafts']} />)
+
+    expect(observeForPreview).toHaveBeenCalledTimes(1)
+    expect(subscriptions.total).toBe(1)
+    expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(false)
+  })
+
+  it('follows the global perspective when the caller does not choose one', () => {
+    const frames: Frame[] = []
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(<Harness value={value} frames={frames} />)
+    expect(observeForPreview).toHaveBeenLastCalledWith(
+      value,
+      schemaType,
+      expect.objectContaining({perspective: ['drafts']}),
+    )
+
+    currentPerspective = {perspectiveStack: ['r2', 'drafts'], selectedVariantName: undefined}
+    rerender(<Harness value={value} frames={frames} />)
+
+    expect(observeForPreview).toHaveBeenCalledTimes(2)
+    expect(observeForPreview).toHaveBeenLastCalledWith(
+      value,
+      schemaType,
+      expect.objectContaining({perspective: ['r2', 'drafts']}),
+    )
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
   })
 
   it('resets to loading when a version slated for unpublishing switches to the published preview', () => {

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -3,7 +3,6 @@ import {act, render} from '@testing-library/react'
 import {Observable, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {type PerspectiveStack} from '../../perspective/types'
 import {useValuePreview} from '../useValuePreview'
 
 const observeForPreview = vi.fn()
@@ -26,16 +25,9 @@ interface Frame {
   error?: Error
 }
 
-function Harness({
-  value,
-  frames,
-  perspectiveStack,
-}: {
-  value: unknown
-  frames: Frame[]
-  perspectiveStack?: PerspectiveStack
-}) {
-  const state = useValuePreview({schemaType, value, perspectiveStack})
+function Harness({frames, ...props}: Parameters<typeof useValuePreview>[0] & {frames: Frame[]}) {
+  // an explicit `schemaType={undefined}` overrides the default
+  const state = useValuePreview({schemaType, ...props})
   frames.push({isLoading: state.isLoading, title: state.value?.title, error: state.error})
   return null
 }
@@ -324,5 +316,43 @@ describe('useValuePreview', () => {
 
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: undefined})
     expect(observeForPreview).not.toHaveBeenCalled()
+  })
+
+  it('drops an inline preview in the render that loses the value, not after an effect', () => {
+    const frames: Frame[] = []
+    // a plain object previewed in place has no id
+    const {rerender} = render(<Harness value={{title: 'one'}} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+    const settled = frames.length
+
+    rerender(<Harness value={undefined} frames={frames} />)
+    expect(frames.length).toBeGreaterThan(settled)
+    for (const frame of frames.slice(settled)) {
+      expect(frame).toEqual({isLoading: false, title: undefined, error: undefined})
+    }
+
+    // nor is the next inline value mistaken for the previous one
+    rerender(<Harness value={{title: 'two'}} frames={frames} />)
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('one')
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'two'})
+  })
+
+  it.each([
+    ['the value is removed', {value: undefined}],
+    ['the preview is disabled', {enabled: false}],
+    ['the schema type is removed', {schemaType: undefined}],
+  ])('renders the idle state, not loading, in the render where %s', async (_, props) => {
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+    const settled = frames.length
+
+    rerender(<Harness value={{_id: 'a', title: 'one'}} {...props} frames={frames} />)
+    expect(frames.length).toBeGreaterThan(settled)
+    for (const frame of frames.slice(settled)) {
+      expect(frame).toEqual({isLoading: false, title: undefined, error: undefined})
+    }
+    // and the document is no longer observed (react-rx releases a swapped-out source a tick later)
+    await vi.waitFor(() => expect(subscriptions.active).toBe(0))
   })
 })

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -284,6 +284,34 @@ describe('useValuePreview', () => {
     expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(false)
   })
 
+  it('does not mistake an id-less object for a document whose id spells its own key', () => {
+    const inline = new Subject<{snapshot: {title: string}}>()
+    observeForPreview.mockImplementation((value: {_id?: string; title: string}) =>
+      value._id === undefined
+        ? inline
+        : new Observable((subscriber) => {
+            subscriber.next({snapshot: {title: value.title}})
+          }),
+    )
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness value={{_id: 'inline', title: 'a document named inline'}} frames={frames} />,
+    )
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'a document named inline'})
+    const settled = frames.length
+
+    rerender(<Harness value={{title: 'plain object'}} frames={frames} />)
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain(
+      'a document named inline',
+    )
+    expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
+
+    act(() => {
+      inline.next({snapshot: {title: 'plain object'}})
+    })
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'plain object'})
+  })
+
   it('previews an array item as it is, without synthesizing a document id', () => {
     const item = {_key: 'item-1', _type: 'item', title: 'In place'}
     const frames: Frame[] = []

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -148,6 +148,48 @@ describe('useValuePreview', () => {
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'two'})
   })
 
+  it('keeps the preview when a draft or version of the same document is materialized', () => {
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)
+    const settled = frames.length
+
+    rerender(<Harness value={{_id: 'drafts.a', title: 'one edited'}} frames={frames} />)
+    rerender(<Harness value={{_id: 'versions.r1.a', title: 'one in release'}} frames={frames} />)
+
+    expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(false)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one in release'})
+  })
+
+  it('resets to loading when a version slated for unpublishing switches to the published preview', () => {
+    const published = new Subject<{snapshot: {title: string}}>()
+    observeForPreview.mockImplementation(
+      (value: {_id: string; title?: string}, _type: unknown, options: {perspective: unknown[]}) =>
+        value._id === 'a' && options.perspective.length === 0
+          ? published
+          : new Observable((subscriber) => {
+              subscriber.next({snapshot: {title: value.title}})
+            }),
+    )
+    const frames: Frame[] = []
+    const version = {_id: 'versions.r1.a', title: 'in release'}
+    const {rerender} = render(<Harness value={version} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'in release'})
+
+    // the same version, now marked for unpublishing: it previews the published document instead
+    rerender(<Harness value={{...version, _system: {delete: true}}} frames={frames} />)
+    expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
+    expect(observeForPreview).toHaveBeenLastCalledWith(
+      {_id: 'a'},
+      schemaType,
+      expect.objectContaining({perspective: [], variant: undefined}),
+    )
+
+    act(() => {
+      published.next({snapshot: {title: 'published'}})
+    })
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'published'})
+  })
+
   it('keeps one observable when the perspective stack is rebuilt every render', () => {
     const frames: Frame[] = []
     const value = {_id: 'a', title: 'one'}
@@ -171,6 +213,61 @@ describe('useValuePreview', () => {
     render(<InlineValue />)
 
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+  })
+
+  it('converges when the value is rebuilt on every render and prepare() returns fresh media', () => {
+    observeForPreview.mockImplementation(
+      (value: {title: string}) =>
+        new Observable((subscriber) => {
+          subscriber.next({
+            // a new component and a new element on every emission, like `media: () => ...` does
+            snapshot: {
+              title: value.title,
+              media: () => <span />,
+              icon: <i />,
+            },
+          })
+        }),
+    )
+    const frames: Frame[] = []
+    function InlineValue() {
+      if (frames.length > 10) throw new Error(`render loop after ${frames.length} renders`)
+      const state = useValuePreview({schemaType, value: {_id: 'a', title: 'one'}})
+      frames.push({isLoading: state.isLoading, title: state.value?.title})
+      return null
+    }
+    render(<InlineValue />)
+
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+    expect(observeForPreview).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-renders when media changes but not when only its identity does', () => {
+    const asset = {_type: 'image', asset: {_ref: 'image-1'}}
+    observeForPreview.mockImplementation(
+      (value: {title: string; media: unknown}) =>
+        new Observable((subscriber) => {
+          subscriber.next({snapshot: {title: value.title, media: value.media}})
+        }),
+    )
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness value={{_id: 'a', title: 'one', media: {...asset}}} frames={frames} />,
+    )
+    const before = frames.length
+
+    // an equal asset object is the same media
+    rerender(<Harness value={{_id: 'a', title: 'one', media: {...asset}}} frames={frames} />)
+    expect(frames.length).toBe(before + 1)
+
+    // a different asset is not
+    rerender(
+      <Harness
+        value={{_id: 'a', title: 'one', media: {_type: 'image', asset: {_ref: 'image-2'}}}}
+        frames={frames}
+      />,
+    )
+    expect(frames.length).toBe(before + 3)
   })
 
   it('surfaces a preview error once, even when the value is rebuilt on every render', () => {

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -1,8 +1,9 @@
 import {type SchemaType} from '@sanity/types'
-import {render} from '@testing-library/react'
-import {Observable} from 'rxjs'
+import {act, render} from '@testing-library/react'
+import {Observable, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {type PerspectiveStack} from '../../perspective/types'
 import {useValuePreview} from '../useValuePreview'
 
 const observeForPreview = vi.fn()
@@ -25,8 +26,16 @@ interface Frame {
   error?: Error
 }
 
-function Harness({value, frames}: {value: unknown; frames: Frame[]}) {
-  const state = useValuePreview({schemaType, value})
+function Harness({
+  value,
+  frames,
+  perspectiveStack,
+}: {
+  value: unknown
+  frames: Frame[]
+  perspectiveStack?: PerspectiveStack
+}) {
+  const state = useValuePreview({schemaType, value, perspectiveStack})
   frames.push({isLoading: state.isLoading, title: state.value?.title, error: state.error})
   return null
 }
@@ -84,6 +93,70 @@ describe('useValuePreview', () => {
     // the edit is previewed, but the equal result does not cause a store-driven render
     expect(observeForPreview).toHaveBeenCalledTimes(2)
     expect(frames.length).toBe(before + 1)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+  })
+
+  it('ignores the timestamps every local mutation bumps when comparing previews', () => {
+    observeForPreview.mockImplementation(
+      (value: {title: string; _updatedAt: string}) =>
+        new Observable((subscriber) => {
+          subscriber.next({
+            snapshot: {title: value.title, _updatedAt: value._updatedAt, _createdAt: '2026-01-01'},
+          })
+        }),
+    )
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness
+        value={{_id: 'a', title: 'one', _updatedAt: '2026-09-11T10:00:00Z'}}
+        frames={frames}
+      />,
+    )
+    const before = frames.length
+
+    rerender(
+      <Harness
+        value={{_id: 'a', title: 'one', _updatedAt: '2026-09-11T10:00:01Z'}}
+        frames={frames}
+      />,
+    )
+
+    expect(frames.length).toBe(before + 1)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+  })
+
+  it('resets to loading when the value previews a different document', () => {
+    const second = new Subject<{snapshot: {title: string}}>()
+    observeForPreview.mockImplementation((value: {_id: string; title: string}) =>
+      value._id === 'b'
+        ? second
+        : new Observable((subscriber) => {
+            subscriber.next({snapshot: {title: value.title}})
+          }),
+    )
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+
+    // the new document's preview is still pending: the previous title must not linger
+    rerender(<Harness value={{_id: 'b', title: 'two'}} frames={frames} />)
+    expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
+
+    act(() => {
+      second.next({snapshot: {title: 'two'}})
+    })
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'two'})
+  })
+
+  it('keeps one observable when the perspective stack is rebuilt every render', () => {
+    const frames: Frame[] = []
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(<Harness value={value} frames={frames} perspectiveStack={[]} />)
+    rerender(<Harness value={value} frames={frames} perspectiveStack={[]} />)
+    rerender(<Harness value={value} frames={frames} perspectiveStack={[]} />)
+
+    expect(observeForPreview).toHaveBeenCalledTimes(1)
+    expect(subscriptions.total).toBe(1)
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
   })
 

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -209,6 +209,81 @@ describe('useValuePreview', () => {
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one · 2026'})
   })
 
+  it('keys array items by their _key as it is, not as a document id', () => {
+    const second = new Subject<{snapshot: {title: string}}>()
+    observeForPreview.mockImplementation((value: {_key: string; title: string}) =>
+      value._key === 'foo'
+        ? second
+        : new Observable((subscriber) => {
+            subscriber.next({snapshot: {title: value.title}})
+          }),
+    )
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness value={{_key: 'drafts.foo', title: 'one'}} frames={frames} />,
+    )
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+    const settled = frames.length
+
+    // `drafts.foo` and `foo` are two items, not a draft and its published document
+    rerender(<Harness value={{_key: 'foo', title: 'two'}} frames={frames} />)
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('one')
+    expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
+
+    act(() => {
+      second.next({snapshot: {title: 'two'}})
+    })
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'two'})
+  })
+
+  it('resets to loading when a version switches to the published preview under an empty perspective stack', () => {
+    const published = new Subject<{snapshot: {title: string}}>()
+    observeForPreview.mockImplementation((value: {_id: string; title?: string}) =>
+      value._id === 'a'
+        ? published
+        : new Observable((subscriber) => {
+            subscriber.next({snapshot: {title: value.title}})
+          }),
+    )
+    const frames: Frame[] = []
+    const version = {_id: 'versions.r1.a', title: 'in release'}
+    const {rerender} = render(<Harness value={version} perspectiveStack={[]} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'in release'})
+    const settled = frames.length
+
+    // the caller's stack is already empty, so only the switch to the published document itself
+    // distinguishes the new target from the version
+    rerender(
+      <Harness
+        value={{...version, _system: {delete: true}}}
+        perspectiveStack={[]}
+        frames={frames}
+      />,
+    )
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('in release')
+    expect(frames.at(-1)).toEqual({isLoading: true, title: undefined, error: undefined})
+
+    act(() => {
+      published.next({snapshot: {title: 'published'}})
+    })
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'published'})
+  })
+
+  it('does not resubscribe when the inherited perspective stack is rebuilt with the same contents', () => {
+    const frames: Frame[] = []
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(<Harness value={value} frames={frames} />)
+    const settled = frames.length
+
+    // the perspective context rebuilds its stack whenever the releases change
+    currentPerspective = {perspectiveStack: ['drafts'], selectedVariantName: undefined}
+    rerender(<Harness value={value} frames={frames} />)
+
+    expect(observeForPreview).toHaveBeenCalledTimes(1)
+    expect(subscriptions.total).toBe(1)
+    expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(false)
+  })
+
   it('previews an array item as it is, without synthesizing a document id', () => {
     const item = {_key: 'item-1', _type: 'item', title: 'In place'}
     const frames: Frame[] = []

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -91,7 +91,7 @@ describe('useValuePreview', () => {
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
   })
 
-  it('ignores the timestamps every local mutation bumps when comparing previews', () => {
+  it('re-emits when only the preserved timestamps change, since consumers may render them', () => {
     observeForPreview.mockImplementation(
       (value: {title: string; _updatedAt: string}) =>
         new Observable((subscriber) => {
@@ -116,7 +116,8 @@ describe('useValuePreview', () => {
       />,
     )
 
-    expect(frames.length).toBe(before + 1)
+    // `PreviewValue` carries `_updatedAt`: the rerender plus the store-driven render for the new stamp
+    expect(frames.length).toBe(before + 2)
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
   })
 
@@ -320,6 +321,31 @@ describe('useValuePreview', () => {
     // the very object, so nothing downstream can mistake it for a document
     expect(observeForPreview.mock.lastCall?.[0]).toBe(item)
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'In place'})
+  })
+
+  it('feeds a pipeline rebuilt in the same render as a value change the new value only', async () => {
+    const byDate: SortOrdering = {
+      name: 'byDate',
+      title: 'By date',
+      by: [{field: 'date', direction: 'asc'}],
+    }
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)
+    expect(observeForPreview).toHaveBeenCalledTimes(1)
+
+    // a recycled list row: another document and a new ordering arrive in one render
+    rerender(<Harness value={{_id: 'b', title: 'two'}} ordering={byDate} frames={frames} />)
+
+    // the rebuilt pipeline never previews the previous document under the new ordering
+    expect(observeForPreview).toHaveBeenCalledTimes(2)
+    expect(observeForPreview).toHaveBeenLastCalledWith(
+      {_id: 'b', title: 'two'},
+      schemaType,
+      expect.objectContaining({viewOptions: {ordering: byDate}}),
+    )
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'two'})
+    // the replaced pipeline is released a tick later (react-rx's teardown grace)
+    await vi.waitFor(() => expect(subscriptions.active).toBe(1))
   })
 
   it('keeps the preview when a draft or version of the same document is materialized', () => {

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -1,0 +1,129 @@
+import {type SchemaType} from '@sanity/types'
+import {render} from '@testing-library/react'
+import {Observable} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useValuePreview} from '../useValuePreview'
+
+const observeForPreview = vi.fn()
+const subscriptions = {active: 0, total: 0}
+
+vi.mock('../../store/datastores', () => ({
+  useDocumentPreviewStore: () => ({observeForPreview}),
+}))
+// Stable like the real context value: a fresh array per render would rebuild the observable.
+const perspective = {perspectiveStack: ['drafts'], selectedVariantName: undefined}
+vi.mock('../../perspective/usePerspective', () => ({
+  usePerspective: () => perspective,
+}))
+
+const schemaType = {name: 'book', jsonType: 'object', preview: {}} as unknown as SchemaType
+
+interface Frame {
+  isLoading: boolean
+  title: unknown
+  error?: Error
+}
+
+function Harness({value, frames}: {value: unknown; frames: Frame[]}) {
+  const state = useValuePreview({schemaType, value})
+  frames.push({isLoading: state.isLoading, title: state.value?.title, error: state.error})
+  return null
+}
+
+describe('useValuePreview', () => {
+  beforeEach(() => {
+    subscriptions.active = 0
+    subscriptions.total = 0
+    observeForPreview.mockReset()
+    observeForPreview.mockImplementation(
+      (value: {title: string}) =>
+        new Observable((subscriber) => {
+          subscriptions.active++
+          subscriptions.total++
+          subscriber.next({snapshot: {title: value.title}})
+          return () => {
+            subscriptions.active--
+          }
+        }),
+    )
+  })
+
+  it('previews the latest value without dropping back to the loading state', () => {
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+
+    const settled = frames.length
+    rerender(<Harness value={{_id: 'a', title: 'two'}} frames={frames} />)
+    rerender(<Harness value={{_id: 'a', title: 'three'}} frames={frames} />)
+
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'three'})
+    expect(frames.slice(settled).some((frame) => frame.isLoading)).toBe(false)
+    // each value is previewed once, and only the latest preview stays subscribed
+    expect(observeForPreview).toHaveBeenCalledTimes(3)
+    expect(subscriptions.active).toBe(1)
+  })
+
+  it('previews an unchanged value only once', () => {
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(<Harness value={value} frames={[]} />)
+    rerender(<Harness value={value} frames={[]} />)
+
+    expect(observeForPreview).toHaveBeenCalledTimes(1)
+    expect(subscriptions.total).toBe(1)
+  })
+
+  it('does not re-render consumers when an edit leaves the prepared preview unchanged', () => {
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)
+    const before = frames.length
+
+    rerender(<Harness value={{_id: 'a', title: 'one', body: 'edited'}} frames={frames} />)
+
+    // the edit is previewed, but the equal result does not cause a store-driven render
+    expect(observeForPreview).toHaveBeenCalledTimes(2)
+    expect(frames.length).toBe(before + 1)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+  })
+
+  it('converges when the value object is rebuilt on every render', () => {
+    const frames: Frame[] = []
+    function InlineValue() {
+      if (frames.length > 10) throw new Error(`render loop after ${frames.length} renders`)
+      const state = useValuePreview({schemaType, value: {_id: 'a', title: 'one'}})
+      frames.push({isLoading: state.isLoading, title: state.value?.title})
+      return null
+    }
+    render(<InlineValue />)
+
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one'})
+  })
+
+  it('surfaces a preview error once, even when the value is rebuilt on every render', () => {
+    observeForPreview.mockImplementation(
+      () =>
+        new Observable(() => {
+          throw new Error('boom')
+        }),
+    )
+    const frames: Frame[] = []
+    function Failing() {
+      if (frames.length > 10) throw new Error(`render loop after ${frames.length} renders`)
+      const state = useValuePreview({schemaType, value: {_id: 'a', title: 'one'}})
+      frames.push({isLoading: state.isLoading, title: state.value?.title, error: state.error})
+      return null
+    }
+    render(<Failing />)
+
+    expect(frames.at(-1)).toMatchObject({isLoading: false, error: new Error('boom')})
+  })
+
+  it('renders the idle state without a value', () => {
+    const frames: Frame[] = []
+    render(<Harness value={undefined} frames={frames} />)
+
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: undefined})
+    expect(observeForPreview).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -209,6 +209,16 @@ describe('useValuePreview', () => {
     expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'one · 2026'})
   })
 
+  it('previews an array item as it is, without synthesizing a document id', () => {
+    const item = {_key: 'item-1', _type: 'item', title: 'In place'}
+    const frames: Frame[] = []
+    render(<Harness value={item} frames={frames} />)
+
+    // the very object, so nothing downstream can mistake it for a document
+    expect(observeForPreview.mock.lastCall?.[0]).toBe(item)
+    expect(frames.at(-1)).toMatchObject({isLoading: false, title: 'In place'})
+  })
+
   it('keeps the preview when a draft or version of the same document is materialized', () => {
     const frames: Frame[] = []
     const {rerender} = render(<Harness value={{_id: 'a', title: 'one'}} frames={frames} />)

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -12,6 +12,7 @@ import {
   merge,
   type Observable,
   of,
+  ReplaySubject,
   retry,
   timer,
 } from 'rxjs'
@@ -22,7 +23,6 @@ import {
   mergeMap,
   reduce,
   share,
-  shareReplay,
   startWith,
   switchMap,
   tap,
@@ -111,6 +111,12 @@ type CachedFieldObserver = {
   fields: FieldName[]
   changes$: Observable<any>
 }
+
+// How long a field observer stays connected after its last subscriber leaves. Consumers swap
+// subscriptions all the time — a preview pipeline is rebuilt for a new value, a component
+// re-subscribes on commit — and every reconnect replays the listener's `connected` event, which
+// costs a fetch. Bridging the gap keeps those swaps from turning into a query per edit.
+const TEARDOWN_GRACE_PERIOD = 1_000
 
 type Cache = {
   [id: string]: CachedFieldObserver[]
@@ -332,7 +338,10 @@ export function createObserveFields(options: {
         : currentDatasetListenFields(id, fields, perspective, variant)) as Observable<T>,
     ).pipe(
       tap((v: T | null) => (latest = v)),
-      shareReplay({refCount: true, bufferSize: 1}),
+      share({
+        connector: () => new ReplaySubject(1),
+        resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD),
+      }),
     )
 
     return {id, fields, changes$}

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -6,9 +6,9 @@ import {
 } from '@sanity/types'
 import {dequal} from 'dequal'
 import isPlainObject from 'lodash-es/isPlainObject.js'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo} from 'react'
 import {useSyncObservable} from 'react-rx'
-import {BehaviorSubject, concat, type Observable, of} from 'rxjs'
+import {concat, type Observable, of, Subject} from 'rxjs'
 import {catchError, distinctUntilChanged, map, scan, switchMap} from 'rxjs/operators'
 
 import {type PerspectiveStack} from '../perspective/types'
@@ -47,9 +47,6 @@ function isSameError(a: Error | undefined, b: Error | undefined): boolean {
   return a === b || (!!a && !!b && a.name === b.name && a.message === b.message)
 }
 
-// Every local mutation bumps the timestamps `prepareForPreview` preserves, and nothing renders them.
-const IGNORED_PREVIEW_KEYS = new Set(['_createdAt', '_updatedAt'])
-
 // React elements and portals are plain objects too, recognisable by `$$typeof`.
 function isReactNodeObject(value: unknown): boolean {
   return typeof value === 'object' && value !== null && '$$typeof' in value
@@ -66,13 +63,15 @@ function isSameMedia(a: unknown, b: unknown): boolean {
   return dequal(a, b)
 }
 
+// Every field takes part, the `_createdAt` / `_updatedAt` that `prepareForPreview` preserves
+// included: `PreviewValue` is public and `PreviewLoader` forwards the whole value, so a custom
+// preview component may well render them.
 function isSamePreview(a: PreviewValue | undefined, b: PreviewValue | undefined): boolean {
   if (a === b) return true
   if (!a || !b) return false
   const recordA = a as Record<string, unknown>
   const recordB = b as Record<string, unknown>
   for (const key of new Set([...Object.keys(recordA), ...Object.keys(recordB)])) {
-    if (IGNORED_PREVIEW_KEYS.has(key)) continue
     const same =
       key === 'media' ? isSameMedia(recordA[key], recordB[key]) : dequal(recordA[key], recordB[key])
     if (!same) return false
@@ -80,8 +79,8 @@ function isSamePreview(a: PreviewValue | undefined, b: PreviewValue | undefined)
   return true
 }
 
-// Prepared previews are small, so comparing them is cheap: editing a field the preview does not
-// select leaves the rendered state alone instead of re-rendering every preview consumer.
+// Prepared previews are small, so comparing them is cheap: an emission that prepares to the same
+// preview as the last one leaves the rendered state alone instead of re-rendering every consumer.
 function isSameState(a: State, b: State): boolean {
   return (
     a.isLoading === b.isLoading && isSameError(a.error, b.error) && isSamePreview(a.value, b.value)
@@ -184,14 +183,6 @@ export function useValuePreview(props: {
   const perspective = useShallowUnique(chosenPerspectiveStackProp ?? perspectiveStack)
   const variant = chosenVariant ?? (chosenPerspectiveStackProp ? undefined : selectedVariantName)
 
-  // The value is a new object on every edit. It enters the pipeline through a subject so the
-  // observable identity — and with it the subscription and the field observers it holds — survives
-  // keystrokes; a new identity per value would resubscribe and refetch every reference it follows.
-  const [value$] = useState(() => new BehaviorSubject<unknown>(previewValue))
-  useEffect(() => {
-    value$.next(previewValue)
-  }, [previewValue, value$])
-
   const resolveTarget = useCallback(
     (value: unknown): PreviewTarget | undefined => {
       if (!enabled || !value || !schemaType) return undefined
@@ -217,44 +208,57 @@ export function useValuePreview(props: {
     [enabled, schemaType, perspective, variant],
   )
 
-  const observable = useMemo<Observable<Emission>>(
-    () =>
-      value$.pipe(
-        // An edit replaces the changed field on the document, so a shallow compare catches every
-        // real change while an equal object built during render (`{_id}` in a dialog) is not
-        // previewed again — which would loop whenever `prepare()` returns a fresh media component.
-        distinctUntilChanged(shallowEquals),
-        scan<unknown, {target: PreviewTarget | undefined; targetChanged: boolean}>(
-          (previous, value) => {
-            const target = resolveTarget(value)
-            return {target, targetChanged: target?.key !== previous.target?.key}
-          },
-          {target: undefined, targetChanged: false},
-        ),
-        switchMap(({target, targetChanged}): Observable<Emission> => {
-          // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
-          if (!target || !schemaType) return of({key: null, state: IDLE_STATE})
-
-          const {key} = target
-          const preview$ = observeForPreview(target.previewable, schemaType, {
-            perspective: target.perspective,
-            variant: target.variant,
-            viewOptions: {ordering: ordering},
-          }).pipe(
-            map((event) => ({key, state: {isLoading: false, value: event.snapshot || undefined}})),
-            catchError((error) => of({key, state: {isLoading: false, error}})),
-          )
-
-          // A different target must not keep showing the previous one's preview while it loads.
-          return targetChanged ? concat(of({key, state: INITIAL_STATE}), preview$) : preview$
-        }),
-        distinctUntilChanged((a, b) => a.key === b.key && isSameState(a.state, b.state)),
+  // The value is a new object on every edit. It enters the pipeline through a subject so the
+  // observable identity — and with it the subscription and the field observers it holds — survives
+  // keystrokes; a new identity per value would resubscribe and refetch every reference it follows.
+  // Each pipeline has its own subject, fed from the effect below `useSyncObservable`: react-rx
+  // keeps a replaced pipeline subscribed for a tick after its successor took over, and a shared
+  // subject would feed the new value to both.
+  const [observable, feed] = useMemo((): [Observable<Emission>, (value: unknown) => void] => {
+    const value$ = new Subject<unknown>()
+    const emissions$ = value$.pipe(
+      // An edit replaces the changed field on the document, so a shallow compare catches every
+      // real change while an equal object built during render (`{_id}` in a dialog) is not
+      // previewed again — which would loop whenever `prepare()` returns a fresh media component.
+      distinctUntilChanged(shallowEquals),
+      scan<unknown, {target: PreviewTarget | undefined; targetChanged: boolean}>(
+        (previous, value) => {
+          const target = resolveTarget(value)
+          return {target, targetChanged: target?.key !== previous.target?.key}
+        },
+        {target: undefined, targetChanged: false},
       ),
-    [value$, resolveTarget, schemaType, observeForPreview, ordering],
-  )
+      switchMap(({target, targetChanged}): Observable<Emission> => {
+        // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
+        if (!target || !schemaType) return of({key: null, state: IDLE_STATE})
+
+        const {key} = target
+        const preview$ = observeForPreview(target.previewable, schemaType, {
+          perspective: target.perspective,
+          variant: target.variant,
+          viewOptions: {ordering: ordering},
+        }).pipe(
+          map((event) => ({key, state: {isLoading: false, value: event.snapshot || undefined}})),
+          catchError((error) => of({key, state: {isLoading: false, error}})),
+        )
+
+        // A different target must not keep showing the previous one's preview while it loads.
+        return targetChanged ? concat(of({key, state: INITIAL_STATE}), preview$) : preview$
+      }),
+      distinctUntilChanged((a, b) => a.key === b.key && isSameState(a.state, b.state)),
+    )
+    return [emissions$, (value) => value$.next(value)]
+  }, [resolveTarget, schemaType, observeForPreview, ordering])
 
   // Do not defer: search/reference UIs assert on preview titles synchronously after selection.
   const emission = useSyncObservable(observable, INITIAL_EMISSION)
+
+  // Declared after `useSyncObservable` on purpose: effects run in order, so a pipeline (re)built in
+  // this commit is subscribed by the time it is fed. Nothing is replayed, so a pipeline rebuilt
+  // together with a new value sees only the new value, and exactly once.
+  useEffect(() => {
+    feed(previewValue)
+  }, [feed, previewValue])
 
   // The subject is fed after commit, so the render that first receives a new value still holds
   // the previous target's emission. Nothing to preview needs no emission at all; otherwise compare

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -136,15 +136,15 @@ function getPreviewTargetKey(
     _projectId?: string
     _dataset?: string
   }
+  // Each kind of identity has its own prefix: `inline` is a valid document id, and only prefixes
+  // keep a document, an array item and an id-less object from ever sharing a segment.
   const documentId = _id ?? _ref
   const document =
     documentId === undefined
       ? _key === undefined
         ? INLINE_TARGET_KEY
         : `key:${_key}`
-      : _dataset
-        ? `${_projectId}/${_dataset}/${getPublishedId(documentId)}`
-        : getPublishedId(documentId)
+      : `doc:${_dataset ? `${_projectId}/${_dataset}/` : ''}${getPublishedId(documentId)}`
   return `${document}|${perspective.join(',')}|${variant ?? ''}|${publishedOnly ? 'published' : ''}`
 }
 /**

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -5,7 +5,8 @@ import {
   type SortOrdering,
 } from '@sanity/types'
 import {dequal} from 'dequal'
-import {isValidElement, useEffect, useMemo, useState} from 'react'
+import isPlainObject from 'lodash-es/isPlainObject.js'
+import {useEffect, useMemo, useState} from 'react'
 import {useSyncObservable} from 'react-rx'
 import {BehaviorSubject, concat, type Observable, of} from 'rxjs'
 import {catchError, distinctUntilChanged, map, scan, switchMap} from 'rxjs/operators'
@@ -15,6 +16,7 @@ import {usePerspective} from '../perspective/usePerspective'
 import {isGoingToUnpublish} from '../releases/util/isGoingToUnpublish'
 import {useDocumentPreviewStore} from '../store/datastores'
 import {getPublishedId} from '../util/draftUtils'
+import {shallowEquals} from '../util/shallowEquals'
 import {useShallowUnique} from '../util/useShallowUnique'
 import {type Previewable} from './types'
 
@@ -48,13 +50,13 @@ function isSameError(a: Error | undefined, b: Error | undefined): boolean {
 // Every local mutation bumps the timestamps `prepareForPreview` preserves, and nothing renders them.
 const IGNORED_PREVIEW_KEYS = new Set(['_createdAt', '_updatedAt'])
 
-// Components and elements compare by identity (walking an element's props could reach fibers);
-// plain media values such as image assets compare by content.
+// Plain media values such as image assets compare by content. Anything else — components,
+// elements, arrays of elements, portals — compares by identity: walking React internals is not
+// safe, and `prepare()` may build a fresh one per emission, in which case the preview simply
+// re-renders as it did before.
 function isSameMedia(a: unknown, b: unknown): boolean {
   if (a === b) return true
-  if (typeof a === 'function' || typeof b === 'function') return false
-  if (isValidElement(a) || isValidElement(b)) return false
-  return dequal(a, b)
+  return isPlainObject(a) && isPlainObject(b) && dequal(a, b)
 }
 
 function isSamePreview(a: PreviewValue | undefined, b: PreviewValue | undefined): boolean {
@@ -71,24 +73,39 @@ function isSamePreview(a: PreviewValue | undefined, b: PreviewValue | undefined)
   return true
 }
 
-// Prepared previews are small, so comparing them is cheap. Editing a field the preview does not
-// select, or passing an equal value object built during render, then leaves the rendered state
-// alone instead of re-rendering every preview consumer (or, for the latter, looping).
+// Prepared previews are small, so comparing them is cheap: editing a field the preview does not
+// select leaves the rendered state alone instead of re-rendering every preview consumer.
 function isSameState(a: State, b: State): boolean {
   return (
     a.isLoading === b.isLoading && isSameError(a.error, b.error) && isSamePreview(a.value, b.value)
   )
 }
 
+interface PreviewTarget {
+  previewable: Previewable
+  perspective: PerspectiveStack
+  variant: string | undefined
+  /**
+   * What the preview shows, independent of the input's shape. A change resets the preview to
+   * loading; edits to the same target keep the current preview until the next one arrives.
+   */
+  key: string | undefined
+}
+
 /**
- * Identifies what a value previews: a document or reference by id (per dataset for cross-dataset
- * references), an array item by key. A change of target resets the preview to loading; edits to
- * the same target keep the current preview until the next one arrives. Values without any of
- * these identifiers (plain objects previewed in place) all count as one target.
+ * Keys a target by the document it previews and the perspective it is seen through: a document
+ * or reference by its published id — so `drafts.x`, `versions.*.x` and `x` are one document and
+ * materializing a draft does not reset the preview — per project and dataset for cross-dataset
+ * references, an array item by key. Values without any identifier (plain objects previewed in
+ * place) all count as one target. The perspective is part of the key because a version slated
+ * for unpublishing switches to previewing the published document.
  */
-function getPreviewTargetKey(value: unknown): string | undefined {
-  if (!value || typeof value !== 'object') return undefined
-  const {_id, _ref, _key, _projectId, _dataset} = value as {
+function getPreviewTargetKey(
+  previewable: Previewable,
+  perspective: PerspectiveStack,
+  variant: string | undefined,
+): string | undefined {
+  const {_id, _ref, _key, _projectId, _dataset} = previewable as {
     _id?: string
     _ref?: string
     _key?: string
@@ -97,7 +114,8 @@ function getPreviewTargetKey(value: unknown): string | undefined {
   }
   const id = _id ?? _ref ?? _key
   if (id === undefined) return undefined
-  return _dataset ? `${_projectId}/${_dataset}/${id}` : id
+  const document = _dataset ? `${_projectId}/${_dataset}/${id}` : getPublishedId(id)
+  return `${document}|${perspective.join(',')}|${variant ?? ''}`
 }
 /**
  * @internal
@@ -139,71 +157,79 @@ export function useValuePreview(props: {
     value$.next(previewValue)
   }, [previewValue, value$])
 
-  const observable = useMemo<Observable<State>>(
-    () =>
-      value$.pipe(
-        distinctUntilChanged(),
-        scan<unknown, {value: unknown; key: string | undefined; targetChanged: boolean}>(
-          (previous, value) => {
-            const key = getPreviewTargetKey(value)
-            return {value, key, targetChanged: key !== previous.key}
-          },
-          {value: undefined, key: undefined, targetChanged: false},
-        ),
-        switchMap(({value, targetChanged}) => {
-          // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
-          if (!enabled || !value || !schemaType) return of(IDLE_STATE)
+  const observable = useMemo<Observable<State>>(() => {
+    const resolveTarget = (value: unknown): PreviewTarget | undefined => {
+      if (!enabled || !value || !schemaType) return undefined
 
-          const goingToUnpublish = isGoingToUnpublish(value as SanityDocument)
+      const goingToUnpublish = isGoingToUnpublish(value as SanityDocument)
 
-          const updatedStack = goingToUnpublish ? [] : (chosenPerspectiveStack ?? perspectiveStack)
-          // A document slated for unpublishing is previewed as its published version, which is
-          // outside of any variant. Otherwise the variant follows the perspective: only inherited
-          // from the context when the perspective is too.
-          const updatedVariant = goingToUnpublish
-            ? undefined
-            : (chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName))
-          const updatedDocId = goingToUnpublish
-            ? getPublishedId((value as SanityDocument)._id)
-            : (value as SanityDocument)._id
+      const perspective = goingToUnpublish ? [] : (chosenPerspectiveStack ?? perspectiveStack)
+      // A document slated for unpublishing is previewed as its published version, which is
+      // outside of any variant. Otherwise the variant follows the perspective: only inherited
+      // from the context when the perspective is too.
+      const variant = goingToUnpublish
+        ? undefined
+        : (chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName))
+      const id = goingToUnpublish
+        ? getPublishedId((value as SanityDocument)._id)
+        : (value as SanityDocument)._id
 
-          // allow for previewing the published document when a version is slated for unpublishing
-          // but if it's not for unpublishing, then we want to preview the content as was before
-          const restPreviewValue = goingToUnpublish ? {} : {...(value as Previewable)}
+      // allow for previewing the published document when a version is slated for unpublishing
+      // but if it's not for unpublishing, then we want to preview the content as was before
+      const previewable: Previewable = {
+        _id: id,
+        ...(goingToUnpublish ? {} : (value as Previewable)),
+      }
 
-          const preview$ = observeForPreview(
-            {
-              _id: updatedDocId,
-              ...restPreviewValue,
-            },
-            schemaType,
-            {
-              perspective: updatedStack,
-              variant: updatedVariant,
-              viewOptions: {ordering: ordering},
-            },
-          ).pipe(
-            map((event) => ({isLoading: false, value: event.snapshot || undefined})),
-            catchError((error) => of({isLoading: false, error})),
-          )
+      return {
+        previewable,
+        perspective,
+        variant,
+        key: getPreviewTargetKey(previewable, perspective, variant),
+      }
+    }
 
-          // A different document must not keep showing the previous one's preview while it loads.
-          return targetChanged ? concat(of(INITIAL_STATE), preview$) : preview$
-        }),
-        distinctUntilChanged(isSameState),
+    return value$.pipe(
+      // An edit replaces the changed field on the document, so a shallow compare catches every real
+      // change while an equal object built during render (`{_id}` in a dialog) is not previewed
+      // again — which would loop whenever `prepare()` returns a fresh media component.
+      distinctUntilChanged(shallowEquals),
+      scan<unknown, {target: PreviewTarget | undefined; targetChanged: boolean}>(
+        (previous, value) => {
+          const target = resolveTarget(value)
+          return {target, targetChanged: target?.key !== previous.target?.key}
+        },
+        {target: undefined, targetChanged: false},
       ),
-    [
-      value$,
-      enabled,
-      schemaType,
-      chosenPerspectiveStack,
-      perspectiveStack,
-      chosenVariant,
-      selectedVariantName,
-      observeForPreview,
-      ordering,
-    ],
-  )
+      switchMap(({target, targetChanged}) => {
+        // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
+        if (!target || !schemaType) return of(IDLE_STATE)
+
+        const preview$ = observeForPreview(target.previewable, schemaType, {
+          perspective: target.perspective,
+          variant: target.variant,
+          viewOptions: {ordering: ordering},
+        }).pipe(
+          map((event) => ({isLoading: false, value: event.snapshot || undefined})),
+          catchError((error) => of({isLoading: false, error})),
+        )
+
+        // A different target must not keep showing the previous one's preview while it loads.
+        return targetChanged ? concat(of(INITIAL_STATE), preview$) : preview$
+      }),
+      distinctUntilChanged(isSameState),
+    )
+  }, [
+    value$,
+    enabled,
+    schemaType,
+    chosenPerspectiveStack,
+    perspectiveStack,
+    chosenVariant,
+    selectedVariantName,
+    observeForPreview,
+    ordering,
+  ])
 
   // Do not defer: search/reference UIs assert on preview titles synchronously after selection.
   return useSyncObservable(observable, INITIAL_STATE)

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -135,7 +135,8 @@ function getPreviewTargetKey(
   }
   const id = _id ?? _ref ?? _key
   if (id === undefined) return INLINE_TARGET_KEY
-  const document = _dataset ? `${_projectId}/${_dataset}/${id}` : getPublishedId(id)
+  const publishedId = getPublishedId(id)
+  const document = _dataset ? `${_projectId}/${_dataset}/${publishedId}` : publishedId
   return `${document}|${perspective.join(',')}|${variant ?? ''}`
 }
 /**
@@ -169,6 +170,11 @@ export function useValuePreview(props: {
   // Callers build this inline (`useDocumentTitle` passes `[]`); keyed by contents so a fresh array
   // per render does not rebuild the observable.
   const chosenPerspectiveStack = useShallowUnique(chosenPerspectiveStackProp)
+  // A caller previewing a specific version is not affected by the global selection, so resolve
+  // which perspective and variant apply up front: only those take part in the pipeline's identity,
+  // and a global perspective or variant change does not resubscribe such a preview.
+  const perspective = chosenPerspectiveStack ?? perspectiveStack
+  const variant = chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName)
 
   // The value is a new object on every edit. It enters the pipeline through a subject so the
   // observable identity — and with it the subscription and the field observers it holds — survives
@@ -184,13 +190,10 @@ export function useValuePreview(props: {
 
       const goingToUnpublish = isGoingToUnpublish(value as SanityDocument)
 
-      const perspective = goingToUnpublish ? [] : (chosenPerspectiveStack ?? perspectiveStack)
       // A document slated for unpublishing is previewed as its published version, which is
-      // outside of any variant. Otherwise the variant follows the perspective: only inherited
-      // from the context when the perspective is too.
-      const variant = goingToUnpublish
-        ? undefined
-        : (chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName))
+      // outside of any perspective or variant.
+      const targetPerspective = goingToUnpublish ? [] : perspective
+      const targetVariant = goingToUnpublish ? undefined : variant
       const id = goingToUnpublish
         ? getPublishedId((value as SanityDocument)._id)
         : (value as SanityDocument)._id
@@ -204,19 +207,12 @@ export function useValuePreview(props: {
 
       return {
         previewable,
-        perspective,
-        variant,
-        key: getPreviewTargetKey(previewable, perspective, variant),
+        perspective: targetPerspective,
+        variant: targetVariant,
+        key: getPreviewTargetKey(previewable, targetPerspective, targetVariant),
       }
     },
-    [
-      enabled,
-      schemaType,
-      chosenPerspectiveStack,
-      perspectiveStack,
-      chosenVariant,
-      selectedVariantName,
-    ],
+    [enabled, schemaType, perspective, variant],
   )
 
   const observable = useMemo<Observable<Emission>>(

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -110,21 +110,24 @@ interface Emission {
 
 const INITIAL_EMISSION: Emission = {key: null, state: INITIAL_STATE}
 
-// Plain objects previewed in place carry no identifier; they all share this key.
+// Plain objects previewed in place carry no identifier; they all share this document segment.
 const INLINE_TARGET_KEY = 'inline'
 
 /**
  * Keys a target by the document it previews and the perspective it is seen through: a document
  * or reference by its published id — so `drafts.x`, `versions.*.x` and `x` are one document and
  * materializing a draft does not reset the preview — per project and dataset for cross-dataset
- * references, an array item by key. Values without any identifier (plain objects previewed in
- * place) all count as one target. The perspective is part of the key because a version slated
- * for unpublishing switches to previewing the published document.
+ * references, an array item by its `_key` as it is (an item key is not a document id). Values
+ * without any identifier (plain objects previewed in place) all count as one target. The
+ * perspective is part of the key, and so is previewing the published document in place of a
+ * version slated for unpublishing: that switch must reset even when the perspective stack is
+ * already empty.
  */
 function getPreviewTargetKey(
   previewable: Previewable,
   perspective: PerspectiveStack,
   variant: string | undefined,
+  publishedOnly: boolean,
 ): string {
   const {_id, _ref, _key, _projectId, _dataset} = previewable as {
     _id?: string
@@ -133,11 +136,16 @@ function getPreviewTargetKey(
     _projectId?: string
     _dataset?: string
   }
-  const id = _id ?? _ref ?? _key
-  if (id === undefined) return INLINE_TARGET_KEY
-  const publishedId = getPublishedId(id)
-  const document = _dataset ? `${_projectId}/${_dataset}/${publishedId}` : publishedId
-  return `${document}|${perspective.join(',')}|${variant ?? ''}`
+  const documentId = _id ?? _ref
+  const document =
+    documentId === undefined
+      ? _key === undefined
+        ? INLINE_TARGET_KEY
+        : `key:${_key}`
+      : _dataset
+        ? `${_projectId}/${_dataset}/${getPublishedId(documentId)}`
+        : getPublishedId(documentId)
+  return `${document}|${perspective.join(',')}|${variant ?? ''}|${publishedOnly ? 'published' : ''}`
 }
 /**
  * @internal
@@ -167,14 +175,14 @@ export function useValuePreview(props: {
   } = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
   const {perspectiveStack, selectedVariantName} = usePerspective()
-  // Callers build this inline (`useDocumentTitle` passes `[]`); keyed by contents so a fresh array
-  // per render does not rebuild the observable.
-  const chosenPerspectiveStack = useShallowUnique(chosenPerspectiveStackProp)
   // A caller previewing a specific version is not affected by the global selection, so resolve
   // which perspective and variant apply up front: only those take part in the pipeline's identity,
-  // and a global perspective or variant change does not resubscribe such a preview.
-  const perspective = chosenPerspectiveStack ?? perspectiveStack
-  const variant = chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName)
+  // and a global perspective or variant change does not resubscribe such a preview. The stack is
+  // keyed by contents — callers build theirs inline (`useDocumentTitle` passes `[]`) and the
+  // perspective context rebuilds its own whenever the releases change — so a fresh array with the
+  // same entries does not rebuild the observable and resubscribe every preview.
+  const perspective = useShallowUnique(chosenPerspectiveStackProp ?? perspectiveStack)
+  const variant = chosenVariant ?? (chosenPerspectiveStackProp ? undefined : selectedVariantName)
 
   // The value is a new object on every edit. It enters the pipeline through a subject so the
   // observable identity — and with it the subscription and the field observers it holds — survives
@@ -203,7 +211,7 @@ export function useValuePreview(props: {
         previewable,
         perspective: targetPerspective,
         variant: targetVariant,
-        key: getPreviewTargetKey(previewable, targetPerspective, targetVariant),
+        key: getPreviewTargetKey(previewable, targetPerspective, targetVariant, goingToUnpublish),
       }
     },
     [enabled, schemaType, perspective, variant],

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -5,16 +5,17 @@ import {
   type SortOrdering,
 } from '@sanity/types'
 import {dequal} from 'dequal'
-import {useEffect, useMemo, useState} from 'react'
+import {isValidElement, useEffect, useMemo, useState} from 'react'
 import {useSyncObservable} from 'react-rx'
-import {BehaviorSubject, type Observable, of} from 'rxjs'
-import {catchError, distinctUntilChanged, map, switchMap} from 'rxjs/operators'
+import {BehaviorSubject, concat, type Observable, of} from 'rxjs'
+import {catchError, distinctUntilChanged, map, scan, switchMap} from 'rxjs/operators'
 
 import {type PerspectiveStack} from '../perspective/types'
 import {usePerspective} from '../perspective/usePerspective'
 import {isGoingToUnpublish} from '../releases/util/isGoingToUnpublish'
 import {useDocumentPreviewStore} from '../store/datastores'
 import {getPublishedId} from '../util/draftUtils'
+import {useShallowUnique} from '../util/useShallowUnique'
 import {type Previewable} from './types'
 
 /**
@@ -44,11 +45,59 @@ function isSameError(a: Error | undefined, b: Error | undefined): boolean {
   return a === b || (!!a && !!b && a.name === b.name && a.message === b.message)
 }
 
+// Every local mutation bumps the timestamps `prepareForPreview` preserves, and nothing renders them.
+const IGNORED_PREVIEW_KEYS = new Set(['_createdAt', '_updatedAt'])
+
+// Components and elements compare by identity (walking an element's props could reach fibers);
+// plain media values such as image assets compare by content.
+function isSameMedia(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (typeof a === 'function' || typeof b === 'function') return false
+  if (isValidElement(a) || isValidElement(b)) return false
+  return dequal(a, b)
+}
+
+function isSamePreview(a: PreviewValue | undefined, b: PreviewValue | undefined): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  const recordA = a as Record<string, unknown>
+  const recordB = b as Record<string, unknown>
+  for (const key of new Set([...Object.keys(recordA), ...Object.keys(recordB)])) {
+    if (IGNORED_PREVIEW_KEYS.has(key)) continue
+    const same =
+      key === 'media' ? isSameMedia(recordA[key], recordB[key]) : dequal(recordA[key], recordB[key])
+    if (!same) return false
+  }
+  return true
+}
+
 // Prepared previews are small, so comparing them is cheap. Editing a field the preview does not
 // select, or passing an equal value object built during render, then leaves the rendered state
 // alone instead of re-rendering every preview consumer (or, for the latter, looping).
 function isSameState(a: State, b: State): boolean {
-  return a.isLoading === b.isLoading && isSameError(a.error, b.error) && dequal(a.value, b.value)
+  return (
+    a.isLoading === b.isLoading && isSameError(a.error, b.error) && isSamePreview(a.value, b.value)
+  )
+}
+
+/**
+ * Identifies what a value previews: a document or reference by id (per dataset for cross-dataset
+ * references), an array item by key. A change of target resets the preview to loading; edits to
+ * the same target keep the current preview until the next one arrives. Values without any of
+ * these identifiers (plain objects previewed in place) all count as one target.
+ */
+function getPreviewTargetKey(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const {_id, _ref, _key, _projectId, _dataset} = value as {
+    _id?: string
+    _ref?: string
+    _key?: string
+    _projectId?: string
+    _dataset?: string
+  }
+  const id = _id ?? _ref ?? _key
+  if (id === undefined) return undefined
+  return _dataset ? `${_projectId}/${_dataset}/${id}` : id
 }
 /**
  * @internal
@@ -73,11 +122,14 @@ export function useValuePreview(props: {
     ordering,
     schemaType,
     value: previewValue,
-    perspectiveStack: chosenPerspectiveStack,
+    perspectiveStack: chosenPerspectiveStackProp,
     variant: chosenVariant,
   } = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
   const {perspectiveStack, selectedVariantName} = usePerspective()
+  // Callers build this inline (`useDocumentTitle` passes `[]`); keyed by contents so a fresh array
+  // per render does not rebuild the observable.
+  const chosenPerspectiveStack = useShallowUnique(chosenPerspectiveStackProp)
 
   // The value is a new object on every edit. It enters the pipeline through a subject so the
   // observable identity — and with it the subscription and the field observers it holds — survives
@@ -91,7 +143,14 @@ export function useValuePreview(props: {
     () =>
       value$.pipe(
         distinctUntilChanged(),
-        switchMap((value) => {
+        scan<unknown, {value: unknown; key: string | undefined; targetChanged: boolean}>(
+          (previous, value) => {
+            const key = getPreviewTargetKey(value)
+            return {value, key, targetChanged: key !== previous.key}
+          },
+          {value: undefined, key: undefined, targetChanged: false},
+        ),
+        switchMap(({value, targetChanged}) => {
           // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
           if (!enabled || !value || !schemaType) return of(IDLE_STATE)
 
@@ -112,7 +171,7 @@ export function useValuePreview(props: {
           // but if it's not for unpublishing, then we want to preview the content as was before
           const restPreviewValue = goingToUnpublish ? {} : {...(value as Previewable)}
 
-          return observeForPreview(
+          const preview$ = observeForPreview(
             {
               _id: updatedDocId,
               ...restPreviewValue,
@@ -127,6 +186,9 @@ export function useValuePreview(props: {
             map((event) => ({isLoading: false, value: event.snapshot || undefined})),
             catchError((error) => of({isLoading: false, error})),
           )
+
+          // A different document must not keep showing the previous one's preview while it loads.
+          return targetChanged ? concat(of(INITIAL_STATE), preview$) : preview$
         }),
         distinctUntilChanged(isSameState),
       ),

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -190,20 +190,14 @@ export function useValuePreview(props: {
 
       const goingToUnpublish = isGoingToUnpublish(value as SanityDocument)
 
-      // A document slated for unpublishing is previewed as its published version, which is
-      // outside of any perspective or variant.
+      // A document slated for unpublishing is previewed as its published version — outside of any
+      // perspective or variant — and none of its own content. Anything else is previewed as it is:
+      // a document or reference by its id, an array item (`_key` only) or a plain object in place.
+      const previewable: Previewable = goingToUnpublish
+        ? {_id: getPublishedId((value as SanityDocument)._id)}
+        : (value as Previewable)
       const targetPerspective = goingToUnpublish ? [] : perspective
       const targetVariant = goingToUnpublish ? undefined : variant
-      const id = goingToUnpublish
-        ? getPublishedId((value as SanityDocument)._id)
-        : (value as SanityDocument)._id
-
-      // allow for previewing the published document when a version is slated for unpublishing
-      // but if it's not for unpublishing, then we want to preview the content as was before
-      const previewable: Previewable = {
-        _id: id,
-        ...(goingToUnpublish ? {} : (value as Previewable)),
-      }
 
       return {
         previewable,

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -6,7 +6,7 @@ import {
 } from '@sanity/types'
 import {dequal} from 'dequal'
 import isPlainObject from 'lodash-es/isPlainObject.js'
-import {useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useState} from 'react'
 import {useSyncObservable} from 'react-rx'
 import {BehaviorSubject, concat, type Observable, of} from 'rxjs'
 import {catchError, distinctUntilChanged, map, scan, switchMap} from 'rxjs/operators'
@@ -50,13 +50,20 @@ function isSameError(a: Error | undefined, b: Error | undefined): boolean {
 // Every local mutation bumps the timestamps `prepareForPreview` preserves, and nothing renders them.
 const IGNORED_PREVIEW_KEYS = new Set(['_createdAt', '_updatedAt'])
 
+// React elements and portals are plain objects too, recognisable by `$$typeof`.
+function isReactNodeObject(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && '$$typeof' in value
+}
+
 // Plain media values such as image assets compare by content. Anything else — components,
-// elements, arrays of elements, portals — compares by identity: walking React internals is not
-// safe, and `prepare()` may build a fresh one per emission, in which case the preview simply
-// re-renders as it did before.
+// elements, arrays of elements, portals — compares by identity: walking React internals (an
+// element's props or `_owner`) is not safe, and `prepare()` may build a fresh one per emission,
+// in which case the preview simply re-renders as it did before.
 function isSameMedia(a: unknown, b: unknown): boolean {
   if (a === b) return true
-  return isPlainObject(a) && isPlainObject(b) && dequal(a, b)
+  if (!isPlainObject(a) || !isPlainObject(b)) return false
+  if (isReactNodeObject(a) || isReactNodeObject(b)) return false
+  return dequal(a, b)
 }
 
 function isSamePreview(a: PreviewValue | undefined, b: PreviewValue | undefined): boolean {
@@ -91,6 +98,14 @@ interface PreviewTarget {
    */
   key: string | undefined
 }
+
+/** A state together with the key of the target it was computed for. */
+interface Emission {
+  key: string | undefined
+  state: State
+}
+
+const INITIAL_EMISSION: Emission = {key: undefined, state: INITIAL_STATE}
 
 /**
  * Keys a target by the document it previews and the perspective it is seen through: a document
@@ -157,8 +172,8 @@ export function useValuePreview(props: {
     value$.next(previewValue)
   }, [previewValue, value$])
 
-  const observable = useMemo<Observable<State>>(() => {
-    const resolveTarget = (value: unknown): PreviewTarget | undefined => {
+  const resolveTarget = useCallback(
+    (value: unknown): PreviewTarget | undefined => {
       if (!enabled || !value || !schemaType) return undefined
 
       const goingToUnpublish = isGoingToUnpublish(value as SanityDocument)
@@ -187,50 +202,58 @@ export function useValuePreview(props: {
         variant,
         key: getPreviewTargetKey(previewable, perspective, variant),
       }
-    }
+    },
+    [
+      enabled,
+      schemaType,
+      chosenPerspectiveStack,
+      perspectiveStack,
+      chosenVariant,
+      selectedVariantName,
+    ],
+  )
 
-    return value$.pipe(
-      // An edit replaces the changed field on the document, so a shallow compare catches every real
-      // change while an equal object built during render (`{_id}` in a dialog) is not previewed
-      // again — which would loop whenever `prepare()` returns a fresh media component.
-      distinctUntilChanged(shallowEquals),
-      scan<unknown, {target: PreviewTarget | undefined; targetChanged: boolean}>(
-        (previous, value) => {
-          const target = resolveTarget(value)
-          return {target, targetChanged: target?.key !== previous.target?.key}
-        },
-        {target: undefined, targetChanged: false},
+  const observable = useMemo<Observable<Emission>>(
+    () =>
+      value$.pipe(
+        // An edit replaces the changed field on the document, so a shallow compare catches every
+        // real change while an equal object built during render (`{_id}` in a dialog) is not
+        // previewed again — which would loop whenever `prepare()` returns a fresh media component.
+        distinctUntilChanged(shallowEquals),
+        scan<unknown, {target: PreviewTarget | undefined; targetChanged: boolean}>(
+          (previous, value) => {
+            const target = resolveTarget(value)
+            return {target, targetChanged: target?.key !== previous.target?.key}
+          },
+          {target: undefined, targetChanged: false},
+        ),
+        switchMap(({target, targetChanged}): Observable<Emission> => {
+          // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
+          if (!target || !schemaType) return of({key: undefined, state: IDLE_STATE})
+
+          const {key} = target
+          const preview$ = observeForPreview(target.previewable, schemaType, {
+            perspective: target.perspective,
+            variant: target.variant,
+            viewOptions: {ordering: ordering},
+          }).pipe(
+            map((event) => ({key, state: {isLoading: false, value: event.snapshot || undefined}})),
+            catchError((error) => of({key, state: {isLoading: false, error}})),
+          )
+
+          // A different target must not keep showing the previous one's preview while it loads.
+          return targetChanged ? concat(of({key, state: INITIAL_STATE}), preview$) : preview$
+        }),
+        distinctUntilChanged((a, b) => a.key === b.key && isSameState(a.state, b.state)),
       ),
-      switchMap(({target, targetChanged}) => {
-        // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
-        if (!target || !schemaType) return of(IDLE_STATE)
-
-        const preview$ = observeForPreview(target.previewable, schemaType, {
-          perspective: target.perspective,
-          variant: target.variant,
-          viewOptions: {ordering: ordering},
-        }).pipe(
-          map((event) => ({isLoading: false, value: event.snapshot || undefined})),
-          catchError((error) => of({isLoading: false, error})),
-        )
-
-        // A different target must not keep showing the previous one's preview while it loads.
-        return targetChanged ? concat(of(INITIAL_STATE), preview$) : preview$
-      }),
-      distinctUntilChanged(isSameState),
-    )
-  }, [
-    value$,
-    enabled,
-    schemaType,
-    chosenPerspectiveStack,
-    perspectiveStack,
-    chosenVariant,
-    selectedVariantName,
-    observeForPreview,
-    ordering,
-  ])
+    [value$, resolveTarget, schemaType, observeForPreview, ordering],
+  )
 
   // Do not defer: search/reference UIs assert on preview titles synchronously after selection.
-  return useSyncObservable(observable, INITIAL_STATE)
+  const emission = useSyncObservable(observable, INITIAL_EMISSION)
+
+  // The subject is fed after commit, so the render that first receives a new target still holds
+  // the previous target's emission. Compare against the target this render previews and show
+  // loading until the emission catches up, so nothing stale is ever painted.
+  return emission.key === resolveTarget(previewValue)?.key ? emission.state : INITIAL_STATE
 }

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -96,16 +96,22 @@ interface PreviewTarget {
    * What the preview shows, independent of the input's shape. A change resets the preview to
    * loading; edits to the same target keep the current preview until the next one arrives.
    */
-  key: string | undefined
+  key: string
 }
 
-/** A state together with the key of the target it was computed for. */
+/**
+ * A state together with the key of the target it was computed for; `null` when there was nothing
+ * to preview (disabled, no value, no schema type), which never matches a target.
+ */
 interface Emission {
-  key: string | undefined
+  key: string | null
   state: State
 }
 
-const INITIAL_EMISSION: Emission = {key: undefined, state: INITIAL_STATE}
+const INITIAL_EMISSION: Emission = {key: null, state: INITIAL_STATE}
+
+// Plain objects previewed in place carry no identifier; they all share this key.
+const INLINE_TARGET_KEY = 'inline'
 
 /**
  * Keys a target by the document it previews and the perspective it is seen through: a document
@@ -119,7 +125,7 @@ function getPreviewTargetKey(
   previewable: Previewable,
   perspective: PerspectiveStack,
   variant: string | undefined,
-): string | undefined {
+): string {
   const {_id, _ref, _key, _projectId, _dataset} = previewable as {
     _id?: string
     _ref?: string
@@ -128,7 +134,7 @@ function getPreviewTargetKey(
     _dataset?: string
   }
   const id = _id ?? _ref ?? _key
-  if (id === undefined) return undefined
+  if (id === undefined) return INLINE_TARGET_KEY
   const document = _dataset ? `${_projectId}/${_dataset}/${id}` : getPublishedId(id)
   return `${document}|${perspective.join(',')}|${variant ?? ''}`
 }
@@ -229,7 +235,7 @@ export function useValuePreview(props: {
         ),
         switchMap(({target, targetChanged}): Observable<Emission> => {
           // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
-          if (!target || !schemaType) return of({key: undefined, state: IDLE_STATE})
+          if (!target || !schemaType) return of({key: null, state: IDLE_STATE})
 
           const {key} = target
           const preview$ = observeForPreview(target.previewable, schemaType, {
@@ -252,8 +258,11 @@ export function useValuePreview(props: {
   // Do not defer: search/reference UIs assert on preview titles synchronously after selection.
   const emission = useSyncObservable(observable, INITIAL_EMISSION)
 
-  // The subject is fed after commit, so the render that first receives a new target still holds
-  // the previous target's emission. Compare against the target this render previews and show
-  // loading until the emission catches up, so nothing stale is ever painted.
-  return emission.key === resolveTarget(previewValue)?.key ? emission.state : INITIAL_STATE
+  // The subject is fed after commit, so the render that first receives a new value still holds
+  // the previous target's emission. Nothing to preview needs no emission at all; otherwise compare
+  // against the target this render previews and show loading until the emission catches up, so
+  // nothing stale is ever painted.
+  const target = resolveTarget(previewValue)
+  if (!target) return IDLE_STATE
+  return emission.key === target.key ? emission.state : INITIAL_STATE
 }

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -4,10 +4,11 @@ import {
   type SchemaType,
   type SortOrdering,
 } from '@sanity/types'
-import {useMemo} from 'react'
+import {dequal} from 'dequal'
+import {useEffect, useMemo, useState} from 'react'
 import {useSyncObservable} from 'react-rx'
-import {type Observable, of} from 'rxjs'
-import {catchError, map} from 'rxjs/operators'
+import {BehaviorSubject, type Observable, of} from 'rxjs'
+import {catchError, distinctUntilChanged, map, switchMap} from 'rxjs/operators'
 
 import {type PerspectiveStack} from '../perspective/types'
 import {usePerspective} from '../perspective/usePerspective'
@@ -38,6 +39,17 @@ const IDLE_STATE: State = {
     description: undefined,
   },
 }
+
+function isSameError(a: Error | undefined, b: Error | undefined): boolean {
+  return a === b || (!!a && !!b && a.name === b.name && a.message === b.message)
+}
+
+// Prepared previews are small, so comparing them is cheap. Editing a field the preview does not
+// select, or passing an equal value object built during render, then leaves the rendered state
+// alone instead of re-rendering every preview consumer (or, for the latter, looping).
+function isSameState(a: State, b: State): boolean {
+  return a.isLoading === b.isLoading && isSameError(a.error, b.error) && dequal(a.value, b.value)
+}
 /**
  * @internal
  */
@@ -66,57 +78,70 @@ export function useValuePreview(props: {
   } = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
   const {perspectiveStack, selectedVariantName} = usePerspective()
-  const observable = useMemo<Observable<State>>(() => {
-    // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
-    if (!enabled || !previewValue || !schemaType) return of(IDLE_STATE)
 
-    const goingToUnpublish = isGoingToUnpublish(previewValue as SanityDocument)
+  // The value is a new object on every edit. It enters the pipeline through a subject so the
+  // observable identity — and with it the subscription and the field observers it holds — survives
+  // keystrokes; a new identity per value would resubscribe and refetch every reference it follows.
+  const [value$] = useState(() => new BehaviorSubject<unknown>(previewValue))
+  useEffect(() => {
+    value$.next(previewValue)
+  }, [previewValue, value$])
 
-    const updatedStack = goingToUnpublish ? [] : (chosenPerspectiveStack ?? perspectiveStack)
-    // A document slated for unpublishing is previewed as its published version, which is outside
-    // of any variant. Otherwise the variant follows the perspective: only inherited from the
-    // context when the perspective is too.
-    const updatedVariant = goingToUnpublish
-      ? undefined
-      : (chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName))
-    const updatedDocId = goingToUnpublish
-      ? getPublishedId((previewValue as SanityDocument)._id)
-      : (previewValue as SanityDocument)._id
+  const observable = useMemo<Observable<State>>(
+    () =>
+      value$.pipe(
+        distinctUntilChanged(),
+        switchMap((value) => {
+          // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
+          if (!enabled || !value || !schemaType) return of(IDLE_STATE)
 
-    // allow for previewing the published document when a version is slated for unpublishing
-    // but if it's not for unpublishing, then we want to preview the content as was before
-    const restPreviewValue = goingToUnpublish
-      ? {}
-      : {
-          ...(previewValue as Previewable),
-        }
+          const goingToUnpublish = isGoingToUnpublish(value as SanityDocument)
 
-    return observeForPreview(
-      {
-        _id: updatedDocId,
-        ...restPreviewValue,
-      },
+          const updatedStack = goingToUnpublish ? [] : (chosenPerspectiveStack ?? perspectiveStack)
+          // A document slated for unpublishing is previewed as its published version, which is
+          // outside of any variant. Otherwise the variant follows the perspective: only inherited
+          // from the context when the perspective is too.
+          const updatedVariant = goingToUnpublish
+            ? undefined
+            : (chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName))
+          const updatedDocId = goingToUnpublish
+            ? getPublishedId((value as SanityDocument)._id)
+            : (value as SanityDocument)._id
+
+          // allow for previewing the published document when a version is slated for unpublishing
+          // but if it's not for unpublishing, then we want to preview the content as was before
+          const restPreviewValue = goingToUnpublish ? {} : {...(value as Previewable)}
+
+          return observeForPreview(
+            {
+              _id: updatedDocId,
+              ...restPreviewValue,
+            },
+            schemaType,
+            {
+              perspective: updatedStack,
+              variant: updatedVariant,
+              viewOptions: {ordering: ordering},
+            },
+          ).pipe(
+            map((event) => ({isLoading: false, value: event.snapshot || undefined})),
+            catchError((error) => of({isLoading: false, error})),
+          )
+        }),
+        distinctUntilChanged(isSameState),
+      ),
+    [
+      value$,
+      enabled,
       schemaType,
-      {
-        perspective: updatedStack,
-        variant: updatedVariant,
-        viewOptions: {ordering: ordering},
-      },
-    ).pipe(
-      map((event) => ({isLoading: false, value: event.snapshot || undefined})),
-      catchError((error) => of({isLoading: false, error})),
-    )
-  }, [
-    enabled,
-    previewValue,
-    schemaType,
-    chosenPerspectiveStack,
-    perspectiveStack,
-    chosenVariant,
-    selectedVariantName,
-    observeForPreview,
-    ordering,
-  ])
+      chosenPerspectiveStack,
+      perspectiveStack,
+      chosenVariant,
+      selectedVariantName,
+      observeForPreview,
+      ordering,
+    ],
+  )
 
   // Do not defer: search/reference UIs assert on preview titles synchronously after selection.
   return useSyncObservable(observable, INITIAL_STATE)

--- a/packages/sanity/src/core/util/shallowEquals.test.ts
+++ b/packages/sanity/src/core/util/shallowEquals.test.ts
@@ -28,6 +28,9 @@ describe('shallowEquals', () => {
     expect(shallowEquals({a: 1, b: undefined}, {a: 1})).toBe(false)
     expect(shallowEquals({a: 1}, {a: 1, b: undefined})).toBe(false)
     expect(shallowEquals({a: 1, b: undefined}, {a: 1, b: undefined})).toBe(true)
+    // same number of keys, but one of them swapped for another
+    expect(shallowEquals({_id: 'a', title: undefined}, {_id: 'a', subtitle: 'new'})).toBe(false)
+    expect(shallowEquals({_id: 'a', subtitle: 'new'}, {_id: 'a', title: undefined})).toBe(false)
   })
 
   it('compares nested values by reference only', () => {

--- a/packages/sanity/src/core/util/shallowEquals.ts
+++ b/packages/sanity/src/core/util/shallowEquals.ts
@@ -27,7 +27,12 @@ export function shallowEquals<T>(a: T, b: T): boolean {
   let countB = 0
   for (const key in recordA) {
     if (Object.prototype.hasOwnProperty.call(recordA, key)) {
-      if (recordA[key] !== recordB[key]) return false
+      // A key that is missing on `b` reads as `undefined` there, which would pass the value
+      // comparison for an `undefined`-valued key on `a` and let equal key counts hide a swap
+      // of one key for another.
+      if (!Object.prototype.hasOwnProperty.call(recordB, key) || recordA[key] !== recordB[key]) {
+        return false
+      }
       countA++
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to #14643 (react-rx 7). The bench A/Bs on that PR showed the experiment issuing roughly one extra GROQ `query` per mutation in every scenario (article 308→359 requests per session, reproduced locally at 273→313), with no latency signal above one quantisation step. This PR fixes the cause.

`useValuePreview` memoized its observable on the document value, so every keystroke produced a new observable identity. Under react-rx 7 that swap is unsubscribe-then-subscribe on commit (v6 bridged it with its render-phase warm-up), which:

1. dropped every followed reference's cached field observer (`observeFields`, `shareReplay({refCount: true})`) to zero subscribers,
2. tore the connection down, and
3. on the immediate re-subscribe replayed the global listener's `connected` event, which `currentDatasetListenFields` treats as "fetch now" — one query per edit per followed reference.

It also rendered `INITIAL_STATE` (`isLoading: true`) for one pass per keystroke.

Changes:

- `useValuePreview`: the value enters a single, stable pipeline through a subject and `switchMap`; the observable is memoized on everything except the value, so its identity — and the subscription — survives edits. Each pipeline owns its own non-replaying subject and is fed from an effect declared after `useSyncObservable`: react-rx keeps a replaced pipeline subscribed for a tick after its successor took over, so a shared subject would feed a value that arrives together with a schema type / ordering / perspective change to both pipelines; now a rebuilt pipeline sees the current value exactly once and an obsolete one never again. Input values are deduplicated with a shallow compare (an edit replaces the changed top-level field), so an equal object built during render (`UnpublishVersionDialog` passes `{_id}` inline) is not previewed again. The perspective and variant that apply are resolved up front (`chosenPerspectiveStack ?? perspectiveStack`, and the variant only inherited from the context when the perspective is), and only those enter the pipeline's dependencies: a caller previewing a specific version is not resubscribed by a global perspective or variant change. The resolved stack is keyed by contents (`useShallowUnique`): callers build theirs inline (`useDocumentTitle` passes `[]`) and `PerspectiveProvider` rebuilds the inherited one whenever the releases change, and neither may rebuild the observable and resubscribe every preview. Only a version slated for unpublishing gets a synthesized previewable (its published id); every other value — document, reference, `_key`-only array item, plain object — is handed to the preview store as it is, instead of as a `{_id, ...value}` copy.
- Preview target resets: each value resolves to a target (unpublish → published id, perspective, variant) keyed by the target's *published* id plus perspective, variant and whether the published document is previewed in place of a version slated for unpublishing — so `drafts.x`, `versions.*.x` and `x` are one target (also per project and dataset for cross-dataset references) and materializing a draft keeps the preview, while the unpublish switch resets even when the caller's perspective stack is already empty. Array items are keyed by their `_key` as it is (an item key is not a document id, so `drafts.foo` and `foo` are two items). Each kind of identity has its own prefix — `doc:` for documents and references, `key:` for array items, `inline` for id-less objects — so no two kinds can share a key even though `inline` is itself a valid document id. A target change emits the loading state before the new preview, and the hook also compares the emission's target key against the current value's target *during render*, so the render that first receives a different document shows loading instead of the previous document's title or error — no dependence on when the effect pushes the value. An emission's key is `null` when there was nothing to preview, so it never matches a target; a render with nothing to preview (no value, disabled, no schema type) returns the idle state directly, in that same render. Inputs that rebuild the pipeline (schema type, ordering, perspective) need no key of their own: react-rx keeps one store per observable, so a rebuilt pipeline renders the initial emission — whose `null` key matches nothing — until it emits.
- Equal prepared previews are not re-emitted, so an emission that prepares to the same preview as the last one (a listener echo, an edit to a field the preview does not select and that leaves the preserved fields alone) no longer re-renders every consumer. Every field takes part in the comparison — `_createdAt` / `_updatedAt` included, since `PreviewValue` is public and `PreviewLoader` forwards the whole value to the preview component; `media` compares by content only for plain objects without `$$typeof` (image assets) and by identity for components, elements, portals and arrays; errors by name/message.
- `shallowEquals` (shared util): a key missing on one side read as `undefined` there, so `{_id: 'a', title: undefined}` compared equal to `{_id: 'a', subtitle: 'new'}` (equal key counts, all values "equal"). It now requires the same own keys on both sides, which is what the value dedupe above — and the ten other call sites — need.
- `observeFields`: cached field observers keep their connection for 1 s after the last subscriber leaves (`share` with `resetOnRefCountZero: () => timer(1_000)`, the same pattern as `editState`'s teardown grace), so any subscription swap — a preview rebuilt for a new value, a component re-subscribing on commit — no longer costs a refetch. The `latest` memo replay for cold subscribers is unchanged.

Not done here: piping the preview straight from the document store's observable instead of bridging the React value through a subject. `useDocumentTitle` could do that, but `PreviewLoader` / list items only have plain values, so the hook keeps its value-based API.

### What to review

- `useValuePreview`: `resolveTarget` is shared by the pipeline (`scan` → `switchMap`) and the render-time key comparison; the returned `State` shape is unchanged (the `{key, state}` pairing is internal). The `useMemo` returns the pipeline together with its `feed` function; the effect that feeds it is deliberately declared after `useSyncObservable`.
- `getPreviewTargetKey`: four segments — document (`doc:<published id>`, `doc:<project>/<dataset>/<published id>` for cross-dataset references, `key:<_key>` for array items, `inline` for id-less objects), perspective, variant, published-only marker. Only `_id` / `_ref` are normalized with `getPublishedId`.
- `shallowEquals`: the new own-key check on `b` is the only semantic change (an `undefined`-valued key no longer matches a missing one when key counts happen to agree).
- `observeFields`: `shareReplay({refCount: true, bufferSize: 1})` → `share({connector: () => new ReplaySubject(1), resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD)})`. `resetOnComplete` differs between the two defaults, but the source is an infinite listener stream.
- Whether 1 s is the grace you want; it only delays teardown of idle field observers.

### Testing

- `useValuePreview.test.tsx` (29 tests): same-document edits never regress to loading and keep one live subscription; unchanged value previewed once; an edit leaving the preview equal causes no store-driven render; a timestamp-only change re-emits; switching `_id` resets to loading in the very render that receives the new value and stays there until its preview emits; a delayed schema-type change and a delayed ordering change likewise reset in the render that receives them and never show the previous pipeline's preview; a value change arriving together with an ordering change is previewed once, under the new ordering only; array items keyed `drafts.foo` and `foo` are two targets; a document named `inline` and an id-less object are two targets; a `_key`-only array item reaches the preview store as the very same object; `drafts.x` / `versions.*.x` keep the preview, for same-dataset and cross-dataset targets alike (another dataset still resets); a caller-chosen `perspectiveStack` is not resubscribed by a global perspective or variant change, an inherited stack rebuilt with the same contents does not resubscribe either, while a caller inheriting the selection follows a real change; a version marked for unpublishing resets and previews `{_id: 'a'}` with `perspective: []`, also when the caller's stack is already empty; an inline `perspectiveStack` keeps one observable; an inline value converges, also when `prepare()` returns fresh function/element media; element media compares by identity without walking it (cyclic prop); plain asset media compares by content; errors surface once; idle state without a value; an inline preview is dropped in the render that loses its value (and the next inline value is previewed afresh); removing the value, disabling, or removing the schema type renders idle — not loading — in that render and releases the document subscription. Each behavioural test was verified to fail without its respective change.
- `shallowEquals.test.ts`: swapped-key objects with equal key counts compare unequal (fails on the previous comparator).
- `createPathObserver` test: an array item carrying an own `_id: undefined` is previewed in place without any `observeFields` lookup.
- `observeFields` tests: a subscriber replaced right away does not refetch (fails on the previous `shareReplay`, verified), a subscriber arriving after the grace period does.
- Preview folder 11 files / 104 tests; the `shallowEquals` consumer areas (`core/util`, `core/store`, `core/form/*`, `core/validation`, structure components and document lists) and the preview consumers (`useDocumentTitle`, `DocumentHeaderTitle`, `StructureTitle`, release dialogs, navbar search, tree-editing, single-doc release) pass; repo oxlint clean on the changed files.
- Local `perf/bench` A/B (`article`, 4+4 sessions, converged, reference = this PR's base built with the reference config): all four interaction metrics neutral (`string inside object` Δ +0.0 ms [+0.0, +8.0]); requests per session 309.5 → 301.5. The earlier react-rx 6→7 A/B measured 273 → 313 on the same host, so this recovers part of that increase; the remaining per-keystroke requests come from elsewhere and are worth a separate ledger diff.

### Notes for release

N/A – Internal performance fix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecba6160-9aa0-437c-8149-2c038b1efeb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecba6160-9aa0-437c-8149-2c038b1efeb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

