### PR TITLE
chore: migrate flex in core/components

### DIFF
--- a/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
@@ -1,4 +1,3 @@
-import {Flex} from '@sanity/ui'
 import difference from 'lodash-es/difference.js'
 import {
   Children,
@@ -12,6 +11,7 @@ import {
   type RefAttributes,
 } from 'react'
 import {css, styled} from 'styled-components'
+import {Flex, type MarginProps, type GapProps} from 'ui5'
 
 import {type MenuButtonProps} from '../../../ui-components/menuButton/MenuButton'
 import {Tooltip} from '../../../ui-components/tooltip/Tooltip'
@@ -26,7 +26,7 @@ export interface CollapseMenuProps {
   collapsed?: boolean
   collapseText?: boolean
   disableRestoreFocusOnClose?: boolean
-  gap?: number | number[]
+  gap?: GapProps['gap']
   menuButtonProps?: Omit<MenuButtonProps, 'id' | 'menu' | 'button'> & {
     id?: string
     button?: React.JSX.Element
@@ -274,15 +274,14 @@ export function AutoCollapseMenu(
   )
 
   return (
-    <OuterFlex
-      align="center"
-      data-ui="CollapseMenu"
-      overflow="hidden"
-      sizing="border"
-      ref={ref}
-      {...rest}
-    >
-      <RootFlex direction="column" flex={1} justify="center" ref={setRootEl}>
+    <OuterFlex alignItems="center" data-ui="CollapseMenu" overflow="hidden" ref={ref} {...rest}>
+      <RootFlex
+        flexDirection="column"
+        flexBasis="0%"
+        flexGrow={1}
+        justifyContent="center"
+        ref={setRootEl}
+      >
         {/* The actual visible options */}
         <RowFlex gap={gap}>
           {pendingIntersections.length === 0 &&
@@ -325,7 +324,7 @@ export function AutoCollapseMenu(
 
       {/* Show the collapsed items that doesn't fit in a menu */}
       {overflowingCollapsedOptionElements.length > 0 && (
-        <Flex marginLeft={gap}>
+        <Flex marginLeft={gap as MarginProps['marginLeft']}>
           <CollapseOverflowMenu
             disableRestoreFocusOnClose={disableRestoreFocusOnClose}
             menuButton={menuButton}
@@ -341,7 +340,7 @@ export function AutoCollapseMenu(
 
 const RenderHidden = memo(function RenderHidden(props: {
   elements: React.JSX.Element[]
-  gap?: number | number[]
+  gap?: GapProps['gap']
   intersectionOptions: IntersectionObserverInit
   onIntersectionChange: (e: IntersectionObserverEntry, element: React.JSX.Element) => void
 }) {

--- a/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
@@ -1,5 +1,5 @@
-import {Flex} from '@sanity/ui'
 import {useEffect, useState} from 'react'
+import {Flex} from 'ui5'
 
 interface ObserveElementProps {
   children: React.JSX.Element

--- a/packages/sanity/src/core/components/collapseTabList/CollapseTabList.test.tsx
+++ b/packages/sanity/src/core/components/collapseTabList/CollapseTabList.test.tsx
@@ -24,7 +24,9 @@ it('merges consumer style with required layout styles', () => {
   const root = screen.getByTestId('collapse-tab-list')
 
   expect(root.style.position).toBe('relative')
-  expect(root.style.minWidth).toBe('0px')
+  // ui5 Flex defaults minWidth to 0 via CSS variable, not inline style
+  expect(root.style.getPropertyValue('--min-width')).toBe('0')
+  expect(root.className).toContain('sui-min-width')
   expect(root.style.width).toBe('200px')
   expect(root.style.color).toBe('red')
 })

--- a/packages/sanity/src/core/components/collapseTabList/CollapseTabList.tsx
+++ b/packages/sanity/src/core/components/collapseTabList/CollapseTabList.tsx
@@ -1,4 +1,3 @@
-import {Flex} from '@sanity/ui'
 import {
   Children,
   cloneElement,
@@ -10,6 +9,7 @@ import {
   type RefAttributes,
 } from 'react'
 import {styled} from 'styled-components'
+import {Flex, type GapProps} from 'ui5'
 
 import {type MenuButtonProps} from '../../../ui-components/menuButton/MenuButton'
 import {CollapseOverflowMenu} from '../collapseMenu/CollapseOverflowMenu'
@@ -41,7 +41,7 @@ const MenuButtonPlaceholder = styled.div`
 
 interface CollapseTabListProps {
   children: ReactNode
-  gap?: number | number[]
+  gap?: GapProps['gap']
   menuButtonProps?: Omit<MenuButtonProps, 'id' | 'menu' | 'button'> & {
     id?: string
     button?: React.JSX.Element
@@ -120,13 +120,15 @@ export function CollapseTabList(props: CollapseTabListProps & RefAttributes<HTML
 
   return (
     <Flex
-      direction="column"
+      flexDirection="column"
       ref={ref}
-      sizing="border"
       {...rest}
-      style={{position: 'relative', minWidth: 0, ...style}}
+      style={{
+        position: 'relative',
+        ...style,
+      }}
     >
-      <Flex justify="center" gap={gap} flex={1}>
+      <Flex justifyContent="center" gap={gap} flexBasis="0%" flexGrow={1}>
         {hasMeasured ? displayChildren : null}
         {hiddenChildren.length > 0 ? (
           <CollapseOverflowMenu
@@ -152,7 +154,13 @@ export function CollapseTabList(props: CollapseTabListProps & RefAttributes<HTML
       </Flex>
 
       {/* Element that always render all the children to keep track of their position and if the available space to render them */}
-      <HiddenRow justify="flex-start" gap={gap} ref={setRootEl} data-hidden aria-hidden="true">
+      <HiddenRow
+        justifyContent="flex-start"
+        gap={gap}
+        ref={setRootEl}
+        data-hidden
+        aria-hidden="true"
+      >
         {cloneElement(menuButton, {
           'disabled': true,
           'aria-hidden': true,

--- a/packages/sanity/src/core/components/detailLayout/DetailActionRail.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailActionRail.tsx
@@ -1,5 +1,5 @@
-import {Flex} from '@sanity/ui'
 import {type ReactNode} from 'react'
+import {Flex} from 'ui5'
 
 /**
  * The top-right action rail of an entity detail page: optional secondary action(s), one prominent
@@ -19,7 +19,14 @@ export function DetailActionRail(props: {
 }): React.JSX.Element {
   const {secondary, primary, menu} = props
   return (
-    <Flex flex="none" gap={2} align="center" data-ui="detail-action-rail">
+    <Flex
+      flexBasis="auto"
+      flexGrow={0}
+      flexShrink={0}
+      gap={2}
+      alignItems="center"
+      data-ui="detail-action-rail"
+    >
       {secondary}
       {primary}
       {menu}

--- a/packages/sanity/src/core/components/detailLayout/DetailIdentity.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailIdentity.tsx
@@ -1,8 +1,8 @@
-import {Flex, Stack, Text} from '@sanity/ui'
+import {Stack, Text} from '@sanity/ui'
 import {getTheme_v2} from '@sanity/ui/theme'
 import {type ElementType} from 'react'
 import {css, styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Tooltip} from '../../../ui-components/tooltip/Tooltip'
 
@@ -52,7 +52,7 @@ export function DetailIdentity(props: {
 
   return (
     <Stack gap={3}>
-      <Flex align="center" gap={2}>
+      <Flex alignItems="center" gap={2}>
         {/* Box flex={1} lets the title shrink and truncate instead of overflowing its
             zone; the full title is available on hover. */}
         <Box flexBasis="0%" flexGrow={1}>

--- a/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
@@ -1,8 +1,8 @@
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {getTheme_v2} from '@sanity/ui/theme'
 import {Fragment, type ReactNode} from 'react'
 import {css, styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 // At or above this many rows, a `multiColumn` section splits into two side-by-side columns so a
 // long list (e.g. six targeting conditions) reads as a compact block instead of a tall stack.
@@ -168,7 +168,7 @@ export function DetailPropertiesPanel(props: {
                 </Text>
               )}
               {splitIntoColumns ? (
-                <Flex gap={4} wrap="wrap">
+                <Flex gap={4} flexWrap="wrap">
                   <PropertyRowsGrid hasGlyphs={hasGlyphs} rows={rows.slice(0, leftCount)} />
                   <PropertyRowsGrid hasGlyphs={hasGlyphs} rows={rows.slice(leftCount)} />
                 </Flex>

--- a/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
@@ -103,7 +103,7 @@ function PropertyRowsGrid({
           </Text>
           {/* Pure-text value on one left edge; a long value truncates (title tooltip shows the full
               text) rather than wrapping and breaking the single-line grid. */}
-          <Box style={{minWidth: 0}}>
+          <Box>
             {typeof row.value === 'string' ? (
               <Text size={1} textOverflow="ellipsis" title={row.value}>
                 {row.value}

--- a/packages/sanity/src/core/components/detailLayout/__tests__/DetailLayoutStory.tsx
+++ b/packages/sanity/src/core/components/detailLayout/__tests__/DetailLayoutStory.tsx
@@ -1,6 +1,7 @@
 import {CalendarIcon} from '@sanity/icons/Calendar'
 import {EarthGlobeIcon} from '@sanity/icons/EarthGlobe'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {TestWrapper} from '../../../../../test/browser/TestWrapper'
 import {DetailIdentity} from '../DetailIdentity'
@@ -31,7 +32,7 @@ export function DetailLayoutStory() {
             <Text muted size={1} weight="medium">
               titled with description
             </Text>
-            <Flex align="flex-start" gap={4} justify="space-between">
+            <Flex alignItems="flex-start" gap={4} justifyContent="space-between">
               <DetailIdentity
                 description={CLAMPED_DESCRIPTION}
                 title="Summer editorial"

--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -1,6 +1,7 @@
 import {type PreviewValue, type SanityDocument} from '@sanity/types'
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {useMemo} from 'react'
+import {Flex} from 'ui5'
 
 import {useRelativeTime} from '../../hooks/useRelativeTime'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
@@ -42,10 +43,10 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
 
   return (
     <Flex
-      align={singleLine ? 'center' : 'flex-start'}
-      direction={singleLine ? 'row' : 'column'}
+      alignItems={singleLine ? 'center' : 'flex-start'}
+      flexDirection={singleLine ? 'row' : 'column'}
       gap={3}
-      wrap="nowrap"
+      flexWrap="nowrap"
     >
       {published && (
         <VersionStatus
@@ -115,7 +116,7 @@ const VersionStatus = ({
   })
 
   return (
-    <Flex align="center" gap={2}>
+    <Flex alignItems="center" gap={2}>
       <ReleaseAvatar release={release} padding={0} />
       <Text size={1}>
         {title} -{' '}

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionIcons.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionIcons.tsx
@@ -1,4 +1,5 @@
-import {Card, Flex, Text} from '@sanity/ui'
+import {Card, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {RhombusIcon} from '../../components/temporary-icons/Rhombus'
 import {ReleaseAvatar} from '../../releases/components/ReleaseAvatar'
@@ -29,7 +30,7 @@ export function DocumentVersionIcons({version}: {version: VersionInfoDocumentStu
     : undefined
 
   return (
-    <Flex align="center" flex="none" gap={1}>
+    <Flex alignItems="center" flexBasis="auto" flexGrow={0} flexShrink={0} gap={1}>
       {variantsEnabled && variant ? (
         <Card className={variantIconCard} tone="suggest">
           <Text size={2}>

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -1,6 +1,6 @@
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {useDocumentVersionTitle} from '../../hooks/useDocumentVersionTitle'
 import {useRelativeTime} from '../../hooks/useRelativeTime'
@@ -85,7 +85,7 @@ function VersionStatus({version}: DocumentVersionStatusItem) {
 
   return (
     <Box className={versionStatusItem}>
-      <Flex gap={2} justify="space-between" paddingY={2}>
+      <Flex gap={2} justifyContent="space-between" paddingY={2}>
         <Stack className={titleStack} gap={2}>
           <Text size={1} title={isTruncated ? fullTitle : undefined} weight="medium">
             {title}

--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentStatusIndicator.tsx
@@ -1,6 +1,6 @@
-import {Flex} from '@sanity/ui'
 import {useMemo} from 'react'
 import {css, styled} from 'styled-components'
+import {Flex} from 'ui5'
 
 import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'

--- a/packages/sanity/src/core/components/documentStatusIndicator/DocumentVersionsStatusIndicator.tsx
+++ b/packages/sanity/src/core/components/documentStatusIndicator/DocumentVersionsStatusIndicator.tsx
@@ -1,6 +1,7 @@
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {type ReactNode} from 'react'
 import {styled} from 'styled-components'
+import {Flex} from 'ui5'
 
 import {type TargetPerspective} from '../../perspective/types'
 import {usePerspective} from '../../perspective/usePerspective'
@@ -113,7 +114,7 @@ export function DocumentVersionsStatusIndicator({documentVersions}: DocumentStat
   }
 
   return (
-    <Flex align="center">
+    <Flex alignItems="center">
       {icons.map((icon) => renderDocumentStatusIcon(icon, selectedPerspective))}
     </Flex>
   )

--- a/packages/sanity/src/core/components/documentTable/EditedByCell.tsx
+++ b/packages/sanity/src/core/components/documentTable/EditedByCell.tsx
@@ -1,5 +1,6 @@
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {styled} from 'styled-components'
+import {Flex} from 'ui5'
 
 import {useDocumentLastEditedBy} from '../../store/translog/useDocumentLastEditedBy'
 import {useUser} from '../../store/user/hooks'
@@ -49,7 +50,7 @@ export function EditedByAvatar({
   }
 
   return (
-    <CellRoot align="center" gap={2}>
+    <CellRoot alignItems="center" gap={2}>
       <UserAvatar size={0} user={userId} withTooltip />
       {user?.displayName && (
         <NameText muted size={1} textOverflow="ellipsis">

--- a/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarFilter.tsx
+++ b/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarFilter.tsx
@@ -1,6 +1,6 @@
 import {ChevronLeftIcon} from '@sanity/icons/ChevronLeft'
 import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
-import {Flex, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {addDays} from 'date-fns/addDays'
 import {addMonths} from 'date-fns/addMonths'
 import {setHours} from 'date-fns/setHours'
@@ -15,7 +15,7 @@ import {
   useState,
   type RefAttributes,
 } from 'react'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {TooltipDelayGroupProvider} from '../../../../../ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider'
@@ -172,7 +172,7 @@ export function CalendarFilter(props: CalendarProps & RefAttributes<HTMLDivEleme
     <Box data-ui="Calendar" {...restProps} ref={ref}>
       {/* Month + Year header */}
       <Flex
-        align="center"
+        alignItems="center"
         paddingLeft={4}
         style={{
           borderBottom: '1px solid var(--card-border-color)',
@@ -181,7 +181,7 @@ export function CalendarFilter(props: CalendarProps & RefAttributes<HTMLDivEleme
           top: 0,
         }}
       >
-        <Flex align="center" flex={1} justify="space-between">
+        <Flex alignItems="center" flexBasis="0%" flexGrow={1} justifyContent="space-between">
           <Text weight="medium" size={1}>
             {DEFAULT_MONTH_NAMES[focusedDate?.getMonth()]} {focusedDate?.getFullYear()}
           </Text>

--- a/packages/sanity/src/core/components/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/DateTimeInput.tsx
@@ -1,5 +1,5 @@
 import {CalendarIcon} from '@sanity/icons/Calendar'
-import {Card, Flex, LayerProvider, Text, useClickOutsideEvent, useLayer} from '@sanity/ui'
+import {Card, LayerProvider, Text, useClickOutsideEvent, useLayer} from '@sanity/ui'
 import {isPast} from 'date-fns/isPast'
 import {
   type FocusEvent,
@@ -14,7 +14,7 @@ import {
   type RefAttributes,
 } from 'react'
 import FocusLock from 'react-focus-lock'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Popover} from '../../../../ui-components/popover/Popover'

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -2,7 +2,7 @@ import {TZDate} from '@date-fns/tz'
 import {ChevronLeftIcon} from '@sanity/icons/ChevronLeft'
 import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
 import {EarthGlobeIcon} from '@sanity/icons/EarthGlobe'
-import {Flex, Select, Text} from '@sanity/ui'
+import {Select, Text} from '@sanity/ui'
 import {format} from '@sanity/util/legacyDateFormat'
 import {addDays} from 'date-fns/addDays'
 import {addMonths} from 'date-fns/addMonths'
@@ -25,7 +25,7 @@ import {
   useState,
   type RefAttributes,
 } from 'react'
-import {Grid, Box, type PaddingProps} from 'ui5'
+import {Flex, Grid, Box, type PaddingProps} from 'ui5'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {TooltipDelayGroupProvider} from '../../../../../ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider'
@@ -271,7 +271,7 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
     if (monthPickerVariant === 'carousel') {
       return (
         <Flex
-          align="center"
+          alignItems="center"
           paddingLeft={4}
           style={{
             borderBottom: '1px solid var(--card-border-color)',
@@ -280,8 +280,8 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
             top: 0,
           }}
         >
-          <Flex align="center" flex={1} justify="space-between">
-            <Flex align="center" flex={1}>
+          <Flex alignItems="center" flexBasis="0%" flexGrow={1} justifyContent="space-between">
+            <Flex alignItems="center" flexBasis="0%" flexGrow={1}>
               <Text weight="medium" size={1}>
                 {labels.monthNames[(focusedDate || new Date())?.getMonth()]}{' '}
                 {(focusedDate || new Date())?.getFullYear()}
@@ -393,11 +393,11 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
       </Box>
 
       <Box padding={2} style={{borderTop: '1px solid var(--card-border-color)'}}>
-        <Flex align="center" justify="space-between">
+        <Flex alignItems="center" justifyContent="space-between">
           {/* Select time */}
           {selectTime && (
             <>
-              <Flex align="center">
+              <Flex alignItems="center">
                 <TimeInput
                   aria-label={labels.selectTime}
                   value={timeValue}
@@ -426,7 +426,12 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
               )}
 
               {features.timePresets && (
-                <Flex direction="row" justify="center" align="center" style={{marginTop: 5}}>
+                <Flex
+                  flexDirection="row"
+                  justifyContent="center"
+                  alignItems="center"
+                  style={{marginTop: 5}}
+                >
                   {DEFAULT_TIME_PRESETS.map(([hours, minutes]) => {
                     const text = formatTime(hours, minutes)
                     return (
@@ -476,7 +481,7 @@ function CalendarMonthSelect(props: {
   const {onChange, value, monthNames} = props
 
   return (
-    <Flex flex={1} gap={1}>
+    <Flex flexBasis="0%" flexGrow={1} gap={1}>
       <Box flexBasis="0%" flexGrow={1}>
         <Select fontSize={1} radius={2} value={value} onChange={onChange} padding={2}>
           {monthNames.map((monthName, i) => (

--- a/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
@@ -1,17 +1,9 @@
 import {CloseIcon} from '@sanity/icons/Close'
-import {
-  Flex,
-  Layer,
-  type ResponsiveWidthProps,
-  Stack,
-  Text,
-  type Theme,
-  usePortal,
-} from '@sanity/ui'
+import {Layer, type ResponsiveWidthProps, Stack, Text, type Theme, usePortal} from '@sanity/ui'
 import {type Dispatch, type ReactNode, type SetStateAction, useCallback} from 'react'
 import TrapFocus, {type ReactFocusLockProps} from 'react-focus-lock'
 import {css, styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {Button} from '../../../ui-components/button/Button'
 import {Popover, type PopoverProps} from '../../../ui-components/popover/Popover'
@@ -90,7 +82,7 @@ export function PopoverDialog(props: PopoverDialogProps) {
         <Stack ref={containerRef}>
           <StickyLayer>
             <Box padding={2} paddingLeft={4}>
-              <Flex align="center" gap={2}>
+              <Flex alignItems="center" gap={2}>
                 <Box flexBasis="0%" flexGrow={1}>
                   <Text size={1} textOverflow="ellipsis" weight="medium">
                     {header}

--- a/packages/sanity/src/core/components/previews/general/CompactPreview.tsx
+++ b/packages/sanity/src/core/components/previews/general/CompactPreview.tsx
@@ -1,6 +1,6 @@
-import {Flex, rem, Skeleton, Stack, Text, TextSkeleton} from '@sanity/ui'
+import {rem, Skeleton, Stack, Text, TextSkeleton} from '@sanity/ui'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -48,13 +48,13 @@ export function CompactPreview(props: CompactPreviewProps) {
   if (isPlaceholder) {
     return (
       <Root
-        align="center"
+        alignItems="center"
         data-testid="default-preview"
         paddingLeft={media ? 1 : 2}
         paddingRight={2}
         paddingY={1}
       >
-        <Flex align="center" flex={1} gap={2}>
+        <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={2}>
           {media && <Skeleton animated radius={2} style={PREVIEW_SIZES.compact.media} />}
 
           <Stack data-testid="compact-preview__heading" flex={1} gap={2}>
@@ -69,13 +69,13 @@ export function CompactPreview(props: CompactPreviewProps) {
 
   return (
     <Root
-      align="center"
+      alignItems="center"
       data-testid="compact-preview"
       paddingLeft={media ? 1 : 2}
       paddingRight={2}
       paddingY={1}
     >
-      <Flex align="center" flex={1} gap={2}>
+      <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={2}>
         {media && (
           <Media
             border={false}

--- a/packages/sanity/src/core/components/previews/general/DefaultPreview.tsx
+++ b/packages/sanity/src/core/components/previews/general/DefaultPreview.tsx
@@ -1,7 +1,7 @@
-import {Flex, rem, Skeleton, Stack, Text, TextSkeleton} from '@sanity/ui'
+import {rem, Skeleton, Stack, Text, TextSkeleton} from '@sanity/ui'
 import {clsx} from 'clsx'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -69,13 +69,13 @@ export function DefaultPreview(props: DefaultPreviewProps) {
   if (isPlaceholder) {
     return (
       <Root
-        align="center"
+        alignItems="center"
         className={styles?.placeholder}
         data-testid="default-preview"
         padding={2}
         paddingLeft={media ? 2 : 3}
       >
-        <Flex align="center" flex={1} gap={2}>
+        <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={2}>
           {media && (
             <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
               <Skeleton
@@ -102,13 +102,13 @@ export function DefaultPreview(props: DefaultPreviewProps) {
 
   return (
     <Root
-      align="center"
+      alignItems="center"
       className={rootClassName}
       data-testid="default-preview"
       padding={2}
       paddingLeft={media ? 2 : 3}
     >
-      <Flex align="center" flex={1} gap={2}>
+      <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={2}>
         {media && (
           <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
             <Media

--- a/packages/sanity/src/core/components/previews/general/DetailPreview.styled.ts
+++ b/packages/sanity/src/core/components/previews/general/DetailPreview.styled.ts
@@ -1,10 +1,10 @@
-import {Flex, rem, Skeleton, Text, TextSkeleton} from '@sanity/ui'
+import {rem, Skeleton, Text, TextSkeleton} from '@sanity/ui'
 import {css, styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {PREVIEW_SIZES} from '../constants'
 
-export const RootFlex = styled(Flex).attrs({align: 'center'})`
+export const RootFlex = styled(Flex).attrs({alignItems: 'center'})`
   height: ${rem(PREVIEW_SIZES.detail.media.height)};
 `
 

--- a/packages/sanity/src/core/components/previews/general/DetailPreview.tsx
+++ b/packages/sanity/src/core/components/previews/general/DetailPreview.tsx
@@ -1,5 +1,5 @@
-import {Flex, Stack, Text} from '@sanity/ui'
-import {Box} from 'ui5'
+import {Stack, Text} from '@sanity/ui'
+import {Flex, Box} from 'ui5'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -59,10 +59,15 @@ export function DetailPreview(props: DetailPreviewProps) {
         paddingRight={2}
         paddingY={2}
       >
-        <Flex align="center" flex={1} gap={3}>
+        <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={3}>
           {media && <MediaSkeleton data-testid="detail-preview__media" />}
 
-          <Flex align="center" data-testid="detail-preview__header" flex={1}>
+          <Flex
+            alignItems="center"
+            data-testid="detail-preview__header"
+            flexBasis="0%"
+            flexGrow={1}
+          >
             <Stack flex={1} gap={2}>
               <TitleSkeleton />
               <SubtitleSkeleton />
@@ -87,10 +92,10 @@ export function DetailPreview(props: DetailPreviewProps) {
       paddingRight={2}
       paddingY={2}
     >
-      <Flex align="center" flex={1} gap={3}>
+      <Flex alignItems="center" flexBasis="0%" flexGrow={1} gap={3}>
         {media && <Media dimensions={mediaDimensions} layout="detail" media={media as any} />}
 
-        <Flex align="center" data-testid="detail-preview__header" flex={1}>
+        <Flex alignItems="center" data-testid="detail-preview__header" flexBasis="0%" flexGrow={1}>
           <Stack flex={1} gap={2}>
             <Text textOverflow="ellipsis" size={1} style={{color: 'inherit'}} weight="medium">
               {title && renderPreviewNode(title, 'detail')}

--- a/packages/sanity/src/core/components/previews/general/MediaPreview.styled.ts
+++ b/packages/sanity/src/core/components/previews/general/MediaPreview.styled.ts
@@ -1,12 +1,12 @@
-import {Flex, rem, Skeleton, Stack} from '@sanity/ui'
+import {rem, Skeleton, Stack} from '@sanity/ui'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 export const RootBox = styled(Box)`
   position: relative;
 `
 
-export const MediaFlex = styled(Flex).attrs({align: 'center', justify: 'center'})`
+export const MediaFlex = styled(Flex).attrs({alignItems: 'center', justifyContent: 'center'})`
   position: absolute;
   left: 0;
   top: 0;
@@ -19,7 +19,7 @@ export const MediaSkeleton = styled(Skeleton).attrs({animated: true, radius: 2})
   height: 100%;
 `
 
-export const ProgressFlex = styled(Flex).attrs({align: 'center', justify: 'center'})`
+export const ProgressFlex = styled(Flex).attrs({alignItems: 'center', justifyContent: 'center'})`
   position: absolute;
   left: 0;
   top: 0;

--- a/packages/sanity/src/core/components/previews/portableText/BlockImagePreview.styled.tsx
+++ b/packages/sanity/src/core/components/previews/portableText/BlockImagePreview.styled.tsx
@@ -1,10 +1,10 @@
-import {Card, Flex, rem} from '@sanity/ui'
+import {Card, rem} from '@sanity/ui'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 
 import {PREVIEW_SIZES} from '../constants'
 
-export const HeaderFlex = styled(Flex).attrs({align: 'center'})`
+export const HeaderFlex = styled(Flex).attrs({alignItems: 'center'})`
   height: ${rem(PREVIEW_SIZES.block.media.height)};
   white-space: nowrap;
   position: relative;

--- a/packages/sanity/src/core/components/previews/portableText/BlockImagePreview.tsx
+++ b/packages/sanity/src/core/components/previews/portableText/BlockImagePreview.tsx
@@ -1,5 +1,5 @@
-import {Flex, Stack, Text} from '@sanity/ui'
-import {Box} from 'ui5'
+import {Stack, Text} from '@sanity/ui'
+import {Flex, Box} from 'ui5'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {Media} from '../_common/Media'

--- a/packages/sanity/src/core/components/previews/portableText/BlockPreview.tsx
+++ b/packages/sanity/src/core/components/previews/portableText/BlockPreview.tsx
@@ -1,6 +1,6 @@
-import {Flex, rem, Stack, Text} from '@sanity/ui'
+import {rem, Stack, Text} from '@sanity/ui'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {LinearProgress} from '../../progress/LinearProgress'
@@ -16,7 +16,7 @@ const DEFAULT_MEDIA_DIMENSIONS: PreviewMediaDimensions = {
   dpr: getDevicePixelRatio(),
 }
 
-const HeaderFlex = styled(Flex).attrs({align: 'center'})`
+const HeaderFlex = styled(Flex).attrs({alignItems: 'center'})`
   min-height: ${rem(PREVIEW_SIZES.block.media.height)};
 `
 

--- a/packages/sanity/src/core/components/previews/template/TemplatePreview.tsx
+++ b/packages/sanity/src/core/components/previews/template/TemplatePreview.tsx
@@ -1,8 +1,8 @@
-import {Flex, rem, Stack, Text, TextSkeleton} from '@sanity/ui'
+import {rem, Stack, Text, TextSkeleton} from '@sanity/ui'
 import {type ElementType, isValidElement, type ReactNode} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
-import {Box} from 'ui5'
+import {Flex, Box} from 'ui5'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
 import {Media, type MediaProps} from '../_common/Media'
@@ -41,7 +41,7 @@ const Root = styled(Box)`
   }
 `
 
-const HeaderFlex = styled(Flex).attrs({align: 'center'})`
+const HeaderFlex = styled(Flex).attrs({alignItems: 'center'})`
   height: ${rem(PREVIEW_SIZES.default.media.height)};
 `
 
@@ -105,7 +105,7 @@ export function TemplatePreview(props: TemplatePreviewProps) {
         </Stack>
 
         {media && (
-          <Flex align="flex-start" paddingLeft={2}>
+          <Flex alignItems="flex-start" paddingLeft={2}>
             <Media dimensions={mediaDimensions} layout="default" media={media} />
           </Flex>
         )}

--- a/packages/sanity/src/core/components/timeZone/DialogTimeZone.tsx
+++ b/packages/sanity/src/core/components/timeZone/DialogTimeZone.tsx
@@ -1,8 +1,9 @@
 import {SearchIcon} from '@sanity/icons/Search'
-import {Card, Flex, Inline, Stack, Text, type Theme} from '@sanity/ui'
+import {Card, Inline, Stack, Text, type Theme} from '@sanity/ui'
 import {Autocomplete} from '@sanity/ui/autocomplete'
 import {useCallback, useMemo, useState} from 'react'
 import {css, styled} from 'styled-components'
+import {Flex} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {type TimeZoneScope, type TimeZoneScopeType, useTimeZone} from '../../hooks/useTimeZone'
@@ -145,7 +146,7 @@ const DialogTimeZone = (props: DialogTimeZoneProps) => {
       <Stack padding={4} gap={5}>
         <Text size={1}>{timeZoneScopeTypeToLabel[timeZoneScope.type]}</Text>
         <Stack gap={3}>
-          <Flex align="center" justify="space-between">
+          <Flex alignItems="center" justifyContent="space-between">
             <Inline gap={2}>
               <Text size={1} weight="semibold">
                 {t('time-zone.time-zone')}

--- a/packages/sanity/src/core/form/inputs/files/__tests__/FileInputWarningsStory.tsx
+++ b/packages/sanity/src/core/form/inputs/files/__tests__/FileInputWarningsStory.tsx
@@ -1,5 +1,6 @@
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import noop from 'lodash-es/noop.js'
+import {Flex} from 'ui5'
 
 import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
 import {AccessPolicyBadge} from '../common/AccessPolicyBadge'
@@ -43,7 +44,7 @@ export function FileInputWarningsStory() {
             <Text muted size={1} weight="medium">
               access policy (FileActionsMenu row)
             </Text>
-            <Flex justify="center" gap={2}>
+            <Flex justifyContent="center" gap={2}>
               <AccessPolicyBadge />
             </Flex>
           </Stack>

--- a/packages/sanity/src/core/releases/components/__tests__/ReleaseAvatar.stories.tsx
+++ b/packages/sanity/src/core/releases/components/__tests__/ReleaseAvatar.stories.tsx
@@ -1,5 +1,6 @@
-import {type BadgeTone, Card, Flex, Stack, Text} from '@sanity/ui'
+import {type BadgeTone, Card, Stack, Text} from '@sanity/ui'
 import {type Meta, type StoryObj} from '@storybook/react-vite'
+import {Flex} from 'ui5'
 
 import {
   activeASAPRelease,
@@ -33,7 +34,7 @@ export const AllVariants: Story = {
           <Text muted size={1} weight="medium">
             by releaseType
           </Text>
-          <Flex align="center" gap={3}>
+          <Flex alignItems="center" gap={3}>
             <ReleaseAvatar releaseType="asap" />
             <ReleaseAvatar releaseType="scheduled" />
             <ReleaseAvatar releaseType="undecided" />
@@ -43,7 +44,7 @@ export const AllVariants: Story = {
           <Text muted size={1} weight="medium">
             by release document
           </Text>
-          <Flex align="center" gap={3}>
+          <Flex alignItems="center" gap={3}>
             <ReleaseAvatar release={activeASAPRelease} />
             <ReleaseAvatar release={activeScheduledRelease} />
             <ReleaseAvatar release={activeUndecidedRelease} />
@@ -55,7 +56,7 @@ export const AllVariants: Story = {
           <Text muted size={1} weight="medium">
             by tone
           </Text>
-          <Flex align="center" gap={3}>
+          <Flex alignItems="center" gap={3}>
             {TONES.map((tone) => (
               // oxlint-disable-next-line no-deprecated -- deprecated tone path is still rendered in production
               <ReleaseAvatar key={tone} tone={tone} />

--- a/packages/sanity/src/core/variants/tool/overview/__tests__/VariantsEmptyStateStory.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/__tests__/VariantsEmptyStateStory.tsx
@@ -1,4 +1,5 @@
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
+import {Flex} from 'ui5'
 
 import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
 import {Button} from '../../../../../ui-components/button/Button'
@@ -22,7 +23,7 @@ export function VariantsEmptyStateStory() {
             <Text muted size={1} weight="medium">
               docs link only
             </Text>
-            <Flex justify="center">
+            <Flex justifyContent="center">
               <VariantsEmptyState />
             </Flex>
           </Stack>
@@ -30,7 +31,7 @@ export function VariantsEmptyStateStory() {
             <Text muted size={1} weight="medium">
               with create action
             </Text>
-            <Flex justify="center">
+            <Flex justifyContent="center">
               <VariantsEmptyState createVariantButton={<Button text="Create variant" />} />
             </Flex>
           </Stack>

--- a/packages/sanity/test/setup/browser.ts
+++ b/packages/sanity/test/setup/browser.ts
@@ -4,6 +4,7 @@
 // @sanity/ui ships its static styles as a stylesheet consumers import themselves, so load it here
 // the same way the studio entry point does.
 import '@sanity/ui/styles.css'
+import 'ui5/styles.css'
 
 import {afterEach} from 'vitest'
 import {cleanup} from 'vitest-browser-react'


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR migrates the Flex component from `@sanity/ui` v4 to v5 in the `packages/sanity/src/core/components` directory. It updates Flex across 30 files containing 62 JSX or styled-component instances.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop and type updates look correct.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I did some manual QA focusing on general layouts, Releases, Schedules, and Variants.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide UI surface area (toolbars, previews, calendars, detail layouts) with prop renames only—visual/layout regressions are possible though behavior is unchanged.
> 
> **Overview**
> Migrates **`Flex`** in `packages/sanity/src/core/components` (and a few related stories/tests) from **`@sanity/ui`** to **`ui5`**, updating the v5 layout prop names everywhere it’s used (`align` → `alignItems`, `direction` → `flexDirection`, `justify` → `justifyContent`, `wrap` → `flexWrap`, shorthand `flex` → explicit `flexBasis` / `flexGrow` / `flexShrink`). **`gap`** props on collapse menus now use **`GapProps['gap']`** instead of `number | number[]`.
> 
> A few layout tweaks follow ui5 defaults: **`CollapseMenu`** drops `sizing="border"`; **`CollapseTabList`** no longer sets inline `minWidth: 0` (ui5 applies it via CSS variable/class); **`DetailPropertiesPanel`** drops redundant `minWidth: 0` on value cells. **`CollapseTabList.test.tsx`** asserts `--min-width` and `sui-min-width` instead of inline `minWidth`. Browser tests load **`ui5/styles.css`** alongside `@sanity/ui` styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b51daea4dd350a99092c140ff8b4b5df5b08b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->