### PR TITLE
fix(sanity): choose-document-destination banner incorrectly superseded deleted-document banners

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -242,6 +242,8 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       return <ArchivedReleaseDocumentBanner releaseId={archivedReleaseId} />
     }
 
+    const deletedDocumentBanners = activeView.type === 'form' ? <DeletedDocumentBanners /> : null
+
     const isScheduledRelease =
       isReleaseDocument(selectedPerspective) && isReleaseScheduledOrScheduling(selectedPerspective)
 
@@ -264,13 +266,16 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       })
     ) {
       return (
-        !isSelectedPerspectiveWriteable.result && (
-          <ChooseNewDocumentDestinationBanner
-            schemaType={schemaType}
-            selectedPerspective={selectedPerspective}
-            reason={isSelectedPerspectiveWriteable.reason}
-          />
-        )
+        <>
+          {!isSelectedPerspectiveWriteable.result && (
+            <ChooseNewDocumentDestinationBanner
+              schemaType={schemaType}
+              selectedPerspective={selectedPerspective}
+              reason={isSelectedPerspectiveWriteable.reason}
+            />
+          )}
+          {deletedDocumentBanners}
+        </>
       )
     }
 
@@ -379,7 +384,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
         <ReferenceChangedBanner />
         <DeprecatedDocumentTypeBanner />
         <CanvasLinkedBanner />
-        <DeletedDocumentBanners />
+        {deletedDocumentBanners}
         <UnpublishedDocumentBanner />
         <OpenReleaseToEditBanner
           documentId={displayed?._id ?? documentId}

--- a/packages/sanity/src/structure/panes/document/documentPanel/__tests__/DocumentPanel.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/__tests__/DocumentPanel.test.tsx
@@ -1,8 +1,10 @@
 import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import {PerspectiveContext} from 'sanity/_singletons'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {perspectiveContextValueMock} from '../../../../__mocks__/usePerspective.mock'
 import {structureUsEnglishLocaleBundle} from '../../../../i18n'
 import {useStructureTool} from '../../../../useStructureTool'
 import {useDocumentPane} from '../../useDocumentPane'
@@ -30,10 +32,6 @@ vi.mock('../../useDocumentPane', () => ({
 
 vi.mock('../../../../hasObsoleteDraft', () => ({
   hasObsoleteDraft: vi.fn(() => ({result: false})),
-}))
-
-vi.mock('../../../../mustChooseNewDocumentDestination', () => ({
-  mustChooseNewDocumentDestination: vi.fn(() => false),
 }))
 
 vi.mock('../header/DocumentPanelSubHeader', () => ({
@@ -80,6 +78,11 @@ vi.mock('sanity', async (importOriginal) => ({
 
 const mockUseDocumentPane = vi.mocked(useDocumentPane)
 const mockUseStructureTool = vi.mocked(useStructureTool)
+
+const publishedPerspectiveContextValue = {
+  ...perspectiveContextValueMock,
+  selectedPerspective: 'published' as const,
+}
 
 const splitPanesFeatures = {resizablePanes: true, splitPanes: true}
 const collapsedLayoutFeatures = {resizablePanes: false, splitPanes: false}
@@ -158,5 +161,51 @@ describe('DocumentPanel form persistence', () => {
     expect(screen.getByTestId('document-panel-form-view')).toBeVisible()
     expect(screen.getByTestId('form-state')).toHaveTextContent('1')
     expect(screen.getByTestId('fullscreen-pte')).toBeVisible()
+  })
+})
+
+describe('DocumentPanel banners', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseStructureTool.mockReturnValue({
+      features: splitPanesFeatures,
+    } as ReturnType<typeof useStructureTool>)
+  })
+
+  function deletedDocumentPaneValue({isDeleted}: {isDeleted: boolean}) {
+    return {
+      ...documentPaneValue(),
+      editState: {ready: true, draft: null, published: null, version: null},
+      isDeleted,
+      isDeleting: false,
+    } as unknown as ReturnType<typeof useDocumentPane>
+  }
+
+  async function renderBanners() {
+    const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+    return render(
+      <PerspectiveContext.Provider value={publishedPerspectiveContextValue}>
+        {renderDocumentPanel()}
+      </PerspectiveContext.Provider>,
+      {wrapper},
+    )
+  }
+
+  it('shows the deleted document banner alongside the choose destination banner', async () => {
+    mockUseDocumentPane.mockReturnValue(deletedDocumentPaneValue({isDeleted: true}))
+
+    await renderBanners()
+
+    expect(screen.getByTestId('choose-new-document-destination-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('deleted-document-banner')).toBeInTheDocument()
+  })
+
+  it('shows only the choose destination banner when the document was never created', async () => {
+    mockUseDocumentPane.mockReturnValue(deletedDocumentPaneValue({isDeleted: false}))
+
+    await renderBanners()
+
+    expect(screen.getByTestId('choose-new-document-destination-banner')).toBeInTheDocument()
+    expect(screen.queryByTestId('deleted-document-banner')).toBeNull()
   })
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ChooseNewDocumentDestinationBanner.tsx
@@ -86,6 +86,7 @@ export const ChooseNewDocumentDestinationBanner: ComponentType<Props> = ({
     <Banner
       tone="caution"
       icon={WarningOutlineIcon}
+      data-testid="choose-new-document-destination-banner"
       content={
         <Flex alignItems="center" gap={2}>
           <Text size={1}>


### PR DESCRIPTION
### Description

It was impossible to restore deleted documents from the published
perspective in Studio. This branch fixes the problem by allowing the
choose-document-destination banner and deleted-documents to appear in
parallel if necessary.

This means it's once again possible to restore deleted documents that
only ever existed as published documents—editors just need to first
switch to the published perspective.

This is a blunt fix, but we're all aware the banner rendering code could use a refactor.

| Before (no restore banner) | After (restore banner) |
| --- | --- |
|  <img width="1010" height="724" alt="banners-before" src="https://github.com/user-attachments/assets/7c3966b5-7fa1-426a-9bb9-8444580051ec" /> |  <img width="1010" height="724" alt="banners-after" src="https://github.com/user-attachments/assets/79d81ab2-7a7b-4d22-916b-da24533db040" /> |

### What to review

The logic driving the presence of the choose-document-destination and deleted-document banners.

### Testing

Verified manually and with unit tests: if a published document has been deleted, it must show both the choose-document-destination banner and deleted-documents banners.

### Notes for release

Fixes a bug preventing restoration of documents that only ever existed in a published form (e.g. without a draft or other version ever existing). The "Restore most recent revision" action is now available for these documents—switch to the "published" perspective to access it.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only change to banner composition in the document pane; it restores document-restore actions without touching auth, data APIs, or persistence.
> 
> **Overview**
> Fixes a Studio bug where viewing a **deleted** document on a non-writeable perspective (e.g. **published**) only showed the choose-new-document-destination banner and hid **Restore most recent revision**.
> 
> **DocumentPanel** no longer returns early with only `ChooseNewDocumentDestinationBanner` when `mustChooseNewDocumentDestination` applies. It now renders that banner together with `DeletedDocumentBanners` (form view only) via a shared `deletedDocumentBanners` node, matching the default banner stack.
> 
> Tests cover both banners when `isDeleted` is true, and only the destination banner when the document was never created. `ChooseNewDocumentDestinationBanner` gains `data-testid="choose-new-document-destination-banner"` for assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3aff10d72e8d1bf1d153c94fd410cafa95ef83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->