### PR TITLE
fix(releases): resolve every document's revert target before reverting a release

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -348,6 +348,32 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
     'This will revert {{releaseDocumentsLength}} document versions.',
   /** Title for the dialog confirming the revert of a release */
   'revert-dialog.confirm-revert.title': "Are you sure you want to revert the '{{title}}' release?",
+  /** Shown in the revert dialog while the previous state of each document is being looked up */
+  'revert-dialog.confirm-revert.resolving': 'Checking document history…',
+  /** Revert dialog summary line for documents that will be restored to a previous revision */
+  'revert-dialog.confirm-revert.summary-restore_one':
+    '{{count}} document will be restored to its last published revision from before this release.',
+  /** Revert dialog summary line for documents that will be restored to a previous revision */
+  'revert-dialog.confirm-revert.summary-restore_other':
+    '{{count}} documents will be restored to their last published revision from before this release.',
+  /** Revert dialog summary line for documents that will be unpublished because they were not published right before the release */
+  'revert-dialog.confirm-revert.summary-unpublish_one':
+    '{{count}} document will be unpublished because it was not published before this release.',
+  /** Revert dialog summary line for documents that will be unpublished because they were not published right before the release */
+  'revert-dialog.confirm-revert.summary-unpublish_other':
+    '{{count}} documents will be unpublished because they were not published before this release.',
+  /** Error card in the revert dialog when the history needed to revert some documents is no longer available */
+  'revert-dialog.confirm-revert.history-unavailable-card_one':
+    'The previous state of {{count}} document is no longer available in the document history, so the release cannot be reverted.',
+  /** Error card in the revert dialog when the history needed to revert some documents is no longer available */
+  'revert-dialog.confirm-revert.history-unavailable-card_other':
+    'The previous state of {{count}} documents is no longer available in the document history, so the release cannot be reverted.',
+  /** Error card in the revert dialog when the previous state of some documents could not be determined */
+  'revert-dialog.confirm-revert.unresolved-card_one':
+    'The previous state of {{count}} document could not be determined, so the release cannot be reverted.',
+  /** Error card in the revert dialog when the previous state of some documents could not be determined */
+  'revert-dialog.confirm-revert.unresolved-card_other':
+    'The previous state of {{count}} documents could not be determined, so the release cannot be reverted.',
   /** Checkbox label to confirm whether to create a staged release for revert or immediately revert */
   'revert-dialog.confirm-revert.stage-revert-checkbox-label': 'Immediately revert the release',
   /** Warning card text for when immediately revert a release with history */

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
@@ -74,7 +74,15 @@ const ConfirmReleaseDialog = ({
   const releaseDisplayTitle =
     release.metadata.title || tCore('release.placeholder-untitled-release')
   const hasPostPublishTransactions = usePostPublishTransactions(documents)
-  const getDocumentRevertStates = useDocumentRevertStates(documents)
+  const documentRevertStates = useDocumentRevertStates(documents)
+  const isResolvingRevertStates = documentRevertStates === null
+  const unresolvedCount = documentRevertStates?.unresolvedDocumentIds.length ?? 0
+  // Two cards: a failed request can be retried, history pruned by retention cannot
+  const requestFailedCount =
+    documentRevertStates?.states.filter(
+      (state) => state.type === 'unresolved' && state.reason === 'request-failed',
+    ).length ?? 0
+  const historyUnavailableCount = unresolvedCount - requestFailedCount
   const [stageNewRevertRelease, setStageNewRevertRelease] = useState(true)
   const toast = useToast()
   const telemetry = useTelemetry()
@@ -89,19 +97,19 @@ const ConfirmReleaseDialog = ({
 
   const handleRevertRelease = useCallback(async () => {
     setRevertReleaseStatus('reverting')
-    const documentRevertStates = await getDocumentRevertStates()
 
     const revertReleaseId = createReleaseId()
 
     // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
     const run = async () => {
-      if (!documentRevertStates) {
-        throw new Error('Unable to find documents to revert')
+      // The confirm button is disabled in these states; this guards against a stale click.
+      if (!documentRevertStates || documentRevertStates.unresolvedDocumentIds.length > 0) {
+        throw new Error('Unable to determine the previous state of every document in the release')
       }
 
       await revertRelease(
         revertReleaseId,
-        documentRevertStates,
+        documentRevertStates.revertDocuments,
         {
           title: t('revert-release.title', {
             title: releaseDisplayTitle,
@@ -175,7 +183,7 @@ const ConfirmReleaseDialog = ({
       })
   }, [
     setRevertReleaseStatus,
-    getDocumentRevertStates,
+    documentRevertStates,
     revertRelease,
     t,
     releaseDisplayTitle,
@@ -206,8 +214,9 @@ const ConfirmReleaseDialog = ({
           ),
           tone: 'positive',
           onClick: handleRevertRelease,
-          loading: revertReleaseStatus === 'reverting',
-          disabled: revertReleaseStatus === 'reverting',
+          loading: revertReleaseStatus === 'reverting' || isResolvingRevertStates,
+          disabled:
+            revertReleaseStatus === 'reverting' || isResolvingRevertStates || unresolvedCount > 0,
         },
       }}
     >
@@ -222,6 +231,61 @@ const ConfirmReleaseDialog = ({
           />
         }
       </Text>
+      {isResolvingRevertStates && (
+        <Box paddingTop={3}>
+          <Text muted size={1} data-testid="revert-resolving">
+            {t('revert-dialog.confirm-revert.resolving')}
+          </Text>
+        </Box>
+      )}
+      {documentRevertStates && documentRevertStates.revertCount > 0 && (
+        <Box paddingTop={3}>
+          <Text muted size={1} data-testid="revert-summary-restore">
+            {t('revert-dialog.confirm-revert.summary-restore', {
+              count: documentRevertStates.revertCount,
+            })}
+          </Text>
+        </Box>
+      )}
+      {documentRevertStates && documentRevertStates.unpublishCount > 0 && (
+        <Box paddingTop={3}>
+          <Text muted size={1} data-testid="revert-summary-unpublish">
+            {t('revert-dialog.confirm-revert.summary-unpublish', {
+              count: documentRevertStates.unpublishCount,
+            })}
+          </Text>
+        </Box>
+      )}
+      {historyUnavailableCount > 0 && (
+        <Card
+          marginTop={4}
+          padding={3}
+          radius={2}
+          shadow={1}
+          tone="critical"
+          data-testid="revert-history-unavailable-card"
+        >
+          <Text muted size={1}>
+            {t('revert-dialog.confirm-revert.history-unavailable-card', {
+              count: historyUnavailableCount,
+            })}
+          </Text>
+        </Card>
+      )}
+      {requestFailedCount > 0 && (
+        <Card
+          marginTop={4}
+          padding={3}
+          radius={2}
+          shadow={1}
+          tone="critical"
+          data-testid="revert-unresolved-card"
+        >
+          <Text muted size={1}>
+            {t('revert-dialog.confirm-revert.unresolved-card', {count: requestFailedCount})}
+          </Text>
+        </Card>
+      )}
       <Flex alignItems="center" paddingTop={4}>
         <Checkbox
           onChange={() => setStageNewRevertRelease((current) => !current)}

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/ReleaseRevertButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/ReleaseRevertButton.test.tsx
@@ -1,0 +1,176 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, type Mock, test, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../../test/testUtils/TestProvider'
+import {publishedASAPRelease} from '../../../../../__fixtures__/release.fixture'
+import {releasesUsEnglishLocaleBundle} from '../../../../../i18n'
+import {
+  mockUseReleaseOperations,
+  useReleaseOperationsMockReturn,
+} from '../../../../../store/__tests__/__mocks/useReleaseOperations.mock'
+import {
+  mockUseReleasePermissions,
+  useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnTrue,
+} from '../../../../../store/__tests__/__mocks/useReleasePermissions.mock'
+import {type DocumentInRelease} from '../../../../detail/types'
+import {ReleaseRevertButton} from '../ReleaseRevertButton'
+import {type DocumentRevertStates, useDocumentRevertStates} from '../useDocumentRevertStates'
+import {usePostPublishTransactions} from '../usePostPublishTransactions'
+
+vi.mock('../../../../../store/useReleaseOperations', () => ({
+  useReleaseOperations: vi.fn(() => useReleaseOperationsMockReturn),
+}))
+
+vi.mock('../../../../../store/useReleasePermissions', () => ({
+  useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn().mockReturnValue({state: {}, navigate: vi.fn()}),
+}))
+
+// The fallback upsell context never invokes the guarded callback, so the dialog would never open
+vi.mock('../../../../../contexts/upsell/useReleasesUpsell', () => ({
+  useReleasesUpsell: () => ({
+    guardWithReleaseLimitUpsell: async (callback: () => void) => callback(),
+  }),
+}))
+
+vi.mock('../useDocumentRevertStates', () => ({
+  useDocumentRevertStates: vi.fn(),
+}))
+
+vi.mock('../usePostPublishTransactions', () => ({
+  usePostPublishTransactions: vi.fn(() => false),
+}))
+
+const mockUseDocumentRevertStates = useDocumentRevertStates as Mock<typeof useDocumentRevertStates>
+const mockUsePostPublishTransactions = usePostPublishTransactions as Mock<
+  typeof usePostPublishTransactions
+>
+
+const documents = ['doc1', 'doc2', 'doc3'].map((id): DocumentInRelease => ({
+  memoKey: id,
+  document: {
+    _id: id,
+    _type: 'test-document',
+    _createdAt: '2023-10-01T08:00:00Z',
+    _updatedAt: '2023-10-01T09:00:00Z',
+    _rev: 'publishRev',
+    publishedDocumentExists: true,
+  },
+  validation: {isValidating: false, hasError: false, validation: []},
+}))
+
+const resolvedStates: DocumentRevertStates = {
+  states: [
+    {documentId: 'doc1', type: 'revert', document: {_id: 'doc1'} as never},
+    {documentId: 'doc2', type: 'revert', document: {_id: 'doc2'} as never},
+    {documentId: 'doc3', type: 'unpublish', document: {_id: 'doc3'} as never},
+  ],
+  revertDocuments: [{_id: 'doc1'}, {_id: 'doc2'}, {_id: 'doc3'}] as never,
+  revertCount: 2,
+  unpublishCount: 1,
+  unresolvedDocumentIds: [],
+}
+
+const unresolvedStates: DocumentRevertStates = {
+  states: [
+    {documentId: 'doc1', type: 'revert', document: {_id: 'doc1'} as never},
+    {documentId: 'doc2', type: 'unresolved', reason: 'request-failed'},
+    {documentId: 'doc3', type: 'unresolved', reason: 'request-failed'},
+  ],
+  revertDocuments: [{_id: 'doc1'}] as never,
+  revertCount: 1,
+  unpublishCount: 0,
+  unresolvedDocumentIds: ['doc2', 'doc3'],
+}
+
+const historyUnavailableStates: DocumentRevertStates = {
+  ...unresolvedStates,
+  states: [
+    unresolvedStates.states[0],
+    {documentId: 'doc2', type: 'unresolved', reason: 'history-unavailable'},
+    {documentId: 'doc3', type: 'unresolved', reason: 'request-failed'},
+  ],
+}
+
+async function openConfirmRevertDialog() {
+  const wrapper = await createTestProvider({resources: [releasesUsEnglishLocaleBundle]})
+  render(<ReleaseRevertButton release={publishedASAPRelease} documents={documents} />, {wrapper})
+
+  await waitFor(() => expect(screen.getByTestId('revert-button')).not.toBeDisabled())
+  await userEvent.click(screen.getByTestId('revert-button'))
+  await screen.findByTestId('confirm-button')
+}
+
+describe('ReleaseRevertButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+    mockUseReleaseOperations.mockReturnValue(useReleaseOperationsMockReturn)
+    useReleaseOperationsMockReturn.revertRelease.mockResolvedValue(undefined)
+    mockUsePostPublishTransactions.mockReturnValue(false)
+  })
+
+  test('keeps confirm disabled while revert states are resolving', async () => {
+    mockUseDocumentRevertStates.mockReturnValue(null)
+    await openConfirmRevertDialog()
+
+    expect(screen.getByTestId('revert-resolving')).toBeInTheDocument()
+    expect(screen.getByTestId('confirm-button')).toBeDisabled()
+  })
+
+  test('summarises restores and unpublishes, then reverts with the resolved documents', async () => {
+    mockUseDocumentRevertStates.mockReturnValue(resolvedStates)
+    await openConfirmRevertDialog()
+
+    expect(screen.getByTestId('revert-summary-restore')).toHaveTextContent(
+      '2 documents will be restored to their last published revision from before this release.',
+    )
+    expect(screen.getByTestId('revert-summary-unpublish')).toHaveTextContent(
+      '1 document will be unpublished because it was not published before this release.',
+    )
+    expect(screen.queryByTestId('revert-unresolved-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('confirm-button')).not.toBeDisabled()
+
+    await userEvent.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(useReleaseOperationsMockReturn.revertRelease).toHaveBeenCalledWith(
+        expect.any(String),
+        resolvedStates.revertDocuments,
+        expect.objectContaining({releaseType: 'asap'}),
+        'staged',
+      )
+    })
+  })
+
+  test('refuses to revert while any document is unresolved', async () => {
+    mockUseDocumentRevertStates.mockReturnValue(unresolvedStates)
+    await openConfirmRevertDialog()
+
+    expect(screen.getByTestId('revert-unresolved-card')).toHaveTextContent(
+      'The previous state of 2 documents could not be determined, so the release cannot be reverted.',
+    )
+    expect(screen.queryByTestId('revert-history-unavailable-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('confirm-button')).toBeDisabled()
+    expect(useReleaseOperationsMockReturn.revertRelease).not.toHaveBeenCalled()
+  })
+
+  test('separates documents whose history is gone from documents whose request failed', async () => {
+    mockUseDocumentRevertStates.mockReturnValue(historyUnavailableStates)
+    await openConfirmRevertDialog()
+
+    expect(screen.getByTestId('revert-history-unavailable-card')).toHaveTextContent(
+      'The previous state of 1 document is no longer available in the document history, so the release cannot be reverted.',
+    )
+    expect(screen.getByTestId('revert-unresolved-card')).toHaveTextContent(
+      'The previous state of 1 document could not be determined, so the release cannot be reverted.',
+    )
+    expect(screen.getByTestId('confirm-button')).toBeDisabled()
+  })
+})

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
@@ -1,7 +1,10 @@
 import {type SanityClient} from '@sanity/client'
-import {type TransactionLogEventWithEffects} from '@sanity/types'
+import {
+  type TransactionLogEventWithEffects,
+  type TransactionLogEventWithMutations,
+} from '@sanity/types'
 import {renderHook, waitFor} from '@testing-library/react'
-import {of} from 'rxjs'
+import {of, throwError} from 'rxjs'
 import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {useClient} from '../../../../../../hooks/useClient'
@@ -233,6 +236,54 @@ describe('useDocumentRevertStates', () => {
     expect(mockGetTransactionsLogs).toHaveBeenCalledWith(mockClient, ['doc1', 'doc2'], {
       toTransaction: 'rev1',
       reverse: true,
+    })
+  })
+  it('looks up a document missing from the bulk translog response instead of marking it for deletion', async () => {
+    // The bulk request is capped (default limit 50) and the window is shared across every
+    // document in the release, so doc2's pre-release transaction can fall outside it even though
+    // doc2 has history. It must be resolved individually, not turned into an unpublish action.
+    mockGetTransactionsLogs.mockImplementation((_client, documentIds) =>
+      Promise.resolve(
+        (Array.isArray(documentIds)
+          ? [{id: 'trans0_doc1', documentIDs: ['doc1'], timestamp: new Date().toISOString()}]
+          : [
+              {id: 'trans0_doc2', documentIDs: ['doc2'], timestamp: new Date().toISOString()},
+            ]) as unknown as (TransactionLogEventWithEffects & TransactionLogEventWithMutations)[],
+      ),
+    )
+
+    const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
+
+    await waitFor(async () => {
+      const resolvedResult = await result.current()
+      expect(resolvedResult).toEqual([
+        {_id: 'doc1', _rev: 'observable-rev-1', title: 'Reverted Document 1'},
+        {_id: 'doc2', _rev: 'observable-rev-2', title: 'Reverted Document 2'},
+      ])
+    })
+
+    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(
+      mockClient,
+      'doc2',
+      expect.objectContaining({toTransaction: 'rev1', reverse: true}),
+    )
+  })
+
+  it('does not silently drop a document whose revision fetch fails', async () => {
+    mockClient.observable.request.mockImplementation(({url}) => {
+      if (url!.includes('doc2')) return throwError(() => new Error('Failed to fetch'))
+      return of({
+        documents: [{_id: 'doc1', _rev: 'observable-rev-1', title: 'Reverted Document 1'}],
+      })
+    })
+
+    const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
+
+    await waitFor(async () => {
+      const resolvedResult = await result.current()
+      // The revert must account for every document in the release: a document whose previous
+      // revision could not be fetched may not be left out of the revert release unnoticed.
+      expect(resolvedResult).toHaveLength(2)
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
@@ -1,16 +1,24 @@
 import {type SanityClient} from '@sanity/client'
 import {
+  type MendozaEffectPair,
   type TransactionLogEventWithEffects,
   type TransactionLogEventWithMutations,
 } from '@sanity/types'
 import {renderHook, waitFor} from '@testing-library/react'
-import {of, throwError} from 'rxjs'
+import {delay, of, throwError} from 'rxjs'
 import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {useClient} from '../../../../../../hooks/useClient'
 import {getTransactionsLogs} from '../../../../../../store/translog/getTransactionsLogs'
+import {passthroughErrorHandler} from '../../../../../../studio/requestErrors/createRequestErrorChannel'
+import {type StudioErrorHandler} from '../../../../../../studio/requestErrors/types'
+import {useStudioErrorHandler} from '../../../../../../studio/requestErrors/useStudioErrorHandler'
 import {type DocumentInRelease} from '../../../../detail/types'
-import {useDocumentRevertStates} from '../useDocumentRevertStates'
+import {type DocumentRevertStates, useDocumentRevertStates} from '../useDocumentRevertStates'
+
+vi.mock('../../../../../../studio/requestErrors/useStudioErrorHandler', () => ({
+  useStudioErrorHandler: vi.fn(),
+}))
 
 vi.mock('../../../../../../hooks/useClient', () => ({
   useClient: vi.fn(),
@@ -20,13 +28,73 @@ vi.mock('../../../../../../store/translog/getTransactionsLogs', () => ({
   getTransactionsLogs: vi.fn(),
 }))
 
+type Transaction = TransactionLogEventWithEffects & TransactionLogEventWithMutations
+
+const PUBLISH_REV = 'publishRev'
+
+// Mendoza shapes: `[0, null]` maps a document to nothing; anything else is an ordinary edit
+const DELETE_PATCH = [0, null]
+const EDIT_PATCH = [11, 3, 'edit']
+const edited: MendozaEffectPair = {apply: EDIT_PATCH, revert: EDIT_PATCH}
+const created: MendozaEffectPair = {apply: EDIT_PATCH, revert: DELETE_PATCH}
+const deleted: MendozaEffectPair = {apply: DELETE_PATCH, revert: EDIT_PATCH}
+
+function transaction(
+  id: string,
+  documentIDs: string[],
+  effects: Record<string, MendozaEffectPair> = Object.fromEntries(
+    documentIDs.map((documentId) => [documentId, edited]),
+  ),
+): Transaction {
+  return {id, documentIDs, effects, timestamp: new Date().toISOString()} as unknown as Transaction
+}
+
+/** The release publish transaction, touching both documents; `createdIds` did not exist before */
+function publishTransaction(createdIds: string[] = []): Transaction {
+  return transaction(PUBLISH_REV, ['doc1', 'doc2'], {
+    doc1: createdIds.includes('doc1') ? created : edited,
+    doc2: createdIds.includes('doc2') ? created : edited,
+  })
+}
+
+const bulkParams = {
+  toTransaction: PUBLISH_REV,
+  reverse: true,
+  limit: 1000,
+  effectFormat: 'mendoza',
+}
+const perDocumentParams = {
+  toTransaction: PUBLISH_REV,
+  reverse: true,
+  limit: 2,
+  effectFormat: 'mendoza',
+}
+const publishTransactionParams = {
+  fromTransaction: PUBLISH_REV,
+  toTransaction: PUBLISH_REV,
+  limit: 1,
+  effectFormat: 'mendoza',
+}
+
+function revisionDocument(documentId: string, revision: string) {
+  return {_id: documentId, _rev: revision, title: `${documentId} @ ${revision}`}
+}
+
+const doc2Tombstone = {_id: 'doc2', _rev: PUBLISH_REV, _system: {delete: true}}
+
+async function resolveStates(documents: DocumentInRelease[]): Promise<DocumentRevertStates> {
+  const {result} = renderHook(() => useDocumentRevertStates(documents))
+  await waitFor(() => expect(result.current).not.toBeNull())
+  return result.current!
+}
+
 describe('useDocumentRevertStates', () => {
+  // Documents of a published release share the publish transaction as `_rev`
   const mockDocuments = [
-    {document: {_id: 'versions.r1.doc1', _rev: 'rev1'}},
-    {document: {_id: 'versions.r1.doc2', _rev: 'rev2'}},
+    {document: {_id: 'versions.r1.doc1', _rev: PUBLISH_REV, publishedDocumentExists: true}},
+    {document: {_id: 'versions.r1.doc2', _rev: PUBLISH_REV, publishedDocumentExists: true}},
   ] as DocumentInRelease[]
 
-  /** @todo improve the useClient mock */
   const mockClient = {
     getUrl: vi.fn(),
     config: vi.fn().mockReturnValue({dataset: 'test-dataset'}),
@@ -42,248 +110,375 @@ describe('useDocumentRevertStates', () => {
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const mockUseClient = useClient as Mock<typeof useClient>
   const mockGetTransactionsLogs = getTransactionsLogs as Mock<typeof getTransactionsLogs>
+  const mockUseStudioErrorHandler = useStudioErrorHandler as Mock<typeof useStudioErrorHandler>
+
+  /**
+   * Routes the three translog request kinds: bulk requests (array of ids), per-document publish
+   * transaction lookups (single id, `fromTransaction` set) and per-document history lookups
+   */
+  function mockTranslog(handlers: {
+    bulk?: (documentIds: string[]) => Promise<Transaction[]>
+    publish?: (documentId: string) => Promise<Transaction[]>
+    perDocument?: (documentId: string) => Promise<Transaction[]>
+  }) {
+    const none = () => Promise.resolve([])
+    mockGetTransactionsLogs.mockImplementation((_client, documentIds, params) => {
+      if (Array.isArray(documentIds)) return (handlers.bulk ?? none)(documentIds)
+      return params.fromTransaction
+        ? (handlers.publish ?? none)(documentIds)
+        : (handlers.perDocument ?? none)(documentIds)
+    })
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
-    // Suppress expected console.error from the revert states pipeline
-    // (async fetch errors during test teardown and intentional error tests)
-    vi.spyOn(console, 'error').mockImplementation(() => {})
 
     mockUseClient.mockReturnValue(mockClient)
-
-    // @ts-expect-error -- pre-existing, fix later
-    mockGetTransactionsLogs.mockResolvedValue([
-      {id: 'trans0_doc1', documentIDs: ['doc1'], timestamp: new Date().toISOString()},
-      {id: 'trans1_doc1', documentIDs: ['doc1'], timestamp: new Date().toISOString()},
-      {id: 'trans0_doc2', documentIDs: ['doc2'], timestamp: new Date().toISOString()},
-      {id: 'trans1_doc2', documentIDs: ['doc2'], timestamp: new Date().toISOString()},
-    ] as TransactionLogEventWithEffects[])
+    // Outside a WorkspacesProvider the real hook returns this passthrough: no dialog, errors reject
+    mockUseStudioErrorHandler.mockReturnValue(passthroughErrorHandler)
 
     mockClient.observable.request.mockImplementation(({url}) => {
-      if (url!.includes('doc1')) {
-        return of({
-          documents: [
-            {
-              _id: 'doc1',
-              _rev: 'observable-rev-1',
-              title: 'Reverted Document 1',
-            },
-          ],
-        })
-      }
-      if (url!.includes('doc2')) {
-        return of({
-          documents: [
-            {
-              _id: 'doc2',
-              _rev: 'observable-rev-2',
-              title: 'Reverted Document 2',
-            },
-          ],
-        })
-      }
-      return of({documents: []})
+      const [, documentId, revision] = url!.match(/documents\/([^?]+)\?revision=(.+)$/) ?? []
+      return of({documents: [revisionDocument(documentId, revision)]})
     })
   })
 
-  it('should return a function', () => {
+  it('is null while resolving', () => {
+    mockTranslog({bulk: () => new Promise(() => {})})
     const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
-    expect(typeof result.current).toBe('function')
+    expect(result.current).toBeNull()
   })
 
-  it('should fetch adjacent transactions and resolve to revert states', async () => {
-    const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
-
-    await waitFor(async () => {
-      const resolvedResult = await result.current()
-      expect(resolvedResult).toEqual([
-        {
-          _id: 'doc1',
-          _rev: 'observable-rev-1',
-          title: 'Reverted Document 1',
-        },
-        {
-          _id: 'doc2',
-          _rev: 'observable-rev-2',
-          title: 'Reverted Document 2',
-        },
-      ])
+  it('resolves every document from a single bulk translog request, skipping the publish transaction', async () => {
+    mockTranslog({
+      bulk: () =>
+        Promise.resolve([
+          publishTransaction(),
+          transaction('t1_doc1', ['doc1']),
+          transaction('t0_doc1', ['doc1']),
+          transaction('t1_doc2', ['doc2']),
+        ]),
     })
 
-    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(mockClient, ['doc1', 'doc2'], {
-      toTransaction: 'rev1',
-      reverse: true,
-    })
+    const states = await resolveStates(mockDocuments)
 
-    expect(mockClient.observable.request).toHaveBeenNthCalledWith(1, {
-      url: '/data/history/test-dataset/documents/doc1?revision=trans0_doc1',
-    })
-    expect(mockClient.observable.request).toHaveBeenNthCalledWith(2, {
-      url: '/data/history/test-dataset/documents/doc2?revision=trans0_doc2',
-    })
-  })
-
-  it('should handle missing revisions and mark for deletion', async () => {
-    // Empty transactions array causes all documents to be marked for deletion
-    mockGetTransactionsLogs.mockResolvedValue([])
-
-    const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
-
-    await waitFor(async () => {
-      const resolvedResult = await result.current()
-      expect(resolvedResult).toEqual([
-        {
-          _id: 'doc1',
-          _rev: 'rev1',
-          _system: {delete: true},
-        },
-        {
-          _id: 'doc2',
-          _rev: 'rev2',
-          _system: {delete: true},
-        },
-      ])
-    })
-
-    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(mockClient, ['doc1', 'doc2'], {
-      toTransaction: 'rev1',
-      reverse: true,
-    })
-  })
-
-  it('should return null if no transactions exist', async () => {
-    mockGetTransactionsLogs.mockResolvedValue([])
-
-    const {result} = renderHook(() => useDocumentRevertStates([]))
-
-    await waitFor(async () => {
-      const resolvedResult = await result.current()
-      expect(resolvedResult).toBeNull()
-    })
-
-    expect(mockGetTransactionsLogs).not.toHaveBeenCalled()
-    expect(mockClient.observable.request).not.toHaveBeenCalled()
-  })
-
-  it('should handle errors gracefully and return undefined', async () => {
-    mockGetTransactionsLogs.mockRejectedValue(new Error('Failed to fetch transactions'))
-
-    const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
-
-    await waitFor(async () => {
-      const resolvedResult = await result.current()
-      expect(resolvedResult).toBeUndefined()
-    })
-
-    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(mockClient, ['doc1', 'doc2'], {
-      toTransaction: 'rev1',
-      reverse: true,
-    })
-
-    expect(mockClient.observable.request).not.toHaveBeenCalled() // No API calls on failure
-    expect(console.error).toHaveBeenCalledWith(
-      'Error in document revert states pipeline:',
-      expect.any(Error),
-    )
-  })
-
-  it('should handle a mix of existing and missing revisions', async () => {
-    mockGetTransactionsLogs.mockResolvedValue([
-      // Only doc1 has a transaction
-      // @ts-expect-error -- pre-existing, fix later
-      {
-        id: 'trans0_doc1',
-        effects: {},
-        author: 'author',
-        documentIDs: ['doc1'],
-        timestamp: new Date().toISOString(),
-      },
+    expect(states.revertDocuments).toEqual([
+      revisionDocument('doc1', 't1_doc1'),
+      revisionDocument('doc2', 't1_doc2'),
     ])
+    expect(states).toMatchObject({revertCount: 2, unpublishCount: 0, unresolvedDocumentIds: []})
 
-    mockClient.observable.request.mockImplementation(({url}) => {
-      if (url!.includes('doc1')) {
-        return of({
-          documents: [
-            {
-              _id: 'doc1',
-              _rev: 'observable-rev-1',
-              title: 'Reverted Document 1',
-            },
-          ],
-        })
-      }
-      return of({documents: []})
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(1)
+    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(mockClient, ['doc1', 'doc2'], bulkParams)
+    expect(mockClient.observable.request).toHaveBeenCalledWith({
+      url: '/data/history/test-dataset/documents/doc1?revision=t1_doc1',
     })
-
-    const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
-
-    await waitFor(async () => {
-      const resolvedResult = await result.current()
-      expect(resolvedResult).toEqual([
-        {
-          _id: 'doc1',
-          _rev: 'observable-rev-1',
-          title: 'Reverted Document 1',
-        },
-        {
-          _id: 'doc2',
-          _rev: 'rev2',
-          _system: {delete: true},
-        },
-      ])
-    })
-
-    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(mockClient, ['doc1', 'doc2'], {
-      toTransaction: 'rev1',
-      reverse: true,
+    expect(mockClient.observable.request).toHaveBeenCalledWith({
+      url: '/data/history/test-dataset/documents/doc2?revision=t1_doc2',
     })
   })
-  it('looks up a document missing from the bulk translog response instead of marking it for deletion', async () => {
-    // The bulk request is capped (default limit 50) and the window is shared across every
-    // document in the release, so doc2's pre-release transaction can fall outside it even though
-    // doc2 has history. It must be resolved individually, not turned into an unpublish action.
-    mockGetTransactionsLogs.mockImplementation((_client, documentIds) =>
-      Promise.resolve(
-        (Array.isArray(documentIds)
-          ? [{id: 'trans0_doc1', documentIDs: ['doc1'], timestamp: new Date().toISOString()}]
-          : [
-              {id: 'trans0_doc2', documentIDs: ['doc2'], timestamp: new Date().toISOString()},
-            ]) as unknown as (TransactionLogEventWithEffects & TransactionLogEventWithMutations)[],
-      ),
-    )
 
-    const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
-
-    await waitFor(async () => {
-      const resolvedResult = await result.current()
-      expect(resolvedResult).toEqual([
-        {_id: 'doc1', _rev: 'observable-rev-1', title: 'Reverted Document 1'},
-        {_id: 'doc2', _rev: 'observable-rev-2', title: 'Reverted Document 2'},
-      ])
+  it('looks up documents missing from the bulk response individually instead of unpublishing them', async () => {
+    // doc2 fell outside the bulk window (e.g. doc1 has more recent history than the limit covers)
+    mockTranslog({
+      bulk: () => Promise.resolve([transaction('t1_doc1', ['doc1'])]),
+      perDocument: (documentId) =>
+        Promise.resolve([
+          transaction(PUBLISH_REV, [documentId]),
+          transaction(`old_${documentId}`, [documentId]),
+        ]),
     })
 
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([
+      revisionDocument('doc1', 't1_doc1'),
+      revisionDocument('doc2', 'old_doc2'),
+    ])
+    expect(states).toMatchObject({revertCount: 2, unpublishCount: 0, unresolvedDocumentIds: []})
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(2)
+    expect(mockGetTransactionsLogs).toHaveBeenCalledWith(mockClient, 'doc2', perDocumentParams)
+  })
+
+  it('unpublishes a document only when the publish transaction proves the release created it', async () => {
+    mockTranslog({
+      bulk: () => Promise.resolve([publishTransaction(['doc2']), transaction('t1_doc1', ['doc1'])]),
+      // doc2 has no history before the publish
+      perDocument: () => Promise.resolve([]),
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([revisionDocument('doc1', 't1_doc1'), doc2Tombstone])
+    expect(states).toMatchObject({revertCount: 1, unpublishCount: 1, unresolvedDocumentIds: []})
+    // the publish transaction came with the bulk response, so no extra request for it
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(2)
+  })
+
+  it('fetches the publish transaction for a document when the bulk response does not include it', async () => {
+    mockTranslog({
+      bulk: () => Promise.resolve([transaction('t1_doc1', ['doc1'])]),
+      perDocument: () => Promise.resolve([]),
+      publish: () => Promise.resolve([publishTransaction(['doc2'])]),
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([revisionDocument('doc1', 't1_doc1'), doc2Tombstone])
     expect(mockGetTransactionsLogs).toHaveBeenCalledWith(
       mockClient,
       'doc2',
-      expect.objectContaining({toTransaction: 'rev1', reverse: true}),
+      publishTransactionParams,
     )
   })
 
-  it('does not silently drop a document whose revision fetch fails', async () => {
+  it('splits the bulk request into chunks that keep the joined ids within the URL budget', async () => {
+    // Long ids (Sanity allows up to 128 characters) force several chunks
+    const manyDocuments = Array.from({length: 250}, (_, i) => ({
+      document: {
+        _id: `versions.r1.${String(i).padStart(3, '0')}-${'x'.repeat(115)}`,
+        _rev: PUBLISH_REV,
+        publishedDocumentExists: true,
+      },
+    })) as DocumentInRelease[]
+    const publishedIds = manyDocuments.map((doc) => doc.document._id.replace('versions.r1.', ''))
+    mockTranslog({
+      bulk: (documentIds) =>
+        Promise.resolve(
+          documentIds.map((documentId) => transaction(`t1_${documentId}`, [documentId])),
+        ),
+    })
+
+    const states = await resolveStates(manyDocuments)
+
+    expect(states.revertCount).toBe(250)
+    expect(states.unresolvedDocumentIds).toEqual([])
+    const bulkChunks = mockGetTransactionsLogs.mock.calls
+      .filter(([, ids]) => Array.isArray(ids))
+      .map(([, ids]) => ids as string[])
+    expect(bulkChunks.length).toBeGreaterThan(1)
+    for (const ids of bulkChunks) {
+      expect(ids.join(',').length).toBeLessThanOrEqual(6000)
+    }
+    expect(bulkChunks.flat()).toEqual(publishedIds)
+  })
+
+  it('only trusts a bulk response for the ids it was requested for', async () => {
+    // A transaction touching documents in two chunks comes back in both responses. If the chunk
+    // that does not own a document completes first, that shared transaction must not shadow the
+    // newer transaction in the document's own chunk.
+    const longId = (i: number) => `${String(i).padStart(3, '0')}-${'x'.repeat(115)}`
+    const documents = Array.from({length: 60}, (_, i) => ({
+      document: {_id: `versions.r1.${longId(i)}`, _rev: PUBLISH_REV, publishedDocumentExists: true},
+    })) as DocumentInRelease[]
+    const docA = longId(0) // first chunk
+    const docB = longId(59) // second chunk
+    const shared = transaction('shared_older', [docA, docB])
+    const newerForB = transaction('newer_for_b', [docB])
+    const others = (documentIds: string[], except: string) =>
+      documentIds.filter((id) => id !== except).map((id) => transaction(`t_${id}`, [id]))
+    mockTranslog({
+      bulk: (documentIds) =>
+        documentIds.includes(docA)
+          ? Promise.resolve([shared, ...others(documentIds, docA)])
+          : new Promise((resolve) =>
+              setTimeout(() => resolve([newerForB, shared, ...others(documentIds, docB)]), 20),
+            ),
+    })
+
+    const states = await resolveStates(documents)
+
+    expect(mockGetTransactionsLogs.mock.calls.filter(([, ids]) => Array.isArray(ids))).toHaveLength(
+      2,
+    )
+    expect(states.unresolvedDocumentIds).toEqual([])
+    expect(mockClient.observable.request).toHaveBeenCalledWith({
+      url: `/data/history/test-dataset/documents/${docA}?revision=shared_older`,
+    })
+    expect(mockClient.observable.request).toHaveBeenCalledWith({
+      url: `/data/history/test-dataset/documents/${docB}?revision=newer_for_b`,
+    })
+  })
+
+  it('marks a document unresolved when it has no pre-release history and the release did not create it', async () => {
+    // Retention pruned doc2's older history: the publish transaction edited an existing document
+    mockTranslog({
+      bulk: () => Promise.resolve([publishTransaction(), transaction('t1_doc1', ['doc1'])]),
+      perDocument: () => Promise.resolve([]),
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([revisionDocument('doc1', 't1_doc1')])
+    expect(states).toMatchObject({
+      revertCount: 1,
+      unpublishCount: 0,
+      unresolvedDocumentIds: ['doc2'],
+    })
+    expect(states.states[1]).toMatchObject({
+      documentId: 'doc2',
+      type: 'unresolved',
+      reason: 'history-unavailable',
+    })
+  })
+
+  it('unpublishes a document whose last pre-release transaction deleted it, without fetching a snapshot', async () => {
+    mockTranslog({
+      bulk: () =>
+        Promise.resolve([
+          transaction('t1_doc1', ['doc1']),
+          transaction('delete_doc2', ['doc2'], {doc2: deleted}),
+        ]),
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([revisionDocument('doc1', 't1_doc1'), doc2Tombstone])
+    expect(states).toMatchObject({revertCount: 1, unpublishCount: 1, unresolvedDocumentIds: []})
+    expect(mockClient.observable.request).toHaveBeenCalledTimes(1)
+    expect(mockClient.observable.request).not.toHaveBeenCalledWith(
+      expect.objectContaining({url: expect.stringContaining('doc2')}),
+    )
+  })
+
+  it('marks a document unresolved when its pre-release snapshot is no longer in history', async () => {
+    mockTranslog({
+      bulk: () =>
+        Promise.resolve([transaction('t1_doc1', ['doc1']), transaction('t1_doc2', ['doc2'])]),
+    })
+    mockClient.observable.request.mockImplementation(({url}) => {
+      if (url!.includes('doc2')) return of({documents: []})
+      return of({documents: [revisionDocument('doc1', 't1_doc1')]})
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([revisionDocument('doc1', 't1_doc1')])
+    expect(states.unresolvedDocumentIds).toEqual(['doc2'])
+    expect(states.states[1]).toMatchObject({
+      type: 'unresolved',
+      reason: 'history-unavailable',
+      error: expect.objectContaining({message: expect.stringContaining('no longer available')}),
+    })
+  })
+
+  it('marks a document unresolved when its individual translog lookup fails', async () => {
+    mockTranslog({
+      bulk: () => Promise.resolve([transaction('t1_doc1', ['doc1'])]),
+      perDocument: () => Promise.reject(new Error('403 Forbidden')),
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([revisionDocument('doc1', 't1_doc1')])
+    expect(states).toMatchObject({
+      revertCount: 1,
+      unpublishCount: 0,
+      unresolvedDocumentIds: ['doc2'],
+    })
+    expect(states.states[1]).toMatchObject({
+      documentId: 'doc2',
+      type: 'unresolved',
+      reason: 'request-failed',
+    })
+  })
+
+  it('marks a document unresolved when fetching its previous revision fails', async () => {
+    mockTranslog({
+      bulk: () =>
+        Promise.resolve([transaction('t1_doc1', ['doc1']), transaction('t1_doc2', ['doc2'])]),
+    })
     mockClient.observable.request.mockImplementation(({url}) => {
       if (url!.includes('doc2')) return throwError(() => new Error('Failed to fetch'))
-      return of({
-        documents: [{_id: 'doc1', _rev: 'observable-rev-1', title: 'Reverted Document 1'}],
-      })
+      return of({documents: [revisionDocument('doc1', 't1_doc1')]})
     })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([revisionDocument('doc1', 't1_doc1')])
+    expect(states.unresolvedDocumentIds).toEqual(['doc2'])
+    expect(states.states[1]).toMatchObject({type: 'unresolved', reason: 'request-failed'})
+  })
+
+  it('marks every document unresolved when the bulk request fails, without per-document retries', async () => {
+    mockTranslog({
+      bulk: () => Promise.reject(new Error('403 Forbidden')),
+      perDocument: (documentId) => Promise.resolve([transaction(`t1_${documentId}`, [documentId])]),
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments).toEqual([])
+    expect(states.unresolvedDocumentIds).toEqual(['doc1', 'doc2'])
+    expect(mockGetTransactionsLogs).toHaveBeenCalledTimes(1)
+    expect(mockClient.observable.request).not.toHaveBeenCalled()
+  })
+
+  it('runs every history request through the studio error handler as a retryable read', async () => {
+    const attempt = vi.fn(passthroughErrorHandler.attempt)
+    mockUseStudioErrorHandler.mockReturnValue({
+      ...passthroughErrorHandler,
+      attempt: attempt as StudioErrorHandler['attempt'],
+    })
+    mockTranslog({
+      bulk: () => Promise.resolve([transaction('t1_doc1', ['doc1'])]),
+      perDocument: (documentId) => Promise.resolve([transaction(`t1_${documentId}`, [documentId])]),
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.unresolvedDocumentIds).toEqual([])
+    // bulk translog + doc2 translog + two revision fetches
+    expect(attempt).toHaveBeenCalledTimes(4)
+    for (const call of attempt.mock.calls) {
+      expect(call[1]).toEqual({retryable: true})
+    }
+  })
+
+  it('stays in the resolving state while the studio error handler holds a claimed request', async () => {
+    // A claimed error (network, 5xx, 429) parks the request behind the studio dialog: the
+    // returned promise stays pending until "Try again" succeeds, so nothing resolves here.
+    const parked: StudioErrorHandler = {
+      ...passthroughErrorHandler,
+      attempt: () => new Promise(() => {}),
+    }
+    mockUseStudioErrorHandler.mockReturnValue(parked)
+    mockTranslog({bulk: () => Promise.reject(new Error('network error'))})
 
     const {result} = renderHook(() => useDocumentRevertStates(mockDocuments))
+    await new Promise((resolve) => setTimeout(resolve, 20))
 
-    await waitFor(async () => {
-      const resolvedResult = await result.current()
-      // The revert must account for every document in the release: a document whose previous
-      // revision could not be fetched may not be left out of the revert release unnoticed.
-      expect(resolvedResult).toHaveLength(2)
+    expect(result.current).toBeNull()
+  })
+
+  it('keeps release order even when documents resolve out of order', async () => {
+    mockTranslog({
+      bulk: () =>
+        Promise.resolve([transaction('t1_doc1', ['doc1']), transaction('t1_doc2', ['doc2'])]),
     })
+    mockClient.observable.request.mockImplementation(({url}) => {
+      if (url!.includes('doc1')) {
+        return of({documents: [revisionDocument('doc1', 't1_doc1')]}).pipe(delay(20))
+      }
+      return of({documents: [revisionDocument('doc2', 't1_doc2')]})
+    })
+
+    const states = await resolveStates(mockDocuments)
+
+    expect(states.revertDocuments.map((doc) => doc._id)).toEqual(['doc1', 'doc2'])
+  })
+
+  it('resolves to an empty state without requests when the release has no documents', async () => {
+    const states = await resolveStates([])
+
+    expect(states).toEqual({
+      states: [],
+      revertDocuments: [],
+      revertCount: 0,
+      unpublishCount: 0,
+      unresolvedDocumentIds: [],
+    })
+    expect(mockGetTransactionsLogs).not.toHaveBeenCalled()
+    expect(mockClient.observable.request).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
@@ -1,12 +1,16 @@
-import {type SanityDocument} from '@sanity/types'
-import {useCallback, useEffect, useMemo, useRef} from 'react'
-import {useSyncObservable} from 'react-rx'
-import {catchError, forkJoin, from, map, type Observable, of, switchMap} from 'rxjs'
+import {
+  type MendozaPatch,
+  type SanityDocument,
+  type TransactionLogEventWithEffects,
+} from '@sanity/types'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, defer, from, map, mergeMap, type Observable, of, startWith, toArray} from 'rxjs'
 
 import {useClient} from '../../../../../hooks/useClient'
 import {getTransactionsLogs} from '../../../../../store/translog/getTransactionsLogs'
+import {useStudioErrorHandler} from '../../../../../studio/requestErrors/useStudioErrorHandler'
 import {getPublishedId} from '../../../../../util/draftUtils'
-import {promiseWithResolvers} from '../../../../../util/promiseWithResolvers'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../../../util/releasesClient'
 import {type DocumentInRelease} from '../../../detail/types'
 
@@ -16,125 +20,366 @@ export type RevertDocument = SanityDocument & {
   }
 }
 
-type RevertDocuments = RevertDocument[]
+/**
+ * How a single document in a published release should be reverted.
+ *
+ * - `revert`: the document existed before the release; `document` is its last published
+ *   revision from before the release publish, fetched from the history API.
+ * - `unpublish`: the document did not exist right before the release was published. Proven from
+ *   mendoza effects in the transaction log, never assumed: either the publish transaction created
+ *   it, or its last pre-release transaction deleted it. Reverting means unpublishing it.
+ * - `unresolved`: no safe revert target is known. `request-failed` means a history request failed
+ *   with an error the studio's request-error handler did not claim; `history-unavailable` means
+ *   the history needed to decide is gone (retention), so retrying will not help. The revert must
+ *   not proceed while any document is unresolved.
+ */
+export type DocumentRevertState =
+  | {documentId: string; type: 'revert'; document: RevertDocument}
+  | {documentId: string; type: 'unpublish'; document: RevertDocument}
+  | {
+      documentId: string
+      type: 'unresolved'
+      reason: 'request-failed' | 'history-unavailable'
+      error?: unknown
+    }
 
-type DocumentRevertStates = RevertDocuments | null | undefined
+export interface DocumentRevertStates {
+  states: DocumentRevertState[]
+  /** Documents to write into the revert release, in release order. Excludes unresolved documents. */
+  revertDocuments: RevertDocument[]
+  revertCount: number
+  unpublishCount: number
+  unresolvedDocumentIds: string[]
+}
 
-export const useDocumentRevertStates = (releaseDocuments: DocumentInRelease[]) => {
+/**
+ * Upper bound per bulk translog request. The window is shared across the documents in the request,
+ * so any document whose newest pre-release transaction falls outside it is resolved individually
+ * instead. Content is excluded, so entries are small.
+ */
+const BULK_TRANSLOG_LIMIT = 1000
+
+/**
+ * Character budget for the comma-joined document ids of one bulk translog request. Ids go into the
+ * URL path, and Sanity ids can be up to 128 characters, so a fixed count is not enough to keep a
+ * large release under common proxy URL limits (8 KB); the budget leaves room for host, path and
+ * query.
+ */
+const BULK_TRANSLOG_IDS_CHAR_BUDGET = 6000
+
+/**
+ * The history endpoint is not CDN-cached and counts fully against the per-IP rate limit; ten
+ * concurrent requests is the highest that has been observed not to trigger 429s.
+ */
+const HISTORY_CONCURRENCY = 10
+
+const EMPTY_STATES: DocumentRevertStates = {
+  states: [],
+  revertDocuments: [],
+  revertCount: 0,
+  unpublishCount: 0,
+  unresolvedDocumentIds: [],
+}
+
+/**
+ * A mendoza patch that maps a document to nothing. As the `apply` of an effect it means the
+ * transaction deleted the document; as the `revert` it means the document did not exist before
+ * the transaction, i.e. the transaction created it. Same rule as the events store's
+ * `getEffectState`.
+ */
+function isDeletePatch(patch: MendozaPatch | undefined): boolean {
+  return patch !== undefined && patch[0] === 0 && patch[1] === null
+}
+
+/** Greedily packs ids into chunks whose comma-joined length stays within `maxChars`. */
+function chunkIdsByLength(ids: string[], maxChars: number): string[][] {
+  const chunks: string[][] = []
+  let current: string[] = []
+  let currentLength = 0
+  for (const id of ids) {
+    const added = current.length ? id.length + 1 : id.length
+    if (current.length && currentLength + added > maxChars) {
+      chunks.push(current)
+      current = []
+      currentLength = 0
+    }
+    current.push(id)
+    currentLength += current.length === 1 ? id.length : id.length + 1
+  }
+  if (current.length) chunks.push(current)
+  return chunks
+}
+
+interface BulkChunk {
+  /** The document ids this chunk was requested for */
+  ids: string[]
+  /** The chunk's response, newest transaction first */
+  transactions: TransactionLogEventWithEffects[]
+}
+
+interface BulkIndex {
+  newestPreRelease: Map<string, TransactionLogEventWithEffects>
+  publish: Map<string, TransactionLogEventWithEffects>
+}
+
+/**
+ * Indexes the bulk responses once so per-document resolution is a map lookup: the newest
+ * pre-release transaction per document, and the publish transaction per document it carries an
+ * effect for. A transaction can touch documents in several chunks and so appear in several
+ * responses, and chunks complete in any order, so each response is only trusted for the ids it
+ * was requested for; within a response, first occurrence is newest.
+ */
+function indexBulkChunks(chunks: BulkChunk[], publishTransactionId: string | undefined): BulkIndex {
+  const newestPreRelease = new Map<string, TransactionLogEventWithEffects>()
+  const publish = new Map<string, TransactionLogEventWithEffects>()
+  for (const {ids, transactions} of chunks) {
+    const requested = new Set(ids)
+    for (const transaction of transactions) {
+      if (transaction.id === publishTransactionId) {
+        for (const documentId of Object.keys(transaction.effects)) {
+          if (requested.has(documentId) && !publish.has(documentId)) {
+            publish.set(documentId, transaction)
+          }
+        }
+        continue
+      }
+      for (const documentId of transaction.documentIDs) {
+        if (requested.has(documentId) && !newestPreRelease.has(documentId)) {
+          newestPreRelease.set(documentId, transaction)
+        }
+      }
+    }
+  }
+  return {newestPreRelease, publish}
+}
+
+function aggregateStates(states: DocumentRevertState[]): DocumentRevertStates {
+  return states.reduce<DocumentRevertStates>(
+    (acc, state) => {
+      if (state.type === 'unresolved') {
+        acc.unresolvedDocumentIds.push(state.documentId)
+        return acc
+      }
+      acc.revertDocuments.push(state.document)
+      if (state.type === 'revert') acc.revertCount += 1
+      else acc.unpublishCount += 1
+      return acc
+    },
+    {states, revertDocuments: [], revertCount: 0, unpublishCount: 0, unresolvedDocumentIds: []},
+  )
+}
+
+function toUnpublishState(document: DocumentInRelease['document']): DocumentRevertState {
+  const {
+    publishedDocumentExists: _publishedDocumentExists,
+    draftDocumentExists: _draftDocumentExists,
+    ...unpublishDocument
+  } = document
+  return {
+    documentId: document._id,
+    type: 'unpublish',
+    document: {...unpublishDocument, _system: {delete: true}} as RevertDocument,
+  }
+}
+
+function historyUnavailable(documentId: string, message: string): DocumentRevertState {
+  return {documentId, type: 'unresolved', reason: 'history-unavailable', error: new Error(message)}
+}
+
+/**
+ * Resolves, for each document in a published release, the state to revert it to.
+ *
+ * Returns `null` while resolving, then a {@link DocumentRevertStates}.
+ *
+ * Every history request goes through the studio's request-error handler as a retryable read.
+ * Translog requests surface non-OK responses as `@sanity/client` `HttpError`s (see
+ * `getJsonStream`) and revision fetches go through the client, so network failures, 5xx responses
+ * and rate limiting on any of them surface the studio's error dialog, whose "Try again" re-runs the
+ * request; the hook simply stays in the resolving state meanwhile. Errors the handler does not
+ * claim (other 4xx, parse errors) mark the affected document unresolved rather than being dropped
+ * or turned into an unpublish action, so callers can refuse to revert until every document has a
+ * known target.
+ */
+export const useDocumentRevertStates = (
+  releaseDocuments: DocumentInRelease[],
+): DocumentRevertStates | null => {
   const client = useClient(RELEASES_STUDIO_CLIENT_OPTIONS)
   const observableClient = client.observable
-  const transactionId = releaseDocuments[0]?.document._rev
+  const errorHandler = useStudioErrorHandler()
+  const publishTransactionId = releaseDocuments[0]?.document._rev
   const {dataset} = client.config()
 
-  const resultPromiseRef = useRef<Promise<DocumentRevertStates> | null>(null)
-  const resolvedDocumentRevertStatesPromiseRef = useRef<
-    ((value: DocumentRevertStates) => void) | null
-  >(null)
-  const resolvedDocumentRevertStatesResultRef = useRef<DocumentRevertStates | null>(null)
-
-  useEffect(() => {
-    if (!resultPromiseRef.current) {
-      const {promise, resolve} = promiseWithResolvers<DocumentRevertStates>()
-
-      resultPromiseRef.current = promise
-      resolvedDocumentRevertStatesPromiseRef.current = resolve
-    }
-  }, [])
-
-  const memoDocumentRevertStates = useMemo(() => {
-    if (!releaseDocuments.length) return of(undefined)
+  const documentRevertStates$ = useMemo((): Observable<DocumentRevertStates | null> => {
+    if (!releaseDocuments.length) return of(EMPTY_STATES)
 
     const publishedDocuments = releaseDocuments.map(({document}) => ({
       ...document,
       _id: getPublishedId(document._id),
     }))
+    const publishedIds = publishedDocuments.map((document) => document._id)
 
-    const documentRevertStates$: Observable<RevertDocuments | null | undefined> = from(
-      getTransactionsLogs(
-        client,
-        publishedDocuments.map((document) => document._id),
-        {
-          toTransaction: transactionId,
-          // reverse order so most recent publish before release is second element
-          // (first is the release publish itself)
-          reverse: true,
-        },
-      ),
+    // History reads are idempotent, so the studio dialog may re-run them. `defer` keeps the
+    // request from firing until subscription, since `attempt()` runs its thunk immediately.
+    const request = <T>(thunk: () => PromiseLike<T> | Observable<T>): Observable<T> =>
+      defer(() => from(errorHandler.attempt(thunk, {retryable: true})))
+
+    // The release publish transaction itself is never a revert target. Filtering by id rather
+    // than position keeps this correct whether or not the API includes `toTransaction`.
+    const isPreReleaseTransaction = (transaction: TransactionLogEventWithEffects) =>
+      transaction.id !== publishTransactionId
+
+    // Bulk requests covering all documents in chunks; most recent first within each chunk.
+    // Documents not represented are looked up individually below, so a truncated response only
+    // costs extra requests, never a wrong answer. An unclaimed bulk failure is not retried per
+    // document; it falls through to the pipeline-level handler, which marks every document
+    // unresolved.
+    const bulkTransactions$ = from(
+      chunkIdsByLength(publishedIds, BULK_TRANSLOG_IDS_CHAR_BUDGET),
     ).pipe(
-      map((transactions) => {
-        const getDocumentTransaction = (docId: string) =>
-          transactions.find(({documentIDs}) => documentIDs.includes(docId))?.id
-
-        return publishedDocuments.map((document) => ({
-          docId: document._id,
-          revisionId: getDocumentTransaction(document._id),
-        }))
-      }),
-      switchMap((docRevisionPairs) => {
-        if (!docRevisionPairs) return of(undefined)
-
-        return forkJoin(
-          docRevisionPairs.map(({docId, revisionId}) => {
-            if (!revisionId) {
-              const {publishedDocumentExists, ...unpublishDocument} =
-                publishedDocuments.find((document) => document._id === docId) || {}
-
-              return of({
-                ...unpublishDocument,
-                _system: {delete: true},
-              } as RevertDocument)
-            }
-
-            return observableClient
-              .request<{
-                documents: RevertDocuments
-              }>({
-                url: `/data/history/${dataset}/documents/${docId}?revision=${revisionId}`,
-              })
-              .pipe(
-                map(({documents: [revertDocument]}) => revertDocument),
-                catchError((err) => {
-                  console.error(`Error fetching document ${docId}:`, err)
-                  return of(undefined)
-                }),
-              )
-          }),
-        )
-      }),
-      map((results) => results?.filter((result) => result !== undefined)),
-      catchError((err) => {
-        console.error('Error in document revert states pipeline:', err)
-        return of(undefined)
-      }),
+      mergeMap(
+        (ids) =>
+          request(() =>
+            getTransactionsLogs(client, ids, {
+              toTransaction: publishTransactionId,
+              reverse: true,
+              limit: BULK_TRANSLOG_LIMIT,
+              effectFormat: 'mendoza',
+            }),
+          ).pipe(map((transactions): BulkChunk => ({ids, transactions}))),
+        2,
+      ),
+      toArray(),
+      map((chunks) => indexBulkChunks(chunks, publishTransactionId)),
     )
 
-    return documentRevertStates$
-  }, [client, releaseDocuments, transactionId, observableClient, dataset])
+    // The newest transaction touching the document before the release publish, if any.
+    const findPreReleaseTransaction = (
+      documentId: string,
+      bulk: BulkIndex,
+    ): Observable<TransactionLogEventWithEffects | undefined> => {
+      const fromBulk = bulk.newestPreRelease.get(documentId)
+      if (fromBulk) return of(fromBulk)
 
-  // Kept synchronous: the effect below resolves an imperative promise/ref with
-  // this value for the revert action, so a deferred snapshot could delay the
-  // resolution or hand the action a stale revert state.
-  const documentRevertStatesResult = useSyncObservable(memoDocumentRevertStates, null)
-
-  useEffect(() => {
-    if (documentRevertStatesResult !== null) {
-      resolvedDocumentRevertStatesResultRef.current = documentRevertStatesResult
-
-      // Resolve promise if it exists
-      if (resolvedDocumentRevertStatesPromiseRef.current) {
-        resolvedDocumentRevertStatesPromiseRef.current(documentRevertStatesResult)
-        resolvedDocumentRevertStatesPromiseRef.current = null
-        resultPromiseRef.current = null // Reset resultPromiseRef for future fetches
-      }
-    }
-  }, [documentRevertStatesResult])
-
-  return useCallback(() => {
-    if (resolvedDocumentRevertStatesResultRef.current) {
-      // Return resolved value immediately if available
-      return Promise.resolve(resolvedDocumentRevertStatesResultRef.current)
+      return request(() =>
+        getTransactionsLogs(client, documentId, {
+          toTransaction: publishTransactionId,
+          reverse: true,
+          // the publish transaction may be included; one more entry is enough to see past it
+          limit: 2,
+          effectFormat: 'mendoza',
+        }),
+      ).pipe(map((transactions) => transactions.find(isPreReleaseTransaction)))
     }
 
-    return resultPromiseRef.current
-  }, [])
+    // The publish transaction's effect on the document is the only proof that the release created
+    // it. Taken from the bulk response when present, otherwise fetched for this document alone.
+    const findPublishTransaction = (
+      documentId: string,
+      bulk: BulkIndex,
+    ): Observable<TransactionLogEventWithEffects | undefined> => {
+      const fromBulk = bulk.publish.get(documentId)
+      if (fromBulk) return of(fromBulk)
+
+      return request(() =>
+        getTransactionsLogs(client, documentId, {
+          fromTransaction: publishTransactionId,
+          toTransaction: publishTransactionId,
+          limit: 1,
+          effectFormat: 'mendoza',
+        }),
+      ).pipe(
+        map((transactions) =>
+          transactions.find((transaction) => transaction.id === publishTransactionId),
+        ),
+      )
+    }
+
+    const resolveState = (
+      document: (typeof publishedDocuments)[number],
+      bulk: BulkIndex,
+    ): Observable<DocumentRevertState> => {
+      const documentId = document._id
+      return findPreReleaseTransaction(documentId, bulk).pipe(
+        mergeMap((transaction): Observable<DocumentRevertState> => {
+          if (!transaction) {
+            // Nothing before the publish in the log. Either the release created the document, or
+            // its older history has been pruned by retention. Only the publish transaction's
+            // effect can tell the two apart.
+            return findPublishTransaction(documentId, bulk).pipe(
+              map((publishTransaction) =>
+                isDeletePatch(publishTransaction?.effects[documentId]?.revert)
+                  ? toUnpublishState(document)
+                  : historyUnavailable(
+                      documentId,
+                      `No history before the release publish for document ${documentId}`,
+                    ),
+              ),
+            )
+          }
+
+          // The last thing that happened to the document before the release was a delete, so it
+          // did not exist when the release was published. No snapshot to fetch.
+          if (isDeletePatch(transaction.effects[documentId]?.apply)) {
+            return of(toUnpublishState(document))
+          }
+
+          return request(() =>
+            observableClient.request<{documents: RevertDocument[]}>({
+              url: `/data/history/${dataset}/documents/${documentId}?revision=${transaction.id}`,
+            }),
+          ).pipe(
+            map(({documents: [revertDocument]}): DocumentRevertState =>
+              revertDocument
+                ? {documentId, type: 'revert', document: revertDocument}
+                : // The transaction is in the log but its snapshot is not: history retention.
+                  historyUnavailable(
+                    documentId,
+                    `Revision ${transaction.id} of document ${documentId} is no longer available in history`,
+                  ),
+            ),
+          )
+        }),
+        catchError((error) =>
+          of<DocumentRevertState>({
+            documentId,
+            type: 'unresolved',
+            reason: 'request-failed',
+            error,
+          }),
+        ),
+      )
+    }
+
+    return bulkTransactions$.pipe(
+      mergeMap((bulk) =>
+        from(publishedDocuments).pipe(
+          mergeMap(
+            (document, index) =>
+              resolveState(document, bulk).pipe(map((state) => ({index, state}))),
+            HISTORY_CONCURRENCY,
+          ),
+          toArray(),
+          map((indexed) => indexed.sort((a, b) => a.index - b.index).map(({state}) => state)),
+        ),
+      ),
+      map(aggregateStates),
+      catchError((error) =>
+        of(
+          aggregateStates(
+            publishedIds.map((documentId): DocumentRevertState => ({
+              documentId,
+              type: 'unresolved',
+              reason: 'request-failed',
+              error,
+            })),
+          ),
+        ),
+      ),
+      // Not redundant with the `useObservable` initial value: it resets the hook to the resolving
+      // state when `releaseDocuments` changes and a new pipeline replaces a resolved one.
+      startWith(null),
+    )
+  }, [client, releaseDocuments, publishTransactionId, observableClient, dataset, errorHandler])
+
+  return useObservable(documentRevertStates$, null)
 }

--- a/packages/sanity/src/core/store/events/getJsonStream.test.ts
+++ b/packages/sanity/src/core/store/events/getJsonStream.test.ts
@@ -1,0 +1,73 @@
+import {ClientError, isHttpError, ServerError} from '@sanity/client'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {getJsonStream} from './getJsonStream'
+
+const URL = 'https://test.api.sanity.test/v1/data/history/test/transactions/doc1'
+
+async function readAll<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader()
+  const items: T[] = []
+  for (;;) {
+    const result = await reader.read()
+    if (result.done) return items
+    items.push(result.value)
+  }
+}
+
+describe('getJsonStream', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('streams NDJSON entries from an OK response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('{"id":"tx1"}\n{"id":"tx2"}\n', {
+          headers: {'content-type': 'application/x-ndjson'},
+        }),
+      ),
+    )
+
+    expect(await readAll(await getJsonStream(URL, 'token'))).toEqual([{id: 'tx1'}, {id: 'tx2'}])
+  })
+
+  it('throws a client HttpError for a 429, carrying the status, headers and API message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({error: {type: 'rateLimitError', description: 'Too many requests'}}),
+            {status: 429, headers: {'content-type': 'application/json', 'retry-after': '7'}},
+          ),
+        ),
+    )
+
+    const error = await getJsonStream(URL, 'token').catch((err) => err)
+
+    expect(error).toBeInstanceOf(ClientError)
+    expect(isHttpError(error)).toBe(true)
+    expect(error).toMatchObject({
+      statusCode: 429,
+      message: 'Too many requests',
+      response: {headers: {'retry-after': '7'}, url: URL, method: 'GET'},
+    })
+  })
+
+  it('throws a ServerError for a 5xx response without a JSON body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('upstream unavailable', {status: 503})),
+    )
+
+    const error = await getJsonStream(URL, undefined).catch((err) => err)
+
+    expect(error).toBeInstanceOf(ServerError)
+    expect(isHttpError(error)).toBe(true)
+    expect(error.statusCode).toBe(503)
+    expect(error.message).toContain('HTTP 503')
+  })
+})

--- a/packages/sanity/src/core/store/events/getJsonStream.ts
+++ b/packages/sanity/src/core/store/events/getJsonStream.ts
@@ -1,3 +1,4 @@
+import {ClientError, ServerError} from '@sanity/client'
 import {
   type TransactionLogEventWithMutations,
   type TransactionLogEventWithEffects,
@@ -17,7 +18,37 @@ export async function getJsonStream(
     ? {headers: {...DEFAULT_STUDIO_CLIENT_HEADERS, Authorization: `Bearer ${token}`}}
     : {credentials: 'include', headers: DEFAULT_STUDIO_CLIENT_HEADERS}
   const response = await fetch(url, options)
+  if (!response.ok) {
+    throw await toHttpError(response, url)
+  }
   return getStream(response)
+}
+
+/**
+ * Builds the same error `@sanity/client` throws for a non-OK response, so callers (and the studio's
+ * request-error handler, which only claims `HttpError`s) can treat translog failures like any other
+ * API failure: `statusCode`, `response.headers` (e.g. `retry-after`) and the API's error message.
+ */
+async function toHttpError(response: Response, url: string): Promise<Error> {
+  const text = await response.text()
+  const headers = Object.fromEntries(response.headers.entries())
+  let body: unknown = text
+  if ((headers['content-type'] || '').includes('application/json')) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      // keep the raw text
+    }
+  }
+  const res = {
+    statusCode: response.status,
+    statusMessage: response.statusText,
+    headers,
+    body,
+    url,
+    method: 'GET',
+  }
+  return response.status >= 500 ? new ServerError(res) : new ClientError(res)
 }
 
 function getStream(response: Response): ReadableStream<StreamResult> {


### PR DESCRIPTION
### Description

Reverting a release fetched the previous revision of every document with one translog request, capped at 50 transactions. That cap was shared across the whole release, so on big or busy releases some documents fell outside the window. The code could not tell those apart from documents the release had created, so it unpublished them instead of restoring them. The same thing happened when a document's older history had been removed by retention.

Now a document is only unpublished when the transaction log proves it did not exist before the release, using the same mendoza check the events store uses. If the history cannot prove either way, the revert is blocked. Just raising the limit was not enough: any fixed limit has an edge, and past the edge the result is data loss.

History requests now go through `useStudioErrorHandler`. The translog endpoint did not use the client, so `getJsonStream` now throws the client's `HttpError` classes on non-OK responses. That is a separate commit because the timeline uses the same code.

### What to review

- The two mendoza checks in `useDocumentRevertStates.ts`, and whether blocking on everything else is the right call.
- `getJsonStream.ts`, since other translog consumers get the new error type too.

Known limitation, left for a follow-up: the publish boundary is still the first document's `_rev`. If that document was edited after publish, the boundary moves and revert targets are wrong, but never destructive.

### Testing

The tests in the first commit fail on `main`. The History API was checked against a live dataset and accepts a limit of 1000.

### Notes for release

Fixes reverting a Content Release with many documents, or documents with long or partly expired edit history, where some documents could be unpublished instead of restored. Reverting now restores every document to its pre-release revision, only unpublishes documents that did not exist before the release, and stops if any document's previous state cannot be determined.


---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes release revert data paths and when documents are unpublished; incorrect history resolution could still affect published content, and getJsonStream error behavior now applies to all translog consumers including the timeline.
> 
> **Overview**
> **Release revert** now resolves each document’s revert target up front (via a reactive hook) instead of fetching history only when the user confirms. Unpublishing happens only when transaction-log **mendoza** effects prove the doc did not exist before publish; ambiguous or missing history marks documents **unresolved** and **blocks** revert.
> 
> The resolver uses **chunked bulk translog** requests (higher limit, URL id budget), per-document fallbacks, bounded history concurrency, and **`useStudioErrorHandler`** on all reads. The confirm dialog shows loading, restore/unpublish counts, and separate errors for **pruned history** vs **failed requests**.
> 
> **`getJsonStream`** now throws `@sanity/client` **`HttpError`s** on non-OK responses (shared by translog/timeline). New i18n strings and broad unit tests cover the hook, button, and stream errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb6f2fcdc85ecde359f2fd716af7a955e0979b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->