### PR TITLE
ci(test): test supported react version boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,8 @@ jobs:
       - name: Install minimum supported React
         if: matrix.react == 'minimum'
         run: |
-          export REACT_VERSION=$(pnpm --silent --filter sanity exec node -e "const {minVersion} = require('semver'); process.stdout.write(minVersion(require('./package.json').peerDependencies.react).version)")
+          REACT_VERSION=$(pnpm --silent --filter sanity exec node -e "const {minVersion} = require('semver'); process.stdout.write(minVersion(require('./package.json').peerDependencies.react).version)")
+          export REACT_VERSION
           node --input-type=module <<'EOF'
           import {readFile, writeFile} from 'node:fs/promises'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
   test:
     timeout-minutes: 60
-    name: Test (node ${{ matrix.node }}) - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+    name: Test (node ${{ matrix.node }}, React ${{ matrix.react }}) - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-8core
     needs: [check]
     if: needs.check.outputs.has_code_changes == 'true'
@@ -41,9 +41,15 @@ jobs:
       fail-fast: false
       matrix:
         node: [22, 24, 26]
+        react: [latest, minimum]
         experimental: [false]
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
+        exclude:
+          - node: 22
+            react: minimum
+          - node: 26
+            react: minimum
         # include:
         #   - os: windows-latest
         #     node: 16
@@ -56,6 +62,28 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Install minimum supported React
+        if: matrix.react == 'minimum'
+        run: |
+          export REACT_VERSION=$(pnpm --silent --filter sanity exec node -e "const {minVersion} = require('semver'); process.stdout.write(minVersion(require('./package.json').peerDependencies.react).version)")
+          node --input-type=module <<'EOF'
+          import {readFile, writeFile} from 'node:fs/promises'
+
+          const path = 'pnpm-workspace.yaml'
+          const workspace = await readFile(path, 'utf8')
+          const marker = 'overrides:\n'
+          if (!workspace.includes(marker)) throw new Error(`Missing ${marker.trim()} section`)
+          await writeFile(
+            path,
+            workspace.replace(
+              marker,
+              `${marker}  react: '${process.env.REACT_VERSION}'\n  react-dom: '${process.env.REACT_VERSION}'\n`,
+            ),
+          )
+          EOF
+          pnpm install --no-frozen-lockfile
+          pnpm --filter sanity exec node -e "for (const dependency of ['react', 'react-dom']) { const actual = require(dependency + '/package.json').version; console.log(dependency + '@' + actual); if (actual !== process.env.REACT_VERSION) throw new Error('Expected ' + dependency + '@' + process.env.REACT_VERSION + ', got ' + actual) }"
+
       - name: Build packages
         run: pnpm build --output-logs=full --log-order=grouped
 
@@ -64,7 +92,7 @@ jobs:
         run: |
           # Base arguments for all test runs
           ARGS="--test-timeout=60000 --retry 4 --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }} --passWithNoTests"
-          if [ "${{ matrix.node }}" == "24" ]; then
+          if [ "${{ matrix.node }}" == "24" ] && [ "${{ matrix.react }}" == "latest" ]; then
             # We only gather coverage from a single Node version.
             # We pass in `--reporter=blob` so that we can combine the results from all shards.
             ARGS="$ARGS --coverage --reporter=default --reporter=blob"
@@ -74,7 +102,7 @@ jobs:
           GITHUB_SHARD_IDENTIFIER: ${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
-        if: ${{ !cancelled() && matrix.node == '24' }}
+        if: ${{ !cancelled() && matrix.node == '24' && matrix.react == 'latest' }}
         uses: actions/upload-artifact@v7
         with:
           name: blob-report-${{ github.run_id }}-${{ matrix.shardIndex }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The unit workflow only exercised the lockfile's React version, so the declared minimum could regress unnoticed. The minimum run derives its version from `sanity`'s peer range and asserts the installed runtime before testing. It runs once on Node 24 rather than multiplying every Node permutation.

### What to review

Review the matrix exclusions and the temporary pnpm overrides in `.github/workflows/test.yml`.

### Testing

- Parsed the workflow and verified 12 latest-version jobs plus 4 minimum-version shards on Node 24.
- Ran all 7,127 tests with React and React DOM 19.3.0.
- Ran all 7,127 tests with React and React DOM 19.2.2.
- Both runs produced 7,012 passes and the same single documented Cloud VM baseline failure in `isUsingLegacyHttp.test.ts`.
- `pnpm check:format` passed.
- zizmor reported the 11 documented baseline findings and none in `test.yml`.

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e857038-13c9-4c3b-bb8c-b98449f4a83f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e857038-13c9-4c3b-bb8c-b98449f4a83f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

