### PR TITLE
perf(preview): stream useValuePreview inputs through one subject

### DIFF
--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -1,0 +1,408 @@
+import {type SchemaType} from '@sanity/types'
+import {act, render} from '@testing-library/react'
+import {Observable, Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type PerspectiveStack} from '../../perspective/types'
+import {type ObserveForPreviewFn} from '../documentPreviewStore'
+import {type PreparedSnapshot} from '../types'
+import {useValuePreview} from '../useValuePreview'
+
+const observeForPreview = vi.fn<ObserveForPreviewFn>()
+const subscriptions = {active: 0, total: 0}
+
+vi.mock('../../store/datastores', () => ({
+  useDocumentPreviewStore: () => ({observeForPreview}),
+}))
+
+// Stable across renders, like the real context value.
+const DEFAULT_PERSPECTIVE = {perspectiveStack: ['drafts'], selectedVariantName: undefined}
+let currentPerspective: {perspectiveStack: PerspectiveStack; selectedVariantName?: string} =
+  DEFAULT_PERSPECTIVE
+vi.mock('../../perspective/usePerspective', () => ({
+  usePerspective: () => currentPerspective,
+}))
+
+const bookType = {name: 'book', jsonType: 'object', preview: {}} as unknown as SchemaType
+const authorType = {name: 'author', jsonType: 'object', preview: {}} as unknown as SchemaType
+
+interface Frame {
+  isLoading: boolean
+  title: unknown
+  error?: Error
+}
+
+type HookProps = Parameters<typeof useValuePreview>[0]
+
+function Harness({frames, ...props}: HookProps & {frames: Frame[]}) {
+  const state = useValuePreview(props)
+  frames.push({isLoading: state.isLoading, title: state.value?.title, error: state.error})
+  return null
+}
+
+/** Previews synchronously, with the title taken from the previewed value. */
+function previewTitle(): ObserveForPreviewFn {
+  return (value) =>
+    new Observable<PreparedSnapshot>((subscriber) => {
+      subscriptions.active++
+      subscriptions.total++
+      subscriber.next({snapshot: {title: (value as {title?: string}).title}})
+      return () => {
+        subscriptions.active--
+      }
+    })
+}
+
+/**
+ * Previews synchronously, with a title that records what was asked for: the previewed id, the keys
+ * of the previewed value, the perspective, the variant and the ordering.
+ */
+function previewRequest(): ObserveForPreviewFn {
+  return (value, _type, options) =>
+    new Observable<PreparedSnapshot>((subscriber) => {
+      subscriptions.active++
+      subscriptions.total++
+      subscriber.next({
+        snapshot: {
+          title: JSON.stringify({
+            id: (value as {_id?: string})._id,
+            keys: Object.keys(value).toSorted(),
+            perspective: options?.perspective,
+            variant: options?.variant,
+            ordering: options?.viewOptions?.ordering?.name,
+          }),
+        },
+      })
+      return () => {
+        subscriptions.active--
+      }
+    })
+}
+
+/** Previews asynchronously: each snapshot is delivered by pushing it into the returned subject. */
+function previewLater(): {observe: ObserveForPreviewFn; snapshots$: Subject<PreparedSnapshot>} {
+  const snapshots$ = new Subject<PreparedSnapshot>()
+  return {
+    snapshots$,
+    observe: () =>
+      new Observable<PreparedSnapshot>((subscriber) => {
+        subscriptions.active++
+        subscriptions.total++
+        const subscription = snapshots$.subscribe(subscriber)
+        return () => {
+          subscriptions.active--
+          subscription.unsubscribe()
+        }
+      }),
+  }
+}
+
+function requested(frame: Frame | undefined) {
+  return JSON.parse(frame?.title as string)
+}
+
+const IDLE_FRAME: Frame = {isLoading: false, title: undefined, error: undefined}
+const LOADING_FRAME: Frame = {isLoading: true, title: undefined, error: undefined}
+
+/** Every frame rendered since a switch is the loading state, and there is at least one. */
+function expectOnlyLoadingFrames(frames: Frame[]) {
+  expect(frames.length).toBeGreaterThan(0)
+  expect(frames).toEqual(frames.map(() => LOADING_FRAME))
+}
+
+/** Lets react-rx release the source of an observable that lost its last subscriber. */
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+describe('useValuePreview', () => {
+  beforeEach(() => {
+    subscriptions.active = 0
+    subscriptions.total = 0
+    currentPerspective = DEFAULT_PERSPECTIVE
+    observeForPreview.mockReset()
+    observeForPreview.mockImplementation(previewTitle())
+  })
+
+  it('previews the value', () => {
+    const frames: Frame[] = []
+    render(<Harness schemaType={bookType} value={{_id: 'a', title: 'one'}} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'one', error: undefined})
+  })
+
+  it('keeps one live preview across edits of the same document, without a loading frame', async () => {
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a', title: 'one'}} frames={frames} />,
+    )
+    const settled = frames.length
+
+    rerender(<Harness schemaType={bookType} value={{_id: 'a', title: 'two'}} frames={frames} />)
+    rerender(<Harness schemaType={bookType} value={{_id: 'a', title: 'three'}} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'three', error: undefined})
+    expect(frames.slice(settled).filter((frame) => frame.isLoading)).toEqual([])
+    await flush()
+    // one preview per distinct value, and only the latest one stays subscribed
+    expect(subscriptions).toEqual({active: 1, total: 3})
+  })
+
+  it('renders once for an edit that leaves the preview unchanged', () => {
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a', title: 'one'}} frames={frames} />,
+    )
+    const settled = frames.length
+
+    rerender(
+      <Harness schemaType={bookType} value={{_id: 'a', title: 'one', body: 'x'}} frames={frames} />,
+    )
+
+    expect(frames.slice(settled)).toEqual([{isLoading: false, title: 'one', error: undefined}])
+  })
+
+  it('previews an unchanged value once', async () => {
+    const value = {_id: 'a', title: 'one'}
+    const {rerender} = render(<Harness schemaType={bookType} value={value} frames={[]} />)
+    rerender(<Harness schemaType={bookType} value={value} frames={[]} />)
+    rerender(<Harness schemaType={bookType} value={value} frames={[]} />)
+
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 1})
+  })
+
+  it('previews an equal value built during render once', async () => {
+    const {rerender} = render(<Harness schemaType={bookType} value={{_id: 'a'}} frames={[]} />)
+    rerender(<Harness schemaType={bookType} value={{_id: 'a'}} frames={[]} />)
+    rerender(<Harness schemaType={bookType} value={{_id: 'a'}} frames={[]} />)
+
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 1})
+  })
+
+  it('keeps one live preview when the perspective stack is a new array every render', async () => {
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a'}} perspectiveStack={[]} frames={[]} />,
+    )
+    rerender(<Harness schemaType={bookType} value={{_id: 'a'}} perspectiveStack={[]} frames={[]} />)
+    rerender(<Harness schemaType={bookType} value={{_id: 'a'}} perspectiveStack={[]} frames={[]} />)
+
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 1})
+  })
+
+  it('shows the loading state for another document instead of the previous preview', async () => {
+    const {observe, snapshots$} = previewLater()
+    observeForPreview.mockImplementation(observe)
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness schemaType={bookType} value={{_id: 'a'}} frames={frames} />)
+    act(() => snapshots$.next({snapshot: {title: 'A'}}))
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'A', error: undefined})
+    const settled = frames.length
+
+    rerender(<Harness schemaType={bookType} value={{_id: 'b'}} frames={frames} />)
+    expectOnlyLoadingFrames(frames.slice(settled))
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 2})
+
+    act(() => snapshots$.next({snapshot: {title: 'B'}}))
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'B', error: undefined})
+  })
+
+  it('shows the loading state for another schema type', async () => {
+    const {observe, snapshots$} = previewLater()
+    observeForPreview.mockImplementation(observe)
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness schemaType={bookType} value={{_id: 'a'}} frames={frames} />)
+    act(() => snapshots$.next({snapshot: {title: 'as book'}}))
+    const settled = frames.length
+
+    rerender(<Harness schemaType={authorType} value={{_id: 'a'}} frames={frames} />)
+    expectOnlyLoadingFrames(frames.slice(settled))
+
+    act(() => snapshots$.next({snapshot: {title: 'as author'}}))
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'as author', error: undefined})
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 2})
+  })
+
+  it('updates the preview in place when the perspective changes', async () => {
+    observeForPreview.mockImplementation(previewRequest())
+    const frames: Frame[] = []
+    const {rerender} = render(<Harness schemaType={bookType} value={{_id: 'a'}} frames={frames} />)
+    expect(requested(frames.at(-1))).toEqual({id: 'a', keys: ['_id'], perspective: ['drafts']})
+    const settled = frames.length
+
+    currentPerspective = {perspectiveStack: ['rRelease', 'drafts'], selectedVariantName: 'nb'}
+    rerender(<Harness schemaType={bookType} value={{_id: 'a'}} frames={frames} />)
+
+    expect(requested(frames.at(-1))).toEqual({
+      id: 'a',
+      keys: ['_id'],
+      perspective: ['rRelease', 'drafts'],
+      variant: 'nb',
+    })
+    expect(frames.slice(settled).filter((frame) => frame.isLoading)).toEqual([])
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 2})
+  })
+
+  it('previews through the given perspective stack and variant only', () => {
+    observeForPreview.mockImplementation(previewRequest())
+    currentPerspective = {perspectiveStack: ['drafts'], selectedVariantName: 'nb'}
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'a'}}
+        perspectiveStack={['rRelease', 'drafts']}
+        frames={frames}
+      />,
+    )
+    expect(requested(frames.at(-1))).toEqual({
+      id: 'a',
+      keys: ['_id'],
+      perspective: ['rRelease', 'drafts'],
+    })
+
+    rerender(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'a'}}
+        perspectiveStack={['rRelease', 'drafts']}
+        variant="en"
+        frames={frames}
+      />,
+    )
+    expect(requested(frames.at(-1))).toEqual({
+      id: 'a',
+      keys: ['_id'],
+      perspective: ['rRelease', 'drafts'],
+      variant: 'en',
+    })
+  })
+
+  it('previews a version slated for unpublishing as its published document', () => {
+    observeForPreview.mockImplementation(previewRequest())
+    currentPerspective = {perspectiveStack: ['rRelease', 'drafts'], selectedVariantName: 'nb'}
+    const frames: Frame[] = []
+    render(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'versions.rRelease.a', _system: {delete: true}, title: 'gone'}}
+        frames={frames}
+      />,
+    )
+
+    expect(requested(frames.at(-1))).toEqual({id: 'a', keys: ['_id'], perspective: []})
+  })
+
+  it('re-previews with a new ordering', () => {
+    observeForPreview.mockImplementation(previewRequest())
+    const frames: Frame[] = []
+    const ordering = {
+      name: 'byTitle',
+      title: 'By title',
+      by: [{field: 'title', direction: 'asc' as const}],
+    }
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a'}} ordering={ordering} frames={frames} />,
+    )
+    expect(requested(frames.at(-1))).toEqual({
+      id: 'a',
+      keys: ['_id'],
+      perspective: ['drafts'],
+      ordering: 'byTitle',
+    })
+
+    rerender(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'a'}}
+        ordering={{...ordering, name: 'byYear'}}
+        frames={frames}
+      />,
+    )
+    expect(requested(frames.at(-1))).toEqual({
+      id: 'a',
+      keys: ['_id'],
+      perspective: ['drafts'],
+      ordering: 'byYear',
+    })
+  })
+
+  it('renders the idle state without previewing when disabled', () => {
+    const frames: Frame[] = []
+    render(<Harness schemaType={bookType} value={{_id: 'a'}} enabled={false} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual(IDLE_FRAME)
+    expect(subscriptions).toEqual({active: 0, total: 0})
+  })
+
+  it('renders the idle state without previewing when there is no schema type', () => {
+    const frames: Frame[] = []
+    render(<Harness schemaType={undefined} value={{_id: 'a'}} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual(IDLE_FRAME)
+    expect(subscriptions).toEqual({active: 0, total: 0})
+  })
+
+  it('renders the idle state without previewing when there is no value', () => {
+    const frames: Frame[] = []
+    render(<Harness schemaType={bookType} value={undefined} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual(IDLE_FRAME)
+    expect(subscriptions).toEqual({active: 0, total: 0})
+  })
+
+  it('drops back to the idle state and releases the preview when the value is removed', async () => {
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a', title: 'one'}} frames={frames} />,
+    )
+    expect(subscriptions).toEqual({active: 1, total: 1})
+
+    rerender(<Harness schemaType={bookType} value={undefined} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual(IDLE_FRAME)
+    await flush()
+    expect(subscriptions).toEqual({active: 0, total: 1})
+  })
+
+  it('releases the preview when disabled', async () => {
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a', title: 'one'}} frames={frames} />,
+    )
+
+    rerender(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'a', title: 'one'}}
+        enabled={false}
+        frames={frames}
+      />,
+    )
+
+    expect(frames.at(-1)).toEqual(IDLE_FRAME)
+    await flush()
+    expect(subscriptions).toEqual({active: 0, total: 1})
+  })
+
+  it('surfaces a preview error', () => {
+    const error = new Error('boom')
+    observeForPreview.mockImplementation(
+      () =>
+        new Observable<PreparedSnapshot>((subscriber) => {
+          subscriber.error(error)
+        }),
+    )
+    const frames: Frame[] = []
+    render(<Harness schemaType={bookType} value={{_id: 'a'}} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual({isLoading: false, title: undefined, error})
+  })
+})

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -332,6 +332,29 @@ describe('useValuePreview', () => {
     expect(frames.at(-1)).toEqual({isLoading: false, title: 'from b', error: undefined})
   })
 
+  it('shows the loading state when a document turns into a version slated for unpublishing', () => {
+    const {observe, snapshots$} = previewLater()
+    observeForPreview.mockImplementation(observe)
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a', title: 'draft'}} frames={frames} />,
+    )
+    act(() => snapshots$.next({snapshot: {title: 'draft'}}))
+    const settled = frames.length
+
+    rerender(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'versions.rRelease.a', _system: {delete: true}}}
+        frames={frames}
+      />,
+    )
+    expectOnlyLoadingFrames(frames.slice(settled))
+
+    act(() => snapshots$.next({snapshot: {title: 'published'}}))
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'published', error: undefined})
+  })
+
   it('previews a version slated for unpublishing as its published document', () => {
     observeForPreview.mockImplementation(previewRequest())
     currentPerspective = {perspectiveStack: ['rRelease', 'drafts'], selectedVariantName: 'nb'}

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -1,5 +1,6 @@
 import {type SchemaType} from '@sanity/types'
 import {act, render} from '@testing-library/react'
+import {StrictMode} from 'react'
 import {Observable, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -390,6 +391,50 @@ describe('useValuePreview', () => {
     expect(frames.at(-1)).toEqual(IDLE_FRAME)
     await flush()
     expect(subscriptions).toEqual({active: 0, total: 1})
+  })
+
+  it('previews the current value when re-enabled, not the one it was disabled with', () => {
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness schemaType={bookType} value={{_id: 'a', title: 'one'}} frames={frames} />,
+    )
+    rerender(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'a', title: 'two'}}
+        enabled={false}
+        frames={frames}
+      />,
+    )
+    expect(frames.at(-1)).toEqual(IDLE_FRAME)
+    const settled = frames.length
+
+    rerender(<Harness schemaType={bookType} value={{_id: 'a', title: 'three'}} frames={frames} />)
+
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'three', error: undefined})
+    expect(frames.slice(settled).map((frame) => frame.title)).not.toContain('two')
+  })
+
+  it('behaves the same under StrictMode', async () => {
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <StrictMode>
+        <Harness schemaType={bookType} value={{_id: 'a', title: 'one'}} frames={frames} />
+      </StrictMode>,
+    )
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'one', error: undefined})
+    const settled = frames.length
+
+    rerender(
+      <StrictMode>
+        <Harness schemaType={bookType} value={{_id: 'a', title: 'two'}} frames={frames} />
+      </StrictMode>,
+    )
+
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'two', error: undefined})
+    expect(frames.slice(settled).filter((frame) => frame.isLoading)).toEqual([])
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 2})
   })
 
   it('surfaces a preview error', () => {

--- a/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
+++ b/packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx
@@ -286,6 +286,52 @@ describe('useValuePreview', () => {
     })
   })
 
+  it('ignores a context perspective change when the caller selects the perspective', async () => {
+    observeForPreview.mockImplementation(previewRequest())
+    const frames: Frame[] = []
+    const {rerender} = render(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'a'}}
+        perspectiveStack={['rRelease', 'drafts']}
+        frames={frames}
+      />,
+    )
+    const settled = frames.length
+
+    currentPerspective = {perspectiveStack: ['rOther', 'drafts'], selectedVariantName: 'nb'}
+    rerender(
+      <Harness
+        schemaType={bookType}
+        value={{_id: 'a'}}
+        perspectiveStack={['rRelease', 'drafts']}
+        frames={frames}
+      />,
+    )
+
+    expect(frames.slice(settled)).toEqual([frames[settled - 1]])
+    await flush()
+    expect(subscriptions).toEqual({active: 1, total: 1})
+  })
+
+  it('shows the loading state when a cross-dataset reference moves to another dataset', () => {
+    const {observe, snapshots$} = previewLater()
+    observeForPreview.mockImplementation(observe)
+    const frames: Frame[] = []
+    const reference = {_type: 'crossDatasetReference', _ref: 'x', _projectId: 'p', _dataset: 'a'}
+    const {rerender} = render(<Harness schemaType={bookType} value={reference} frames={frames} />)
+    act(() => snapshots$.next({snapshot: {title: 'from a'}}))
+    const settled = frames.length
+
+    rerender(
+      <Harness schemaType={bookType} value={{...reference, _dataset: 'b'}} frames={frames} />,
+    )
+    expectOnlyLoadingFrames(frames.slice(settled))
+
+    act(() => snapshots$.next({snapshot: {title: 'from b'}}))
+    expect(frames.at(-1)).toEqual({isLoading: false, title: 'from b', error: undefined})
+  })
+
   it('previews a version slated for unpublishing as its published document', () => {
     observeForPreview.mockImplementation(previewRequest())
     currentPerspective = {perspectiveStack: ['rRelease', 'drafts'], selectedVariantName: 'nb'}

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -47,14 +47,13 @@ const IDLE_STATE_OBSERVABLE = of(IDLE_STATE)
 /**
  * Everything the preview is derived from apart from the schema type and the identity of the
  * previewed document. These stream into the live preview observable, so a change updates the
- * preview in place instead of restarting the subscription.
+ * preview in place instead of restarting the subscription. The perspective and variant are the
+ * effective ones, so a context change a caller's own selection overrides never reaches the stream.
  */
 interface PreviewInputs {
   value: unknown
-  chosenPerspectiveStack: PerspectiveStack | undefined
-  perspectiveStack: PerspectiveStack
-  chosenVariant: string | undefined
-  selectedVariantName: string | undefined
+  perspective: PerspectiveStack
+  variant: string | undefined
   ordering: SortOrdering | undefined
 }
 
@@ -65,34 +64,29 @@ interface PreviewTarget {
 }
 
 /**
- * The id `observeForPreview` will observe for a value. A change means a different document is
- * being previewed, which restarts the preview so the previous document's preview is never shown
- * for the new one.
+ * Identifies the document `observeForPreview` will observe for a value. A change means a different
+ * document is being previewed, which restarts the preview so the previous document's preview is
+ * never shown for the new one. A cross-dataset reference is identified by its dataset as well.
  */
-function getPreviewDocumentId(value: unknown): string | undefined {
+function getPreviewDocumentKey(value: unknown): string | undefined {
   if (!value || typeof value !== 'object') return undefined
-  const document = value as SanityDocument & {_ref?: string}
+  const document = value as SanityDocument & {_ref?: string; _dataset?: string; _projectId?: string}
   if (isGoingToUnpublish(document)) return getPublishedId(document._id)
-  return document._id ?? document._ref
+  const id = document._id ?? document._ref
+  return document._dataset ? `${document._projectId}/${document._dataset}/${id}` : id
 }
 
 function resolvePreviewTarget(inputs: PreviewInputs): PreviewTarget | undefined {
-  const {value, chosenPerspectiveStack, perspectiveStack, chosenVariant, selectedVariantName} =
-    inputs
+  const {value, perspective, variant} = inputs
   if (!value) return undefined
 
   const document = value as SanityDocument
   // A document slated for unpublishing is previewed as its published version, which is outside
-  // of any variant. Otherwise the variant follows the perspective: only inherited from the
-  // context when the perspective is too.
+  // of any variant.
   if (isGoingToUnpublish(document)) {
     return {previewable: {_id: getPublishedId(document._id)}, perspective: [], variant: undefined}
   }
-  return {
-    previewable: {_id: document._id, ...(value as Previewable)},
-    perspective: chosenPerspectiveStack ?? perspectiveStack,
-    variant: chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName),
-  }
+  return {previewable: {_id: document._id, ...(value as Previewable)}, perspective, variant}
 }
 
 function isSameState(a: State, b: State): boolean {
@@ -135,11 +129,11 @@ function useInputsSubject(
   schemaType: SchemaType | undefined,
   inputs: PreviewInputs,
 ): BehaviorSubject<PreviewInputs> {
-  const documentId = getPreviewDocumentId(inputs.value)
+  const documentKey = getPreviewDocumentKey(inputs.value)
   const [current, setCurrent] = useState(() => ({
     enabled,
     schemaType,
-    documentId,
+    documentKey,
     inputs$: new BehaviorSubject(inputs),
   }))
 
@@ -147,10 +141,10 @@ function useInputsSubject(
   if (
     current.enabled !== enabled ||
     current.schemaType !== schemaType ||
-    current.documentId !== documentId
+    current.documentKey !== documentKey
   ) {
     inputs$ = new BehaviorSubject(inputs)
-    setCurrent({enabled, schemaType, documentId, inputs$})
+    setCurrent({enabled, schemaType, documentKey, inputs$})
   }
 
   useEffect(() => {
@@ -189,16 +183,12 @@ export function useValuePreview(props: {
   const {observeForPreview} = useDocumentPreviewStore()
   const {perspectiveStack, selectedVariantName} = usePerspective()
 
+  const perspective = chosenPerspectiveStack ?? perspectiveStack
+  // The variant follows the perspective: only inherited from the context when the perspective is too.
+  const variant = chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName)
   const inputs = useMemo<PreviewInputs>(
-    () => ({
-      value,
-      chosenPerspectiveStack,
-      perspectiveStack,
-      chosenVariant,
-      selectedVariantName,
-      ordering,
-    }),
-    [value, chosenPerspectiveStack, perspectiveStack, chosenVariant, selectedVariantName, ordering],
+    () => ({value, perspective, variant, ordering}),
+    [value, perspective, variant, ordering],
   )
   const inputs$ = useInputsSubject(enabled, schemaType, inputs)
 

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -66,12 +66,14 @@ interface PreviewTarget {
 /**
  * Identifies the document `observeForPreview` will observe for a value. A change means a different
  * document is being previewed, which restarts the preview so the previous document's preview is
- * never shown for the new one. A cross-dataset reference is identified by its dataset as well.
+ * never shown for the new one. A cross-dataset reference is identified by its dataset as well, and
+ * a version slated for unpublishing by its own key, so it never continues the published document's
+ * subscription.
  */
 function getPreviewDocumentKey(value: unknown): string | undefined {
   if (!value || typeof value !== 'object') return undefined
   const document = value as SanityDocument & {_ref?: string; _dataset?: string; _projectId?: string}
-  if (isGoingToUnpublish(document)) return getPublishedId(document._id)
+  if (isGoingToUnpublish(document)) return `unpublish:${getPublishedId(document._id)}`
   const id = document._id ?? document._ref
   return document._dataset ? `${document._projectId}/${document._dataset}/${id}` : id
 }

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -126,25 +126,31 @@ function createPreviewObservable(
 
 /**
  * A subject holding the latest inputs. It is replaced together with the observable that reads it,
- * whenever the schema type or the previewed document changes, and seeded with the current render's
- * inputs so the new observable never previews the previous document. Every other change is pushed
- * into the existing subject after commit.
+ * whenever `enabled`, the schema type or the previewed document changes, and seeded with the current
+ * render's inputs so the new observable never previews the inputs of an earlier render. Every other
+ * change is pushed into the existing subject after commit.
  */
 function useInputsSubject(
+  enabled: boolean,
   schemaType: SchemaType | undefined,
   inputs: PreviewInputs,
 ): BehaviorSubject<PreviewInputs> {
   const documentId = getPreviewDocumentId(inputs.value)
   const [current, setCurrent] = useState(() => ({
+    enabled,
     schemaType,
     documentId,
     inputs$: new BehaviorSubject(inputs),
   }))
 
   let {inputs$} = current
-  if (current.schemaType !== schemaType || current.documentId !== documentId) {
+  if (
+    current.enabled !== enabled ||
+    current.schemaType !== schemaType ||
+    current.documentId !== documentId
+  ) {
     inputs$ = new BehaviorSubject(inputs)
-    setCurrent({schemaType, documentId, inputs$})
+    setCurrent({enabled, schemaType, documentId, inputs$})
   }
 
   useEffect(() => {
@@ -194,7 +200,7 @@ export function useValuePreview(props: {
     }),
     [value, chosenPerspectiveStack, perspectiveStack, chosenVariant, selectedVariantName, ordering],
   )
-  const inputs$ = useInputsSubject(schemaType, inputs)
+  const inputs$ = useInputsSubject(enabled, schemaType, inputs)
 
   // Only `enabled`, the schema type and the previewed document change the observable's identity,
   // which is what restarts the subscription and renders the loading state. Everything else

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -4,16 +4,19 @@ import {
   type SchemaType,
   type SortOrdering,
 } from '@sanity/types'
-import {useMemo} from 'react'
+import {dequal} from 'dequal/lite'
+import {useEffect, useMemo, useState} from 'react'
+import isEqual from 'react-fast-compare'
 import {useSyncObservable} from 'react-rx'
-import {type Observable, of} from 'rxjs'
-import {catchError, map} from 'rxjs/operators'
+import {BehaviorSubject, type Observable, of} from 'rxjs'
+import {catchError, distinctUntilChanged, map, switchMap} from 'rxjs/operators'
 
 import {type PerspectiveStack} from '../perspective/types'
 import {usePerspective} from '../perspective/usePerspective'
 import {isGoingToUnpublish} from '../releases/util/isGoingToUnpublish'
 import {useDocumentPreviewStore} from '../store/datastores'
 import {getPublishedId} from '../util/draftUtils'
+import {type ObserveForPreviewFn} from './documentPreviewStore'
 import {type Previewable} from './types'
 
 /**
@@ -38,6 +41,119 @@ const IDLE_STATE: State = {
     description: undefined,
   },
 }
+
+const IDLE_STATE_OBSERVABLE = of(IDLE_STATE)
+
+/**
+ * Everything the preview is derived from apart from the schema type and the identity of the
+ * previewed document. These stream into the live preview observable, so a change updates the
+ * preview in place instead of restarting the subscription.
+ */
+interface PreviewInputs {
+  value: unknown
+  chosenPerspectiveStack: PerspectiveStack | undefined
+  perspectiveStack: PerspectiveStack
+  chosenVariant: string | undefined
+  selectedVariantName: string | undefined
+  ordering: SortOrdering | undefined
+}
+
+interface PreviewTarget {
+  previewable: Previewable
+  perspective: PerspectiveStack
+  variant: string | undefined
+}
+
+/**
+ * The id `observeForPreview` will observe for a value. A change means a different document is
+ * being previewed, which restarts the preview so the previous document's preview is never shown
+ * for the new one.
+ */
+function getPreviewDocumentId(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const document = value as SanityDocument & {_ref?: string}
+  if (isGoingToUnpublish(document)) return getPublishedId(document._id)
+  return document._id ?? document._ref
+}
+
+function resolvePreviewTarget(inputs: PreviewInputs): PreviewTarget | undefined {
+  const {value, chosenPerspectiveStack, perspectiveStack, chosenVariant, selectedVariantName} =
+    inputs
+  if (!value) return undefined
+
+  const document = value as SanityDocument
+  // A document slated for unpublishing is previewed as its published version, which is outside
+  // of any variant. Otherwise the variant follows the perspective: only inherited from the
+  // context when the perspective is too.
+  if (isGoingToUnpublish(document)) {
+    return {previewable: {_id: getPublishedId(document._id)}, perspective: [], variant: undefined}
+  }
+  return {
+    previewable: {_id: document._id, ...(value as Previewable)},
+    perspective: chosenPerspectiveStack ?? perspectiveStack,
+    variant: chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName),
+  }
+}
+
+function isSameState(a: State, b: State): boolean {
+  return a.isLoading === b.isLoading && a.error === b.error && isEqual(a.value, b.value)
+}
+
+function createPreviewObservable(
+  inputs$: Observable<PreviewInputs>,
+  schemaType: SchemaType,
+  observeForPreview: ObserveForPreviewFn,
+): Observable<State> {
+  return inputs$.pipe(
+    distinctUntilChanged(dequal),
+    switchMap((inputs) => {
+      const target = resolvePreviewTarget(inputs)
+      // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
+      if (!target) return IDLE_STATE_OBSERVABLE
+
+      return observeForPreview(target.previewable, schemaType, {
+        perspective: target.perspective,
+        variant: target.variant,
+        viewOptions: {ordering: inputs.ordering},
+      }).pipe(
+        map((event): State => ({isLoading: false, value: event.snapshot || undefined})),
+        catchError((error) => of<State>({isLoading: false, error})),
+      )
+    }),
+    distinctUntilChanged(isSameState),
+  )
+}
+
+/**
+ * A subject holding the latest inputs. It is replaced together with the observable that reads it,
+ * whenever the schema type or the previewed document changes, and seeded with the current render's
+ * inputs so the new observable never previews the previous document. Every other change is pushed
+ * into the existing subject after commit.
+ */
+function useInputsSubject(
+  schemaType: SchemaType | undefined,
+  inputs: PreviewInputs,
+): BehaviorSubject<PreviewInputs> {
+  const documentId = getPreviewDocumentId(inputs.value)
+  const [current, setCurrent] = useState(() => ({
+    schemaType,
+    documentId,
+    inputs$: new BehaviorSubject(inputs),
+  }))
+
+  let {inputs$} = current
+  if (current.schemaType !== schemaType || current.documentId !== documentId) {
+    inputs$ = new BehaviorSubject(inputs)
+    setCurrent({schemaType, documentId, inputs$})
+  }
+
+  useEffect(() => {
+    inputs$.next(inputs)
+  }, [inputs$, inputs])
+
+  return inputs$
+}
+
 /**
  * @internal
  */
@@ -60,63 +176,36 @@ export function useValuePreview(props: {
     enabled = true,
     ordering,
     schemaType,
-    value: previewValue,
+    value,
     perspectiveStack: chosenPerspectiveStack,
     variant: chosenVariant,
   } = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
   const {perspectiveStack, selectedVariantName} = usePerspective()
-  const observable = useMemo<Observable<State>>(() => {
-    // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
-    if (!enabled || !previewValue || !schemaType) return of(IDLE_STATE)
 
-    const goingToUnpublish = isGoingToUnpublish(previewValue as SanityDocument)
+  const inputs = useMemo<PreviewInputs>(
+    () => ({
+      value,
+      chosenPerspectiveStack,
+      perspectiveStack,
+      chosenVariant,
+      selectedVariantName,
+      ordering,
+    }),
+    [value, chosenPerspectiveStack, perspectiveStack, chosenVariant, selectedVariantName, ordering],
+  )
+  const inputs$ = useInputsSubject(schemaType, inputs)
 
-    const updatedStack = goingToUnpublish ? [] : (chosenPerspectiveStack ?? perspectiveStack)
-    // A document slated for unpublishing is previewed as its published version, which is outside
-    // of any variant. Otherwise the variant follows the perspective: only inherited from the
-    // context when the perspective is too.
-    const updatedVariant = goingToUnpublish
-      ? undefined
-      : (chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName))
-    const updatedDocId = goingToUnpublish
-      ? getPublishedId((previewValue as SanityDocument)._id)
-      : (previewValue as SanityDocument)._id
-
-    // allow for previewing the published document when a version is slated for unpublishing
-    // but if it's not for unpublishing, then we want to preview the content as was before
-    const restPreviewValue = goingToUnpublish
-      ? {}
-      : {
-          ...(previewValue as Previewable),
-        }
-
-    return observeForPreview(
-      {
-        _id: updatedDocId,
-        ...restPreviewValue,
-      },
-      schemaType,
-      {
-        perspective: updatedStack,
-        variant: updatedVariant,
-        viewOptions: {ordering: ordering},
-      },
-    ).pipe(
-      map((event) => ({isLoading: false, value: event.snapshot || undefined})),
-      catchError((error) => of({isLoading: false, error})),
-    )
-  }, [
-    enabled,
-    previewValue,
-    schemaType,
-    chosenPerspectiveStack,
-    perspectiveStack,
-    chosenVariant,
-    selectedVariantName,
-    observeForPreview,
-    ordering,
-  ])
+  // Only `enabled`, the schema type and the previewed document change the observable's identity,
+  // which is what restarts the subscription and renders the loading state. Everything else
+  // streams through `inputs$` into the observable that is already subscribed.
+  const observable = useMemo<Observable<State>>(
+    () =>
+      enabled && schemaType
+        ? createPreviewObservable(inputs$, schemaType, observeForPreview)
+        : IDLE_STATE_OBSERVABLE,
+    [enabled, inputs$, observeForPreview, schemaType],
+  )
 
   // Do not defer: search/reference UIs assert on preview titles synchronously after selection.
   return useSyncObservable(observable, INITIAL_STATE)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`useValuePreview` memoized its observable on every input, so each document edit, each new inline `perspectiveStack` array (`useDocumentTitle` passes `[]`) and each inline value (`UnpublishVersionDialog` passes `{_id}`) produced a new observable identity. Every identity change unsubscribes and resubscribes the whole `observeForPreview` chain, and on react-rx 7 (#14643, now on `main`) it also renders `INITIAL_STATE` for a frame: in the test studio that is one loading flash per edit in each of the four components previewing the open document. react-rx 6 hid the flash with its render-phase warm-up but paid the resubscribe. #14708 attacked the same problem with target keys and an emission wrapper; this is the simpler shape.

Now only `enabled`, the schema type and the previewed document key (`getPreviewDocumentKey`: id or `_ref`, dataset-qualified for cross-dataset references, a distinct key for a version slated for unpublishing) change the observable's identity. Those are the cases that should render the loading state. Everything else streams into the subscribed observable through one `BehaviorSubject<PreviewInputs>`, fed from an effect after commit. The stream dedupes inputs with `dequal/lite` before `switchMap`, so a render with equal inputs (inline arrays and stubs) never reaches `observeForPreview`, and dedupes prepared previews with `react-fast-compare` after it (errors by identity, since `Error` has no enumerable keys), so an edit outside the preview's `select` still runs `observeForPreview` but does not re-render the consumer.

Why one subject instead of six: two inputs changing in one render arrive atomically, so `switchMap` never subscribes an intermediate preview. Why the record carries the effective perspective and variant: a context change that a caller's own selection overrides then never reaches the stream. Why the subject is replaced whenever the identity changes (including `enabled`): a replacement observable must never read the inputs of an earlier render. `_updatedAt` stays in the output compare because `PreviewValue._updatedAt` is public and local mutations bump it.

### What to review

- `packages/sanity/src/core/preview/useValuePreview.ts`: `useInputsSubject` (the render-phase reset when `enabled`, the schema type or the document key changes) and `createPreviewObservable` (the two `distinctUntilChanged` boundaries). The `State` shape and the idle/loading contract are unchanged.
- Behaviour change to know about: a perspective or variant change now updates a mounted preview in place instead of flashing the loading state while the new perspective loads. A document key change still renders loading immediately.
- Costs to know about: a value change that does alter the prepared preview takes one extra render (render with the previous snapshot, effect, render with the new one) instead of doing the preview work inside render; `dequal` walks the whole document once per committed change (the shallow alternative would treat nested inline literals as new).
- Package: `sanity` only. No API change.

### Testing

- `packages/sanity/src/core/preview/__test__/useValuePreview.test.tsx` (23 tests) pins the contract: one live preview across edits without a loading frame, one preview for equal inline values and inline perspective arrays, loading state (never the previous document) when the id, dataset, schema type or unpublish mode changes, the current value when re-enabled, StrictMode, perspective/variant/ordering resolution through the rendered title, a context perspective change ignored when the caller selects one, unpublish previews the published id with `perspective: []`, idle state and subscription release when disabled or without value/schema type, error surfacing.
- Same file against `main`'s hook on the installed react-rx 7.0.0: 7 failures (loading frames on same-document edits and perspective changes, a second render for an edit that leaves the preview unchanged, three previews for equal inline inputs, a resubscribe on an overridden context change, StrictMode). This hook passes all 23. On the 6.0.1 dist `main`'s hook fails 2 and this hook passes.
- Consumer suites pass: `packages/sanity/src/core/preview`, `useDocumentTitle`, `DocumentHeaderTitle`, `StructureTitle`, `UnpublishVersionDialog`, `singleDocRelease`, navbar search (36 files, 301 tests). `pnpm check:oxlint` exits 0.
- Studio measurement on react-rx 7.0.0 (test studio, `book` document with an author reference, `console.log` counters in the hook, Playwright driving headed Chrome, same script on both revisions). Four components preview the open document.

  | 10 genre changes / 20 title keystrokes | main | this PR |
  | --- | --- | --- |
  | observable rebuilds | 80 / 96 | 0 / 0 |
  | loading-state frames rendered | 80 / 96 | 0 / 0 |
  | hook renders | 212 / 251 | 220 / 227 |
  | `observeForPreview` subscriptions | 80 / 96 | 80 / 88 |

  On the 6.0.1 dist the same script gave 80 / 96 → 0 rebuilds with no loading frames on either side, the warm-up having absorbed them.

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a34b0d41-fc39-4a4b-85d0-d538ccefe385?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a34b0d41-fc39-4a4b-85d0-d538ccefe385&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

