### PR TITLE
refactor(sanity): move private internals from root export

### DIFF
--- a/.audit/private-sanity-internals.tsv
+++ b/.audit/private-sanity-internals.tsv
@@ -1,0 +1,3 @@
+ts	phase	decision	why	evidence	result
+2026-09-11T13:10:00Z	frame	measured the package root and counted its internal exports before changing the entry points	the migration needs a fixed baseline and a complete symbol inventory	/opt/cursor/artifacts/sanity_package_baseline_summary.log, /opt/cursor/artifacts/sanity_internal_exports_baseline.json	index.js 877.9 kB raw, 800 internal exports
+2026-09-11T13:12:00Z	harness	added signed-out and no-tools startup measurements	before-and-after browser measurements must use the same production Studio and readiness checks	commit a2d2cff580, /opt/cursor/artifacts/sanity_startup_baseline.json	signed-out 1806881 gzip bytes, no-tools 1821452 gzip bytes

--- a/dev/auth-test-studio/sanity.config.ts
+++ b/dev/auth-test-studio/sanity.config.ts
@@ -197,6 +197,14 @@ function createWorkspaces(env: {projectId: string; dataset: string; apiHost?: st
 export default defineConfig([
   ...envs.flatMap(createWorkspaces),
   {
+    ...production.ppsg7ml5,
+    name: `noTools`,
+    title: `No tools`,
+    basePath: `/ppsg7ml5/noTools`,
+    tools: [],
+    schema: {types: []},
+  } satisfies WorkspaceOptions,
+  {
     ...shared,
     ...production.ppsg7ml5,
     name: `noProviders`,

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "lint:fix": "pnpm chore:format:fix && pnpm chore:oxlint:fix",
     "lint:workflows": "if command -v zizmor >/dev/null 2>&1; then zizmor .github --min-severity high; else echo 'zizmor not found. Install it: https://docs.zizmor.sh/installation/'; exit 1; fi",
     "list:deps-updates": "npm-check-updates --workspaces --root -m",
+    "measure:sanity-startup": "tsx scripts/measureSanityStartup.ts",
     "normalize-pkgfields": "tsx scripts/normalizePackageFields.ts",
     "normalize:versions": "tsx scripts/normalizeDependencyVersions.ts",
     "perf:codegen": "cd perf/tests && pnpm perf:codegen",

--- a/packages/@repo/test-dts-exports/test/sanity-release-tags.test.ts
+++ b/packages/@repo/test-dts-exports/test/sanity-release-tags.test.ts
@@ -1,0 +1,56 @@
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import ts from 'typescript'
+import {expect, test} from 'vitest'
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../sanity')
+const configPath = path.join(packageDir, 'tsconfig.lib.json')
+const configFile = ts.readConfigFile(configPath, ts.sys.readFile)
+const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, packageDir)
+const program = ts.createProgram(parsedConfig.fileNames, parsedConfig.options)
+const checker = program.getTypeChecker()
+
+test('the sanity root has no @internal exports', () => {
+  expect(getInternalExports('src/_exports/index.ts')).toEqual([])
+})
+
+test('the private internals entry only has @internal exports', () => {
+  const exports = getExportSymbols(
+    'src/_exports/_dangerously_use_private_internals_that_do_not_follow_semver.ts',
+  )
+  expect(exports.length).toBeGreaterThan(0)
+  expect(exports.filter(({target}) => !hasInternalTag(target)).map(({name}) => name)).toEqual([])
+})
+
+function getInternalExports(relativePath: string): string[] {
+  return getExportSymbols(relativePath)
+    .filter(({target}) => hasInternalTag(target))
+    .map(({name}) => name)
+    .toSorted()
+}
+
+function getExportSymbols(relativePath: string): {name: string; target: ts.Symbol}[] {
+  const sourceFile = program.getSourceFile(path.join(packageDir, relativePath))
+  if (!sourceFile) {
+    throw new Error(`Could not load ${relativePath}`)
+  }
+
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile)
+  if (!moduleSymbol) {
+    throw new Error(`Could not resolve exports from ${relativePath}`)
+  }
+
+  return checker.getExportsOfModule(moduleSymbol).map((symbol) => ({
+    name: symbol.name,
+    target: resolveAlias(symbol),
+  }))
+}
+
+function hasInternalTag(symbol: ts.Symbol): boolean {
+  return symbol.getJsDocTags(checker).some((tag) => tag.name === 'internal')
+}
+
+function resolveAlias(symbol: ts.Symbol): ts.Symbol {
+  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+}

--- a/scripts/measureSanityStartup.ts
+++ b/scripts/measureSanityStartup.ts
@@ -1,0 +1,140 @@
+import {createReadStream} from 'node:fs'
+import {readFile, stat} from 'node:fs/promises'
+import {createServer} from 'node:http'
+import path from 'node:path'
+import process from 'node:process'
+import {gzipSync} from 'node:zlib'
+
+import {chromium, type Page} from 'playwright'
+
+type StartupState = 'no-tools' | 'signed-out'
+
+interface ChunkMeasurement {
+  gzipBytes: number
+  path: string
+  rawBytes: number
+}
+
+interface StartupMeasurement {
+  chunkCount: number
+  chunks: ChunkMeasurement[]
+  gzipBytes: number
+  rawBytes: number
+  state: StartupState
+}
+
+const distDir = path.resolve(process.argv[2] ?? 'dev/auth-test-studio/dist')
+const port = Number(process.env.SANITY_STARTUP_MEASURE_PORT ?? 3333)
+const origin = `http://localhost:${port}`
+const workspacePath = '/ppsg7ml5/noTools'
+const server = createStaticServer(distDir)
+
+await new Promise<void>((resolve, reject) => {
+  server.once('error', reject)
+  server.listen(port, resolve)
+})
+
+try {
+  const browser = await chromium.launch({
+    executablePath: process.env.CHROME_PATH ?? '/usr/bin/google-chrome',
+    headless: true,
+  })
+
+  try {
+    const signedOut = await measureState(await browser.newPage(), 'signed-out')
+    const token = process.env.STUDIO_AUTH_TOKEN
+    if (!token) {
+      throw new Error('STUDIO_AUTH_TOKEN is required to measure the no-tools state')
+    }
+    const noTools = await measureState(await browser.newPage(), 'no-tools', token)
+    process.stdout.write(
+      `${JSON.stringify({distDir, measurements: [signedOut, noTools]}, null, 2)}\n`,
+    )
+  } finally {
+    await browser.close()
+  }
+} finally {
+  server.close()
+}
+
+async function measureState(
+  page: Page,
+  state: StartupState,
+  token?: string,
+): Promise<StartupMeasurement> {
+  const hash = token ? `#token=${encodeURIComponent(token)}` : ''
+  await page.goto(`${origin}${workspacePath}${hash}`, {waitUntil: 'domcontentloaded'})
+
+  if (state === 'signed-out') {
+    await page.getByText('Choose login provider').waitFor()
+  } else {
+    await page.getByRole('heading', {name: 'No configured tools'}).waitFor()
+  }
+
+  await page.waitForTimeout(1_000)
+  const chunkPaths = await page.evaluate(() =>
+    performance
+      .getEntriesByType('resource')
+      .map((entry) => new URL(entry.name))
+      .filter((url) => url.origin === window.location.origin && /\.m?js$/.test(url.pathname))
+      .map((url) => url.pathname)
+      .toSorted(),
+  )
+  const chunks = await Promise.all(
+    [...new Set(chunkPaths)].map(async (chunkPath): Promise<ChunkMeasurement> => {
+      const contents = await readFile(path.join(distDir, chunkPath))
+      return {
+        gzipBytes: gzipSync(contents).byteLength,
+        path: chunkPath,
+        rawBytes: contents.byteLength,
+      }
+    }),
+  )
+
+  return {
+    chunkCount: chunks.length,
+    chunks,
+    gzipBytes: chunks.reduce((total, chunk) => total + chunk.gzipBytes, 0),
+    rawBytes: chunks.reduce((total, chunk) => total + chunk.rawBytes, 0),
+    state,
+  }
+}
+
+function createStaticServer(rootDir: string) {
+  return createServer(async (request, response) => {
+    const requestPath = new URL(request.url ?? '/', origin).pathname
+    const candidatePath = path.join(rootDir, requestPath)
+    const filePath = (await isFile(candidatePath))
+      ? candidatePath
+      : path.join(rootDir, 'index.html')
+    const extension = path.extname(filePath)
+    response.setHeader('Content-Type', contentType(extension))
+    createReadStream(filePath).pipe(response)
+  })
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile()
+  } catch {
+    return false
+  }
+}
+
+function contentType(extension: string): string {
+  switch (extension) {
+    case '.css':
+      return 'text/css'
+    case '.html':
+      return 'text/html'
+    case '.js':
+    case '.mjs':
+      return 'text/javascript'
+    case '.json':
+      return 'application/json'
+    case '.svg':
+      return 'image/svg+xml'
+    default:
+      return 'application/octet-stream'
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The `sanity` root entry exports 800 declarations tagged `@internal`. Because the package marks its entry barrels as side-effectful, those exports also increase the JavaScript reachable from the Studio boot path. This PR adds reproducible startup measurements and a release-tag gate before moving private declarations to an explicitly unsupported entry point.

### What to review

- The signed-out and no-tools measurement in `scripts/measureSanityStartup.ts`.
- The AST-based contract in `sanity-release-tags.test.ts`.
- The baseline decision trail in `.audit/private-sanity-internals.tsv`.
- The release-tag partition and package export changes are still in progress.

### Testing

The baseline production build loads 1,806,881 gzip bytes on the signed-out page and 1,821,452 gzip bytes on the no-tools page. The package analyzer reports an 877.9 kB raw `index.js` entry. The new release-tag test fails against the baseline with 800 internal root exports and a missing private entry, as intended.

### Notes for release

Internal APIs tagged `@internal` move from `sanity` to `sanity/_dangerously_use_private_internals_that_do_not_follow_semver`.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1ea2c77-e281-4203-b6d5-aef6c98b42b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1ea2c77-e281-4203-b6d5-aef6c98b42b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

