### PR TITLE
chore: final pass migrating grid

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGuiHeader.tsx
+++ b/packages/@sanity/vision/src/components/VisionGuiHeader.tsx
@@ -1,5 +1,5 @@
 import {CopyIcon} from '@sanity/icons/Copy'
-import {Button, Card, Flex, Grid, Inline, Select, Stack, Text, TextInput} from '@sanity/ui'
+import {Button, Card, Flex, Inline, Select, Stack, Text, TextInput} from '@sanity/ui'
 import {Tooltip} from '@sanity/ui/tooltip'
 import {
   type ChangeEvent,
@@ -17,7 +17,7 @@ import {
   usePerspective,
   useTranslation,
 } from 'sanity'
-import {Box} from 'ui5'
+import {Box, Grid} from 'ui5'
 
 import {API_VERSIONS} from '../apiVersions'
 import {visionLocaleNamespace} from '../i18n'
@@ -114,7 +114,14 @@ export function VisionGuiHeader({
 
   return (
     <Header paddingX={3} paddingY={2}>
-      <Grid gridTemplateColumns={[1, 4, 8, 12]}>
+      <Grid
+        gridTemplateColumns={[
+          'repeat(1, minmax(0, 1fr))',
+          'repeat(4, minmax(0, 1fr))',
+          'repeat(8, minmax(0, 1fr))',
+          'repeat(12, minmax(0, 1fr))',
+        ]}
+      >
         {/* Dataset selector */}
         <Box padding={1} gridColumn={['span 1 / span 1', 'span 2 / span 2']}>
           <Stack>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR finished up migrating the Grid component from `@sanity/ui` v4 to v5. It turns out there was only 1 file containing 1 JSX instance left.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop updates look right.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I manually QAed in the Vision tab.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Layout-only prop and import change in the Vision settings header; no auth, data, or API behavior changes.
> 
> **Overview**
> Completes the **Grid** migration from `@sanity/ui` v4 to **ui5** in Vision: `VisionGuiHeader` was the last remaining usage.
> 
> **Grid** is imported from `ui5` with `Box` instead of `@sanity/ui`. The header layout grid’s `gridTemplateColumns` is updated from numeric breakpoint values (`[1, 4, 8, 12]`) to explicit CSS templates (`repeat(n, minmax(0, 1fr))`) at the same responsive steps. Child `gridColumn` spans are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dcd235fb7f121f814d9d52fc42bc6812d3b2a06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->