### PR TITLE
fix(portable-text): only show the annotation toolbar popover for collapsed selections

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Annotations.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Annotations.browser.test.tsx
@@ -91,6 +91,19 @@ function MultipleAnnotationsHarness() {
   )
 }
 
+// vitest-browser's `.not.toBeVisible()` throws on a missing element, so this
+// treats the popover being unmounted the same as it being hidden.
+async function expectPopoverAbsentOrHidden() {
+  await expect
+    .poll(() => {
+      const popover = document.querySelector<HTMLElement>(
+        '[data-testid="annotation-toolbar-popover"]',
+      )
+      return !popover || !popover.checkVisibility()
+    })
+    .toBe(true)
+}
+
 describe('Portable Text Input', () => {
   describe('Annotations', () => {
     // Firefox's tab order from the PTE does not reach the annotation toolbar
@@ -144,8 +157,21 @@ describe('Portable Text Input', () => {
 
       const $toolbarPopover = page.getByTestId('annotation-toolbar-popover')
 
+      // Collapse the selection to a caret inside the annotation.
+      await userEvent.keyboard('{ArrowLeft}')
+      await userEvent.keyboard('{ArrowRight}')
+
       // Assertion: the annotation toolbar popover should be visible
-      await expect.element(page.getByTestId('annotation-toolbar-popover')).toBeVisible()
+      await expect.element($toolbarPopover).toBeVisible()
+
+      // Expand the selection by one character while staying inside the annotation.
+      await userEvent.keyboard('{Shift>}{ArrowRight}{/Shift}')
+
+      // Assertion: an expanded selection inside the annotation hides the popover.
+      await expectPopoverAbsentOrHidden()
+
+      // Collapse again so the popover is visible for tabbing into its buttons.
+      await userEvent.keyboard('{ArrowLeft}')
       await expect.element($toolbarPopover).toBeVisible()
 
       // Wait for the popover's focusable buttons to be mounted before tabbing.
@@ -266,8 +292,24 @@ describe('Portable Text Input', () => {
         // Expect the editor to have focus after closing the popover
         await expect.element($pte).toHaveFocus()
 
+        const $toolbarPopover = page.getByTestId('annotation-toolbar-popover')
+
+        // Collapse the selection to a caret inside the annotation.
+        await userEvent.keyboard('{ArrowLeft}')
+        await userEvent.keyboard('{ArrowRight}')
+
         // Assertion: the annotation toolbar popover should be visible
-        await expect.element(page.getByTestId('annotation-toolbar-popover')).toBeVisible()
+        await expect.element($toolbarPopover).toBeVisible()
+
+        // Expand the selection by one character while staying inside the annotation.
+        await userEvent.keyboard('{Shift>}{ArrowRight}{/Shift}')
+
+        // Assertion: an expanded selection inside the annotation hides the popover.
+        await expectPopoverAbsentOrHidden()
+
+        // Collapse again so the popover is visible for clicking the edit button.
+        await userEvent.keyboard('{ArrowLeft}')
+        await expect.element($toolbarPopover).toBeVisible()
 
         // Open up the editing interface again
         await page.getByTestId('edit-annotation-button').click()
@@ -304,6 +346,54 @@ describe('Portable Text Input', () => {
       await $linkInput.element().focus()
       await expect.element($linkInput).toHaveFocus()
     })
+
+    it(
+      'Shows the annotation popover for a collapsed caret but not an expanded selection inside the annotation',
+      {timeout: 30_000},
+      async () => {
+        const {getFocusedPortableTextEditor, insertPortableText} = testHelpers()
+        void render(<AnnotationsHarness />)
+        const $pte = await getFocusedPortableTextEditor('field-body')
+
+        await insertPortableText('Now we should insert a link.', $pte)
+
+        // Backtrack and select the word "link"
+        await userEvent.keyboard('{ArrowLeft}')
+        await userEvent.keyboard('{Shift>}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{/Shift}')
+        await page.getByRole('button', {name: 'Link'}).click()
+
+        const $link = page.elementLocator($pte.element().querySelector('span[data-link]')!)
+        await expect.element($link).toBeVisible()
+
+        const $linkInput = page.getByTestId('popover-edit-dialog').getByLabelText('Link')
+        await expect.element($linkInput).toBeInTheDocument()
+        await $linkInput.element().focus()
+        await userEvent.keyboard('https://www.sanity.io')
+        await userEvent.keyboard('{Escape}')
+
+        // Expect the editor to have focus after closing the popover
+        await expect.element($pte).toHaveFocus()
+
+        const $toolbarPopover = page.getByTestId('annotation-toolbar-popover')
+
+        // Collapse the selection to a caret inside the annotation (between
+        // the first and second letter of "link").
+        await userEvent.keyboard('{ArrowLeft}')
+        await userEvent.keyboard('{ArrowRight}')
+
+        // Assertion (positive control): a collapsed caret inside the
+        // annotation shows the popover.
+        await expect.element($toolbarPopover).toBeVisible()
+
+        // Expand the selection by one character while staying inside the
+        // annotation.
+        await userEvent.keyboard('{Shift>}{ArrowRight}{/Shift}')
+
+        // Assertion: an expanded selection inside the annotation must hide
+        // the popover.
+        await expectPopoverAbsentOrHidden()
+      },
+    )
 
     // Firefox has timing issues with PTE selection events (matches the original
     // Playwright `test.skip(browserName === 'firefox')`).
@@ -357,11 +447,13 @@ describe('Portable Text Input', () => {
         // Expect the editor to have focus after closing the popover
         await expect.element($pte).toHaveFocus()
 
-        // Double-click again to select the annotated text and trigger the popover
+        // Click inside the doubly-annotated text and collapse the selection
+        // to a caret to trigger the popover.
         const $linkedTextAgain = page.elementLocator(
           $pte.element().querySelector('span[data-link]')!,
         )
-        await userEvent.dblClick($linkedTextAgain)
+        await $linkedTextAgain.click()
+        await userEvent.keyboard('{ArrowRight}')
 
         // Assertion: the combined annotation toolbar popover should be visible
         const $toolbarPopover = page.getByTestId('annotation-toolbar-popover')
@@ -385,16 +477,8 @@ describe('Portable Text Input', () => {
         // stays registered while the modal is open (SAPP-2645).
         await page.getByTestId('edit-annotation-button').click()
         // The popover either closes (kept mounted while other annotations are
-        // registered) or unmounts entirely (no annotations registered), so
-        // assert on "absent or hidden" rather than visibility alone.
-        await expect
-          .poll(() => {
-            const popover = document.querySelector<HTMLElement>(
-              '[data-testid="annotation-toolbar-popover"]',
-            )
-            return !popover || !popover.checkVisibility()
-          })
-          .toBe(true)
+        // registered) or unmounts entirely (no annotations registered).
+        await expectPopoverAbsentOrHidden()
 
         let toolbarPopoverReappeared = false
         const observer = new MutationObserver(() => {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
@@ -108,6 +108,14 @@ export function CombinedAnnotationPopover(props: CombinedAnnotationPopoverProps)
 
     const range = sel.getRangeAt(0)
 
+    if (!range.collapsed) {
+      // Expanded selections belong to the comments plugin's floating
+      // "Add comment" popover; this one would cover the selected text.
+      setPopoverOpen(false)
+      setCursorRect(null)
+      return
+    }
+
     // Check if selection is within any of the registered annotation elements
     const isWithinAnnotation = annotations.some((annotation) =>
       annotation.referenceElement?.contains(range.commonAncestorContainer),


### PR DESCRIPTION
### Description

The annotation toolbar popover appeared for any selection inside an annotation, collapsed or expanded. With an expanded selection it sits on top of the selected text and collides with the floating "Add comment" popover, which only shows for expanded selections.

This has been fixed by only showing the popover when the selection is collapsed. This means that double-clicking an annotated word no longer shows the popover. It also means that after a link (or another annotation) has been added to an expanded selection, the popover isn't shown. Both feel like acceptable trade offs and perhaps even idiomatic behaviour.

Before:

<img width="371" height="210" alt="Screenshot 2026-09-11 at 09 11 40" src="https://github.com/user-attachments/assets/0a4fa3c0-196e-442f-b97b-0fd2fa981319" />

After:

<img width="310" height="218" alt="Screenshot 2026-09-11 at 09 10 52" src="https://github.com/user-attachments/assets/36b7b119-ac5b-43a2-8daa-776f743e91b4" />
<img width="294" height="219" alt="Screenshot 2026-09-11 at 09 10 58" src="https://github.com/user-attachments/assets/eda77579-4dc5-4ca3-8444-99c974ae3e56" />


### What to review

Place the caret inside a link in the Portable Text Input: the popover shows. Select text inside or across the link: it hides.

### Testing

A new browser test pins the contract (collapsed caret shows the popover, expanded selection hides it) and fails without the fix. The three existing tests that relied on expanded selections showing the popover now pin the new behavior.

### Notes for release

Fixes an issue where the annotation popover in the Portable Text Input appeared over selected text, colliding with the floating comment button. The popover now only shows when the selection is collapsed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized selection-gating in one popover component with browser tests; no auth, data, or API changes.
> 
> **Overview**
> The **annotation toolbar popover** no longer opens when text inside an annotation is **expanded**; it only appears for a **collapsed caret** within registered annotation spans. **`CombinedAnnotationPopover`** now bails out on `selectionchange` when `range.collapsed` is false, avoiding overlap with the comments plugin’s expanded-selection “Add comment” UI.
> 
> **UX tradeoffs:** double-clicking an annotated word won’t show the toolbar until the user places a caret (e.g. click + arrow keys); the same applies right after creating an annotation from a word selection.
> 
> Browser tests add **`expectPopoverAbsentOrHidden`** (handles unmounted vs hidden popovers in vitest-browser), a dedicated contract test, and updates to keyboard/edit/multi-annotation flows so they **collapse the caret** before asserting the toolbar is visible and assert the popover **hides on shift-expand**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df59ff02caed0927449ed0ecbabd789d20b41050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->